### PR TITLE
Enable Groq fallback for Z.AI theme extraction

### DIFF
--- a/backend/app/services/theme_extraction_service.py
+++ b/backend/app/services/theme_extraction_service.py
@@ -496,7 +496,11 @@ class ThemeExtractionService:
         # Use configured model if set
         model_override = self.configured_model if self.configured_model else None
         active_model = model_override or self.llm.preset.primary.model_id
-        allow_fallbacks = not LLMService._is_zai_model(active_model)
+        # Keep Z.AI as the primary model for every extraction request, but allow the
+        # shared LLM service to fall through to Groq if a single request exhausts its
+        # Z.AI retries. The next request still starts from Z.AI because the active
+        # model selection here is unchanged.
+        allow_fallbacks = True
         max_tokens = (
             self.ZAI_EXTRACTION_MAX_TOKENS
             if LLMService._is_zai_model(active_model)

--- a/backend/tests/unit/test_zai_llm_routing.py
+++ b/backend/tests/unit/test_zai_llm_routing.py
@@ -73,7 +73,7 @@ def test_apply_provider_overrides_clears_zai_overrides_for_non_zai_models() -> N
     assert params["api_base"] == "https://caller.invalid"
 
 
-def test_try_generate_litellm_disables_fallbacks_for_configured_zai_model() -> None:
+def test_try_generate_litellm_enables_fallbacks_for_configured_zai_model() -> None:
     service = ThemeExtractionService.__new__(ThemeExtractionService)
     service.llm = SimpleNamespace(completion=AsyncMock(return_value=_llm_json_response("[]")))
     service.pipeline_config = None
@@ -84,11 +84,11 @@ def test_try_generate_litellm_disables_fallbacks_for_configured_zai_model() -> N
     assert result == "[]"
     kwargs = service.llm.completion.await_args.kwargs
     assert kwargs["model"] == "openai/glm-4.7-flash"
-    assert kwargs["allow_fallbacks"] is False
+    assert kwargs["allow_fallbacks"] is True
     assert kwargs["max_tokens"] == ThemeExtractionService.ZAI_EXTRACTION_MAX_TOKENS
 
 
-def test_try_generate_litellm_disables_fallbacks_for_default_zai_model() -> None:
+def test_try_generate_litellm_enables_fallbacks_for_default_zai_model() -> None:
     service = ThemeExtractionService.__new__(ThemeExtractionService)
     service.llm = SimpleNamespace(
         preset=SimpleNamespace(primary=SimpleNamespace(model_id="openai/glm-4.7-flash")),
@@ -102,7 +102,7 @@ def test_try_generate_litellm_disables_fallbacks_for_default_zai_model() -> None
     assert result == "[]"
     kwargs = service.llm.completion.await_args.kwargs
     assert kwargs["model"] is None
-    assert kwargs["allow_fallbacks"] is False
+    assert kwargs["allow_fallbacks"] is True
     assert kwargs["max_tokens"] == ThemeExtractionService.ZAI_EXTRACTION_MAX_TOKENS
 
 


### PR DESCRIPTION
## Summary
- allow theme extraction requests that start on Z.AI to use the shared fallback chain
- preserve Z.AI as the primary model for each new extraction request
- update routing tests to cover the enabled fallback behavior for Z.AI extraction

## Testing
- /Users/admin/StockScreenClaude/backend/venv/bin/pytest /Users/admin/StockScreenClaude/backend/tests/unit/test_zai_llm_routing.py /Users/admin/StockScreenClaude/backend/tests/unit/test_zai_key_rotation.py /Users/admin/StockScreenClaude/backend/tests/unit/test_settings_llm_keys.py
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
