### PR TITLE
Seed IBD industry groups from bundled canonical CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ frontend/dist
 
 # Data files
 *.csv
+!backend/resources/IBD_industry_group.csv
 *.xlsx
 *.xls
 *.parquet

--- a/backend/README.md
+++ b/backend/README.md
@@ -69,6 +69,12 @@ xui auth login --profile default --path ../data/xui-reader/config.toml
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
+On non-desktop startup, the backend automatically seeds `ibd_industry_groups` from the bundled canonical CSV in `backend/resources/IBD_industry_group.csv` when that table is empty. To repair an already-created database that missed this seed, run:
+
+```bash
+python scripts/seed_ibd_industry_groups.py
+```
+
 ## API Reference
 
 Interactive docs available at:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from sqlalchemy import text
 
 from .config import settings
-from .database import init_db, engine
+from .database import SessionLocal, engine, init_db
 from .infra.db.portability import is_sqlite, table_exists
 from .services.redis_pool import get_redis_client
 
@@ -270,6 +270,17 @@ def initialize_runtime() -> None:
     # Initialize database
     init_db()
     print("Database initialized")
+
+    if not settings.desktop_mode:
+        try:
+            from .services.ibd_industry_service import IBDIndustryService
+
+            with SessionLocal() as db:
+                seed_count = IBDIndustryService.seed_if_empty(db)
+            if seed_count > 0:
+                print(f"Seeded IBD industry mappings: {seed_count}")
+        except Exception as e:
+            print(f"Warning: Failed to seed IBD industry mappings (non-fatal): {e}")
 
     # Verify WAL mode is active (critical for concurrent writers in Docker)
     if is_sqlite(settings.database_url):

--- a/backend/app/services/ibd_industry_service.py
+++ b/backend/app/services/ibd_industry_service.py
@@ -1,49 +1,58 @@
-"""Service for loading and managing IBD Industry Group data"""
+"""Service for loading and managing IBD Industry Group data."""
+
 import csv
 import logging
 from pathlib import Path
-from sqlalchemy.orm import Session
+
 from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
 from ..models.industry import IBDIndustryGroup
 
 logger = logging.getLogger(__name__)
 
 
 class IBDIndustryService:
-    """Manage IBD Industry Group data"""
+    """Manage IBD Industry Group data."""
 
     @staticmethod
-    def load_from_csv(db: Session, csv_path: str = None) -> int:
+    def default_csv_path() -> Path:
+        """Return the canonical bundled IBD industry seed path."""
+        return Path(__file__).resolve().parents[2] / "resources" / "IBD_industry_group.csv"
+
+    @classmethod
+    def resolve_csv_path(cls, csv_path: str | None = None) -> Path:
+        """Resolve the CSV path used to load industry mappings."""
+        return Path(csv_path) if csv_path else cls.default_csv_path()
+
+    @staticmethod
+    def load_from_csv(db: Session, csv_path: str | None = None) -> int:
         """
         Load IBD industry groups from CSV file.
 
         Args:
             db: Database session
-            csv_path: Path to CSV file (defaults to data/IBD_industry_group.csv)
+            csv_path: Path to CSV file (defaults to the configured canonical seed)
 
         Returns:
             Number of records loaded
         """
-        if not csv_path:
-            csv_path = Path(__file__).parent.parent.parent.parent / "data" / "IBD_industry_group.csv"
+        resolved_path = IBDIndustryService.resolve_csv_path(csv_path)
+        if not resolved_path.exists():
+            raise FileNotFoundError(f"IBD industry CSV file not found at {resolved_path}")
 
-        csv_path = Path(csv_path)
-        if not csv_path.exists():
-            raise FileNotFoundError(f"IBD industry CSV file not found at {csv_path}")
+        logger.info("Loading IBD industry groups from %s", resolved_path)
 
-        logger.info(f"Loading IBD industry groups from {csv_path}")
-
-        # Clear existing data
         db.execute(delete(IBDIndustryGroup))
         db.commit()
         logger.info("Cleared existing IBD industry data")
 
         loaded = 0
-        batch = []
+        batch: list[dict[str, str]] = []
 
         try:
-            with open(csv_path, 'r', encoding='utf-8') as f:
-                reader = csv.reader(f)
+            with resolved_path.open("r", encoding="utf-8") as handle:
+                reader = csv.reader(handle)
 
                 for row in reader:
                     if len(row) != 2:
@@ -52,128 +61,109 @@ class IBDIndustryService:
                     symbol, industry_group = row
                     symbol = symbol.strip().upper()
                     industry_group = industry_group.strip()
-
                     if not symbol or not industry_group:
                         continue
 
-                    batch.append({
-                        'symbol': symbol,
-                        'industry_group': industry_group
-                    })
+                    batch.append(
+                        {
+                            "symbol": symbol,
+                            "industry_group": industry_group,
+                        }
+                    )
 
-                    # Batch insert every 500 records
                     if len(batch) >= 500:
                         db.bulk_insert_mappings(IBDIndustryGroup, batch)
                         db.commit()
                         loaded += len(batch)
-                        logger.info(f"Loaded {loaded} IBD industry mappings...")
+                        logger.info("Loaded %s IBD industry mappings...", loaded)
                         batch = []
 
-                # Insert remaining records
                 if batch:
                     db.bulk_insert_mappings(IBDIndustryGroup, batch)
                     db.commit()
                     loaded += len(batch)
 
-            logger.info(f"Successfully loaded {loaded} IBD industry group mappings")
+            logger.info("Successfully loaded %s IBD industry group mappings", loaded)
             return loaded
-
-        except Exception as e:
-            logger.error(f"Error loading IBD industry data: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error loading IBD industry data")
             db.rollback()
             raise
 
-    @staticmethod
-    def get_industry_group(db: Session, symbol: str) -> str:
+    @classmethod
+    def seed_if_empty(cls, db: Session, csv_path: str | None = None) -> int:
         """
-        Get IBD industry group for a symbol.
-
-        Args:
-            db: Database session
-            symbol: Stock symbol
+        Seed the industry mapping table if it is currently empty.
 
         Returns:
-            Industry group name or None if not found
+            Number of records loaded. Returns 0 when data already exists.
         """
+        existing = db.query(IBDIndustryGroup).count()
+        if existing > 0:
+            logger.info(
+                "IBD industry group seed skipped; table already contains %s mappings",
+                existing,
+            )
+            return 0
+
+        resolved_path = cls.resolve_csv_path(csv_path)
+        loaded = cls.load_from_csv(db, str(resolved_path))
+        logger.info(
+            "Seeded IBD industry groups with %s mappings from %s",
+            loaded,
+            resolved_path,
+        )
+        return loaded
+
+    @staticmethod
+    def get_industry_group(db: Session, symbol: str) -> str | None:
+        """Get IBD industry group for a symbol."""
         try:
             record = db.query(IBDIndustryGroup).filter(
                 IBDIndustryGroup.symbol == symbol.upper()
             ).first()
             return record.industry_group if record else None
         except Exception as e:
-            logger.error(f"Error getting industry group for {symbol}: {e}")
+            logger.error("Error getting industry group for %s: %s", symbol, e)
             return None
 
     @staticmethod
-    def get_bulk_industry_groups(db: Session, symbols: list) -> dict:
-        """
-        Bulk fetch IBD industry groups for multiple symbols (performance optimization).
-
-        Args:
-            db: Database session
-            symbols: List of stock symbols
-
-        Returns:
-            Dict mapping symbol -> industry group name
-        """
+    def get_bulk_industry_groups(db: Session, symbols: list[str]) -> dict[str, str]:
+        """Bulk fetch IBD industry groups for multiple symbols."""
         if not symbols:
             return {}
 
         try:
-            # Normalize symbols to uppercase
-            symbols_upper = [s.upper() for s in symbols]
-
-            # Single bulk query instead of N individual queries
+            symbols_upper = [symbol.upper() for symbol in symbols]
             records = db.query(IBDIndustryGroup).filter(
                 IBDIndustryGroup.symbol.in_(symbols_upper)
             ).all()
-
-            # Return as dict for O(1) lookup
             return {record.symbol: record.industry_group for record in records}
-
         except Exception as e:
-            logger.error(f"Error bulk fetching industry groups: {e}")
+            logger.error("Error bulk fetching industry groups: %s", e)
             return {}
 
     @staticmethod
-    def get_group_symbols(db: Session, industry_group: str) -> list:
-        """
-        Get all symbols in an IBD industry group.
-
-        Args:
-            db: Database session
-            industry_group: Industry group name
-
-        Returns:
-            List of symbols in the group
-        """
+    def get_group_symbols(db: Session, industry_group: str) -> list[str]:
+        """Get all symbols in an IBD industry group."""
         try:
             records = db.query(IBDIndustryGroup.symbol).filter(
                 IBDIndustryGroup.industry_group == industry_group
             ).all()
-            return [r.symbol for r in records]
+            return [record.symbol for record in records]
         except Exception as e:
-            logger.error(f"Error getting symbols for group {industry_group}: {e}")
+            logger.error("Error getting symbols for group %s: %s", industry_group, e)
             return []
 
     @staticmethod
-    def get_all_groups(db: Session) -> list:
-        """
-        Get list of all unique industry groups.
-
-        Args:
-            db: Database session
-
-        Returns:
-            List of unique industry group names
-        """
+    def get_all_groups(db: Session) -> list[str]:
+        """Get list of all unique industry groups."""
         try:
             records = db.query(IBDIndustryGroup.industry_group).distinct().all()
-            return [r.industry_group for r in records]
+            return [record.industry_group for record in records]
         except Exception as e:
-            logger.error(f"Error getting all industry groups: {e}")
+            logger.error("Error getting all industry groups: %s", e)
             return []
 
 
-# Singleton instance
 ibd_industry_service = IBDIndustryService()

--- a/backend/resources/IBD_industry_group.csv
+++ b/backend/resources/IBD_industry_group.csv
@@ -1,0 +1,10105 @@
+A,Medical-Research Eqp/Svc
+AA,Mining-Metal Ores
+AAA,Finance-ETF / ETN
+AAAU,Finance-ETF / ETN
+AACG,Consumer Svcs-Education
+AACI,Finance-Blank Check
+AACT,Finance-Blank Check
+AADI,Medical-Biomed/Biotech
+AADR,Finance-ETF / ETN
+AAGIY,Insurance-Diversified
+AAGR,Agricultural Operations
+AAL,Transportation-Airline
+AAMC,Finance-Mrtg&Rel Svc
+AAME,Insurance-Prop/Cas/Titl
+AAN,Retail-Home Furnishings
+AAOI,Telecom-Fiber Optics
+AAON,Bldg-A/C & Heating Prds
+AAP,Retail/Whlsle-Auto Parts
+AAPB,Finance-ETF / ETN
+AAPD,Finance-ETF / ETN
+AAPL,Telecom-Consumer Prods
+AAPU,Finance-ETF / ETN
+AAPX,Finance-ETF / ETN
+AAPY,Finance-ETF / ETN
+AAT,Finance-Property REIT
+AATC,Group not available
+AAU,Mining-Metal Ores
+AAXJ,Finance-ETF / ETN
+AB,Finance-Investment Mgmt
+ABAT,Mining-Metal Ores
+ABBNY,Electrical-Power/Equipmt
+ABBV,Medical-Ethical Drugs
+ABCB,Banks-Southeast
+ABCL,Medical-Biomed/Biotech
+ABCS,Finance-ETF / ETN
+ABEO,Medical-Biomed/Biotech
+ABEQ,Finance-ETF / ETN
+ABEV,Beverages-Alcoholic
+ABG,Retail/Whlsle-Automobile
+ABIO,Medical-Biomed/Biotech
+ABL,Finance-Investment Mgmt
+ABLV,Cosmetics/Personal Care
+ABM,Bldg-Maintenance & Svc
+ABNB,Leisure-Travel Booking
+ABOS,Medical-Biomed/Biotech
+ABR,Finance-Mortgage REIT
+ABSI,Medical-Generic Drugs
+ABT,Medical-Diversified
+ABTS,Internet-Content
+ABUS,Medical-Biomed/Biotech
+ABVC,Medical-Biomed/Biotech
+ABVX,Medical-Biomed/Biotech
+AC,Finance-Investment Mgmt
+ACA,Bldg-Constr Prds/Misc
+ACAB,Finance-Blank Check
+ACAC,Finance-Blank Check
+ACAD,Medical-Biomed/Biotech
+ACAN,Comml Svcs-Consulting
+ACB,Consumer Prod-Specialty
+ACBA,Finance-Blank Check
+ACCD,Medical-Managed Care
+ACCO,Office Supplies Mfg
+ACDC,Oil&Gas-Field Services
+ACEL,Leisure-Gaming/Equip
+ACES,Finance-ETF / ETN
+ACET,Medical-Biomed/Biotech
+ACGL,Insurance-Prop/Cas/Titl
+ACHC,Medical-Outpnt/Hm Care
+ACHL,Medical-Biomed/Biotech
+ACHR,Aerospace/Defense
+ACHV,Medical-Biomed/Biotech
+ACI,Retail-Super/Mini Mkts
+ACIC,Insurance-Prop/Cas/Titl
+ACIO,Finance-ETF / ETN
+ACIU,Medical-Biomed/Biotech
+ACIW,Computer Sftwr-Financial
+ACLS,Elec-Semiconductor Equip
+ACLX,Medical-Biomed/Biotech
+ACM,Bldg-Heavy Construction
+ACMR,Elec-Semiconductor Equip
+ACN,Computer-Tech Services
+ACNB,Banks-Northeast
+ACNT,Steel-Specialty Alloys
+ACON,Medical-Biomed/Biotech
+ACOR,Medical-Biomed/Biotech
+ACP,Finance-Publ Inv Fd-Bond
+ACR,Finance-Mortgage REIT
+ACRE,Finance-Mortgage REIT
+ACRS,Medical-Generic Drugs
+ACRV,Medical-Biomed/Biotech
+ACSI,Finance-ETF / ETN
+ACST,Medical-Biomed/Biotech
+ACT,Finance-Mrtg&Rel Svc
+ACTG,Elec-Misc Products
+ACTV,Finance-ETF / ETN
+ACU,Office Supplies Mfg
+ACV,Finance-Publ Inv Fd-Eqt
+ACVA,Retail/Whlsle-Automobile
+ACVF,Finance-ETF / ETN
+ACWI,Finance-ETF / ETN
+ACWV,Finance-ETF / ETN
+ACWX,Finance-ETF / ETN
+ACXP,Medical-Biomed/Biotech
+ADAG,Medical-Biomed/Biotech
+ADAP,Medical-Biomed/Biotech
+ADBE,Computer Sftwr-Desktop
+ADC,Finance-Property REIT
+ADCT,Medical-Biomed/Biotech
+ADD,Internet-Content
+ADDYY,Apparel-Shoes & Rel Mfg
+ADEA,Internet-Content
+ADFI,Finance-ETF / ETN
+ADI,Elec-Semiconductor Mfg
+ADIL,Medical-Biomed/Biotech
+ADIV,Finance-ETF / ETN
+ADM,Food-Grain & Related
+ADMA,Medical-Biomed/Biotech
+ADME,Finance-ETF / ETN
+ADN,Energy-Alternative/Other
+ADNT,Auto/Truck-Original Eqp
+ADP,Comml Svcs-Outsourcing
+ADPT,Medical-Biomed/Biotech
+ADPV,Finance-ETF / ETN
+ADRNY,Retail-Major Disc Chains
+ADRT,Finance-Blank Check
+ADSE,Electrical-Power/Equipmt
+ADSK,Computer Sftwr-Design
+ADT,Security/Sfty
+ADTH,Comml Svcs-Advertising
+ADTN,Telecom-Cable/Satl Eqp
+ADTX,Medical-Biomed/Biotech
+ADUS,Medical-Outpnt/Hm Care
+ADV,Comml Svcs-Consulting
+ADVE,Finance-ETF / ETN
+ADVM,Medical-Biomed/Biotech
+ADX,Finance-Publ Inv Fd-Eqt
+ADXN,Medical-Biomed/Biotech
+ADYEY,Finance-CrdtCard/PmtPr
+ADYYF,Finance-CrdtCard/PmtPr
+AE,Oil&Gas-Refining/Mktg
+AEAE,Finance-Blank Check
+AEE,Utility-Diversified
+AEF,Finance-Publ Inv Fd-Glbl
+AEG,Insurance-Life
+AEHL,Bldg-Constr Prds/Misc
+AEHR,Elec-Semiconductor Equip
+AEI,Real Estate Dvlpmt/Ops
+AEIS,Elec-Semiconductor Equip
+AEL,Insurance-Life
+AEM,Mining-Gold/Silver/Gems
+AEMB,Finance-ETF / ETN
+AEMD,Medical-Products
+AENT,Retail-Internet
+AEO,Retail-Apparel/Shoes/Acc
+AEON,Medical-Biomed/Biotech
+AEP,Utility-Electric Power
+AER,Comml Svcs-Leasing
+AERG,Aerospace/Defense
+AERT,Computer-Tech Services
+AES,Utility-Electric Power
+AESI,Oil&Gas-Field Services
+AESR,Finance-ETF / ETN
+AETH,Finance-ETF / ETN
+AEVA,Auto/Truck-Original Eqp
+AEYE,Computer Sftwr-Enterprse
+AEYGQ,Telecom-Cable/Satl Eqp
+AEZS,Medical-Biomed/Biotech
+AFAR,Finance-Blank Check
+AFB,Finance-Publ Inv Fd-Bond
+AFBI,Banks-Southeast
+AFCG,Consumer Prod-Specialty
+AFG,Insurance-Prop/Cas/Titl
+AFIB,Medical-Products
+AFIF,Finance-ETF / ETN
+AFIIQ,Group not available
+AFJK,Finance-Blank Check
+AFK,Finance-ETF / ETN
+AFL,Insurance-Acc & Health
+AFLG,Finance-ETF / ETN
+AFMC,Finance-ETF / ETN
+AFMD,Medical-Biomed/Biotech
+AFRI,Food-Grain & Related
+AFRM,Finance-CrdtCard/PmtPr
+AFSM,Finance-ETF / ETN
+AFT,Finance-Publ Inv Fd-Bond
+AFTY,Finance-ETF / ETN
+AFYA,Consumer Svcs-Education
+AG,Mining-Gold/Silver/Gems
+AGAE,Leisure-Services
+AGBA,Finance-Investment Mgmt
+AGCO,Machinery-Farm
+AGD,Finance-Publ Inv Fd-Glbl
+AGEN,Medical-Biomed/Biotech
+AGFY,Agricultural Operations
+AGG,Finance-ETF / ETN
+AGGH,Finance-ETF / ETN
+AGGY,Finance-ETF / ETN
+AGI,Mining-Gold/Silver/Gems
+AGIH,Finance-ETF / ETN
+AGILQ,Computer-Tech Services
+AGIO,Medical-Biomed/Biotech
+AGL,Comml Svcs-Healthcare
+AGM,Finance-Mrtg&Rel Svc
+AGMA,Finance-Mrtg&Rel Svc
+AGMH,Finance-Invest Bnk/Bkrs
+AGNC,Finance-Mortgage REIT
+AGNG,Finance-ETF / ETN
+AGO,Insurance-Prop/Cas/Titl
+AGOV,Finance-ETF / ETN
+AGOX,Finance-ETF / ETN
+AGQ,Finance-ETF / ETN
+AGQI,Finance-ETF / ETN
+AGR,Utility-Diversified
+AGRH,Finance-ETF / ETN
+AGRI,Agricultural Operations
+AGRO,Agricultural Operations
+AGRX,Medical-Products
+AGS,Leisure-Gaming/Equip
+AGTI,Medical-Services
+AGX,Bldg-Heavy Construction
+AGYS,Computer-Integrated Syst
+AGZ,Finance-ETF / ETN
+AGZD,Finance-ETF / ETN
+AHCHY,Bldg-Cement/Concrt/Ag
+AHCO,Medical-Outpnt/Hm Care
+AHG,Financial Svcs-Specialty
+AHH,Finance-Property REIT
+AHI,Computer Sftwr-Medical
+AHKSY,Chemicals-Specialty
+AHLT,Finance-ETF / ETN
+AHOY,Finance-ETF / ETN
+AHPIQ,Medical-Products
+AHR,Finance-Property REIT
+AHT,Finance-Property REIT
+AHYB,Finance-ETF / ETN
+AI,Comp Sftwr-Spec Enterprs
+AIA,Finance-ETF / ETN
+AIB,Finance-Blank Check
+AIEQ,Finance-ETF / ETN
+AIF,Finance-Publ Inv Fd-Bond
+AIG,Insurance-Diversified
+AIH,Medical-Hospitals
+AIHS,Computer Sftwr-Financial
+AIJTY,Finance-Consumer Loans
+AIM,Medical-Biomed/Biotech
+AIMD,Medical-Biomed/Biotech
+AIN,Paper & Paper Products
+AINC,Financial Svcs-Specialty
+AIO,Finance-Publ Inv Fd-Eqt
+AIP,Elec-Semicondctor Fablss
+AIQ,Finance-ETF / ETN
+AIR,Aerospace/Defense
+AIRC,Real Estate Dvlpmt/Ops
+AIRE,Real Estate Dvlpmt/Ops
+AIRG,Electronic-Parts
+AIRI,Aerospace/Defense
+AIRJ,Bldg-A/C & Heating Prds
+AIRL,Finance-ETF / ETN
+AIRR,Finance-ETF / ETN
+AIRS,Medical-Systems/Equip
+AIRT,Transport-Air Freight
+AISP,Computer Sftwr-Enterprse
+AIT,Machinery-Tools & Rel
+AITR,Finance-Blank Check
+AIU,Consumer Svcs-Education
+AIV,Finance-Property REIT
+AIVI,Finance-ETF / ETN
+AIVL,Finance-ETF / ETN
+AIXI,Computer Sftwr-Enterprse
+AIYY,Finance-ETF / ETN
+AIZ,Insurance-Diversified
+AJAN,Finance-ETF / ETN
+AJG,Insurance-Brokers
+AJX,Finance-Property REIT
+AKA,Retail-Apparel/Shoes/Acc
+AKAM,Computer Sftwr-Enterprse
+AKAN,Consumer Prod-Specialty
+AKBA,Medical-Biomed/Biotech
+AKLI,Medical-Biomed/Biotech
+AKOA,Beverages-Non-Alcoholic
+AKOB,Beverages-Non-Alcoholic
+AKR,Finance-Property REIT
+AKRO,Medical-Biomed/Biotech
+AKTS,Elec-Semiconductor Mfg
+AKTX,Medical-Biomed/Biotech
+AKYA,Medical-Systems/Equip
+AKZOY,Chemicals-Paints
+AL,Comml Svcs-Leasing
+ALAB,Elec-Semicondctor Fablss
+ALAR,Computer Sftwr-Security
+ALB,Chemicals-Specialty
+ALBT,Medical-Services
+ALC,Medical-Products
+ALCC,Finance-Blank Check
+ALCE,Energy-Solar
+ALCO,Agricultural Operations
+ALCY,Finance-Blank Check
+ALDX,Medical-Biomed/Biotech
+ALE,Utility-Diversified
+ALEAF,Consumer Prod-Specialty
+ALEC,Medical-Biomed/Biotech
+ALEX,Real Estate Dvlpmt/Ops
+ALFIQ,Group not available
+ALG,Machinery-Farm
+ALGM,Elec-Semicondctor Fablss
+ALGN,Medical-Products
+ALGS,Medical-Biomed/Biotech
+ALGT,Transportation-Airline
+ALHC,Medical-Managed Care
+ALIM,Medical-Biomed/Biotech
+ALIT,Computer Sftwr-Enterprse
+ALIZY,Insurance-Diversified
+ALK,Transportation-Airline
+ALKS,Medical-Biomed/Biotech
+ALKT,Computer Sftwr-Financial
+ALL,Insurance-Prop/Cas/Titl
+ALLE,Security/Sfty
+ALLG,Energy-Alternative/Other
+ALLK,Medical-Biomed/Biotech
+ALLO,Medical-Biomed/Biotech
+ALLR,Medical-Biomed/Biotech
+ALLT,Computer-Networking
+ALLY,Financial Svcs-Specialty
+ALNT,Electrical-Power/Equipmt
+ALNY,Medical-Biomed/Biotech
+ALOR,Finance-Blank Check
+ALOT,Elec-Misc Products
+ALPMY,Medical-Biomed/Biotech
+ALPN,Medical-Biomed/Biotech
+ALPP,Diversified Operations
+ALPSQ,Oil&Gas-Intl Expl&Prod
+ALRM,Security/Sfty
+ALRN,Medical-Biomed/Biotech
+ALRS,Banks-Midwest
+ALSA,Finance-Blank Check
+ALSN,Auto/Truck-Original Eqp
+ALT,Medical-Biomed/Biotech
+ALTG,Comml Svcs-Leasing
+ALTI,Finance-Investment Mgmt
+ALTL,Finance-ETF / ETN
+ALTM,Chemicals-Specialty
+ALTO,Energy-Alternative/Other
+ALTR,Computer Sftwr-Design
+ALTY,Finance-ETF / ETN
+ALUM,Finance-ETF / ETN
+ALUR,Medical-Systems/Equip
+ALV,Auto/Truck-Original Eqp
+ALVO,Medical-Biomed/Biotech
+ALVR,Medical-Biomed/Biotech
+ALX,Finance-Property REIT
+ALXO,Medical-Biomed/Biotech
+ALYAF,Group not available
+ALZN,Medical-Biomed/Biotech
+AM,Oil&Gas-Integrated
+AMADY,Computer-Tech Services
+AMAL,Banks-Northeast
+AMAT,Elec-Semiconductor Equip
+AMAX,Finance-ETF / ETN
+AMBA,Elec-Semicondctor Fablss
+AMBC,Financial Svcs-Specialty
+AMBI,Pollution Control
+AMBO,Consumer Svcs-Education
+AMBP,Food-Packaged
+AMC,Leisure-Movies & Related
+AMCR,Containers/Packaging
+AMCX,Media-Radio/Tv
+AMD,Elec-Semicondctor Fablss
+AMDL,Finance-ETF / ETN
+AMDS,Finance-ETF / ETN
+AMDY,Finance-ETF / ETN
+AME,Electrical-Power/Equipmt
+AMED,Medical-Outpnt/Hm Care
+AMFC,Finance-Savings & Loan
+AMG,Finance-Investment Mgmt
+AMGN,Medical-Biomed/Biotech
+AMH,Finance-Property REIT
+AMID,Finance-ETF / ETN
+AMIX,Medical-Products
+AMJ,Finance-ETF / ETN
+AMJB,Finance-ETF / ETN
+AMK,Finance-Investment Mgmt
+AMKR,Elec-Semiconductor Mfg
+AMLI,Mining-Metal Ores
+AMLP,Finance-ETF / ETN
+AMLX,Medical-Biomed/Biotech
+AMN,Comml Svcs-Staffing
+AMNA,Finance-ETF / ETN
+AMND,Finance-ETF / ETN
+AMOM,Finance-ETF / ETN
+AMP,Finance-Invest Bnk/Bkrs
+AMPD,Finance-ETF / ETN
+AMPE,Medical-Ethical Drugs
+AMPG,Elec-Semiconductor Mfg
+AMPH,Medical-Biomed/Biotech
+AMPL,Computer Sftwr-Enterprse
+AMPS,Utility-Electric Power
+AMPX,Energy-Alternative/Other
+AMPY,Oil&Gas-U S Expl&Prod
+AMR,Energy-Coal
+AMRC,Energy-Alternative/Other
+AMRK,Financial Svcs-Specialty
+AMRN,Medical-Biomed/Biotech
+AMRSQ,Chemicals-Specialty
+AMRX,Medical-Generic Drugs
+AMS,Medical-Services
+AMSC,Electrical-Power/Equipmt
+AMSF,Insurance-Prop/Cas/Titl
+AMST,Computer Sftwr-Edu/Media
+AMSWA,Computer Sftwr-Enterprse
+AMT,Finance-Property REIT
+AMTB,Banks-Southeast
+AMTD,Finance-Investment Mgmt
+AMTR,Finance-ETF / ETN
+AMTX,Energy-Alternative/Other
+AMTY,Auto/Truck-Tires & Misc
+AMUB,Finance-ETF / ETN
+AMWD,Bldg-Constr Prds/Misc
+AMWL,Computer Sftwr-Medical
+AMX,Telecom Svcs- Foreign
+AMZA,Finance-ETF / ETN
+AMZD,Finance-ETF / ETN
+AMZN,Retail-Internet
+AMZP,Finance-ETF / ETN
+AMZU,Finance-ETF / ETN
+AMZY,Finance-ETF / ETN
+AMZZ,Finance-ETF / ETN
+AN,Retail/Whlsle-Automobile
+ANAB,Medical-Biomed/Biotech
+ANDE,Food-Grain & Related
+ANEB,Medical-Biomed/Biotech
+ANET,Computer-Networking
+ANEW,Finance-ETF / ETN
+ANF,Retail-Apparel/Shoes/Acc
+ANGH,Computer Sftwr-Edu/Media
+ANGI,Internet-Content
+ANGL,Finance-ETF / ETN
+ANGO,Medical-Products
+ANIK,Medical-Biomed/Biotech
+ANIP,Medical-Generic Drugs
+ANIX,Medical-Biomed/Biotech
+ANL,Medical-Biomed/Biotech
+ANNX,Medical-Biomed/Biotech
+ANPDY,Apparel-Clothing Mfg
+ANRO,Medical-Biomed/Biotech
+ANSC,Finance-Blank Check
+ANSS,Computer Sftwr-Design
+ANTE,Comml Svcs-Advertising
+ANTX,Medical-Biomed/Biotech
+ANVS,Medical-Biomed/Biotech
+ANY,Comp Sftwr-Spec Enterprs
+AOA,Finance-ETF / ETN
+AOD,Finance-Publ Inv Fd-Glbl
+AOGO,Finance-Blank Check
+AOHY,Finance-ETF / ETN
+AOK,Finance-ETF / ETN
+AOM,Finance-ETF / ETN
+AOMR,Finance-Mortgage REIT
+AON,Insurance-Brokers
+AONC,Medical-Services
+AOR,Finance-ETF / ETN
+AORT,Medical-Products
+AOS,Bldg-A/C & Heating Prds
+AOSL,Elec-Semicondctor Fablss
+AOTG,Finance-ETF / ETN
+AOUT,Leisure-Products
+AP,Steel-Producers
+APA,Oil&Gas-Intl Expl&Prod
+APAC,Finance-Blank Check
+APAM,Finance-Investment Mgmt
+APCA,Finance-Blank Check
+APCB,Finance-ETF / ETN
+APCX,Computer Sftwr-Financial
+APD,Chemicals-Specialty
+APDN,Medical-Research Eqp/Svc
+APEI,Consumer Svcs-Education
+APELY,Electronic-Parts
+APG,Security/Sfty
+APGE,Medical-Biomed/Biotech
+APH,Electronic-Parts
+API,Computer Sftwr-Enterprse
+APIE,Finance-ETF / ETN
+APLD,Financial Svcs-Specialty
+APLE,Finance-Property REIT
+APLM,Medical-Biomed/Biotech
+APLS,Medical-Biomed/Biotech
+APLT,Medical-Biomed/Biotech
+APLY,Finance-ETF / ETN
+APM,Medical-Biomed/Biotech
+APMU,Finance-ETF / ETN
+APO,Finance-Investment Mgmt
+APOG,Bldg-Constr Prds/Misc
+APP,Comp Sftwr-Spec Enterprs
+APPF,Comp Sftwr-Spec Enterprs
+APPN,Computer Sftwr-Design
+APPS,Computer Sftwr-Enterprse
+APRD,Finance-ETF / ETN
+APRE,Medical-Biomed/Biotech
+APRH,Finance-ETF / ETN
+APRJ,Finance-ETF / ETN
+APRQ,Finance-ETF / ETN
+APRT,Finance-ETF / ETN
+APRW,Finance-ETF / ETN
+APRZ,Finance-ETF / ETN
+APT,Bldg-Constr Prds/Misc
+APTO,Medical-Biomed/Biotech
+APTV,Auto/Truck-Original Eqp
+APUE,Finance-ETF / ETN
+APVO,Medical-Biomed/Biotech
+APWC,Electrical-Power/Equipmt
+APXI,Finance-Blank Check
+APYX,Medical-Products
+AQB,Medical-Biomed/Biotech
+AQMS,Chemicals-Specialty
+AQN,Utility-Diversified
+AQST,Medical-Biomed/Biotech
+AQU,Finance-Blank Check
+AQWA,Finance-ETF / ETN
+AR,Oil&Gas-U S Expl&Prod
+ARAY,Medical-Systems/Equip
+ARB,Finance-ETF / ETN
+ARBB,Computer-Integrated Syst
+ARBE,Auto/Truck-Original Eqp
+ARBK,Computer Sftwr-Financial
+ARC,Comml Svcs-Document Mgmt
+ARCB,Transportation-Truck
+ARCC,Finance-Investment Mgmt
+ARCH,Energy-Coal
+ARCM,Finance-ETF / ETN
+ARCO,Retail-Restaurants
+ARCT,Medical-Biomed/Biotech
+ARDC,Finance-Publ Inv Fd-Bond
+ARDS,Medical-Biomed/Biotech
+ARDX,Medical-Biomed/Biotech
+ARE,Finance-Property REIT
+AREB,Retail-Internet
+AREC,Energy-Coal
+AREN,Internet-Content
+ARES,Finance-Investment Mgmt
+ARGT,Finance-ETF / ETN
+ARGX,Medical-Biomed/Biotech
+ARHS,Retail-Home Furnishings
+ARI,Finance-Mortgage REIT
+ARIS,Pollution Control
+ARKA,Finance-ETF / ETN
+ARKAY,Chemicals-Specialty
+ARKB,Finance-ETF / ETN
+ARKC,Finance-ETF / ETN
+ARKD,Finance-ETF / ETN
+ARKF,Finance-ETF / ETN
+ARKG,Finance-ETF / ETN
+ARKK,Finance-ETF / ETN
+ARKO,Retail-Super/Mini Mkts
+ARKQ,Finance-ETF / ETN
+ARKR,Retail-Restaurants
+ARKW,Finance-ETF / ETN
+ARKX,Finance-ETF / ETN
+ARKY,Finance-ETF / ETN
+ARKZ,Finance-ETF / ETN
+ARL,Real Estate Dvlpmt/Ops
+ARLO,Security/Sfty
+ARLP,Energy-Coal
+ARLU,Group not available
+ARLUF,Leisure-Gaming/Equip
+ARM,Elec-Semicondctor Fablss
+ARMK,Comml Svcs-Outsourcing
+ARMN,Mining-Gold/Silver/Gems
+ARMP,Medical-Generic Drugs
+AROC,Oil&Gas-Machinery/Equip
+AROW,Banks-Northeast
+ARP,Finance-ETF / ETN
+ARQ,Pollution Control
+ARQQ,Computer Sftwr-Security
+ARQT,Medical-Biomed/Biotech
+ARR,Finance-Mortgage REIT
+ARRW,Finance-Blank Check
+ARRY,Energy-Solar
+ARTL,Medical-Biomed/Biotech
+ARTNA,Utility-Water Supply
+ARTW,Machinery-Farm
+ARVLF,Auto Manufacturers
+ARVN,Medical-Biomed/Biotech
+ARVR,Finance-ETF / ETN
+ARW,Electronic-Parts
+ARWR,Medical-Biomed/Biotech
+ARYD,Finance-Blank Check
+ARYE,Finance-Blank Check
+AS,Leisure-Products
+ASA,Finance-Publ Inv Fd-Glbl
+ASAI,Retail-Department Stores
+ASAN,Computer Sftwr-Enterprse
+ASAP,Group not available
+ASB,Banks-Midwest
+ASBFY,Retail-Apparel/Shoes/Acc
+ASC,Oil&Gas-Transprt/Pipelne
+ASCA,Finance-Blank Check
+ASCB,Finance-Blank Check
+ASEA,Finance-ETF / ETN
+ASET,Finance-ETF / ETN
+ASG,Finance-Publ Inv Fd-Eqt
+ASGI,Finance-Publ Inv Fd-Eqt
+ASGLY,Bldg-Constr Prds/Misc
+ASGN,Comml Svcs-Staffing
+ASH,Chemicals-Specialty
+ASHR,Finance-ETF / ETN
+ASHS,Finance-ETF / ETN
+ASIA,Finance-ETF / ETN
+ASIX,Chemicals-Plastics
+ASLE,Aerospace/Defense
+ASLN,Medical-Biomed/Biotech
+ASM,Mining-Gold/Silver/Gems
+ASMB,Medical-Biomed/Biotech
+ASML,Elec-Semiconductor Equip
+ASND,Medical-Biomed/Biotech
+ASNS,Telecom Svcs-Cable/Satl
+ASO,Retail-Leisure Products
+ASPI,Chemicals-Specialty
+ASPN,Chemicals-Specialty
+ASPS,Financial Svcs-Specialty
+ASPU,Consumer Svcs-Education
+ASR,Real Estate Dvlpmt/Ops
+ASRT,Medical-Ethical Drugs
+ASRV,Banks-Northeast
+ASST,Comml Svcs-Advertising
+ASTC,Machinery-Gen Industrial
+ASTE,Machinery-Constr/Mining
+ASTH,Medical-Managed Care
+ASTI,Energy-Solar
+ASTL,Steel-Producers
+ASTR,Aerospace/Defense
+ASTS,Telecom Svcs-Cable/Satl
+ASUR,Computer Sftwr-Enterprse
+ASX,Elec-Semiconductor Mfg
+ASXC,Medical-Systems/Equip
+ASYS,Elec-Semiconductor Equip
+ATAI,Medical-Biomed/Biotech
+ATAT,Leisure-Lodging
+ATCH,Computer Sftwr-Financial
+ATEC,Medical-Products
+ATEK,Finance-Blank Check
+ATEN,Computer Sftwr-Enterprse
+ATER,Hsehold-Appliances/Wares
+ATEX,Telecom Svcs-Wireless
+ATEYY,Elec-Semiconductor Equip
+ATFV,Finance-ETF / ETN
+ATGE,Consumer Svcs-Education
+ATGL,Computer-Tech Services
+ATHA,Medical-Biomed/Biotech
+ATHE,Medical-Biomed/Biotech
+ATHM,Internet-Content
+ATHXQ,Medical-Biomed/Biotech
+ATI,Steel-Specialty Alloys
+ATIF,Comml Svcs-Consulting
+ATIP,Medical-Services
+ATKR,Bldg-Constr Prds/Misc
+ATLC,Finance-Consumer Loans
+ATLCY,Machinery-Constr/Mining
+ATLKY,Machinery-Constr/Mining
+ATLO,Banks-Midwest
+ATLX,Mining-Metal Ores
+ATMC,Finance-Blank Check
+ATMP,Finance-ETF / ETN
+ATMU,Auto/Truck-Original Eqp
+ATMV,Finance-Blank Check
+ATNF,Medical-Biomed/Biotech
+ATNI,Telecom Svcs- Foreign
+ATNM,Medical-Biomed/Biotech
+ATO,Utility-Gas Distribution
+ATOM,Elec-Semiconductor Equip
+ATOS,Medical-Services
+ATPC,Cosmetics/Personal Care
+ATR,Containers/Packaging
+ATRA,Medical-Biomed/Biotech
+ATRC,Medical-Systems/Equip
+ATRI,Medical-Products
+ATRO,Aerospace/Defense
+ATROB,Aerospace/Defense
+ATS,Machinery-Gen Industrial
+ATSG,Transport-Air Freight
+ATTOF,Comml Svcs-Outsourcing
+ATUS,Telecom Svcs-Cable/Satl
+ATXG,Diversified Operations
+ATXI,Medical-Biomed/Biotech
+ATXS,Medical-Biomed/Biotech
+AU,Mining-Gold/Silver/Gems
+AUB,Banks-Southeast
+AUBN,Banks-Southeast
+AUDAQ,Media-Radio/Tv
+AUDC,Computer Sftwr-Enterprse
+AUGT,Finance-ETF / ETN
+AUGW,Finance-ETF / ETN
+AUGX,Medical-Services
+AUGZ,Finance-ETF / ETN
+AUID,Security/Sfty
+AULT,Electrical-Power/Equipmt
+AUMI,Finance-ETF / ETN
+AUMN,Mining-Gold/Silver/Gems
+AUNA,Medical-Hospitals
+AUPH,Medical-Biomed/Biotech
+AUR,Auto/Truck-Original Eqp
+AURA,Medical-Biomed/Biotech
+AUSF,Finance-ETF / ETN
+AUST,Mining-Gold/Silver/Gems
+AUTL,Medical-Biomed/Biotech
+AUUD,Media-Radio/Tv
+AUVI,Bldg-Constr Prds/Misc
+AVA,Utility-Diversified
+AVAH,Medical-Outpnt/Hm Care
+AVAL,Banks-Foreign
+AVAV,Aerospace/Defense
+AVB,Finance-Property REIT
+AVBP,Medical-Biomed/Biotech
+AVD,Chemicals-Agricultural
+AVDE,Finance-ETF / ETN
+AVDL,Medical-Biomed/Biotech
+AVDS,Finance-ETF / ETN
+AVDV,Finance-ETF / ETN
+AVDX,Computer Sftwr-Financial
+AVEE,Finance-ETF / ETN
+AVEM,Finance-ETF / ETN
+AVES,Finance-ETF / ETN
+AVGE,Finance-ETF / ETN
+AVGO,Elec-Semicondctor Fablss
+AVGR,Medical-Products
+AVGV,Finance-ETF / ETN
+AVHI,Finance-Blank Check
+AVIE,Finance-ETF / ETN
+AVIG,Finance-ETF / ETN
+AVIR,Medical-Biomed/Biotech
+AVIV,Finance-ETF / ETN
+AVK,Finance-Publ Inv Fd-Bal
+AVLC,Finance-ETF / ETN
+AVLV,Finance-ETF / ETN
+AVMA,Finance-ETF / ETN
+AVMC,Finance-ETF / ETN
+AVMU,Finance-ETF / ETN
+AVMV,Finance-ETF / ETN
+AVNM,Finance-ETF / ETN
+AVNS,Medical-Supplies
+AVNT,Chemicals-Plastics
+AVNV,Finance-ETF / ETN
+AVNW,Telecom-Infrastructure
+AVO,Agricultural Operations
+AVPT,Computer Sftwr-Database
+AVRE,Finance-ETF / ETN
+AVRO,Medical-Biomed/Biotech
+AVSC,Finance-ETF / ETN
+AVSD,Finance-ETF / ETN
+AVSE,Finance-ETF / ETN
+AVSF,Finance-ETF / ETN
+AVSU,Finance-ETF / ETN
+AVT,Electronic-Parts
+AVTA,Computer Sftwr-Financial
+AVTE,Medical-Biomed/Biotech
+AVTR,Medical-Research Eqp/Svc
+AVTX,Medical-Biomed/Biotech
+AVUS,Finance-ETF / ETN
+AVUV,Finance-ETF / ETN
+AVXC,Finance-ETF / ETN
+AVXL,Medical-Biomed/Biotech
+AVY,Office Supplies Mfg
+AWAY,Finance-ETF / ETN
+AWEG,Finance-ETF / ETN
+AWF,Finance-Publ Inv Fd-Glbl
+AWH,Medical-Products
+AWI,Bldg-Constr Prds/Misc
+AWIN,Aerospace/Defense
+AWK,Utility-Water Supply
+AWP,Finance-Publ Inv Fd-Glbl
+AWR,Utility-Water Supply
+AWRE,Telecom-Infrastructure
+AWX,Pollution Control
+AX,Finance-Savings & Loan
+AXAC,Finance-Blank Check
+AXAHY,Insurance-Diversified
+AXDX,Medical-Products
+AXGN,Medical-Products
+AXIL,Consumer Prod-Electronic
+AXL,Auto/Truck-Original Eqp
+AXLA,Medical-Biomed/Biotech
+AXNX,Medical-Systems/Equip
+AXON,Security/Sfty
+AXP,Finance-CrdtCard/PmtPr
+AXR,Real Estate Dvlpmt/Ops
+AXS,Insurance-Prop/Cas/Titl
+AXSM,Medical-Biomed/Biotech
+AXTA,Chemicals-Paints
+AXTI,Elec-Semiconductor Mfg
+AY,Energy-Alternative/Other
+AYI,Bldg-Constr Prds/Misc
+AYRO,Auto Manufacturers
+AYRWF,Consumer Prod-Specialty
+AYTU,Medical-Biomed/Biotech
+AZ,Aerospace/Defense
+AZEK,Bldg-Constr Prds/Misc
+AZN,Medical-Diversified
+AZO,Retail/Whlsle-Auto Parts
+AZPN,Computer Sftwr-Enterprse
+AZREF,Energy-Solar
+AZTA,Medical-Biomed/Biotech
+AZTD,Finance-ETF / ETN
+AZTR,Medical-Biomed/Biotech
+AZUL,Transportation-Airline
+AZZ,Electrical-Power/Equipmt
+B,Metal Proc & Fabrication
+BA,Aerospace/Defense
+BAB,Finance-ETF / ETN
+BABA,Retail-Internet
+BABX,Finance-ETF / ETN
+BAC,Banks-Money Center
+BACA,Finance-Blank Check
+BACK,Medical-Outpnt/Hm Care
+BAER,Aerospace/Defense
+BAESY,Aerospace/Defense
+BAFN,Banks-Southeast
+BAH,Comml Svcs-Consulting
+BAK,Chemicals-Basic
+BALI,Finance-ETF / ETN
+BALL,Containers/Packaging
+BALT,Finance-ETF / ETN
+BALY,Leisure-Gaming/Equip
+BAM,Finance-Investment Mgmt
+BAMA,Finance-ETF / ETN
+BAMB,Finance-ETF / ETN
+BAMD,Finance-ETF / ETN
+BAMG,Finance-ETF / ETN
+BAMO,Finance-ETF / ETN
+BAMU,Finance-ETF / ETN
+BAMV,Finance-ETF / ETN
+BAMY,Finance-ETF / ETN
+BANC,Finance-Savings & Loan
+BAND,Computer Sftwr-Enterprse
+BANF,Banks-West/Southwest
+BANL,Oil&Gas-Refining/Mktg
+BANR,Banks-West/Southwest
+BANX,Finance-Investment Mgmt
+BAOS,Comml Svcs-Advertising
+BAP,Banks-Foreign
+BAPR,Finance-ETF / ETN
+BAR,Finance-ETF / ETN
+BARK,Retail-Specialty
+BASE,Computer Sftwr-Database
+BASFY,Chemicals-Basic
+BATL,Oil&Gas-U S Expl&Prod
+BATRA,Media-Diversified
+BATRB,Media-Diversified
+BATRK,Media-Diversified
+BATT,Finance-ETF / ETN
+BAUG,Finance-ETF / ETN
+BAX,Medical-Products
+BAYA,Finance-Blank Check
+BAYRY,Diversified Operations
+BAYZF,Diversified Operations
+BB,Computer Sftwr-Security
+BBAG,Finance-ETF / ETN
+BBAI,Computer Sftwr-Enterprse
+BBAR,Banks-Foreign
+BBAX,Finance-ETF / ETN
+BBBI,Finance-ETF / ETN
+BBBL,Finance-ETF / ETN
+BBBS,Finance-ETF / ETN
+BBC,Finance-ETF / ETN
+BBCA,Finance-ETF / ETN
+BBCB,Finance-ETF / ETN
+BBCP,Bldg-Cement/Concrt/Ag
+BBD,Banks-Foreign
+BBDC,Finance-Investment Mgmt
+BBDO,Banks-Foreign
+BBEM,Finance-ETF / ETN
+BBEU,Finance-ETF / ETN
+BBGI,Media-Radio/Tv
+BBH,Finance-ETF / ETN
+BBHY,Finance-ETF / ETN
+BBIB,Finance-ETF / ETN
+BBIG,Leisure-Toys/Games/Hobby
+BBIN,Finance-ETF / ETN
+BBIO,Medical-Biomed/Biotech
+BBIP,Finance-ETF / ETN
+BBJP,Finance-ETF / ETN
+BBLB,Finance-ETF / ETN
+BBLG,Medical-Products
+BBLNF,Computer Sftwr-Medical
+BBLU,Finance-ETF / ETN
+BBMC,Finance-ETF / ETN
+BBN,Finance-Publ Inv Fd-Bond
+BBP,Finance-ETF / ETN
+BBRE,Finance-ETF / ETN
+BBSA,Finance-ETF / ETN
+BBSB,Finance-ETF / ETN
+BBSC,Finance-ETF / ETN
+BBSI,Comml Svcs-Staffing
+BBU,Bldg-Heavy Construction
+BBUC,Finance-Investment Mgmt
+BBUS,Finance-ETF / ETN
+BBVA,Banks-Money Center
+BBW,Retail-Leisure Products
+BBWI,Retail-Apparel/Shoes/Acc
+BBY,Retail-Consumer Elec
+BC,Leisure-Products
+BCAB,Medical-Biomed/Biotech
+BCAL,Banks-West/Southwest
+BCAN,Computer Sftwr-Enterprse
+BCAT,Finance-Publ Inv Fd-Bal
+BCBP,Banks-Northeast
+BCC,Bldg-Wood Prds
+BCD,Finance-ETF / ETN
+BCDA,Medical-Biomed/Biotech
+BCDF,Finance-ETF / ETN
+BCE,Telecom Svcs- Foreign
+BCEL,Medical-Biomed/Biotech
+BCG,Finance-Investment Mgmt
+BCH,Banks-Foreign
+BCHP,Finance-ETF / ETN
+BCI,Finance-ETF / ETN
+BCIL,Finance-ETF / ETN
+BCIM,Finance-ETF / ETN
+BCLI,Medical-Biomed/Biotech
+BCML,Banks-West/Southwest
+BCO,Security/Sfty
+BCOV,Computer Sftwr-Edu/Media
+BCOW,Banks-Midwest
+BCPC,Chemicals-Specialty
+BCRX,Medical-Biomed/Biotech
+BCS,Banks-Money Center
+BCSA,Finance-Blank Check
+BCSF,Financial Svcs-Specialty
+BCTX,Medical-Biomed/Biotech
+BCUS,Finance-ETF / ETN
+BCV,Finance-Publ Inv Fd-Bond
+BCX,Finance-Publ Inv Fd-Eqt
+BCYC,Medical-Biomed/Biotech
+BDC,Telecom-Cable/Satl Eqp
+BDCX,Finance-ETF / ETN
+BDCZ,Finance-ETF / ETN
+BDEC,Finance-ETF / ETN
+BDGS,Finance-ETF / ETN
+BDJ,Finance-Publ Inv Fd-Eqt
+BDL,Retail-Restaurants
+BDN,Finance-Property REIT
+BDRL,Group not available
+BDRX,Medical-Biomed/Biotech
+BDRY,Finance-ETF / ETN
+BDSX,Medical-Services
+BDTX,Medical-Biomed/Biotech
+BDVG,Finance-ETF / ETN
+BDX,Medical-Supplies
+BE,Energy-Alternative/Other
+BEAM,Medical-Biomed/Biotech
+BEAT,Medical-Research Eqp/Svc
+BECN,Bldg-Constr Prds/Misc
+BECO,Finance-ETF / ETN
+BEDU,Consumer Svcs-Education
+BEDZ,Finance-ETF / ETN
+BEEM,Electrical-Power/Equipmt
+BEEP,Finance-Property REIT
+BEEZ,Finance-ETF / ETN
+BEKE,Real Estate Dvlpmt/Ops
+BELFA,Electronic-Parts
+BELFB,Electronic-Parts
+BEMB,Finance-ETF / ETN
+BEN,Finance-Investment Mgmt
+BENF,Finance-Investment Mgmt
+BEP,Energy-Alternative/Other
+BEPC,Energy-Alternative/Other
+BERY,Containers/Packaging
+BERZ,Finance-ETF / ETN
+BEST,Transportation-Logistics
+BETE,Finance-ETF / ETN
+BETH,Finance-ETF / ETN
+BETR,Finance-Mrtg&Rel Svc
+BETSF,Beverages-Non-Alcoholic
+BETZ,Finance-ETF / ETN
+BFA,Beverages-Alcoholic
+BFAC,Finance-Blank Check
+BFAM,Consumer Svcs-Education
+BFB,Beverages-Alcoholic
+BFC,Banks-Midwest
+BFEB,Finance-ETF / ETN
+BFH,Finance-CrdtCard/PmtPr
+BFI,Retail-Restaurants
+BFIN,Finance-Savings & Loan
+BFIX,Finance-ETF / ETN
+BFK,Finance-Publ Inv Fd-Bond
+BFLY,Medical-Systems/Equip
+BFOR,Finance-ETF / ETN
+BFRG,Medical-Biomed/Biotech
+BFRI,Medical-Ethical Drugs
+BFS,Finance-Property REIT
+BFST,Financial Svcs-Specialty
+BFXXQ,Leisure-Products
+BFZ,Finance-Publ Inv Fd-Bond
+BG,Agricultural Operations
+BGB,Finance-Publ Inv Fd-Bond
+BGC,Finance-Invest Bnk/Bkrs
+BGFV,Retail-Leisure Products
+BGH,Finance-Publ Inv Fd-Glbl
+BGI,Retail/Whlsle-Jewelry
+BGIG,Finance-ETF / ETN
+BGLC,Chemicals-Specialty
+BGLD,Finance-ETF / ETN
+BGNE,Medical-Biomed/Biotech
+BGR,Finance-Publ Inv Fd-Eqt
+BGRN,Finance-ETF / ETN
+BGRY,Retail-Internet
+BGS,Food-Packaged
+BGSF,Comml Svcs-Staffing
+BGT,Finance-Publ Inv Fd-Glbl
+BGX,Finance-Publ Inv Fd-Bond
+BGXX,Consumer Prod-Specialty
+BGY,Finance-Publ Inv Fd-Glbl
+BH,Retail-Restaurants
+BHA,Retail-Restaurants
+BHAC,Finance-Blank Check
+BHAT,Leisure-Toys/Games/Hobby
+BHB,Banks-Northeast
+BHC,Medical-Ethical Drugs
+BHE,Elec-Contract Mfg
+BHF,Insurance-Life
+BHIL,Agricultural Operations
+BHK,Finance-Publ Inv Fd-Bond
+BHKLY,Banks-Foreign
+BHLB,Finance-Savings & Loan
+BHM,Finance-Property REIT
+BHP,Mining-Metal Ores
+BHR,Finance-Property REIT
+BHRB,Banks-Southeast
+BHV,Finance-Publ Inv Fd-Bond
+BHVN,Medical-Biomed/Biotech
+BHYB,Finance-ETF / ETN
+BIAF,Medical-Services
+BIB,Finance-ETF / ETN
+BIBL,Finance-ETF / ETN
+BICK,Finance-ETF / ETN
+BIDS,Finance-ETF / ETN
+BIDU,Internet-Content
+BIG,Retail-Discount&Variety
+BIGC,Computer Sftwr-Enterprse
+BIGZ,Finance-Publ Inv Fd-Bond
+BIIB,Medical-Biomed/Biotech
+BIL,Finance-ETF / ETN
+BILD,Finance-ETF / ETN
+BILI,Internet-Content
+BILL,Computer Sftwr-Financial
+BILS,Finance-ETF / ETN
+BILZ,Finance-ETF / ETN
+BIMI,Medical-Products
+BINC,Finance-ETF / ETN
+BINV,Finance-ETF / ETN
+BIO,Medical-Research Eqp/Svc
+BIOB,Medical-Products
+BIOCQ,Medical-Research Eqp/Svc
+BIOL,Medical-Systems/Equip
+BIOR,Medical-Services
+BIOX,Agricultural Operations
+BIP,Finance-Investment Mgmt
+BIPC,Finance-Investment Mgmt
+BIRD,Apparel-Shoes & Rel Mfg
+BIRK,Apparel-Shoes & Rel Mfg
+BIS,Finance-ETF / ETN
+BIT,Finance-Publ Inv Fd-Bond
+BITB,Finance-ETF / ETN
+BITC,Finance-ETF / ETN
+BITE,Finance-Blank Check
+BITF,Computer Sftwr-Financial
+BITI,Finance-ETF / ETN
+BITO,Finance-ETF / ETN
+BITQ,Finance-ETF / ETN
+BITS,Finance-ETF / ETN
+BITU,Group not available
+BITW,Finance-Publ Inv Fd-Glbl
+BITX,Finance-ETF / ETN
+BIV,Finance-ETF / ETN
+BIVI,Medical-Biomed/Biotech
+BIZD,Finance-ETF / ETN
+BJ,Retail-Discount&Variety
+BJAN,Finance-ETF / ETN
+BJDX,Medical-Biomed/Biotech
+BJK,Finance-ETF / ETN
+BJRI,Retail-Restaurants
+BJUL,Finance-ETF / ETN
+BJUN,Finance-ETF / ETN
+BK,Banks-Money Center
+BKAG,Finance-ETF / ETN
+BKCH,Finance-ETF / ETN
+BKCI,Finance-ETF / ETN
+BKD,Medical-Long-term Care
+BKE,Retail-Apparel/Shoes/Acc
+BKEM,Finance-ETF / ETN
+BKF,Finance-ETF / ETN
+BKFG,Finance-Investment Mgmt
+BKGI,Finance-ETF / ETN
+BKH,Utility-Diversified
+BKHY,Finance-ETF / ETN
+BKIE,Finance-ETF / ETN
+BKIV,Finance-ETF / ETN
+BKKT,Financial Svcs-Specialty
+BKLC,Finance-ETF / ETN
+BKLN,Finance-ETF / ETN
+BKMC,Finance-ETF / ETN
+BKN,Finance-Publ Inv Fd-Bond
+BKNG,Leisure-Travel Booking
+BKR,Oil&Gas-Machinery/Equip
+BKSC,Banks-Southeast
+BKSE,Finance-ETF / ETN
+BKSY,Telecom Svcs-Cable/Satl
+BKT,Finance-Publ Inv Fd-Bond
+BKTI,Telecom-Consumer Prods
+BKU,Finance-Savings & Loan
+BKUI,Finance-ETF / ETN
+BKWO,Finance-ETF / ETN
+BKYI,Security/Sfty
+BL,Comp Sftwr-Spec Enterprs
+BLAC,Finance-Blank Check
+BLBD,Transportation-Equip Mfg
+BLBX,Computer Sftwr-Financial
+BLCN,Finance-ETF / ETN
+BLCO,Medical-Systems/Equip
+BLCR,Finance-ETF / ETN
+BLCV,Finance-ETF / ETN
+BLD,Bldg-Constr Prds/Misc
+BLDE,Transportation-Airline
+BLDG,Finance-ETF / ETN
+BLDP,Energy-Alternative/Other
+BLDR,Bldg-Constr Prds/Misc
+BLE,Finance-Publ Inv Fd-Bond
+BLES,Finance-ETF / ETN
+BLEU,Finance-Blank Check
+BLFS,Medical-Products
+BLFY,Banks-Northeast
+BLIN,Internet-Network Sltns
+BLK,Finance-Investment Mgmt
+BLKB,Computer Sftwr-Enterprse
+BLKC,Finance-ETF / ETN
+BLLD,Finance-ETF / ETN
+BLMH,Consumer Prod-Specialty
+BLMN,Retail-Restaurants
+BLND,Computer Sftwr-Enterprse
+BLNG,Finance-Blank Check
+BLNK,Energy-Alternative/Other
+BLOK,Finance-ETF / ETN
+BLPH,Medical-Biomed/Biotech
+BLRX,Medical-Biomed/Biotech
+BLTE,Medical-Biomed/Biotech
+BLU,Medical-Biomed/Biotech
+BLUA,Finance-Blank Check
+BLUE,Medical-Biomed/Biotech
+BLV,Finance-ETF / ETN
+BLW,Finance-Publ Inv Fd-Bond
+BLX,Banks-Foreign
+BLZE,Computer-Data Storage
+BMA,Banks-Foreign
+BMAR,Finance-ETF / ETN
+BMAY,Finance-ETF / ETN
+BMBL,Internet-Content
+BME,Finance-Publ Inv Fd-Eqt
+BMEA,Medical-Biomed/Biotech
+BMED,Finance-ETF / ETN
+BMEZ,Finance-Publ Inv Fd-Eqt
+BMI,Machinery-Gen Industrial
+BMMJ,Consumer Prod-Specialty
+BMN,Finance-Publ Inv Fd-Bond
+BMO,Banks-Money Center
+BMR,Computer-Tech Services
+BMRA,Medical-Supplies
+BMRC,Banks-West/Southwest
+BMRN,Medical-Biomed/Biotech
+BMTX,Computer Sftwr-Financial
+BMVP,Finance-ETF / ETN
+BMWYY,Auto Manufacturers
+BMY,Medical-Ethical Drugs
+BN,Finance-Investment Mgmt
+BNAI,Computer Sftwr-Enterprse
+BND,Finance-ETF / ETN
+BNDC,Finance-ETF / ETN
+BNDD,Finance-ETF / ETN
+BNDI,Finance-ETF / ETN
+BNDW,Finance-ETF / ETN
+BNDX,Finance-ETF / ETN
+BNE,Finance-ETF / ETN
+BNED,Retail-Leisure Products
+BNET,Pollution Control
+BNGE,Finance-ETF / ETN
+BNGO,Medical-Products
+BNIX,Finance-Blank Check
+BNKD,Finance-ETF / ETN
+BNKU,Finance-ETF / ETN
+BNL,Finance-Property REIT
+BNO,Finance-ETF / ETN
+BNOV,Finance-ETF / ETN
+BNOX,Medical-Biomed/Biotech
+BNPQY,Banks-Money Center
+BNR,Medical-Services
+BNRE,Insurance-Diversified
+BNRG,Energy-Alternative/Other
+BNS,Banks-Money Center
+BNSOF,Elec-Scientific/Msrng
+BNTC,Medical-Biomed/Biotech
+BNTX,Medical-Biomed/Biotech
+BNZI,Comml Svcs-Market Rsrch
+BOAT,Finance-ETF / ETN
+BOC,Comml Svcs-Advertising
+BOCN,Finance-Blank Check
+BOCT,Finance-ETF / ETN
+BODI,Leisure-Services
+BOE,Finance-Publ Inv Fd-Glbl
+BOF,Food-Packaged
+BOH,Banks-West/Southwest
+BOIL,Finance-ETF / ETN
+BOKF,Banks-West/Southwest
+BOLD,Medical-Biomed/Biotech
+BOLT,Medical-Biomed/Biotech
+BON,Cosmetics/Personal Care
+BOND,Finance-ETF / ETN
+BOOM,Metal Proc & Fabrication
+BOOT,Retail-Apparel/Shoes/Acc
+BORR,Oil&Gas-Drilling
+BOSC,Computer-Networking
+BOSS,Finance-ETF / ETN
+BOTJ,Banks-Southeast
+BOTZ,Finance-ETF / ETN
+BOUT,Finance-ETF / ETN
+BOWL,Leisure-Services
+BOWN,Finance-Blank Check
+BOX,Computer Sftwr-Database
+BOXL,Consumer Prod-Electronic
+BOXX,Finance-ETF / ETN
+BP,Oil&Gas-Integrated
+BPAY,Finance-ETF / ETN
+BPMC,Medical-Biomed/Biotech
+BPOP,Banks-Southeast
+BPRN,Banks-Northeast
+BPT,Oil&Gas-Royalty Trust
+BPTH,Medical-Biomed/Biotech
+BPTS,Medical-Biomed/Biotech
+BQ,Retail-Internet
+BR,Financial Svcs-Specialty
+BRAC,Finance-Blank Check
+BRAG,Computer Sftwr-Gaming
+BRAZ,Finance-ETF / ETN
+BRBR,Cosmetics/Personal Care
+BRBS,Banks-Southeast
+BRC,Office Supplies Mfg
+BRCC,Retail-Restaurants
+BRCNF,Group not available
+BRD,Finance-Blank Check
+BRDCY,Auto/Truck-Tires & Misc
+BRDG,Finance-Mortgage REIT
+BRDSQ,Leisure-Services
+BREA,Leisure-Services
+BREZ,Finance-Blank Check
+BRF,Finance-ETF / ETN
+BRFH,Beverages-Non-Alcoholic
+BRFS,Food-Meat Products
+BRID,Food-Packaged
+BRIV,Finance-Blank Check
+BRKA,Diversified Operations
+BRKB,Diversified Operations
+BRKH,Finance-Blank Check
+BRKL,Finance-Savings & Loan
+BRKR,Medical-Systems/Equip
+BRLN,Finance-ETF / ETN
+BRLS,Food-Packaged
+BRLT,Retail/Whlsle-Jewelry
+BRN,Oil&Gas-Cdn Expl&Prod
+BRNS,Medical-Biomed/Biotech
+BRNY,Finance-ETF / ETN
+BRO,Insurance-Brokers
+BROG,Oil&Gas-Refining/Mktg
+BROS,Retail-Restaurants
+BRP,Insurance-Brokers
+BRQSF,Comp Sftwr-Spec Enterprs
+BRRR,Finance-ETF / ETN
+BRSH,Retail-Consumer Elec
+BRSP,Finance-Mortgage REIT
+BRT,Finance-Property REIT
+BRTR,Finance-ETF / ETN
+BRTX,Medical-Biomed/Biotech
+BRW,Finance-Publ Inv Fd-Bond
+BRX,Finance-Property REIT
+BRY,Oil&Gas-U S Expl&Prod
+BRZE,Computer Sftwr-Enterprse
+BRZU,Finance-ETF / ETN
+BSAC,Banks-Foreign
+BSBK,Banks-Northeast
+BSBR,Banks-Foreign
+BSCO,Finance-ETF / ETN
+BSCP,Finance-ETF / ETN
+BSCQ,Finance-ETF / ETN
+BSCR,Finance-ETF / ETN
+BSCS,Finance-ETF / ETN
+BSCT,Finance-ETF / ETN
+BSCU,Finance-ETF / ETN
+BSCV,Finance-ETF / ETN
+BSCW,Finance-ETF / ETN
+BSCX,Finance-ETF / ETN
+BSEA,Finance-ETF / ETN
+BSEP,Finance-ETF / ETN
+BSET,Hsehold/Office Furniture
+BSFC,Food-Meat Products
+BSGM,Medical-Products
+BSIG,Finance-Investment Mgmt
+BSJO,Finance-ETF / ETN
+BSJP,Finance-ETF / ETN
+BSJQ,Finance-ETF / ETN
+BSJR,Finance-ETF / ETN
+BSJS,Finance-ETF / ETN
+BSJT,Finance-ETF / ETN
+BSJU,Finance-ETF / ETN
+BSJV,Finance-ETF / ETN
+BSL,Finance-Publ Inv Fd-Bond
+BSM,Oil&Gas-U S Expl&Prod
+BSMC,Finance-ETF / ETN
+BSMO,Finance-ETF / ETN
+BSMP,Finance-ETF / ETN
+BSMQ,Finance-ETF / ETN
+BSMR,Finance-ETF / ETN
+BSMS,Finance-ETF / ETN
+BSMT,Finance-ETF / ETN
+BSMU,Finance-ETF / ETN
+BSMV,Finance-ETF / ETN
+BSMW,Finance-ETF / ETN
+BSR,Finance-ETF / ETN
+BSRR,Banks-West/Southwest
+BSSX,Finance-ETF / ETN
+BST,Finance-Publ Inv Fd-Eqt
+BSTP,Finance-ETF / ETN
+BSTZ,Finance-Publ Inv Fd-Eqt
+BSV,Finance-ETF / ETN
+BSVN,Banks-West/Southwest
+BSVO,Finance-ETF / ETN
+BSX,Medical-Products
+BSY,Computer Sftwr-Design
+BTA,Finance-Publ Inv Fd-Bond
+BTAI,Medical-Biomed/Biotech
+BTAL,Finance-ETF / ETN
+BTBD,Retail-Restaurants
+BTBT,Computer Sftwr-Financial
+BTCM,Financial Svcs-Specialty
+BTCO,Finance-ETF / ETN
+BTCS,Financial Svcs-Specialty
+BTCT,Consumer Svcs-Education
+BTCW,Finance-ETF / ETN
+BTCY,Medical-Systems/Equip
+BTDR,Computer Sftwr-Financial
+BTE,Oil&Gas-Cdn Expl&Prod
+BTEC,Finance-ETF / ETN
+BTEK,Finance-ETF / ETN
+BTF,Finance-ETF / ETN
+BTFX,Finance-ETF / ETN
+BTG,Mining-Gold/Silver/Gems
+BTHM,Finance-ETF / ETN
+BTI,Tobacco
+BTM,Finance-Invest Bnk/Bkrs
+BTMD,Medical-Ethical Drugs
+BTO,Finance-Publ Inv Fd-Eqt
+BTOG,Food-Meat Products
+BTOP,Finance-ETF / ETN
+BTR,Finance-ETF / ETN
+BTRN,Finance-ETF / ETN
+BTSG,Medical-Outpnt/Hm Care
+BTT,Finance-Publ Inv Fd-Bond
+BTTR,Retail-Specialty
+BTTX,Medical-Biomed/Biotech
+BTU,Energy-Coal
+BTZ,Finance-Publ Inv Fd-Eqt
+BUCK,Finance-ETF / ETN
+BUD,Beverages-Alcoholic
+BUFB,Finance-ETF / ETN
+BUFC,Finance-ETF / ETN
+BUFD,Finance-ETF / ETN
+BUFF,Finance-ETF / ETN
+BUFG,Finance-ETF / ETN
+BUFQ,Finance-ETF / ETN
+BUFR,Finance-ETF / ETN
+BUFT,Finance-ETF / ETN
+BUFZ,Finance-ETF / ETN
+BUG,Finance-ETF / ETN
+BUI,Finance-Publ Inv Fd-Eqt
+BUJA,Finance-Blank Check
+BUL,Finance-ETF / ETN
+BULD,Finance-ETF / ETN
+BULZ,Finance-ETF / ETN
+BUR,Finance-Investment Mgmt
+BURL,Retail-Apparel/Shoes/Acc
+BURU,Machinery-Gen Industrial
+BUSA,Finance-ETF / ETN
+BUSE,Banks-Midwest
+BUXX,Finance-ETF / ETN
+BUYW,Finance-ETF / ETN
+BUYZ,Finance-ETF / ETN
+BUZZ,Finance-ETF / ETN
+BV,Bldg-Maintenance & Svc
+BVFL,Banks-Northeast
+BVN,Mining-Gold/Silver/Gems
+BVS,Medical-Products
+BW,Electrical-Power/Equipmt
+BWA,Auto/Truck-Original Eqp
+BWAQ,Finance-Blank Check
+BWAY,Medical-Systems/Equip
+BWB,Banks-Midwest
+BWEB,Finance-ETF / ETN
+BWEN,Energy-Alternative/Other
+BWET,Finance-ETF / ETN
+BWFG,Banks-Northeast
+BWG,Finance-Publ Inv Fd-Glbl
+BWMN,Comml Svcs-Consulting
+BWMX,Hsehold-Appliances/Wares
+BWTG,Finance-ETF / ETN
+BWX,Finance-ETF / ETN
+BWXT,Electrical-Power/Equipmt
+BWZ,Finance-ETF / ETN
+BX,Finance-Investment Mgmt
+BXC,Retail/Whlsle-Bldg Prds
+BXMT,Finance-Mortgage REIT
+BXMX,Finance-Publ Inv Fd-Eqt
+BXP,Finance-Property REIT
+BXRXQ,Medical-Biomed/Biotech
+BXSL,Finance-Publ Inv Fd-Bond
+BY,Banks-Midwest
+BYD,Leisure-Gaming/Equip
+BYDDF,Auto Manufacturers
+BYFC,Finance-Savings & Loan
+BYLD,Finance-ETF / ETN
+BYM,Finance-Publ Inv Fd-Bond
+BYND,Food-Meat Products
+BYNO,Finance-Blank Check
+BYON,Retail-Internet
+BYRE,Finance-ETF / ETN
+BYRN,Security/Sfty
+BYSI,Medical-Biomed/Biotech
+BYTE,Finance-ETF / ETN
+BYU,Metal Prds-Distributor
+BZ,Internet-Content
+BZAMF,Consumer Prod-Specialty
+BZFD,Internet-Content
+BZH,Bldg-Resident/Comml
+BZQ,Finance-ETF / ETN
+BZUN,Computer Sftwr-Enterprse
+C,Banks-Money Center
+CA,Finance-ETF / ETN
+CAAA,Finance-ETF / ETN
+CAAP,Real Estate Dvlpmt/Ops
+CAAS,Auto/Truck-Original Eqp
+CABA,Medical-Biomed/Biotech
+CABO,Telecom Svcs-Cable/Satl
+CAC,Banks-Northeast
+CACC,Finance-Consumer Loans
+CACG,Finance-ETF / ETN
+CACI,Computer-Tech Services
+CACO,Transportation-Ship
+CADE,Banks-West/Southwest
+CADL,Medical-Biomed/Biotech
+CAE,Aerospace/Defense
+CAF,Finance-Publ Inv Fd-Glbl
+CAFG,Finance-ETF / ETN
+CAG,Food-Packaged
+CAH,Medical-Whlsle Drg/Suppl
+CAIXY,Financial Svcs-Specialty
+CAKE,Retail-Restaurants
+CAL,Retail-Apparel/Shoes/Acc
+CALA,Medical-Biomed/Biotech
+CALB,Banks-West/Southwest
+CALC,Medical-Biomed/Biotech
+CALF,Finance-ETF / ETN
+CALM,Food-Meat Products
+CALT,Medical-Biomed/Biotech
+CALX,Computer-Networking
+CALY,Finance-ETF / ETN
+CAML,Finance-ETF / ETN
+CAMP,Computer-Networking
+CAMT,Elec-Scientific/Msrng
+CAMX,Finance-ETF / ETN
+CAN,Elec-Semicondctor Fablss
+CANB,Consumer Prod-Specialty
+CANC,Finance-ETF / ETN
+CANE,Finance-ETF / ETN
+CANF,Medical-Biomed/Biotech
+CANG,Computer Sftwr-Financial
+CANN,Consumer Prod-Specialty
+CANOQ,Medical-Long-term Care
+CANQ,Finance-ETF / ETN
+CAOS,Finance-ETF / ETN
+CAPE,Finance-ETF / ETN
+CAPL,Oil&Gas-Refining/Mktg
+CAPR,Medical-Biomed/Biotech
+CAPT,Bldg-Constr Prds/Misc
+CAR,Leisure-Services
+CARA,Medical-Biomed/Biotech
+CARD,Finance-ETF / ETN
+CARE,Banks-Southeast
+CARG,Internet-Content
+CARK,Finance-ETF / ETN
+CARM,Medical-Biomed/Biotech
+CARR,Bldg-A/C & Heating Prds
+CARS,Retail/Whlsle-Automobile
+CART,Retail-Internet
+CARU,Finance-ETF / ETN
+CARV,Finance-Savings & Loan
+CARY,Finance-ETF / ETN
+CARZ,Finance-ETF / ETN
+CASA,Telecom-Infrastructure
+CASH,Finance-Savings & Loan
+CASI,Medical-Biomed/Biotech
+CASS,Finance-CrdtCard/PmtPr
+CASY,Retail-Super/Mini Mkts
+CAT,Machinery-Constr/Mining
+CATC,Banks-Northeast
+CATH,Finance-ETF / ETN
+CATO,Retail-Apparel/Shoes/Acc
+CATX,Medical-Ethical Drugs
+CATY,Banks-West/Southwest
+CAUD,Comml Svcs-Advertising
+CAVA,Retail-Restaurants
+CB,Insurance-Prop/Cas/Titl
+CBAN,Banks-Southeast
+CBAT,Consumer Prod-Specialty
+CBD,Retail-Super/Mini Mkts
+CBFV,Banks-Northeast
+CBH,Finance-Publ Inv Fd-Bond
+CBL,Finance-Property REIT
+CBLS,Finance-ETF / ETN
+CBNK,Banks-Northeast
+CBOE,Financial Svcs-Specialty
+CBON,Finance-ETF / ETN
+CBRE,Real Estate Dvlpmt/Ops
+CBRG,Finance-Blank Check
+CBRL,Retail-Restaurants
+CBSE,Finance-ETF / ETN
+CBSH,Banks-Midwest
+CBSTF,Consumer Prod-Specialty
+CBT,Chemicals-Specialty
+CBU,Banks-Northeast
+CBUS,Agricultural Operations
+CBWTF,Consumer Prod-Specialty
+CBZ,Comml Svcs-Consulting
+CC,Chemicals-Specialty
+CCAP,Finance-Investment Mgmt
+CCB,Finance-Commercial Loans
+CCBG,Banks-Southeast
+CCCC,Medical-Biomed/Biotech
+CCCS,Computer Sftwr-Enterprse
+CCD,Finance-Publ Inv Fd-Eqt
+CCDBF,Containers/Packaging
+CCEF,Finance-ETF / ETN
+CCEL,Medical-Services
+CCEP,Beverages-Non-Alcoholic
+CCG,Insurance-Prop/Cas/Titl
+CCHGY,Beverages-Non-Alcoholic
+CCI,Finance-Property REIT
+CCIF,Finance-Publ Inv Fd-Eqt
+CCJ,Mining-Metal Ores
+CCK,Containers/Packaging
+CCL,Leisure-Services
+CCLD,Computer Sftwr-Medical
+CCM,Medical-Outpnt/Hm Care
+CCMG,Finance-ETF / ETN
+CCNE,Banks-Northeast
+CCO,Comml Svcs-Advertising
+CCOI,Telecom Svcs-Cable/Satl
+CCOR,Finance-ETF / ETN
+CCRD,Computer Sftwr-Financial
+CCRN,Comml Svcs-Staffing
+CCRV,Finance-ETF / ETN
+CCS,Bldg-Resident/Comml
+CCSI,Computer Sftwr-Enterprse
+CCSO,Finance-ETF / ETN
+CCTG,Electrical-Power/Equipmt
+CCTS,Finance-Blank Check
+CCU,Beverages-Alcoholic
+CCVI,Finance-Blank Check
+CD,Internet-Network Sltns
+CDAKQ,Medical-Biomed/Biotech
+CDAQ,Finance-Blank Check
+CDC,Finance-ETF / ETN
+CDE,Mining-Gold/Silver/Gems
+CDEI,Finance-ETF / ETN
+CDIO,Medical-Systems/Equip
+CDL,Finance-ETF / ETN
+CDLR,Transportation-Ship
+CDLX,Computer Sftwr-Enterprse
+CDMO,Medical-Research Eqp/Svc
+CDNA,Medical-Products
+CDNS,Computer Sftwr-Design
+CDP,Finance-Property REIT
+CDRE,Security/Sfty
+CDRO,Leisure-Gaming/Equip
+CDT,Medical-Biomed/Biotech
+CDTX,Medical-Biomed/Biotech
+CDW,Computer-Tech Services
+CDX,Finance-ETF / ETN
+CDXC,Chemicals-Specialty
+CDXS,Medical-Biomed/Biotech
+CDZI,Utility-Water Supply
+CE,Chemicals-Basic
+CEAD,Agricultural Operations
+CECO,Pollution Control
+CEE,Finance-Publ Inv Fd-Glbl
+CEF,Finance-Publ Inv Fd-Glbl
+CEFA,Finance-ETF / ETN
+CEFD,Finance-ETF / ETN
+CEFS,Finance-ETF / ETN
+CEG,Energy-Alternative/Other
+CEI,Oil&Gas-U S Expl&Prod
+CEIX,Energy-Coal
+CELC,Medical-Biomed/Biotech
+CELH,Beverages-Non-Alcoholic
+CELU,Medical-Biomed/Biotech
+CELZ,Medical-Biomed/Biotech
+CEM,Finance-Publ Inv Fd-Eqt
+CEMB,Finance-ETF / ETN
+CENN,Auto Manufacturers
+CENT,Consumer Prod-Specialty
+CENTA,Consumer Prod-Specialty
+CENX,Metal Proc & Fabrication
+CEPU,Utility-Electric Power
+CERE,Medical-Biomed/Biotech
+CERO,Medical-Biomed/Biotech
+CERS,Medical-Biomed/Biotech
+CERT,Computer Sftwr-Medical
+CET,Finance-Publ Inv Fd-Eqt
+CETF,Finance-ETF / ETN
+CETU,Finance-Blank Check
+CETX,Elec-Misc Products
+CETY,Energy-Alternative/Other
+CEV,Finance-Publ Inv Fd-Bond
+CEVA,Elec-Semicondctor Fablss
+CEW,Finance-ETF / ETN
+CF,Chemicals-Agricultural
+CFA,Finance-ETF / ETN
+CFB,Banks-Midwest
+CFBK,Finance-Savings & Loan
+CFCV,Finance-ETF / ETN
+CFFI,Banks-Southeast
+CFFN,Finance-Savings & Loan
+CFFS,Finance-Blank Check
+CFG,Banks-Northeast
+CFLT,Computer Sftwr-Database
+CFO,Finance-ETF / ETN
+CFR,Banks-West/Southwest
+CFRUY,Apparel-Clothing Mfg
+CFRXQ,Medical-Biomed/Biotech
+CFSB,Banks-Northeast
+CG,Finance-Investment Mgmt
+CGA,Chemicals-Agricultural
+CGAU,Mining-Gold/Silver/Gems
+CGBD,Finance-Commercial Loans
+CGBL,Finance-ETF / ETN
+CGC,Consumer Prod-Specialty
+CGCB,Finance-ETF / ETN
+CGCP,Finance-ETF / ETN
+CGDG,Finance-ETF / ETN
+CGDV,Finance-ETF / ETN
+CGEM,Medical-Biomed/Biotech
+CGEMY,Computer-Tech Services
+CGEN,Medical-Biomed/Biotech
+CGGO,Finance-ETF / ETN
+CGGR,Finance-ETF / ETN
+CGIE,Finance-ETF / ETN
+CGMS,Finance-ETF / ETN
+CGMU,Finance-ETF / ETN
+CGNT,Computer Sftwr-Security
+CGNX,Elec-Scientific/Msrng
+CGO,Finance-Publ Inv Fd-Glbl
+CGON,Medical-Biomed/Biotech
+CGRO,Finance-ETF / ETN
+CGSD,Finance-ETF / ETN
+CGSM,Finance-ETF / ETN
+CGTX,Medical-Biomed/Biotech
+CGUS,Finance-ETF / ETN
+CGV,Finance-ETF / ETN
+CGW,Finance-ETF / ETN
+CGXU,Finance-ETF / ETN
+CHAA,Finance-Blank Check
+CHAI,Finance-ETF / ETN
+CHAT,Finance-ETF / ETN
+CHAU,Finance-ETF / ETN
+CHCI,Bldg-Resident/Comml
+CHCO,Banks-Southeast
+CHCT,Finance-Property REIT
+CHD,Soap & Clng Preparatns
+CHDN,Leisure-Gaming/Equip
+CHE,Diversified Operations
+CHEF,Food-Misc Preparation
+CHEK,Medical-Products
+CHGCY,Medical-Ethical Drugs
+CHGG,Consumer Svcs-Education
+CHGX,Finance-ETF / ETN
+CHH,Leisure-Lodging
+CHI,Finance-Publ Inv Fd-Bond
+CHIQ,Finance-ETF / ETN
+CHK,Oil&Gas-U S Expl&Prod
+CHKP,Computer Sftwr-Security
+CHMG,Banks-Northeast
+CHMI,Finance-Mortgage REIT
+CHN,Finance-Publ Inv Fd-Glbl
+CHNR,Mining-Gold/Silver/Gems
+CHPS,Finance-ETF / ETN
+CHPT,Energy-Alternative/Other
+CHR,Internet-Content
+CHRA,Pollution Control
+CHRD,Oil&Gas-U S Expl&Prod
+CHRO,Medical-Biomed/Biotech
+CHRS,Medical-Biomed/Biotech
+CHRW,Transportation-Logistics
+CHSN,Food-Confectionery
+CHT,Telecom Svcs- Foreign
+CHTR,Telecom Svcs-Integrated
+CHUY,Retail-Restaurants
+CHW,Finance-Publ Inv Fd-Glbl
+CHWY,Retail-Internet
+CHX,Oil&Gas-Drilling
+CHY,Finance-Publ Inv Fd-Bond
+CI,Medical-Managed Care
+CIA,Insurance-Life
+CIB,Banks-Foreign
+CIBR,Finance-ETF / ETN
+CICHY,Banks-Foreign
+CID,Finance-ETF / ETN
+CIEN,Telecom-Fiber Optics
+CIF,Finance-Publ Inv Fd-Bond
+CIFR,Computer Sftwr-Financial
+CIG,Utility-Electric Power
+CIGI,Real Estate Dvlpmt/Ops
+CIHKY,Banks-Foreign
+CII,Finance-Publ Inv Fd-Bal
+CIK,Finance-Publ Inv Fd-Bond
+CIL,Finance-ETF / ETN
+CIM,Finance-Mortgage REIT
+CINF,Insurance-Prop/Cas/Titl
+CING,Medical-Biomed/Biotech
+CINT,Computer-Tech Services
+CIO,Finance-Property REIT
+CION,Finance-Commercial Loans
+CISO,Computer Sftwr-Security
+CISS,Transportation-Ship
+CITE,Finance-Blank Check
+CIVB,Banks-Midwest
+CIVI,Oil&Gas-U S Expl&Prod
+CIX,Hsehold/Office Furniture
+CIXXF,Group not available
+CIZ,Finance-ETF / ETN
+CIZN,Banks-Southeast
+CJET,Auto Manufacturers
+CJJD,Retail-Drug Stores
+CKHUY,Real Estate Dvlpmt/Ops
+CKPT,Medical-Biomed/Biotech
+CKX,Real Estate Dvlpmt/Ops
+CL,Cosmetics/Personal Care
+CLAR,Leisure-Products
+CLB,Oil&Gas-Field Services
+CLBK,Banks-Northeast
+CLBR,Finance-Blank Check
+CLBT,Comp Sftwr-Spec Enterprs
+CLCO,Oil&Gas-Transprt/Pipelne
+CLDI,Medical-Biomed/Biotech
+CLDL,Finance-ETF / ETN
+CLDT,Finance-Property REIT
+CLDX,Medical-Biomed/Biotech
+CLEU,Consumer Svcs-Education
+CLF,Steel-Producers
+CLFD,Telecom-Fiber Optics
+CLGN,Medical-Systems/Equip
+CLH,Pollution Control
+CLIA,Finance-ETF / ETN
+CLIP,Finance-ETF / ETN
+CLIR,Energy-Alternative/Other
+CLIX,Finance-ETF / ETN
+CLLS,Medical-Biomed/Biotech
+CLM,Finance-Publ Inv Fd-Eqt
+CLMB,Wholesale-Electronics
+CLMT,Oil&Gas-Refining/Mktg
+CLNE,Energy-Alternative/Other
+CLNN,Medical-Biomed/Biotech
+CLNR,Finance-ETF / ETN
+CLOA,Finance-ETF / ETN
+CLOD,Finance-ETF / ETN
+CLOE,Finance-Blank Check
+CLOI,Finance-ETF / ETN
+CLOU,Finance-ETF / ETN
+CLOV,Medical-Managed Care
+CLOX,Finance-ETF / ETN
+CLOZ,Finance-ETF / ETN
+CLPR,Finance-Property REIT
+CLPS,Computer Sftwr-Financial
+CLPT,Medical-Systems/Equip
+CLRB,Medical-Biomed/Biotech
+CLRC,Finance-Blank Check
+CLRG,Finance-ETF / ETN
+CLRO,Telecom-Infrastructure
+CLS,Elec-Contract Mfg
+CLSD,Medical-Biomed/Biotech
+CLSE,Finance-ETF / ETN
+CLSK,Computer Sftwr-Financial
+CLSM,Finance-ETF / ETN
+CLST,Banks-Southeast
+CLVR,Consumer Prod-Specialty
+CLVSQ,Group not available
+CLVT,Comp Sftwr-Spec Enterprs
+CLW,Paper & Paper Products
+CLWT,Pollution Control
+CLX,Soap & Clng Preparatns
+CM,Banks-Foreign
+CMA,Banks-Super Regional
+CMAX,Medical-Long-term Care
+CMBM,Telecom-Infrastructure
+CMBS,Finance-ETF / ETN
+CMC,Metal Proc & Fabrication
+CMCA,Finance-Blank Check
+CMCI,Finance-ETF / ETN
+CMCL,Mining-Gold/Silver/Gems
+CMCM,Computer Sftwr-Security
+CMCO,Machinery-Mtl Hdlg/Autmn
+CMCSA,Telecom Svcs-Cable/Satl
+CMCT,Finance-Property REIT
+CMDT,Finance-ETF / ETN
+CMDY,Finance-ETF / ETN
+CME,Financial Svcs-Specialty
+CMF,Finance-ETF / ETN
+CMG,Retail-Restaurants
+CMI,Trucks & Parts-Hvy Duty
+CMLS,Media-Radio/Tv
+CMMB,Medical-Biomed/Biotech
+CMND,Medical-Biomed/Biotech
+CMP,Chemicals-Basic
+CMPGY,Food-Misc Preparation
+CMPO,Consumer Prod-Specialty
+CMPR,Comml Svcs-Document Mgmt
+CMPS,Medical-Biomed/Biotech
+CMPX,Medical-Biomed/Biotech
+CMRA,Medical-Biomed/Biotech
+CMRE,Transportation-Ship
+CMRX,Medical-Biomed/Biotech
+CMS,Utility-Diversified
+CMT,Chemicals-Plastics
+CMTG,Finance-Mortgage REIT
+CMTL,Telecom-Cable/Satl Eqp
+CMU,Finance-Publ Inv Fd-Bond
+CNA,Insurance-Prop/Cas/Titl
+CNBS,Finance-ETF / ETN
+CNC,Medical-Managed Care
+CNCE,Medical-Biomed/Biotech
+CNCR,Finance-ETF / ETN
+CNDA,Finance-Blank Check
+CNDT,Comml Svcs-Outsourcing
+CNET,Internet-Content
+CNEY,Chemicals-Specialty
+CNF,Finance-Commercial Loans
+CNFR,Insurance-Prop/Cas/Titl
+CNGL,Finance-Blank Check
+CNHI,Machinery-Constr/Mining
+CNI,Transportation-Rail
+CNK,Leisure-Movies & Related
+CNM,Bldg-Constr Prds/Misc
+CNMD,Medical-Products
+CNNE,Finance-Investment Mgmt
+CNO,Insurance-Acc & Health
+CNOB,Banks-Northeast
+CNP,Utility-Diversified
+CNQ,Oil&Gas-Cdn Expl&Prod
+CNRG,Finance-ETF / ETN
+CNS,Finance-Investment Mgmt
+CNSL,Telecom Svcs-Integrated
+CNSP,Medical-Biomed/Biotech
+CNSWF,Computer-Tech Services
+CNTA,Medical-Research Eqp/Svc
+CNTB,Medical-Biomed/Biotech
+CNTG,Medical-Products
+CNTMF,Consumer Prod-Specialty
+CNTX,Medical-Biomed/Biotech
+CNTY,Leisure-Gaming/Equip
+CNVS,Leisure-Movies & Related
+CNX,Oil&Gas-U S Expl&Prod
+CNXA,Leisure-Services
+CNXC,Computer Sftwr-Enterprse
+CNXN,Wholesale-Electronics
+CNXT,Finance-ETF / ETN
+CNYA,Finance-ETF / ETN
+COAL,Finance-ETF / ETN
+COCH,Medical-Products
+COCO,Beverages-Non-Alcoholic
+COCP,Medical-Biomed/Biotech
+CODA,Aerospace/Defense
+CODI,Finance-Investment Mgmt
+CODX,Medical-Biomed/Biotech
+COE,Consumer Svcs-Education
+COEP,Medical-Biomed/Biotech
+COF,Finance-Consumer Loans
+COFS,Banks-Midwest
+COGNY,Consumer Svcs-Education
+COGT,Medical-Biomed/Biotech
+COHN,Finance-Investment Mgmt
+COHR,Electronic-Parts
+COHU,Elec-Semiconductor Equip
+COIN,Computer Sftwr-Financial
+COKE,Beverages-Non-Alcoholic
+COLB,Banks-West/Southwest
+COLD,Finance-Property REIT
+COLL,Medical-Generic Drugs
+COLM,Apparel-Clothing Mfg
+COM,Finance-ETF / ETN
+COMB,Finance-ETF / ETN
+COMM,Telecom-Infrastructure
+COMP,Computer Sftwr-Enterprse
+COMS,Telecom-Infrastructure
+COMT,Finance-ETF / ETN
+CONL,Finance-ETF / ETN
+CONN,Retail-Consumer Elec
+CONX,Finance-Blank Check
+CONY,Finance-ETF / ETN
+COO,Medical-Products
+COOK,Hsehold-Appliances/Wares
+COOL,Finance-Blank Check
+COOP,Finance-Consumer Loans
+COOT,Food-Misc Preparation
+COP,Oil&Gas-Intl Expl&Prod
+COPJ,Finance-ETF / ETN
+COPP,Finance-ETF / ETN
+COPX,Finance-ETF / ETN
+COR,Medical-Whlsle Drg/Suppl
+CORBF,Medical-Services
+CORN,Finance-ETF / ETN
+CORP,Finance-ETF / ETN
+CORRQ,Finance-Property REIT
+CORS,Finance-Blank Check
+CORT,Medical-Biomed/Biotech
+CORZ,Computer Sftwr-Financial
+COSM,Medical-Biomed/Biotech
+COST,Retail-Major Disc Chains
+COTY,Cosmetics/Personal Care
+COUR,Computer Sftwr-Edu/Media
+COWG,Finance-ETF / ETN
+COWS,Finance-ETF / ETN
+COWTF,Finance-ETF / ETN
+COWZ,Finance-ETF / ETN
+COYA,Medical-Biomed/Biotech
+CP,Transportation-Rail
+CPA,Transportation-Airline
+CPAC,Bldg-Cement/Concrt/Ag
+CPAI,Finance-ETF / ETN
+CPAY,Financial Svcs-Specialty
+CPB,Food-Packaged
+CPBI,Banks-Midwest
+CPER,Finance-ETF / ETN
+CPF,Banks-West/Southwest
+CPG,Oil&Gas-Cdn Expl&Prod
+CPHC,Leisure-Gaming/Equip
+CPHI,Medical-Generic Drugs
+CPI,Finance-ETF / ETN
+CPII,Finance-ETF / ETN
+CPIX,Medical-Ethical Drugs
+CPK,Utility-Diversified
+CPLP,Transportation-Ship
+CPLS,Finance-ETF / ETN
+CPNG,Retail-Internet
+CPOP,Internet-Content
+CPRI,Apparel-Clothing Mfg
+CPRT,Retail/Whlsle-Auto Parts
+CPRX,Medical-Biomed/Biotech
+CPS,Auto/Truck-Original Eqp
+CPSH,Elec-Misc Products
+CPSS,Finance-Consumer Loans
+CPT,Finance-Property REIT
+CPTN,Auto/Truck-Original Eqp
+CPZ,Finance-Publ Inv Fd-Bal
+CQP,Oil&Gas-Transprt/Pipelne
+CQQQ,Finance-ETF / ETN
+CR,Diversified Operations
+CRAI,Comml Svcs-Consulting
+CRAK,Finance-ETF / ETN
+CRBG,Insurance-Life
+CRBJY,Real Estate Dvlpmt/Ops
+CRBN,Finance-ETF / ETN
+CRBP,Medical-Biomed/Biotech
+CRBU,Medical-Biomed/Biotech
+CRC,Oil&Gas-U S Expl&Prod
+CRCT,Computer-Hardware/Perip
+CRDA,Comml Svcs-Outsourcing
+CRDB,Comml Svcs-Outsourcing
+CRDF,Medical-Research Eqp/Svc
+CRDL,Medical-Biomed/Biotech
+CRDO,Internet-Network Sltns
+CRDT,Finance-ETF / ETN
+CRED,Finance-ETF / ETN
+CREG,Energy-Alternative/Other
+CRESY,Finance-Property REIT
+CREV,Auto/Truck-Tires & Misc
+CREX,Comml Svcs-Advertising
+CRF,Finance-Publ Inv Fd-Bond
+CRGEQ,Telecom-Infrastructure
+CRGO,Transport-Air Freight
+CRGX,Medical-Biomed/Biotech
+CRGY,Oil&Gas-U S Expl&Prod
+CRH,Bldg-Cement/Concrt/Ag
+CRI,Apparel-Clothing Mfg
+CRIS,Medical-Biomed/Biotech
+CRIT,Finance-ETF / ETN
+CRK,Oil&Gas-U S Expl&Prod
+CRKN,Bldg-Constr Prds/Misc
+CRL,Medical-Research Eqp/Svc
+CRLBF,Consumer Prod-Specialty
+CRM,Computer Sftwr-Enterprse
+CRMD,Medical-Biomed/Biotech
+CRML,Mining-Metal Ores
+CRMT,Retail/Whlsle-Automobile
+CRNC,Computer Sftwr-Desktop
+CRNT,Telecom-Infrastructure
+CRNX,Medical-Biomed/Biotech
+CRON,Consumer Prod-Specialty
+CROX,Apparel-Shoes & Rel Mfg
+CRPT,Finance-ETF / ETN
+CRS,Steel-Specialty Alloys
+CRSP,Medical-Biomed/Biotech
+CRSR,Computer-Hardware/Perip
+CRT,Oil&Gas-Royalty Trust
+CRTC,Finance-ETF / ETN
+CRTD,Group not available
+CRTO,Comml Svcs-Advertising
+CRUS,Elec-Semicondctor Fablss
+CRUZ,Finance-ETF / ETN
+CRVL,Comml Svcs-Healthcare
+CRVO,Medical-Biomed/Biotech
+CRVS,Medical-Biomed/Biotech
+CRWD,Computer Sftwr-Security
+CRWS,Consumer Prod-Specialty
+CSA,Finance-ETF / ETN
+CSAN,Oil&Gas-Refining/Mktg
+CSB,Finance-ETF / ETN
+CSBR,Medical-Research Eqp/Svc
+CSCO,Computer-Networking
+CSD,Finance-ETF / ETN
+CSF,Finance-ETF / ETN
+CSGP,Comml Svcs-Market Rsrch
+CSGS,Comml Svcs-Outsourcing
+CSHI,Finance-ETF / ETN
+CSIQ,Energy-Solar
+CSL,Diversified Operations
+CSLLY,Medical-Biomed/Biotech
+CSLM,Finance-Blank Check
+CSLR,Energy-Solar
+CSM,Finance-ETF / ETN
+CSMD,Finance-ETF / ETN
+CSML,Finance-ETF / ETN
+CSPI,Computer-Tech Services
+CSQ,Finance-Publ Inv Fd-Bal
+CSR,Finance-Property REIT
+CSSE,Leisure-Movies & Related
+CSTAF,Finance-Blank Check
+CSTE,Bldg-Constr Prds/Misc
+CSTL,Medical-Services
+CSTM,Steel-Specialty Alloys
+CSV,Funeral Svcs & Rel
+CSWC,Finance-Investment Mgmt
+CSWI,Bldg-A/C & Heating Prds
+CSX,Transportation-Rail
+CTA,Finance-ETF / ETN
+CTAS,Comml Svcs-Outsourcing
+CTBI,Banks-Southeast
+CTCX,Medical-Biomed/Biotech
+CTEC,Finance-ETF / ETN
+CTEX,Finance-ETF / ETN
+CTG,Computer-Tech Services
+CTGO,Mining-Gold/Silver/Gems
+CTHR,Retail/Whlsle-Jewelry
+CTIC,Medical-Biomed/Biotech
+CTKB,Medical-Research Eqp/Svc
+CTLP,Finance-CrdtCard/PmtPr
+CTLT,Medical-Research Eqp/Svc
+CTM,Computer-Tech Services
+CTMX,Medical-Biomed/Biotech
+CTNT,Transportation-Logistics
+CTO,Real Estate Dvlpmt/Ops
+CTOS,Comml Svcs-Leasing
+CTR,Finance-Publ Inv Fd-Eqt
+CTRA,Oil&Gas-U S Expl&Prod
+CTRE,Finance-Property REIT
+CTRM,Transportation-Ship
+CTRN,Retail-Apparel/Shoes/Acc
+CTS,Electronic-Parts
+CTSH,Computer-Tech Services
+CTSO,Medical-Products
+CTV,Computer Sftwr-Enterprse
+CTVA,Agricultural Operations
+CTXR,Medical-Biomed/Biotech
+CUBA,Finance-Publ Inv Fd-Glbl
+CUBE,Finance-Property REIT
+CUBI,Banks-Northeast
+CUBT,Medical-Biomed/Biotech
+CUE,Medical-Biomed/Biotech
+CUEN,Finance-CrdtCard/PmtPr
+CUK,Leisure-Services
+CULL,Banks-Southeast
+CULP,Apparel-Clothing Mfg
+CURE,Finance-ETF / ETN
+CURI,Leisure-Movies & Related
+CURLF,Consumer Prod-Specialty
+CUROQ,Finance-Consumer Loans
+CURV,Retail-Apparel/Shoes/Acc
+CUT,Finance-ETF / ETN
+CUTR,Medical-Systems/Equip
+CUZ,Finance-Property REIT
+CVAC,Medical-Biomed/Biotech
+CVAR,Finance-ETF / ETN
+CVBF,Banks-West/Southwest
+CVCO,Bldg-Mobile/Mfg & Rv
+CVE,Oil&Gas-Integrated
+CVEO,Oil&Gas-Field Services
+CVGI,Trucks & Parts-Hvy Duty
+CVGW,Food-Misc Preparation
+CVI,Oil&Gas-Refining/Mktg
+CVIE,Finance-ETF / ETN
+CVII,Finance-Blank Check
+CVKD,Medical-Biomed/Biotech
+CVLC,Finance-ETF / ETN
+CVLG,Transportation-Truck
+CVLT,Computer Sftwr-Database
+CVLY,Banks-Northeast
+CVM,Medical-Biomed/Biotech
+CVMC,Finance-ETF / ETN
+CVNA,Retail/Whlsle-Automobile
+CVR,Auto/Truck-Original Eqp
+CVRD,Finance-ETF / ETN
+CVRT,Finance-ETF / ETN
+CVRX,Medical-Systems/Equip
+CVS,Medical-Managed Care
+CVSB,Finance-ETF / ETN
+CVSE,Finance-ETF / ETN
+CVSI,Consumer Prod-Specialty
+CVU,Aerospace/Defense
+CVV,Elec-Semiconductor Equip
+CVX,Oil&Gas-Integrated
+CVY,Finance-ETF / ETN
+CW,Aerospace/Defense
+CWAN,Financial Svcs-Specialty
+CWB,Finance-ETF / ETN
+CWBC,Banks-West/Southwest
+CWBHF,Consumer Prod-Specialty
+CWBR,Medical-Biomed/Biotech
+CWCO,Utility-Water Supply
+CWD,Finance-Investment Mgmt
+CWEB,Finance-ETF / ETN
+CWEN,Energy-Alternative/Other
+CWENA,Energy-Alternative/Other
+CWH,Retail/Whlsle-Automobile
+CWI,Finance-ETF / ETN
+CWK,Real Estate Dvlpmt/Ops
+CWS,Finance-ETF / ETN
+CWST,Pollution Control
+CWT,Utility-Water Supply
+CX,Bldg-Cement/Concrt/Ag
+CXAI,Comp Sftwr-Spec Enterprs
+CXDO,Internet-Network Sltns
+CXE,Finance-Publ Inv Fd-Bond
+CXH,Finance-Publ Inv Fd-Bond
+CXM,Computer Sftwr-Enterprse
+CXSE,Finance-ETF / ETN
+CXT,Computer Sftwr-Financial
+CXW,Security/Sfty
+CYAN,Cosmetics/Personal Care
+CYBN,Medical-Biomed/Biotech
+CYBR,Computer Sftwr-Security
+CYCC,Medical-Biomed/Biotech
+CYCN,Medical-Biomed/Biotech
+CYD,Trucks & Parts-Hvy Duty
+CYH,Medical-Hospitals
+CYN,Computer-Integrated Syst
+CYRNQ,Computer Sftwr-Security
+CYRX,Transportation-Logistics
+CYTH,Medical-Biomed/Biotech
+CYTK,Medical-Biomed/Biotech
+CYTO,Medical-Biomed/Biotech
+CZA,Finance-ETF / ETN
+CZAR,Finance-ETF / ETN
+CZFS,Banks-Northeast
+CZNC,Banks-Northeast
+CZOO,Retail/Whlsle-Automobile
+CZR,Leisure-Gaming/Equip
+CZWI,Finance-Savings & Loan
+D,Utility-Diversified
+DAC,Transportation-Ship
+DADA,Retail-Internet
+DAIO,Elec-Semiconductor Mfg
+DAKT,Elec-Misc Products
+DAL,Transportation-Airline
+DALI,Finance-ETF / ETN
+DALN,Media-Newspapers
+DALT,Finance-ETF / ETN
+DAN,Auto/Truck-Original Eqp
+DANOY,Food-Dairy Products
+DAO,Computer Sftwr-Edu/Media
+DAPP,Finance-ETF / ETN
+DAPR,Finance-ETF / ETN
+DAR,Agricultural Operations
+DARE,Medical-Biomed/Biotech
+DARP,Finance-ETF / ETN
+DASH,Retail-Internet
+DASTY,Computer Sftwr-Design
+DAT,Finance-ETF / ETN
+DATS,Internet-Content
+DAUG,Finance-ETF / ETN
+DAVA,Computer-Tech Services
+DAVE,Computer-Tech Services
+DAWN,Medical-Biomed/Biotech
+DAX,Finance-ETF / ETN
+DAY,Computer Sftwr-Enterprse
+DB,Banks-Money Center
+DBA,Finance-ETF / ETN
+DBAW,Finance-ETF / ETN
+DBB,Finance-ETF / ETN
+DBC,Finance-ETF / ETN
+DBD,Computer-Integrated Syst
+DBE,Finance-ETF / ETN
+DBEF,Finance-ETF / ETN
+DBEH,Finance-ETF / ETN
+DBEM,Finance-ETF / ETN
+DBEU,Finance-ETF / ETN
+DBEZ,Finance-ETF / ETN
+DBGI,Retail-Apparel/Shoes/Acc
+DBI,Retail-Apparel/Shoes/Acc
+DBJP,Finance-ETF / ETN
+DBL,Finance-Publ Inv Fd-Glbl
+DBMF,Finance-ETF / ETN
+DBND,Finance-ETF / ETN
+DBO,Finance-ETF / ETN
+DBOEF,Financial Svcs-Specialty
+DBP,Finance-ETF / ETN
+DBRG,Finance-Investment Mgmt
+DBSDY,Banks-Money Center
+DBVT,Medical-Biomed/Biotech
+DBX,Computer Sftwr-Database
+DC,Mining-Gold/Silver/Gems
+DCBO,Computer Sftwr-Enterprse
+DCF,Finance-Publ Inv Fd-Bond
+DCFC,Electrical-Power/Equipmt
+DCGO,Medical-Services
+DCI,Pollution Control
+DCMT,Finance-ETF / ETN
+DCO,Aerospace/Defense
+DCOM,Banks-Northeast
+DCOR,Finance-ETF / ETN
+DCPH,Medical-Biomed/Biotech
+DCRE,Finance-ETF / ETN
+DCSX,Computer-Integrated Syst
+DCTH,Medical-Products
+DD,Chemicals-Basic
+DDC,Food-Misc Preparation
+DDD,Machinery-Mtl Hdlg/Autmn
+DDEC,Finance-ETF / ETN
+DDI,Computer Sftwr-Gaming
+DDIV,Finance-ETF / ETN
+DDL,Food-Meat Products
+DDLS,Finance-ETF / ETN
+DDM,Finance-ETF / ETN
+DDOG,Computer Sftwr-Enterprse
+DDS,Retail-Department Stores
+DDWM,Finance-ETF / ETN
+DE,Machinery-Farm
+DEA,Finance-Property REIT
+DEC,Oil&Gas-U S Expl&Prod
+DECA,Finance-Blank Check
+DECK,Apparel-Shoes & Rel Mfg
+DECT,Finance-ETF / ETN
+DECW,Finance-ETF / ETN
+DECZ,Finance-ETF / ETN
+DEED,Finance-ETF / ETN
+DEEF,Finance-ETF / ETN
+DEEP,Finance-ETF / ETN
+DEFI,Finance-ETF / ETN
+DEHP,Finance-ETF / ETN
+DEI,Finance-Property REIT
+DELL,Computer-Hardware/Perip
+DEM,Finance-ETF / ETN
+DEMZ,Finance-ETF / ETN
+DENN,Retail-Restaurants
+DEO,Beverages-Alcoholic
+DERM,Medical-Biomed/Biotech
+DES,Finance-ETF / ETN
+DESK,Finance-ETF / ETN
+DESP,Leisure-Travel Booking
+DEUS,Finance-ETF / ETN
+DEW,Finance-ETF / ETN
+DFAC,Finance-ETF / ETN
+DFAE,Finance-ETF / ETN
+DFAI,Finance-ETF / ETN
+DFAR,Finance-ETF / ETN
+DFAS,Finance-ETF / ETN
+DFAT,Finance-ETF / ETN
+DFAU,Finance-ETF / ETN
+DFAW,Finance-ETF / ETN
+DFAX,Finance-ETF / ETN
+DFCA,Finance-ETF / ETN
+DFCF,Finance-ETF / ETN
+DFE,Finance-ETF / ETN
+DFEB,Finance-ETF / ETN
+DFEM,Finance-ETF / ETN
+DFEN,Finance-ETF / ETN
+DFEV,Finance-ETF / ETN
+DFGP,Finance-ETF / ETN
+DFGR,Finance-ETF / ETN
+DFGX,Finance-ETF / ETN
+DFH,Bldg-Resident/Comml
+DFHY,Finance-ETF / ETN
+DFIC,Finance-ETF / ETN
+DFIN,Financial Svcs-Specialty
+DFIP,Finance-ETF / ETN
+DFIS,Finance-ETF / ETN
+DFIV,Finance-ETF / ETN
+DFJ,Finance-ETF / ETN
+DFLI,Electrical-Power/Equipmt
+DFLV,Finance-ETF / ETN
+DFND,Finance-ETF / ETN
+DFNL,Finance-ETF / ETN
+DFNM,Finance-ETF / ETN
+DFNV,Finance-ETF / ETN
+DFP,Finance-Publ Inv Fd-Eqt
+DFRA,Finance-ETF / ETN
+DFS,Finance-CrdtCard/PmtPr
+DFSB,Finance-ETF / ETN
+DFSD,Finance-ETF / ETN
+DFSE,Finance-ETF / ETN
+DFSI,Finance-ETF / ETN
+DFSU,Finance-ETF / ETN
+DFSV,Finance-ETF / ETN
+DFUS,Finance-ETF / ETN
+DFUV,Finance-ETF / ETN
+DFVE,Finance-ETF / ETN
+DFVX,Finance-ETF / ETN
+DG,Retail-Discount&Variety
+DGCB,Finance-ETF / ETN
+DGHI,Financial Svcs-Specialty
+DGICA,Insurance-Prop/Cas/Titl
+DGICB,Insurance-Prop/Cas/Titl
+DGII,Computer-Networking
+DGIN,Finance-ETF / ETN
+DGLY,Security/Sfty
+DGP,Finance-ETF / ETN
+DGRE,Finance-ETF / ETN
+DGRO,Finance-ETF / ETN
+DGRS,Finance-ETF / ETN
+DGRW,Finance-ETF / ETN
+DGS,Finance-ETF / ETN
+DGT,Finance-ETF / ETN
+DGX,Medical-Services
+DGZ,Finance-ETF / ETN
+DH,Computer Sftwr-Medical
+DHAC,Finance-Blank Check
+DHAI,Machinery-Mtl Hdlg/Autmn
+DHC,Finance-Property REIT
+DHF,Finance-Publ Inv Fd-Bond
+DHI,Bldg-Resident/Comml
+DHIL,Finance-Investment Mgmt
+DHR,Medical-Diversified
+DHS,Finance-ETF / ETN
+DHT,Oil&Gas-Transprt/Pipelne
+DHX,Internet-Content
+DHY,Finance-Publ Inv Fd-Bond
+DIA,Finance-ETF / ETN
+DIAL,Finance-ETF / ETN
+DIAX,Finance-Publ Inv Fd-Eqt
+DIBS,Retail-Internet
+DIDIY,Leisure-Services
+DIEM,Finance-ETF / ETN
+DIG,Finance-ETF / ETN
+DIHP,Finance-ETF / ETN
+DIM,Finance-ETF / ETN
+DIN,Retail-Restaurants
+DINO,Oil&Gas-Refining/Mktg
+DINT,Finance-ETF / ETN
+DIOD,Elec-Semiconductor Mfg
+DIP,Finance-ETF / ETN
+DIS,Media-Diversified
+DISA,Finance-Blank Check
+DISH,Telecom Svcs-Cable/Satl
+DISO,Finance-ETF / ETN
+DIST,Finance-Blank Check
+DISV,Finance-ETF / ETN
+DIT,Wholesale-Food
+DIV,Finance-ETF / ETN
+DIVB,Finance-ETF / ETN
+DIVD,Finance-ETF / ETN
+DIVG,Finance-ETF / ETN
+DIVI,Finance-ETF / ETN
+DIVL,Finance-ETF / ETN
+DIVO,Finance-ETF / ETN
+DIVP,Finance-ETF / ETN
+DIVS,Finance-ETF / ETN
+DIVY,Finance-ETF / ETN
+DIVZ,Finance-ETF / ETN
+DJAN,Finance-ETF / ETN
+DJCB,Finance-ETF / ETN
+DJCO,Media-Newspapers
+DJD,Finance-ETF / ETN
+DJIA,Finance-ETF / ETN
+DJP,Finance-ETF / ETN
+DJT,Media-Diversified
+DJUL,Finance-ETF / ETN
+DJUN,Finance-ETF / ETN
+DK,Oil&Gas-Refining/Mktg
+DKILY,Bldg-A/C & Heating Prds
+DKL,Oil&Gas-Transprt/Pipelne
+DKNG,Leisure-Gaming/Equip
+DKS,Retail-Leisure Products
+DLA,Apparel-Clothing Mfg
+DLB,Elec-Misc Products
+DLHC,Comml Svcs-Staffing
+DLN,Finance-ETF / ETN
+DLNG,Oil&Gas-Transprt/Pipelne
+DLO,Finance-CrdtCard/PmtPr
+DLPN,Leisure-Movies & Related
+DLR,Finance-Property REIT
+DLS,Finance-ETF / ETN
+DLTH,Retail-Apparel/Shoes/Acc
+DLTR,Retail-Discount&Variety
+DLX,Office Supplies Mfg
+DLY,Finance-Publ Inv Fd-Glbl
+DM,Machinery-Mtl Hdlg/Autmn
+DMA,Finance-Publ Inv Fd-Bond
+DMAC,Medical-Biomed/Biotech
+DMAR,Finance-ETF / ETN
+DMAT,Finance-ETF / ETN
+DMAY,Finance-ETF / ETN
+DMB,Finance-Publ Inv Fd-Bond
+DMBS,Finance-ETF / ETN
+DMCY,Finance-ETF / ETN
+DMDV,Finance-ETF / ETN
+DMF,Finance-Publ Inv Fd-Bond
+DMKPQ,Medical-Biomed/Biotech
+DMLP,Oil&Gas-U S Expl&Prod
+DMO,Finance-Publ Inv Fd-Bond
+DMRC,Computer Sftwr-Security
+DMSL,Comml Svcs-Advertising
+DMTK,Medical-Biomed/Biotech
+DMXF,Finance-ETF / ETN
+DMYY,Finance-Blank Check
+DNA,Medical-Biomed/Biotech
+DNAB,Finance-Blank Check
+DNAD,Finance-Blank Check
+DNB,Comml Svcs-Market Rsrch
+DNKEY,Financial Svcs-Specialty
+DNL,Finance-ETF / ETN
+DNLI,Medical-Biomed/Biotech
+DNMR,Chemicals-Plastics
+DNN,Mining-Metal Ores
+DNOV,Finance-ETF / ETN
+DNOW,Oil&Gas-Machinery/Equip
+DNP,Finance-Publ Inv Fd-Bal
+DNTH,Medical-Biomed/Biotech
+DNUT,Retail-Restaurants
+DO,Oil&Gas-Drilling
+DOC,Finance-Property REIT
+DOCN,Computer Sftwr-Enterprse
+DOCS,Computer Sftwr-Medical
+DOCT,Finance-ETF / ETN
+DOCU,Computer Sftwr-Enterprse
+DOG,Finance-ETF / ETN
+DOGG,Finance-ETF / ETN
+DOGZ,Retail-Specialty
+DOL,Finance-ETF / ETN
+DOLE,Food-Misc Preparation
+DOMA,Comp Sftwr-Spec Enterprs
+DOMH,Medical-Biomed/Biotech
+DOMO,Computer Sftwr-Enterprse
+DON,Finance-ETF / ETN
+DOOO,Leisure-Products
+DOOR,Bldg-Constr Prds/Misc
+DORM,Auto/Truck-Replace Parts
+DOUG,Finance-Property REIT
+DOV,Machinery-Gen Industrial
+DOW,Chemicals-Plastics
+DOX,Computer-Tech Services
+DOYU,Internet-Content
+DPCS,Finance-Blank Check
+DPG,Finance-Publ Inv Fd-Glbl
+DPRO,Aerospace/Defense
+DPSI,Computer Sftwr-Enterprse
+DPST,Finance-ETF / ETN
+DPZ,Retail-Restaurants
+DQ,Energy-Solar
+DRCT,Internet-Content
+DRD,Mining-Gold/Silver/Gems
+DRH,Finance-Property REIT
+DRI,Retail-Restaurants
+DRIO,Medical-Products
+DRIP,Finance-ETF / ETN
+DRIV,Finance-ETF / ETN
+DRLL,Finance-ETF / ETN
+DRMA,Medical-Biomed/Biotech
+DRN,Finance-ETF / ETN
+DRQ,Oil&Gas-Machinery/Equip
+DRRX,Medical-Biomed/Biotech
+DRS,Aerospace/Defense
+DRSK,Finance-ETF / ETN
+DRTS,Medical-Biomed/Biotech
+DRTTF,Bldg-Heavy Construction
+DRUG,Medical-Biomed/Biotech
+DRUP,Finance-ETF / ETN
+DRV,Finance-ETF / ETN
+DRVN,Retail/Whlsle-Auto Parts
+DSAQ,Finance-Blank Check
+DSCF,Finance-ETF / ETN
+DSDVY,Transportation-Logistics
+DSEEY,Finance-Invest Bnk/Bkrs
+DSEP,Finance-ETF / ETN
+DSEY,Soap & Clng Preparatns
+DSGN,Medical-Biomed/Biotech
+DSGR,Machinery-Tools & Rel
+DSGX,Comp Sftwr-Spec Enterprs
+DSHK,Group not available
+DSI,Finance-ETF / ETN
+DSL,Finance-Publ Inv Fd-Eqt
+DSM,Finance-Publ Inv Fd-Bond
+DSMC,Finance-ETF / ETN
+DSP,Comml Svcs-Advertising
+DSS,Security/Sfty
+DSTL,Finance-ETF / ETN
+DSTX,Finance-ETF / ETN
+DSU,Finance-Publ Inv Fd-Bond
+DSWL,Consumer Prod-Electronic
+DSX,Transportation-Ship
+DT,Computer Sftwr-Enterprse
+DTC,Leisure-Products
+DTCK,Wholesale-Food
+DTCR,Finance-ETF / ETN
+DTD,Finance-ETF / ETN
+DTE,Utility-Diversified
+DTEAF,Retail-Specialty
+DTEC,Finance-ETF / ETN
+DTEGY,Telecom Svcs- Foreign
+DTF,Finance-Publ Inv Fd-Bond
+DTH,Finance-ETF / ETN
+DTI,Oil&Gas-Machinery/Equip
+DTIL,Medical-Biomed/Biotech
+DTM,Oil&Gas-Transprt/Pipelne
+DTRE,Finance-ETF / ETN
+DTSS,Computer-Networking
+DTST,Computer Sftwr-Database
+DUBS,Finance-ETF / ETN
+DUDE,Finance-ETF / ETN
+DUET,Finance-Blank Check
+DUG,Finance-ETF / ETN
+DUHP,Finance-ETF / ETN
+DUK,Utility-Diversified
+DULL,Finance-ETF / ETN
+DUO,Internet-Content
+DUOL,Computer Sftwr-Edu/Media
+DUOT,Computer Sftwr-Enterprse
+DURA,Finance-ETF / ETN
+DUSA,Finance-ETF / ETN
+DUSB,Finance-ETF / ETN
+DUSL,Finance-ETF / ETN
+DUST,Finance-ETF / ETN
+DV,Comp Sftwr-Spec Enterprs
+DVA,Medical-Outpnt/Hm Care
+DVAL,Finance-ETF / ETN
+DVAX,Medical-Biomed/Biotech
+DVDN,Finance-ETF / ETN
+DVLU,Finance-ETF / ETN
+DVN,Oil&Gas-U S Expl&Prod
+DVND,Finance-ETF / ETN
+DVOL,Finance-ETF / ETN
+DVY,Finance-ETF / ETN
+DVYA,Finance-ETF / ETN
+DVYE,Finance-ETF / ETN
+DWAS,Finance-ETF / ETN
+DWAT,Finance-ETF / ETN
+DWAW,Finance-ETF / ETN
+DWCR,Finance-ETF / ETN
+DWLD,Finance-ETF / ETN
+DWM,Finance-ETF / ETN
+DWMF,Finance-ETF / ETN
+DWSH,Finance-ETF / ETN
+DWSN,Oil&Gas-Field Services
+DWUS,Finance-ETF / ETN
+DWX,Finance-ETF / ETN
+DX,Finance-Mortgage REIT
+DXC,Computer-Tech Services
+DXCM,Medical-Products
+DXD,Finance-ETF / ETN
+DXF,Finance-Commercial Loans
+DXJ,Finance-ETF / ETN
+DXJS,Finance-ETF / ETN
+DXLG,Retail-Apparel/Shoes/Acc
+DXPE,Machinery-Gen Industrial
+DXR,Medical-Systems/Equip
+DXYN,Retail-Home Furnishings
+DXYZ,Finance-Publ Inv Fd-Eqt
+DY,Telecom-Infrastructure
+DYAI,Medical-Biomed/Biotech
+DYFI,Finance-ETF / ETN
+DYLD,Finance-ETF / ETN
+DYLG,Finance-ETF / ETN
+DYN,Medical-Biomed/Biotech
+DYNF,Finance-ETF / ETN
+DYNI,Finance-ETF / ETN
+DYNT,Medical-Systems/Equip
+DYTA,Finance-ETF / ETN
+DZSI,Telecom-Fiber Optics
+DZZ,Finance-ETF / ETN
+E,Oil&Gas-Integrated
+EA,Computer Sftwr-Gaming
+EAD,Finance-Publ Inv Fd-Bond
+EADSY,Aerospace/Defense
+EAF,Steel-Specialty Alloys
+EAFG,Finance-ETF / ETN
+EAGG,Finance-ETF / ETN
+EAGL,Finance-ETF / ETN
+EALT,Finance-ETF / ETN
+EAOA,Finance-ETF / ETN
+EAOK,Finance-ETF / ETN
+EAOM,Finance-ETF / ETN
+EAOR,Finance-ETF / ETN
+EAPR,Finance-ETF / ETN
+EARN,Finance-Mortgage REIT
+EASG,Finance-ETF / ETN
+EAST,Beverages-Alcoholic
+EAT,Retail-Restaurants
+EATV,Finance-ETF / ETN
+EATZ,Finance-ETF / ETN
+EB,Computer Sftwr-Edu/Media
+EBAY,Retail-Internet
+EBC,Banks-Northeast
+EBET,Leisure-Gaming/Equip
+EBF,Office Supplies Mfg
+EBIXQ,Computer Sftwr-Enterprse
+EBIZ,Finance-ETF / ETN
+EBLU,Finance-ETF / ETN
+EBMT,Banks-West/Southwest
+EBND,Finance-ETF / ETN
+EBON,Elec-Semicondctor Fablss
+EBR,Utility-Electric Power
+EBRB,Utility-Electric Power
+EBS,Medical-Biomed/Biotech
+EBTC,Banks-Northeast
+EC,Oil&Gas-Integrated
+ECAT,Finance-Publ Inv Fd-Eqt
+ECBK,Banks-Northeast
+ECC,Finance-Publ Inv Fd-Bond
+ECDA,Retail/Whlsle-Automobile
+ECF,Finance-Publ Inv Fd-Bond
+ECH,Finance-ETF / ETN
+ECL,Soap & Clng Preparatns
+ECLN,Finance-ETF / ETN
+ECML,Finance-ETF / ETN
+ECNS,Finance-ETF / ETN
+ECO,Transportation-Ship
+ECON,Finance-ETF / ETN
+ECOR,Medical-Biomed/Biotech
+ECOW,Finance-ETF / ETN
+ECPG,Financial Svcs-Specialty
+ECVT,Chemicals-Basic
+ECX,Comp Sftwr-Spec Enterprs
+ED,Utility-Diversified
+EDAP,Medical-Systems/Equip
+EDBL,Agricultural Operations
+EDC,Finance-ETF / ETN
+EDD,Finance-Publ Inv Fd-Glbl
+EDEN,Finance-ETF / ETN
+EDF,Finance-Publ Inv Fd-Glbl
+EDI,Finance-Publ Inv Fd-Bond
+EDIT,Medical-Biomed/Biotech
+EDIV,Finance-ETF / ETN
+EDN,Utility-Electric Power
+EDOC,Finance-ETF / ETN
+EDOG,Finance-ETF / ETN
+EDOW,Finance-ETF / ETN
+EDPFY,Utility-Electric Power
+EDR,Leisure-Services
+EDRY,Transportation-Ship
+EDSA,Medical-Biomed/Biotech
+EDTK,Consumer Svcs-Education
+EDU,Consumer Svcs-Education
+EDUC,Media-Books
+EDV,Finance-ETF / ETN
+EDZ,Finance-ETF / ETN
+EE,Utility-Gas Distribution
+EEA,Finance-Publ Inv Fd-Glbl
+EEFT,Finance-CrdtCard/PmtPr
+EEIQ,Consumer Svcs-Education
+EELV,Finance-ETF / ETN
+EEM,Finance-ETF / ETN
+EEMA,Finance-ETF / ETN
+EEMD,Finance-ETF / ETN
+EEMO,Finance-ETF / ETN
+EEMS,Finance-ETF / ETN
+EEMV,Finance-ETF / ETN
+EEMX,Finance-ETF / ETN
+EES,Finance-ETF / ETN
+EET,Finance-ETF / ETN
+EETH,Finance-ETF / ETN
+EEV,Finance-ETF / ETN
+EEX,Comml Svcs-Advertising
+EFA,Finance-ETF / ETN
+EFAD,Finance-ETF / ETN
+EFAS,Finance-ETF / ETN
+EFAV,Finance-ETF / ETN
+EFAX,Finance-ETF / ETN
+EFC,Finance-Investment Mgmt
+EFG,Finance-ETF / ETN
+EFIV,Finance-ETF / ETN
+EFIX,Finance-ETF / ETN
+EFNL,Finance-ETF / ETN
+EFO,Finance-ETF / ETN
+EFOI,Bldg-Constr Prds/Misc
+EFR,Finance-Publ Inv Fd-Bond
+EFRA,Finance-ETF / ETN
+EFSC,Banks-Midwest
+EFSH,Diversified Operations
+EFT,Finance-Publ Inv Fd-Bond
+EFTR,Medical-Biomed/Biotech
+EFU,Finance-ETF / ETN
+EFUT,Finance-ETF / ETN
+EFV,Finance-ETF / ETN
+EFX,Financial Svcs-Specialty
+EFXT,Oil&Gas-Machinery/Equip
+EFZ,Finance-ETF / ETN
+EG,Insurance-Prop/Cas/Titl
+EGAN,Computer Sftwr-Enterprse
+EGBN,Banks-Northeast
+EGF,Finance-Publ Inv Fd-Bond
+EGHT,Computer Sftwr-Enterprse
+EGIO,Internet-Network Sltns
+EGLE,Transportation-Ship
+EGLXF,Computer Sftwr-Gaming
+EGO,Mining-Gold/Silver/Gems
+EGOX,Auto Manufacturers
+EGP,Finance-Property REIT
+EGRX,Medical-Generic Drugs
+EGUS,Finance-ETF / ETN
+EGY,Oil&Gas-Intl Expl&Prod
+EH,Aerospace/Defense
+EHAB,Medical-Outpnt/Hm Care
+EHC,Medical-Outpnt/Hm Care
+EHI,Finance-Publ Inv Fd-Bond
+EHTH,Insurance-Brokers
+EIC,Finance-Publ Inv Fd-Bond
+EIDO,Finance-ETF / ETN
+EIG,Insurance-Prop/Cas/Titl
+EIGR,Medical-Biomed/Biotech
+EIM,Finance-Publ Inv Fd-Bond
+EINC,Finance-ETF / ETN
+EIPX,Finance-ETF / ETN
+EIRL,Finance-ETF / ETN
+EIS,Finance-ETF / ETN
+EIX,Utility-Electric Power
+EJAN,Finance-ETF / ETN
+EJH,Bldg-Maintenance & Svc
+EJPRY,Transportation-Rail
+EJUL,Finance-ETF / ETN
+EKG,Finance-ETF / ETN
+EKSO,Medical-Products
+EL,Cosmetics/Personal Care
+ELA,Retail/Whlsle-Jewelry
+ELAB,Cosmetics/Personal Care
+ELAN,Medical-Supplies
+ELBM,Electrical-Power/Equipmt
+ELD,Finance-ETF / ETN
+ELDN,Medical-Biomed/Biotech
+ELEV,Medical-Biomed/Biotech
+ELF,Cosmetics/Personal Care
+ELIQ,Utility-Electric Power
+ELLO,Energy-Alternative/Other
+ELMD,Medical-Systems/Equip
+ELME,Finance-Property REIT
+ELMSQ,Group not available
+ELOX,Medical-Biomed/Biotech
+ELP,Utility-Electric Power
+ELPC,Utility-Electric Power
+ELQD,Finance-ETF / ETN
+ELS,Finance-Property REIT
+ELSE,Machinery-Gen Industrial
+ELTK,Elec-Contract Mfg
+ELTP,Medical-Ethical Drugs
+ELTX,Medical-Biomed/Biotech
+ELUT,Medical-Products
+ELUXY,Hsehold-Appliances/Wares
+ELV,Medical-Managed Care
+ELVA,Auto/Truck-Original Eqp
+ELVN,Medical-Biomed/Biotech
+ELWS,Computer Sftwr-Financial
+ELYM,Medical-Biomed/Biotech
+ELYS,Leisure-Gaming/Equip
+EM,Electrical-Power/Equipmt
+EMB,Finance-ETF / ETN
+EMBC,Medical-Supplies
+EMBD,Finance-ETF / ETN
+EMC,Finance-ETF / ETN
+EMCA,Finance-ETF / ETN
+EMCB,Finance-ETF / ETN
+EMCC,Finance-ETF / ETN
+EMCG,Finance-Blank Check
+EMCH,Finance-ETF / ETN
+EMCR,Finance-ETF / ETN
+EMD,Finance-Publ Inv Fd-Glbl
+EMDM,Finance-ETF / ETN
+EMDV,Finance-ETF / ETN
+EME,Bldg-Maintenance & Svc
+EMF,Finance-Publ Inv Fd-Glbl
+EMFM,Finance-ETF / ETN
+EMFQ,Finance-ETF / ETN
+EMGC,Finance-ETF / ETN
+EMGF,Finance-ETF / ETN
+EMHC,Finance-ETF / ETN
+EMHY,Finance-ETF / ETN
+EMIF,Finance-ETF / ETN
+EMKR,Elec-Misc Products
+EML,Security/Sfty
+EMLC,Finance-ETF / ETN
+EMLD,Finance-Blank Check
+EMLP,Finance-ETF / ETN
+EMM,Finance-ETF / ETN
+EMMF,Finance-ETF / ETN
+EMN,Chemicals-Plastics
+EMNT,Finance-ETF / ETN
+EMO,Finance-Publ Inv Fd-Eqt
+EMPW,Finance-ETF / ETN
+EMQQ,Finance-ETF / ETN
+EMR,Diversified Operations
+EMSF,Finance-ETF / ETN
+EMSG,Finance-ETF / ETN
+EMTL,Finance-ETF / ETN
+EMTY,Finance-ETF / ETN
+EMWPF,Group not available
+EMX,Mining-Gold/Silver/Gems
+EMXC,Finance-ETF / ETN
+EMXF,Finance-ETF / ETN
+EMZA,Finance-ETF / ETN
+ENB,Oil&Gas-Transprt/Pipelne
+ENDPQ,Group not available
+ENFN,Computer Sftwr-Enterprse
+ENFR,Finance-ETF / ETN
+ENG,Bldg-Heavy Construction
+ENGN,Medical-Generic Drugs
+ENIC,Utility-Electric Power
+ENLC,Oil&Gas-Transprt/Pipelne
+ENLT,Energy-Alternative/Other
+ENLV,Medical-Biomed/Biotech
+ENOR,Finance-ETF / ETN
+ENOV,Medical-Products
+ENPH,Energy-Solar
+ENR,Consumer Prod-Specialty
+ENS,Electrical-Power/Equipmt
+ENSC,Medical-Biomed/Biotech
+ENSG,Medical-Long-term Care
+ENSV,Oil&Gas-Field Services
+ENTA,Medical-Biomed/Biotech
+ENTF,Finance-Blank Check
+ENTG,Elec-Semiconductor Equip
+ENTR,Finance-ETF / ETN
+ENTX,Medical-Biomed/Biotech
+ENV,Financial Svcs-Specialty
+ENVA,Finance-Consumer Loans
+ENVB,Medical-Biomed/Biotech
+ENVX,Electrical-Power/Equipmt
+ENX,Finance-Publ Inv Fd-Bond
+ENZ,Medical-Research Eqp/Svc
+ENZL,Finance-ETF / ETN
+EOCT,Finance-ETF / ETN
+EOCW,Finance-Blank Check
+EOD,Finance-Publ Inv Fd-Glbl
+EOG,Oil&Gas-U S Expl&Prod
+EOI,Finance-Publ Inv Fd-Eqt
+EOLS,Medical-Ethical Drugs
+EONGY,Utility-Diversified
+EOS,Finance-Publ Inv Fd-Eqt
+EOSE,Electrical-Power/Equipmt
+EOT,Finance-Publ Inv Fd-Bond
+EP,Oil&Gas-U S Expl&Prod
+EPAC,Machinery-Tools & Rel
+EPAM,Computer-Tech Services
+EPC,Cosmetics/Personal Care
+EPD,Oil&Gas-Transprt/Pipelne
+EPHE,Finance-ETF / ETN
+EPI,Finance-ETF / ETN
+EPIX,Medical-Biomed/Biotech
+EPM,Oil&Gas-U S Expl&Prod
+EPOL,Finance-ETF / ETN
+EPOW,Electrical-Power/Equipmt
+EPP,Finance-ETF / ETN
+EPR,Finance-Property REIT
+EPRF,Finance-ETF / ETN
+EPRT,Finance-Property REIT
+EPS,Finance-ETF / ETN
+EPSN,Oil&Gas-U S Expl&Prod
+EPU,Finance-ETF / ETN
+EPV,Finance-ETF / ETN
+EQ,Medical-Biomed/Biotech
+EQAL,Finance-ETF / ETN
+EQBK,Banks-Midwest
+EQC,Finance-Property REIT
+EQH,Finance-Investment Mgmt
+EQIX,Finance-Property REIT
+EQL,Finance-ETF / ETN
+EQLS,Finance-ETF / ETN
+EQNR,Oil&Gas-Integrated
+EQOP,Finance-ETF / ETN
+EQOSQ,Group not available
+EQR,Finance-Property REIT
+EQRR,Finance-ETF / ETN
+EQS,Finance-Investment Mgmt
+EQT,Oil&Gas-Integrated
+EQTY,Finance-ETF / ETN
+EQUL,Finance-ETF / ETN
+EQWL,Finance-ETF / ETN
+EQX,Mining-Gold/Silver/Gems
+ERAS,Medical-Biomed/Biotech
+ERC,Finance-Publ Inv Fd-Bond
+ERET,Finance-ETF / ETN
+ERF,Oil&Gas-Cdn Expl&Prod
+ERH,Finance-Publ Inv Fd-Bal
+ERIC,Telecom-Infrastructure
+ERIE,Insurance-Brokers
+ERII,Machinery-Gen Industrial
+ERJ,Aerospace/Defense
+ERM,Finance-ETF / ETN
+ERNA,Medical-Biomed/Biotech
+ERO,Mining-Metal Ores
+ERTH,Finance-ETF / ETN
+ERX,Finance-ETF / ETN
+ERY,Finance-ETF / ETN
+ES,Utility-Electric Power
+ESAB,Machinery-Gen Industrial
+ESCA,Leisure-Products
+ESE,Machinery-Gen Industrial
+ESEA,Transportation-Ship
+ESG,Finance-ETF / ETN
+ESGA,Finance-ETF / ETN
+ESGB,Finance-ETF / ETN
+ESGD,Finance-ETF / ETN
+ESGE,Finance-ETF / ETN
+ESGG,Finance-ETF / ETN
+ESGL,Pollution Control
+ESGN,Finance-ETF / ETN
+ESGR,Insurance-Prop/Cas/Titl
+ESGS,Finance-ETF / ETN
+ESGU,Finance-ETF / ETN
+ESGV,Finance-ETF / ETN
+ESGY,Finance-ETF / ETN
+ESHA,Finance-Blank Check
+ESI,Chemicals-Specialty
+ESIX,Finance-ETF / ETN
+ESLA,Medical-Biomed/Biotech
+ESLOY,Medical-Products
+ESLT,Aerospace/Defense
+ESML,Finance-ETF / ETN
+ESMV,Finance-ETF / ETN
+ESNT,Finance-Mrtg&Rel Svc
+ESOA,Oil&Gas-Transprt/Pipelne
+ESP,Aerospace/Defense
+ESPO,Finance-ETF / ETN
+ESPR,Medical-Biomed/Biotech
+ESQ,Finance-Commercial Loans
+ESRT,Finance-Property REIT
+ESS,Finance-Property REIT
+ESSA,Finance-Savings & Loan
+ESTA,Medical-Products
+ESTC,Computer Sftwr-Database
+ESUS,Finance-ETF / ETN
+ET,Oil&Gas-Transprt/Pipelne
+ETAO,Medical-Hospitals
+ETB,Finance-Publ Inv Fd-Eqt
+ETD,Retail-Home Furnishings
+ETEC,Finance-ETF / ETN
+ETG,Finance-Publ Inv Fd-Eqt
+ETHE,Finance-Publ Inv Fd-Eqt
+ETHO,Finance-ETF / ETN
+ETJ,Finance-Publ Inv Fd-Eqt
+ETN,Diversified Operations
+ETNB,Medical-Biomed/Biotech
+ETO,Finance-Publ Inv Fd-Glbl
+ETON,Medical-Biomed/Biotech
+ETR,Utility-Electric Power
+ETRN,Oil&Gas-Transprt/Pipelne
+ETSY,Retail-Internet
+ETV,Finance-Publ Inv Fd-Eqt
+ETW,Finance-Publ Inv Fd-Glbl
+ETWO,Computer Sftwr-Enterprse
+ETX,Finance-Publ Inv Fd-Bond
+ETY,Finance-Publ Inv Fd-Eqt
+EU,Mining-Metal Ores
+EUDA,Computer Sftwr-Medical
+EUDG,Finance-ETF / ETN
+EUDV,Finance-ETF / ETN
+EUFN,Finance-ETF / ETN
+EUM,Finance-ETF / ETN
+EUO,Finance-ETF / ETN
+EURL,Finance-ETF / ETN
+EURN,Oil&Gas-Transprt/Pipelne
+EUSA,Finance-ETF / ETN
+EUSB,Finance-ETF / ETN
+EUSC,Finance-ETF / ETN
+EV,Finance-ETF / ETN
+EVA,Energy-Alternative/Other
+EVAV,Finance-ETF / ETN
+EVAX,Medical-Biomed/Biotech
+EVBG,Computer Sftwr-Enterprse
+EVBN,Banks-Northeast
+EVC,Media-Radio/Tv
+EVCM,Computer Sftwr-Enterprse
+EVE,Finance-Blank Check
+EVER,Insurance-Diversified
+EVEX,Aerospace/Defense
+EVF,Finance-Publ Inv Fd-Bond
+EVFM,Group not available
+EVG,Finance-Publ Inv Fd-Glbl
+EVGN,Agricultural Operations
+EVGO,Electrical-Power/Equipmt
+EVGR,Finance-Blank Check
+EVH,Computer Sftwr-Medical
+EVHY,Finance-ETF / ETN
+EVI,Machinery-Gen Industrial
+EVIM,Finance-ETF / ETN
+EVKG,Group not available
+EVLN,Finance-ETF / ETN
+EVLO,Medical-Biomed/Biotech
+EVLV,Security/Sfty
+EVM,Finance-Publ Inv Fd-Bond
+EVMT,Finance-ETF / ETN
+EVN,Finance-Publ Inv Fd-Bond
+EVNT,Finance-ETF / ETN
+EVO,Medical-Biomed/Biotech
+EVOK,Medical-Biomed/Biotech
+EVOL,Group not available
+EVR,Finance-Invest Bnk/Bkrs
+EVRG,Utility-Electric Power
+EVRI,Finance-CrdtCard/PmtPr
+EVSB,Finance-ETF / ETN
+EVSM,Finance-ETF / ETN
+EVT,Finance-Publ Inv Fd-Eqt
+EVTC,Finance-CrdtCard/PmtPr
+EVTL,Aerospace/Defense
+EVTR,Finance-ETF / ETN
+EVTV,Auto Manufacturers
+EVUS,Finance-ETF / ETN
+EVV,Finance-Publ Inv Fd-Bond
+EVVTY,Leisure-Gaming/Equip
+EVX,Finance-ETF / ETN
+EW,Medical-Products
+EWA,Finance-ETF / ETN
+EWBC,Banks-West/Southwest
+EWC,Finance-ETF / ETN
+EWCZ,Cosmetics/Personal Care
+EWD,Finance-ETF / ETN
+EWG,Finance-ETF / ETN
+EWH,Finance-ETF / ETN
+EWI,Finance-ETF / ETN
+EWJ,Finance-ETF / ETN
+EWJV,Finance-ETF / ETN
+EWK,Finance-ETF / ETN
+EWL,Finance-ETF / ETN
+EWM,Finance-ETF / ETN
+EWN,Finance-ETF / ETN
+EWO,Finance-ETF / ETN
+EWP,Finance-ETF / ETN
+EWQ,Finance-ETF / ETN
+EWS,Finance-ETF / ETN
+EWT,Finance-ETF / ETN
+EWTX,Medical-Biomed/Biotech
+EWU,Finance-ETF / ETN
+EWUS,Finance-ETF / ETN
+EWV,Finance-ETF / ETN
+EWW,Finance-ETF / ETN
+EWX,Finance-ETF / ETN
+EWY,Finance-ETF / ETN
+EWZ,Finance-ETF / ETN
+EWZS,Finance-ETF / ETN
+EXAI,Medical-Biomed/Biotech
+EXAS,Medical-Biomed/Biotech
+EXC,Utility-Diversified
+EXEL,Medical-Biomed/Biotech
+EXFY,Computer Sftwr-Financial
+EXG,Finance-Publ Inv Fd-Glbl
+EXI,Finance-ETF / ETN
+EXK,Mining-Gold/Silver/Gems
+EXLS,Comml Svcs-Outsourcing
+EXNRF,Group not available
+EXP,Bldg-Cement/Concrt/Ag
+EXPD,Transportation-Logistics
+EXPE,Leisure-Travel Booking
+EXPI,Real Estate Dvlpmt/Ops
+EXPO,Comml Svcs-Consulting
+EXPR,Retail-Apparel/Shoes/Acc
+EXR,Finance-Property REIT
+EXTO,Retail-Super/Mini Mkts
+EXTR,Computer-Networking
+EYE,Retail-Specialty
+EYEG,Finance-ETF / ETN
+EYEN,Medical-Biomed/Biotech
+EYLD,Finance-ETF / ETN
+EYPT,Medical-Biomed/Biotech
+EZA,Finance-ETF / ETN
+EZBC,Finance-ETF / ETN
+EZFL,Oil&Gas-Transprt/Pipelne
+EZGO,Electrical-Power/Equipmt
+EZJ,Finance-ETF / ETN
+EZM,Finance-ETF / ETN
+EZPW,Finance-Consumer Loans
+EZU,Finance-ETF / ETN
+F,Auto Manufacturers
+FA,Comml Svcs-Staffing
+FAAR,Finance-ETF / ETN
+FAB,Finance-ETF / ETN
+FAD,Finance-ETF / ETN
+FAF,Insurance-Prop/Cas/Titl
+FAIL,Finance-ETF / ETN
+FALN,Finance-ETF / ETN
+FAM,Finance-Publ Inv Fd-Glbl
+FAMI,Food-Packaged
+FAN,Finance-ETF / ETN
+FANG,Oil&Gas-U S Expl&Prod
+FANH,Insurance-Brokers
+FANUY,Machinery-Mtl Hdlg/Autmn
+FAPR,Finance-ETF / ETN
+FARM,Wholesale-Food
+FARO,Elec-Scientific/Msrng
+FAS,Finance-ETF / ETN
+FAST,Machinery-Tools & Rel
+FAT,Retail-Restaurants
+FATBB,Retail-Restaurants
+FATE,Medical-Biomed/Biotech
+FATH,Retail-Internet
+FATP,Finance-Blank Check
+FAUG,Finance-ETF / ETN
+FAX,Finance-Publ Inv Fd-Glbl
+FAZ,Finance-ETF / ETN
+FBCG,Finance-ETF / ETN
+FBCV,Finance-ETF / ETN
+FBGX,Finance-ETF / ETN
+FBIN,Bldg-Constr Prds/Misc
+FBIO,Medical-Biomed/Biotech
+FBIZ,Banks-Midwest
+FBK,Banks-Southeast
+FBL,Finance-ETF / ETN
+FBLG,Medical-Biomed/Biotech
+FBMS,Banks-Southeast
+FBNC,Banks-Southeast
+FBND,Finance-ETF / ETN
+FBOT,Finance-ETF / ETN
+FBP,Banks-Southeast
+FBRT,Finance-Property REIT
+FBRX,Medical-Biomed/Biotech
+FBT,Finance-ETF / ETN
+FBTC,Finance-ETF / ETN
+FBY,Finance-ETF / ETN
+FBYD,Leisure-Services
+FBZ,Finance-ETF / ETN
+FC,Consumer Svcs-Education
+FCA,Finance-ETF / ETN
+FCAL,Finance-ETF / ETN
+FCAP,Finance-Savings & Loan
+FCBC,Banks-Southeast
+FCCO,Banks-Southeast
+FCEF,Finance-ETF / ETN
+FCEL,Energy-Alternative/Other
+FCF,Banks-Northeast
+FCFS,Finance-Consumer Loans
+FCFY,Finance-ETF / ETN
+FCG,Finance-ETF / ETN
+FCLD,Finance-ETF / ETN
+FCN,Comml Svcs-Consulting
+FCNCA,Banks-Southeast
+FCO,Finance-Publ Inv Fd-Glbl
+FCOM,Finance-ETF / ETN
+FCOR,Finance-ETF / ETN
+FCPI,Finance-ETF / ETN
+FCPT,Finance-Property REIT
+FCSH,Finance-ETF / ETN
+FCT,Finance-Publ Inv Fd-Bond
+FCTR,Finance-ETF / ETN
+FCUS,Finance-ETF / ETN
+FCUV,Telecom Svcs-Wireless
+FCVT,Finance-ETF / ETN
+FCX,Mining-Metal Ores
+FDAT,Finance-ETF / ETN
+FDBC,Banks-Northeast
+FDCE,Finance-ETF / ETN
+FDCF,Finance-ETF / ETN
+FDD,Finance-ETF / ETN
+FDEC,Finance-ETF / ETN
+FDEM,Finance-ETF / ETN
+FDEV,Finance-ETF / ETN
+FDFF,Finance-ETF / ETN
+FDG,Finance-ETF / ETN
+FDGR,Finance-ETF / ETN
+FDHT,Finance-ETF / ETN
+FDHY,Finance-ETF / ETN
+FDIF,Finance-ETF / ETN
+FDIG,Finance-ETF / ETN
+FDIS,Finance-ETF / ETN
+FDIV,Finance-ETF / ETN
+FDL,Finance-ETF / ETN
+FDLO,Finance-ETF / ETN
+FDLS,Finance-ETF / ETN
+FDM,Finance-ETF / ETN
+FDMO,Finance-ETF / ETN
+FDMT,Medical-Biomed/Biotech
+FDN,Finance-ETF / ETN
+FDND,Finance-ETF / ETN
+FDNI,Finance-ETF / ETN
+FDP,Food-Misc Preparation
+FDRR,Finance-ETF / ETN
+FDRV,Finance-ETF / ETN
+FDS,Comml Svcs-Market Rsrch
+FDT,Finance-ETF / ETN
+FDTB,Finance-ETF / ETN
+FDTS,Finance-ETF / ETN
+FDTX,Finance-ETF / ETN
+FDUS,Finance-Investment Mgmt
+FDV,Finance-ETF / ETN
+FDVL,Finance-ETF / ETN
+FDVV,Finance-ETF / ETN
+FDWM,Finance-ETF / ETN
+FDX,Transport-Air Freight
+FE,Utility-Electric Power
+FEAM,Mining-Metal Ores
+FEBO,Consumer Prod-Electronic
+FEBP,Finance-ETF / ETN
+FEBT,Finance-ETF / ETN
+FEBW,Finance-ETF / ETN
+FEBZ,Finance-ETF / ETN
+FEDL,Finance-ETF / ETN
+FEDM,Finance-ETF / ETN
+FEDU,Consumer Svcs-Education
+FEEM,Finance-ETF / ETN
+FEHY,Finance-ETF / ETN
+FEI,Finance-Publ Inv Fd-Eqt
+FEIG,Finance-ETF / ETN
+FEIM,Telecom-Cable/Satl Eqp
+FELC,Finance-ETF / ETN
+FELE,Electrical-Power/Equipmt
+FELG,Finance-ETF / ETN
+FELV,Finance-ETF / ETN
+FEM,Finance-ETF / ETN
+FEMB,Finance-ETF / ETN
+FEMS,Finance-ETF / ETN
+FEMY,Medical-Systems/Equip
+FEN,Finance-Publ Inv Fd-Eqt
+FENC,Medical-Biomed/Biotech
+FENG,Internet-Content
+FENI,Finance-ETF / ETN
+FENY,Finance-ETF / ETN
+FEP,Finance-ETF / ETN
+FEPI,Finance-ETF / ETN
+FERG,Bldg-Constr Prds/Misc
+FESM,Finance-ETF / ETN
+FET,Oil&Gas-Machinery/Equip
+FEUS,Finance-ETF / ETN
+FEUZ,Finance-ETF / ETN
+FEX,Finance-ETF / ETN
+FEXD,Finance-Blank Check
+FEZ,Finance-ETF / ETN
+FF,Chemicals-Specialty
+FFA,Finance-Publ Inv Fd-Eqt
+FFBC,Finance-Savings & Loan
+FFBW,Finance-Savings & Loan
+FFC,Finance-Publ Inv Fd-Eqt
+FFEB,Finance-ETF / ETN
+FFIC,Banks-Northeast
+FFIE,Auto Manufacturers
+FFIN,Banks-West/Southwest
+FFIU,Finance-ETF / ETN
+FFIV,Internet-Network Sltns
+FFLC,Finance-ETF / ETN
+FFLG,Finance-ETF / ETN
+FFLS,Finance-ETF / ETN
+FFLV,Finance-ETF / ETN
+FFND,Finance-ETF / ETN
+FFNTF,Consumer Prod-Specialty
+FFNW,Finance-Savings & Loan
+FFOG,Finance-ETF / ETN
+FFSM,Finance-ETF / ETN
+FFTY,Finance-ETF / ETN
+FFWM,Banks-West/Southwest
+FG,Insurance-Life
+FGB,Finance-Publ Inv Fd-Glbl
+FGBI,Banks-Southeast
+FGD,Finance-ETF / ETN
+FGDL,Finance-ETF / ETN
+FGEN,Medical-Biomed/Biotech
+FGF,Insurance-Diversified
+FGI,Retail-Home Furnishings
+FGM,Finance-ETF / ETN
+FGROY,Transportation-Logistics
+FHB,Banks-West/Southwest
+FHI,Finance-Investment Mgmt
+FHLC,Finance-ETF / ETN
+FHLT,Finance-Blank Check
+FHN,Banks-Southeast
+FHTX,Medical-Biomed/Biotech
+FHYS,Finance-ETF / ETN
+FI,Financial Svcs-Specialty
+FIAC,Finance-Blank Check
+FIAX,Finance-ETF / ETN
+FIBK,Banks-West/Southwest
+FIBR,Finance-ETF / ETN
+FICO,Computer Sftwr-Financial
+FICS,Finance-ETF / ETN
+FID,Finance-ETF / ETN
+FIDI,Finance-ETF / ETN
+FIDU,Finance-ETF / ETN
+FIF,Finance-Publ Inv Fd-Eqt
+FIG,Finance-ETF / ETN
+FIGB,Finance-ETF / ETN
+FIGS,Apparel-Clothing Mfg
+FIHL,Insurance-Prop/Cas/Titl
+FIIG,Finance-ETF / ETN
+FILL,Finance-ETF / ETN
+FINE,Finance-ETF / ETN
+FINS,Finance-Publ Inv Fd-Eqt
+FINV,Financial Svcs-Specialty
+FINW,Banks-West/Southwest
+FINX,Finance-ETF / ETN
+FIP,Transportation-Equip Mfg
+FIS,Financial Svcs-Specialty
+FISI,Banks-Northeast
+FISR,Finance-ETF / ETN
+FITB,Banks-Super Regional
+FITE,Finance-ETF / ETN
+FIVA,Finance-ETF / ETN
+FIVE,Retail-Discount&Variety
+FIVG,Finance-ETF / ETN
+FIVN,Computer Sftwr-Enterprse
+FIW,Finance-ETF / ETN
+FIX,Bldg-A/C & Heating Prds
+FIXD,Finance-ETF / ETN
+FIXT,Finance-ETF / ETN
+FIZZ,Beverages-Non-Alcoholic
+FJAN,Finance-ETF / ETN
+FJP,Finance-ETF / ETN
+FJTSY,Computer-Tech Services
+FJUL,Finance-ETF / ETN
+FJUN,Finance-ETF / ETN
+FKU,Finance-ETF / ETN
+FKWL,Telecom-Cable/Satl Eqp
+FL,Retail-Apparel/Shoes/Acc
+FLAO,Group not available
+FLAU,Finance-ETF / ETN
+FLAX,Finance-ETF / ETN
+FLBL,Finance-ETF / ETN
+FLBR,Finance-ETF / ETN
+FLC,Finance-Publ Inv Fd-Bond
+FLCA,Finance-ETF / ETN
+FLCB,Finance-ETF / ETN
+FLCH,Finance-ETF / ETN
+FLCO,Finance-ETF / ETN
+FLDB,Finance-ETF / ETN
+FLDR,Finance-ETF / ETN
+FLDZ,Finance-ETF / ETN
+FLEE,Finance-ETF / ETN
+FLEU,Finance-ETF / ETN
+FLEX,Elec-Contract Mfg
+FLFV,Finance-Blank Check
+FLGB,Finance-ETF / ETN
+FLGC,Consumer Prod-Specialty
+FLGR,Finance-ETF / ETN
+FLGT,Medical-Research Eqp/Svc
+FLGV,Finance-ETF / ETN
+FLHK,Finance-ETF / ETN
+FLHY,Finance-ETF / ETN
+FLIA,Finance-ETF / ETN
+FLIC,Banks-Northeast
+FLIN,Finance-ETF / ETN
+FLJ,Real Estate Dvlpmt/Ops
+FLJH,Finance-ETF / ETN
+FLJJ,Finance-ETF / ETN
+FLJP,Finance-ETF / ETN
+FLKR,Finance-ETF / ETN
+FLL,Leisure-Gaming/Equip
+FLLA,Finance-ETF / ETN
+FLLV,Finance-ETF / ETN
+FLMB,Finance-ETF / ETN
+FLMI,Finance-ETF / ETN
+FLMX,Finance-ETF / ETN
+FLN,Finance-ETF / ETN
+FLNC,Energy-Alternative/Other
+FLNG,Oil&Gas-Transprt/Pipelne
+FLNT,Comml Svcs-Advertising
+FLO,Food-Packaged
+FLOT,Finance-ETF / ETN
+FLOW,Finance-ETF / ETN
+FLQL,Finance-ETF / ETN
+FLQM,Finance-ETF / ETN
+FLQS,Finance-ETF / ETN
+FLR,Bldg-Heavy Construction
+FLRG,Finance-ETF / ETN
+FLRN,Finance-ETF / ETN
+FLRT,Finance-ETF / ETN
+FLS,Machinery-Gen Industrial
+FLSA,Finance-ETF / ETN
+FLSP,Finance-ETF / ETN
+FLSW,Finance-ETF / ETN
+FLTB,Finance-ETF / ETN
+FLTR,Finance-ETF / ETN
+FLTW,Finance-ETF / ETN
+FLUD,Finance-ETF / ETN
+FLUT,Leisure-Gaming/Equip
+FLUX,Electrical-Power/Equipmt
+FLV,Finance-ETF / ETN
+FLWS,Retail-Mail Order&Direct
+FLXS,Hsehold/Office Furniture
+FLYD,Finance-ETF / ETN
+FLYU,Finance-ETF / ETN
+FLYW,Finance-CrdtCard/PmtPr
+FLYX,Aerospace/Defense
+FM,Finance-ETF / ETN
+FMAG,Finance-ETF / ETN
+FMAO,Banks-Midwest
+FMAR,Finance-ETF / ETN
+FMAT,Finance-ETF / ETN
+FMAY,Finance-ETF / ETN
+FMB,Finance-ETF / ETN
+FMBH,Banks-Midwest
+FMC,Chemicals-Agricultural
+FMCC,Finance-Mrtg&Rel Svc
+FMCX,Finance-ETF / ETN
+FMDE,Finance-ETF / ETN
+FMED,Finance-ETF / ETN
+FMET,Finance-ETF / ETN
+FMF,Finance-ETF / ETN
+FMHI,Finance-ETF / ETN
+FMIV,Finance-Blank Check
+FMN,Finance-Publ Inv Fd-Bond
+FMNB,Banks-Midwest
+FMNY,Finance-ETF / ETN
+FMQQ,Finance-ETF / ETN
+FMS,Medical-Outpnt/Hm Care
+FMST,Mining-Metal Ores
+FMX,Beverages-Non-Alcoholic
+FMY,Finance-Publ Inv Fd-Bal
+FN,Elec-Contract Mfg
+FNA,Medical-Products
+FNB,Banks-Northeast
+FNCB,Banks-Northeast
+FNCH,Medical-Biomed/Biotech
+FNCL,Finance-ETF / ETN
+FND,Retail/Whlsle-Bldg Prds
+FNDA,Finance-ETF / ETN
+FNDB,Finance-ETF / ETN
+FNDC,Finance-ETF / ETN
+FNDE,Finance-ETF / ETN
+FNDF,Finance-ETF / ETN
+FNDX,Finance-ETF / ETN
+FNF,Insurance-Prop/Cas/Titl
+FNGD,Finance-ETF / ETN
+FNGG,Finance-ETF / ETN
+FNGO,Finance-ETF / ETN
+FNGR,Telecom-Infrastructure
+FNGS,Finance-ETF / ETN
+FNGU,Finance-ETF / ETN
+FNK,Finance-ETF / ETN
+FNKO,Leisure-Toys/Games/Hobby
+FNLC,Banks-Northeast
+FNMA,Finance-Mrtg&Rel Svc
+FNMAS,Finance-Mrtg&Rel Svc
+FNOV,Finance-ETF / ETN
+FNV,Mining-Gold/Silver/Gems
+FNVT,Finance-Blank Check
+FNWB,Banks-West/Southwest
+FNWD,Banks-Midwest
+FNX,Finance-ETF / ETN
+FNY,Finance-ETF / ETN
+FOA,Finance-Mrtg&Rel Svc
+FOCT,Finance-ETF / ETN
+FOF,Finance-Publ Inv Fd-Bal
+FOLD,Medical-Biomed/Biotech
+FONR,Medical-Systems/Equip
+FOR,Real Estate Dvlpmt/Ops
+FORA,Computer Sftwr-Medical
+FORD,Containers/Packaging
+FORH,Finance-ETF / ETN
+FORL,Finance-Blank Check
+FORM,Elec-Semiconductor Equip
+FORR,Comml Svcs-Market Rsrch
+FORTY,Computer-Tech Services
+FOSL,Retail/Whlsle-Jewelry
+FOUR,Finance-CrdtCard/PmtPr
+FOVL,Finance-ETF / ETN
+FOX,Media-Diversified
+FOXA,Media-Diversified
+FOXF,Leisure-Products
+FOXO,Medical-Research Eqp/Svc
+FPA,Finance-ETF / ETN
+FPAFY,Telecom Svcs- Foreign
+FPAG,Finance-ETF / ETN
+FPAY,Retail-Internet
+FPE,Finance-ETF / ETN
+FPEI,Finance-ETF / ETN
+FPF,Finance-Publ Inv Fd-Eqt
+FPFD,Finance-ETF / ETN
+FPH,Real Estate Dvlpmt/Ops
+FPI,Finance-Property REIT
+FPL,Finance-Publ Inv Fd-Eqt
+FPRO,Finance-ETF / ETN
+FPX,Finance-ETF / ETN
+FPXE,Finance-ETF / ETN
+FPXI,Finance-ETF / ETN
+FQAL,Finance-ETF / ETN
+FR,Finance-Property REIT
+FRA,Finance-Publ Inv Fd-Bond
+FRAF,Banks-Northeast
+FRBA,Banks-Northeast
+FRBK,Banks-Northeast
+FRCB,Banks-West/Southwest
+FRCOY,Retail-Apparel/Shoes/Acc
+FRD,Metal Proc & Fabrication
+FRDM,Finance-ETF / ETN
+FREE,Food-Misc Preparation
+FREL,Finance-ETF / ETN
+FRES,Medical-Services
+FREY,Energy-Alternative/Other
+FRFHF,Insurance-Prop/Cas/Titl
+FRGE,Finance-Invest Bnk/Bkrs
+FRGT,Computer Sftwr-Enterprse
+FRHC,Finance-Invest Bnk/Bkrs
+FRI,Finance-ETF / ETN
+FRLA,Finance-Blank Check
+FRME,Banks-Midwest
+FRNW,Finance-ETF / ETN
+FRO,Oil&Gas-Transprt/Pipelne
+FROG,Computer Sftwr-Enterprse
+FRPH,Real Estate Dvlpmt/Ops
+FRPT,Food-Packaged
+FRSH,Computer Sftwr-Enterprse
+FRST,Banks-Southeast
+FRSX,Auto/Truck-Original Eqp
+FRT,Finance-Property REIT
+FRTX,Medical-Biomed/Biotech
+FRTY,Finance-ETF / ETN
+FRXB,Finance-Blank Check
+FRZA,Leisure-Products
+FSBC,Banks-West/Southwest
+FSBD,Finance-ETF / ETN
+FSBW,Banks-West/Southwest
+FSCO,Finance-Publ Inv Fd-Bond
+FSD,Finance-Publ Inv Fd-Bond
+FSEA,Finance-Savings & Loan
+FSEC,Finance-ETF / ETN
+FSEP,Finance-ETF / ETN
+FSFG,Finance-Savings & Loan
+FSI,Chemicals-Specialty
+FSIG,Finance-ETF / ETN
+FSK,Finance-Investment Mgmt
+FSLD,Finance-ETF / ETN
+FSLR,Energy-Solar
+FSLY,Computer Sftwr-Enterprse
+FSM,Mining-Gold/Silver/Gems
+FSMB,Finance-ETF / ETN
+FSMD,Finance-ETF / ETN
+FSP,Finance-Property REIT
+FSRN,Auto Manufacturers
+FSS,Security/Sfty
+FSST,Finance-ETF / ETN
+FSTA,Finance-ETF / ETN
+FSTR,Metal Proc & Fabrication
+FSV,Real Estate Dvlpmt/Ops
+FSYD,Finance-ETF / ETN
+FSZ,Finance-ETF / ETN
+FT,Finance-Publ Inv Fd-Bal
+FTA,Finance-ETF / ETN
+FTAG,Finance-ETF / ETN
+FTAI,Aerospace/Defense
+FTBD,Finance-ETF / ETN
+FTC,Finance-ETF / ETN
+FTCB,Finance-ETF / ETN
+FTCHF,Retail-Internet
+FTCI,Computer-Tech Services
+FTCS,Finance-ETF / ETN
+FTDR,Bldg-Maintenance & Svc
+FTDS,Finance-ETF / ETN
+FTEC,Finance-ETF / ETN
+FTEK,Pollution Control
+FTEL,Leisure-Services
+FTF,Finance-Publ Inv Fd-Bond
+FTFT,Computer-Tech Services
+FTGC,Finance-ETF / ETN
+FTGS,Finance-ETF / ETN
+FTHF,Finance-ETF / ETN
+FTHI,Finance-ETF / ETN
+FTHM,Real Estate Dvlpmt/Ops
+FTHY,Finance-Publ Inv Fd-Eqt
+FTI,Oil&Gas-Machinery/Equip
+FTIF,Finance-ETF / ETN
+FTII,Finance-Blank Check
+FTK,Oil&Gas-Field Services
+FTLF,Cosmetics/Personal Care
+FTLS,Finance-ETF / ETN
+FTNT,Computer Sftwr-Security
+FTQI,Finance-ETF / ETN
+FTRE,Medical-Research Eqp/Svc
+FTRI,Finance-ETF / ETN
+FTS,Utility-Diversified
+FTSD,Finance-ETF / ETN
+FTSL,Finance-ETF / ETN
+FTSM,Finance-ETF / ETN
+FTV,Machinery-Gen Industrial
+FTWO,Finance-ETF / ETN
+FTXG,Finance-ETF / ETN
+FTXH,Finance-ETF / ETN
+FTXL,Finance-ETF / ETN
+FTXN,Finance-ETF / ETN
+FTXO,Finance-ETF / ETN
+FTXR,Finance-ETF / ETN
+FUBO,Leisure-Movies & Related
+FUFU,Financial Svcs-Specialty
+FUJHY,Auto Manufacturers
+FUJIY,Computer-Hardware/Perip
+FUL,Chemicals-Specialty
+FULC,Medical-Biomed/Biotech
+FULT,Banks-Super Regional
+FUMB,Finance-ETF / ETN
+FUN,Leisure-Services
+FUNC,Banks-Northeast
+FUND,Finance-Publ Inv Fd-Glbl
+FUNL,Finance-ETF / ETN
+FURY,Mining-Gold/Silver/Gems
+FUSB,Banks-Southeast
+FUSI,Finance-ETF / ETN
+FUSN,Medical-Biomed/Biotech
+FUTU,Finance-Invest Bnk/Bkrs
+FUTY,Finance-ETF / ETN
+FUV,Auto Manufacturers
+FV,Finance-ETF / ETN
+FVAL,Finance-ETF / ETN
+FVC,Finance-ETF / ETN
+FVCB,Banks-Southeast
+FVD,Finance-ETF / ETN
+FVRR,Retail-Internet
+FWBI,Medical-Biomed/Biotech
+FWD,Finance-ETF / ETN
+FWONA,Media-Diversified
+FWONB,Media-Diversified
+FWONK,Media-Diversified
+FWRD,Transportation-Truck
+FWRG,Retail-Restaurants
+FXA,Finance-ETF / ETN
+FXB,Finance-ETF / ETN
+FXC,Finance-ETF / ETN
+FXCO,Finance-Blank Check
+FXD,Finance-ETF / ETN
+FXE,Finance-ETF / ETN
+FXED,Finance-ETF / ETN
+FXF,Finance-ETF / ETN
+FXG,Finance-ETF / ETN
+FXH,Finance-ETF / ETN
+FXI,Finance-ETF / ETN
+FXL,Finance-ETF / ETN
+FXLV,Leisure-Services
+FXN,Finance-ETF / ETN
+FXNC,Banks-Southeast
+FXO,Finance-ETF / ETN
+FXP,Finance-ETF / ETN
+FXR,Finance-ETF / ETN
+FXU,Finance-ETF / ETN
+FXY,Finance-ETF / ETN
+FXZ,Finance-ETF / ETN
+FYBR,Telecom Svcs-Integrated
+FYC,Finance-ETF / ETN
+FYLD,Finance-ETF / ETN
+FYLG,Finance-ETF / ETN
+FYT,Finance-ETF / ETN
+FYX,Finance-ETF / ETN
+G,Comml Svcs-Outsourcing
+GAA,Finance-ETF / ETN
+GAB,Finance-Publ Inv Fd-Eqt
+GABC,Banks-Midwest
+GABF,Finance-ETF / ETN
+GAIA,Leisure-Movies & Related
+GAIN,Finance-Investment Mgmt
+GAL,Finance-ETF / ETN
+GALT,Medical-Biomed/Biotech
+GAM,Finance-Publ Inv Fd-Eqt
+GAMB,Comml Svcs-Advertising
+GAMC,Finance-Blank Check
+GAME,Internet-Content
+GAMI,Group not available
+GAMR,Finance-ETF / ETN
+GAN,Leisure-Gaming/Equip
+GANX,Medical-Biomed/Biotech
+GAPR,Finance-ETF / ETN
+GAQ,Finance-Blank Check
+GASS,Oil&Gas-Transprt/Pipelne
+GAST,Finance-ETF / ETN
+GATE,Finance-Blank Check
+GATO,Mining-Gold/Silver/Gems
+GATX,Comml Svcs-Leasing
+GAU,Mining-Gold/Silver/Gems
+GAUG,Finance-ETF / ETN
+GB,Finance-CrdtCard/PmtPr
+GBAB,Finance-Publ Inv Fd-Bond
+GBBK,Finance-Blank Check
+GBCI,Banks-West/Southwest
+GBDC,Finance-Investment Mgmt
+GBF,Finance-ETF / ETN
+GBIL,Finance-ETF / ETN
+GBIO,Medical-Biomed/Biotech
+GBLD,Finance-ETF / ETN
+GBLI,Insurance-Prop/Cas/Titl
+GBNHF,Medical-Biomed/Biotech
+GBNY,Banks-Northeast
+GBR,Oil&Gas-U S Expl&Prod
+GBTC,Finance-Publ Inv Fd-Eqt
+GBTG,Leisure-Travel Booking
+GBUY,Finance-ETF / ETN
+GBX,Transportation-Equip Mfg
+GCAD,Finance-ETF / ETN
+GCBC,Finance-Savings & Loan
+GCC,Finance-ETF / ETN
+GCI,Media-Newspapers
+GCLN,Finance-ETF / ETN
+GCMG,Finance-Investment Mgmt
+GCO,Retail-Apparel/Shoes/Acc
+GCOR,Finance-ETF / ETN
+GCOW,Finance-ETF / ETN
+GCT,Computer-Tech Services
+GCTK,Medical-Products
+GCTS,Elec-Semiconductor Mfg
+GCV,Finance-Publ Inv Fd-Eqt
+GD,Aerospace/Defense
+GDC,Pollution Control
+GDDY,Computer Sftwr-Enterprse
+GDE,Finance-ETF / ETN
+GDEC,Finance-ETF / ETN
+GDEF,Finance-ETF / ETN
+GDEN,Leisure-Gaming/Equip
+GDEV,Computer Sftwr-Gaming
+GDHG,Leisure-Services
+GDIV,Finance-ETF / ETN
+GDL,Finance-Publ Inv Fd-Eqt
+GDLC,Finance-Publ Inv Fd-Eqt
+GDMA,Finance-ETF / ETN
+GDMN,Finance-ETF / ETN
+GDNR,Finance-Blank Check
+GDNSF,Consumer Prod-Specialty
+GDO,Finance-Publ Inv Fd-Glbl
+GDOC,Finance-ETF / ETN
+GDOT,Finance-CrdtCard/PmtPr
+GDRX,Computer Sftwr-Medical
+GDS,Internet-Network Sltns
+GDST,Finance-Blank Check
+GDTC,Medical-Biomed/Biotech
+GDV,Finance-Publ Inv Fd-Eqt
+GDVD,Finance-ETF / ETN
+GDX,Finance-ETF / ETN
+GDXD,Finance-ETF / ETN
+GDXJ,Finance-ETF / ETN
+GDXU,Finance-ETF / ETN
+GDYN,Computer-Tech Services
+GE,Diversified Operations
+GECC,Finance-Investment Mgmt
+GEF,Containers/Packaging
+GEFB,Containers/Packaging
+GEG,Internet-Network Sltns
+GEHC,Medical-Systems/Equip
+GEL,Oil&Gas-Refining/Mktg
+GEM,Finance-ETF / ETN
+GEMD,Finance-ETF / ETN
+GEN,Computer Sftwr-Security
+GENC,Machinery-Gen Industrial
+GENE,Medical-Biomed/Biotech
+GENI,Leisure-Gaming/Equip
+GENK,Retail-Restaurants
+GEO,Security/Sfty
+GEOS,Oil&Gas-Machinery/Equip
+GER,Finance-Publ Inv Fd-Eqt
+GERM,Finance-ETF / ETN
+GERN,Medical-Biomed/Biotech
+GES,Retail-Apparel/Shoes/Acc
+GETR,Leisure-Services
+GETY,Internet-Content
+GEV,Group not available
+GEVO,Chemicals-Specialty
+GF,Finance-Publ Inv Fd-Glbl
+GFAI,Security/Sfty
+GFEB,Finance-ETF / ETN
+GFF,Bldg-Constr Prds/Misc
+GFGF,Finance-ETF / ETN
+GFI,Mining-Gold/Silver/Gems
+GFL,Pollution Control
+GFOF,Finance-ETF / ETN
+GFR,Oil&Gas-Cdn Expl&Prod
+GFS,Elec-Semiconductor Mfg
+GGAAF,Finance-Blank Check
+GGAL,Banks-Foreign
+GGB,Steel-Producers
+GGBXF,Consumer Prod-Specialty
+GGE,Bldg-Resident/Comml
+GGG,Machinery-Gen Industrial
+GGLL,Finance-ETF / ETN
+GGLS,Finance-ETF / ETN
+GGM,Finance-ETF / ETN
+GGME,Finance-ETF / ETN
+GGN,Finance-Publ Inv Fd-Eqt
+GGR,Auto Manufacturers
+GGRW,Finance-ETF / ETN
+GGT,Finance-Publ Inv Fd-Glbl
+GGUS,Finance-ETF / ETN
+GGZ,Finance-Publ Inv Fd-Eqt
+GH,Medical-Services
+GHC,Media-Diversified
+GHEE,Finance-ETF / ETN
+GHG,Leisure-Lodging
+GHI,Finance-Mrtg&Rel Svc
+GHIX,Finance-Blank Check
+GHLD,Finance-Mrtg&Rel Svc
+GHM,Machinery-Gen Industrial
+GHMS,Finance-ETF / ETN
+GHRS,Medical-Biomed/Biotech
+GHSI,Medical-Research Eqp/Svc
+GHTA,Finance-ETF / ETN
+GHY,Finance-Publ Inv Fd-Bond
+GHYB,Finance-ETF / ETN
+GHYG,Finance-ETF / ETN
+GIB,Computer-Tech Services
+GIC,Retail/Whlsle-Bldg Prds
+GIFI,Oil&Gas-Machinery/Equip
+GIGB,Finance-ETF / ETN
+GIGM,Computer Sftwr-Gaming
+GII,Finance-ETF / ETN
+GIII,Apparel-Clothing Mfg
+GIL,Apparel-Clothing Mfg
+GILD,Medical-Biomed/Biotech
+GILT,Telecom-Cable/Satl Eqp
+GINN,Finance-ETF / ETN
+GINX,Finance-ETF / ETN
+GIPR,Finance-Property REIT
+GIS,Food-Packaged
+GJAN,Finance-ETF / ETN
+GJUL,Finance-ETF / ETN
+GJUN,Finance-ETF / ETN
+GK,Finance-ETF / ETN
+GKOS,Medical-Products
+GL,Insurance-Life
+GLAC,Finance-Blank Check
+GLAD,Finance-Investment Mgmt
+GLBE,Computer Sftwr-Enterprse
+GLBS,Transportation-Ship
+GLBZ,Banks-Northeast
+GLD,Finance-ETF / ETN
+GLDD,Bldg-Heavy Construction
+GLDG,Mining-Gold/Silver/Gems
+GLDI,Finance-ETF / ETN
+GLDM,Finance-ETF / ETN
+GLIF,Finance-ETF / ETN
+GLIN,Finance-ETF / ETN
+GLL,Finance-ETF / ETN
+GLLI,Finance-Blank Check
+GLMD,Medical-Biomed/Biotech
+GLNCY,Energy-Coal
+GLNG,Oil&Gas-Transprt/Pipelne
+GLO,Finance-Publ Inv Fd-Bal
+GLOB,Computer-Tech Services
+GLOF,Finance-ETF / ETN
+GLOV,Finance-ETF / ETN
+GLP,Oil&Gas-Refining/Mktg
+GLPG,Medical-Biomed/Biotech
+GLPI,Finance-Property REIT
+GLQ,Finance-Publ Inv Fd-Eqt
+GLRE,Insurance-Prop/Cas/Titl
+GLRY,Finance-ETF / ETN
+GLSHQ,Medical-Biomed/Biotech
+GLSI,Medical-Biomed/Biotech
+GLST,Finance-Blank Check
+GLT,Paper & Paper Products
+GLTO,Medical-Biomed/Biotech
+GLTR,Finance-ETF / ETN
+GLU,Finance-Publ Inv Fd-Eqt
+GLUE,Medical-Biomed/Biotech
+GLV,Finance-Publ Inv Fd-Eqt
+GLW,Elec-Misc Products
+GLYC,Medical-Biomed/Biotech
+GM,Auto Manufacturers
+GMAB,Medical-Biomed/Biotech
+GMAR,Finance-ETF / ETN
+GMAY,Finance-ETF / ETN
+GMBL,Computer Sftwr-Gaming
+GMDA,Medical-Biomed/Biotech
+GME,Retail-Consumer Elec
+GMED,Medical-Products
+GMET,Finance-ETF / ETN
+GMF,Finance-ETF / ETN
+GMFI,Finance-Blank Check
+GMGI,Computer Sftwr-Gaming
+GMM,Computer-Tech Services
+GMOM,Finance-ETF / ETN
+GMRE,Finance-Property REIT
+GMS,Bldg-Constr Prds/Misc
+GMUN,Finance-ETF / ETN
+GMVDF,Medical-Systems/Equip
+GNCAQ,Group not available
+GNE,Utility-Diversified
+GNFT,Medical-Biomed/Biotech
+GNK,Transportation-Ship
+GNL,Finance-Property REIT
+GNLN,Consumer Prod-Specialty
+GNLX,Medical-Biomed/Biotech
+GNMA,Finance-ETF / ETN
+GNOM,Finance-ETF / ETN
+GNOV,Finance-ETF / ETN
+GNPX,Medical-Biomed/Biotech
+GNR,Finance-ETF / ETN
+GNRC,Electrical-Power/Equipmt
+GNS,Computer Sftwr-Edu/Media
+GNSS,Security/Sfty
+GNT,Finance-Publ Inv Fd-Eqt
+GNTA,Medical-Biomed/Biotech
+GNTX,Auto/Truck-Original Eqp
+GNTY,Banks-West/Southwest
+GNW,Insurance-Life
+GO,Retail-Discount&Variety
+GOAU,Finance-ETF / ETN
+GOCO,Insurance-Brokers
+GOCT,Finance-ETF / ETN
+GODN,Finance-Blank Check
+GOEV,Auto Manufacturers
+GOEX,Finance-ETF / ETN
+GOF,Finance-Publ Inv Fd-Bond
+GOGL,Transportation-Ship
+GOGO,Telecom-Infrastructure
+GOLD,Mining-Gold/Silver/Gems
+GOLF,Leisure-Products
+GOLLQ,Transportation-Airline
+GOLY,Finance-ETF / ETN
+GOOD,Finance-Property REIT
+GOOG,Internet-Content
+GOOGL,Internet-Content
+GOOP,Finance-ETF / ETN
+GOOS,Apparel-Clothing Mfg
+GOOX,Finance-ETF / ETN
+GOOY,Finance-ETF / ETN
+GORO,Mining-Gold/Silver/Gems
+GORV,Retail/Whlsle-Automobile
+GOSS,Medical-Biomed/Biotech
+GOTU,Consumer Svcs-Education
+GOVI,Finance-ETF / ETN
+GOVT,Finance-ETF / ETN
+GOVX,Medical-Biomed/Biotech
+GOVZ,Finance-ETF / ETN
+GP,Auto Manufacturers
+GPAC,Finance-Blank Check
+GPAK,Internet-Content
+GPC,Retail/Whlsle-Auto Parts
+GPCR,Medical-Biomed/Biotech
+GPI,Retail/Whlsle-Automobile
+GPIQ,Finance-ETF / ETN
+GPIX,Finance-ETF / ETN
+GPK,Paper & Paper Products
+GPMT,Finance-Mortgage REIT
+GPN,Finance-CrdtCard/PmtPr
+GPOR,Oil&Gas-U S Expl&Prod
+GPOW,Finance-ETF / ETN
+GPRE,Energy-Alternative/Other
+GPRK,Oil&Gas-Intl Expl&Prod
+GPRO,Consumer Prod-Electronic
+GPS,Retail-Apparel/Shoes/Acc
+GQI,Finance-ETF / ETN
+GQRE,Finance-ETF / ETN
+GRAB,Leisure-Services
+GRBK,Bldg-Resident/Comml
+GRC,Machinery-Gen Industrial
+GRDI,Computer Sftwr-Financial
+GREE,Financial Svcs-Specialty
+GREI,Finance-ETF / ETN
+GREK,Finance-ETF / ETN
+GRES,Finance-ETF / ETN
+GRF,Finance-Publ Inv Fd-Eqt
+GRFS,Medical-Ethical Drugs
+GRFX,Energy-Alternative/Other
+GRI,Medical-Biomed/Biotech
+GRID,Finance-ETF / ETN
+GRIN,Transportation-Ship
+GRMN,Consumer Prod-Electronic
+GRN,Finance-ETF / ETN
+GRNA,Medical-Biomed/Biotech
+GRNB,Finance-ETF / ETN
+GRND,Internet-Content
+GRNQ,Finance-Investment Mgmt
+GRNT,Oil&Gas-Royalty Trust
+GROM,Internet-Content
+GROV,Retail-Specialty
+GROW,Finance-Investment Mgmt
+GROY,Mining-Gold/Silver/Gems
+GRPM,Finance-ETF / ETN
+GRPN,Retail-Internet
+GRPZ,Finance-ETF / ETN
+GRRR,Computer-Tech Services
+GRTS,Medical-Biomed/Biotech
+GRTX,Medical-Biomed/Biotech
+GRVY,Computer Sftwr-Gaming
+GRWG,Retail-Specialty
+GRX,Finance-Publ Inv Fd-Eqt
+GRYP,Computer Sftwr-Financial
+GS,Banks-Money Center
+GSAT,Telecom Svcs-Wireless
+GSBC,Banks-Midwest
+GSBD,Finance-Commercial Loans
+GSC,Finance-ETF / ETN
+GSDI,Finance-Blank Check
+GSEE,Finance-ETF / ETN
+GSEP,Finance-ETF / ETN
+GSEU,Finance-ETF / ETN
+GSEW,Finance-ETF / ETN
+GSFP,Finance-ETF / ETN
+GSG,Finance-ETF / ETN
+GSHD,Insurance-Prop/Cas/Titl
+GSIB,Finance-ETF / ETN
+GSID,Finance-ETF / ETN
+GSIE,Finance-ETF / ETN
+GSIG,Finance-ETF / ETN
+GSIT,Elec-Semicondctor Fablss
+GSIW,Finance-Investment Mgmt
+GSJY,Finance-ETF / ETN
+GSK,Medical-Diversified
+GSL,Transportation-Ship
+GSLC,Finance-ETF / ETN
+GSM,Steel-Specialty Alloys
+GSPY,Finance-ETF / ETN
+GSSC,Finance-ETF / ETN
+GSST,Finance-ETF / ETN
+GSUN,Consumer Svcs-Education
+GSUS,Finance-ETF / ETN
+GSY,Finance-ETF / ETN
+GT,Auto/Truck-Tires & Misc
+GTAC,Finance-Blank Check
+GTBIF,Consumer Prod-Specialty
+GTBP,Medical-Biomed/Biotech
+GTE,Oil&Gas-Intl Expl&Prod
+GTEC,Auto/Truck-Original Eqp
+GTEK,Finance-ETF / ETN
+GTES,Electrical-Power/Equipmt
+GTHX,Medical-Biomed/Biotech
+GTI,Metal Proc & Fabrication
+GTIM,Retail-Restaurants
+GTIP,Finance-ETF / ETN
+GTLB,Computer-Tech Services
+GTLS,Oil&Gas-Machinery/Equip
+GTN,Media-Radio/Tv
+GTNA,Media-Radio/Tv
+GTO,Finance-ETF / ETN
+GTPS,Finance-Savings & Loan
+GTR,Finance-ETF / ETN
+GTX,Auto/Truck-Original Eqp
+GTY,Finance-Property REIT
+GUG,Finance-Publ Inv Fd-Bal
+GUNR,Finance-ETF / ETN
+GURE,Chemicals-Basic
+GURU,Finance-ETF / ETN
+GUSA,Finance-ETF / ETN
+GUSH,Finance-ETF / ETN
+GUT,Finance-Publ Inv Fd-Eqt
+GUTS,Medical-Biomed/Biotech
+GV,Consumer Svcs-Education
+GVA,Bldg-Heavy Construction
+GVAL,Finance-ETF / ETN
+GVH,Transportation-Logistics
+GVI,Finance-ETF / ETN
+GVIP,Finance-ETF / ETN
+GVLU,Finance-ETF / ETN
+GVP,Computer Sftwr-Design
+GVUS,Finance-ETF / ETN
+GWAV,Pollution Control
+GWH,Electrical-Power/Equipmt
+GWRE,Computer Sftwr-Financial
+GWRS,Utility-Water Supply
+GWW,Machinery-Tools & Rel
+GWX,Finance-ETF / ETN
+GXAI,Computer Sftwr-Gaming
+GXC,Finance-ETF / ETN
+GXG,Finance-ETF / ETN
+GXO,Transportation-Logistics
+GXTG,Finance-ETF / ETN
+GXUS,Finance-ETF / ETN
+GYLD,Finance-ETF / ETN
+GYRE,Medical-Biomed/Biotech
+GYRO,Finance-Property REIT
+H,Leisure-Lodging
+HA,Transportation-Airline
+HACK,Finance-ETF / ETN
+HAE,Medical-Systems/Equip
+HAFC,Banks-West/Southwest
+HAIA,Finance-Blank Check
+HAIL,Finance-ETF / ETN
+HAIN,Food-Packaged
+HAL,Oil&Gas-Field Services
+HALL,Insurance-Prop/Cas/Titl
+HALO,Medical-Biomed/Biotech
+HAO,Comml Svcs-Advertising
+HAP,Finance-ETF / ETN
+HAPI,Finance-ETF / ETN
+HAPS,Finance-ETF / ETN
+HAPY,Finance-ETF / ETN
+HARD,Finance-ETF / ETN
+HART,Finance-ETF / ETN
+HAS,Leisure-Toys/Games/Hobby
+HASI,Finance-Mortgage REIT
+HAUS,Finance-ETF / ETN
+HAUZ,Finance-ETF / ETN
+HAWX,Finance-ETF / ETN
+HAYN,Metal Proc & Fabrication
+HAYW,Retail-Leisure Products
+HBAN,Banks-Super Regional
+HBB,Hsehold-Appliances/Wares
+HBCP,Finance-Savings & Loan
+HBI,Apparel-Clothing Mfg
+HBIO,Medical-Products
+HBM,Mining-Metal Ores
+HBNC,Banks-Midwest
+HBT,Banks-Midwest
+HCA,Medical-Hospitals
+HCAT,Computer Sftwr-Medical
+HCC,Energy-Coal
+HCDIQ,Real Estate Dvlpmt/Ops
+HCI,Insurance-Prop/Cas/Titl
+HCKT,Computer-Tech Services
+HCM,Medical-Biomed/Biotech
+HCMLY,Bldg-Constr Prds/Misc
+HCMT,Finance-ETF / ETN
+HCOM,Finance-ETF / ETN
+HCOW,Finance-ETF / ETN
+HCP,Computer Sftwr-Enterprse
+HCRB,Finance-ETF / ETN
+HCSG,Comml Svcs-Healthcare
+HCTI,Comml Svcs-Healthcare
+HCVI,Finance-Blank Check
+HCWB,Medical-Biomed/Biotech
+HD,Retail/Whlsle-Bldg Prds
+HDAW,Finance-ETF / ETN
+HDB,Banks-Foreign
+HDEF,Finance-ETF / ETN
+HDG,Finance-ETF / ETN
+HDGE,Finance-ETF / ETN
+HDLB,Finance-ETF / ETN
+HDMV,Finance-ETF / ETN
+HDRO,Finance-ETF / ETN
+HDSN,Pollution Control
+HDUS,Finance-ETF / ETN
+HDV,Finance-ETF / ETN
+HE,Utility-Electric Power
+HEAR,Consumer Prod-Electronic
+HEAT,Finance-ETF / ETN
+HEDJ,Finance-ETF / ETN
+HEEM,Finance-ETF / ETN
+HEES,Comml Svcs-Leasing
+HEET,Finance-ETF / ETN
+HEFA,Finance-ETF / ETN
+HEGD,Finance-ETF / ETN
+HEGIY,Cosmetics/Personal Care
+HEI,Aerospace/Defense
+HEIA,Aerospace/Defense
+HEINY,Beverages-Alcoholic
+HELE,Cosmetics/Personal Care
+HELO,Finance-ETF / ETN
+HELX,Finance-ETF / ETN
+HENKY,Chemicals-Specialty
+HEPA,Medical-Biomed/Biotech
+HEPS,Retail-Internet
+HEQ,Finance-Publ Inv Fd-Eqt
+HEQT,Finance-ETF / ETN
+HERD,Finance-ETF / ETN
+HERO,Finance-ETF / ETN
+HES,Oil&Gas-Intl Expl&Prod
+HESM,Oil&Gas-Transprt/Pipelne
+HEWG,Finance-ETF / ETN
+HEWJ,Finance-ETF / ETN
+HEZU,Finance-ETF / ETN
+HF,Finance-ETF / ETN
+HFBL,Finance-Savings & Loan
+HFFG,Wholesale-Food
+HFGO,Finance-ETF / ETN
+HFND,Finance-ETF / ETN
+HFRO,Finance-Publ Inv Fd-Bond
+HFWA,Banks-West/Southwest
+HFXI,Finance-ETF / ETN
+HG,Insurance-Diversified
+HGAS,Utility-Gas Distribution
+HGBL,Finance-Investment Mgmt
+HGENQ,Medical-Biomed/Biotech
+HGER,Finance-ETF / ETN
+HGLB,Finance-ETF / ETN
+HGTY,Insurance-Prop/Cas/Titl
+HGV,Leisure-Services
+HHGC,Finance-Blank Check
+HHH,Real Estate Dvlpmt/Ops
+HHS,Comml Svcs-Advertising
+HI,Machinery-Gen Industrial
+HIBB,Retail-Leisure Products
+HIBL,Finance-ETF / ETN
+HIBS,Finance-ETF / ETN
+HIDE,Finance-ETF / ETN
+HIDV,Finance-ETF / ETN
+HIE,Finance-Publ Inv Fd-Eqt
+HIFS,Banks-Northeast
+HIG,Insurance-Diversified
+HIGH,Finance-ETF / ETN
+HIHO,Metal Proc & Fabrication
+HII,Aerospace/Defense
+HIMS,Computer Sftwr-Medical
+HIMX,Elec-Semicondctor Fablss
+HIO,Finance-Publ Inv Fd-Bond
+HIPO,Insurance-Prop/Cas/Titl
+HIPS,Finance-ETF / ETN
+HISF,Finance-ETF / ETN
+HITI,Consumer Prod-Specialty
+HIVE,Financial Svcs-Specialty
+HIW,Finance-Property REIT
+HIX,Finance-Publ Inv Fd-Bond
+HIYS,Finance-ETF / ETN
+HJAN,Finance-ETF / ETN
+HJEN,Finance-ETF / ETN
+HKD,Finance-Investment Mgmt
+HKIT,Computer-Hardware/Perip
+HKND,Finance-ETF / ETN
+HKXCY,Financial Svcs-Specialty
+HL,Mining-Gold/Silver/Gems
+HLAL,Finance-ETF / ETN
+HLF,Cosmetics/Personal Care
+HLGE,Finance-ETF / ETN
+HLGN,Energy-Solar
+HLI,Finance-Invest Bnk/Bkrs
+HLIO,Machinery-Gen Industrial
+HLIT,Telecom-Cable/Satl Eqp
+HLLY,Auto/Truck-Original Eqp
+HLMN,Retail/Whlsle-Bldg Prds
+HLN,Medical-Generic Drugs
+HLNE,Finance-Investment Mgmt
+HLP,Steel-Producers
+HLT,Leisure-Lodging
+HLTH,Computer Sftwr-Medical
+HLTOY,Telecom Svcs- Foreign
+HLVX,Medical-Biomed/Biotech
+HLX,Oil&Gas-Field Services
+HLXB,Finance-Blank Check
+HMA,Finance-Blank Check
+HMC,Auto Manufacturers
+HMN,Insurance-Prop/Cas/Titl
+HMNF,Finance-Savings & Loan
+HMOP,Finance-ETF / ETN
+HMRZF,Retail-Apparel/Shoes/Acc
+HMST,Banks-West/Southwest
+HMY,Mining-Gold/Silver/Gems
+HNDL,Finance-ETF / ETN
+HNI,Hsehold/Office Furniture
+HNNA,Finance-Investment Mgmt
+HNRA,Finance-Blank Check
+HNRG,Energy-Coal
+HNST,Cosmetics/Personal Care
+HNVR,Banks-Northeast
+HNW,Finance-Publ Inv Fd-Bond
+HOCPY,Medical-Systems/Equip
+HOCT,Finance-ETF / ETN
+HODL,Finance-ETF / ETN
+HOFT,Hsehold/Office Furniture
+HOFV,Leisure-Services
+HOG,Leisure-Products
+HOLD,Finance-ETF / ETN
+HOLI,Machinery-Mtl Hdlg/Autmn
+HOLO,Elec-Semiconductor Mfg
+HOLX,Medical-Systems/Equip
+HOMB,Banks-Southeast
+HOMZ,Finance-ETF / ETN
+HON,Diversified Operations
+HONE,Banks-Northeast
+HOOD,Finance-Invest Bnk/Bkrs
+HOOK,Medical-Biomed/Biotech
+HOPE,Banks-West/Southwest
+HOTH,Medical-Biomed/Biotech
+HOUR,Retail-Mail Order&Direct
+HOUS,Real Estate Dvlpmt/Ops
+HOV,Bldg-Resident/Comml
+HOVR,Aerospace/Defense
+HOWL,Medical-Biomed/Biotech
+HP,Oil&Gas-Drilling
+HPCO,Tobacco
+HPE,Computer-Tech Services
+HPF,Finance-Publ Inv Fd-Eqt
+HPH,Finance-Investment Mgmt
+HPI,Finance-Publ Inv Fd-Eqt
+HPK,Oil&Gas-U S Expl&Prod
+HPP,Finance-Property REIT
+HPQ,Computer-Hardware/Perip
+HPS,Finance-Publ Inv Fd-Eqt
+HQGO,Finance-ETF / ETN
+HQH,Finance-Publ Inv Fd-Eqt
+HQI,Comml Svcs-Staffing
+HQL,Finance-Publ Inv Fd-Eqt
+HQY,Comml Svcs-Outsourcing
+HR,Finance-Property REIT
+HRB,Financial Svcs-Specialty
+HRI,Comml Svcs-Leasing
+HRL,Food-Meat Products
+HRMY,Medical-Biomed/Biotech
+HROW,Medical-Biomed/Biotech
+HRT,Computer Sftwr-Security
+HRTG,Insurance-Prop/Cas/Titl
+HRTS,Finance-ETF / ETN
+HRTX,Medical-Biomed/Biotech
+HRYU,Internet-Content
+HRZN,Finance-Investment Mgmt
+HSAI,Auto/Truck-Original Eqp
+HSBC,Banks-Money Center
+HSCS,Medical-Products
+HSCZ,Finance-ETF / ETN
+HSDT,Medical-Products
+HSHP,Transportation-Ship
+HSIC,Medical-Supplies
+HSII,Comml Svcs-Staffing
+HSMV,Finance-ETF / ETN
+HSON,Comml Svcs-Staffing
+HSPO,Finance-Blank Check
+HSRT,Finance-ETF / ETN
+HST,Finance-Property REIT
+HSTM,Comml Svcs-Healthcare
+HSTO,Group not available
+HSUN,Finance-ETF / ETN
+HSY,Food-Confectionery
+HTAB,Finance-ETF / ETN
+HTBI,Banks-Southeast
+HTBK,Banks-West/Southwest
+HTCR,Computer Sftwr-Enterprse
+HTD,Finance-Publ Inv Fd-Bal
+HTEC,Finance-ETF / ETN
+HTGC,Finance-Investment Mgmt
+HTGMQ,Medical-Research Eqp/Svc
+HTH,Banks-West/Southwest
+HTHIY,Diversified Operations
+HTHT,Leisure-Lodging
+HTLD,Transportation-Truck
+HTLF,Banks-Midwest
+HTOO,Energy-Alternative/Other
+HTRB,Finance-ETF / ETN
+HTUS,Finance-ETF / ETN
+HTY,Finance-Publ Inv Fd-Glbl
+HTZ,Leisure-Services
+HUBB,Electrical-Power/Equipmt
+HUBC,Computer Sftwr-Security
+HUBG,Transportation-Logistics
+HUBS,Comp Sftwr-Spec Enterprs
+HUDA,Finance-Blank Check
+HUDI,Steel-Producers
+HUGE,Consumer Prod-Specialty
+HUIZ,Insurance-Life
+HUM,Medical-Managed Care
+HUMA,Medical-Biomed/Biotech
+HUN,Chemicals-Basic
+HURC,Machinery-Mtl Hdlg/Autmn
+HURN,Comml Svcs-Consulting
+HUSA,Oil&Gas-Intl Expl&Prod
+HUSV,Finance-ETF / ETN
+HUT,Financial Svcs-Specialty
+HUYA,Internet-Content
+HVT,Retail-Home Furnishings
+HVTA,Retail-Home Furnishings
+HWBK,Banks-Midwest
+HWC,Banks-Southeast
+HWEL,Finance-Blank Check
+HWH,Comml Svcs-Market Rsrch
+HWKN,Chemicals-Basic
+HWKZ,Finance-Blank Check
+HWM,Aerospace/Defense
+HXL,Aerospace/Defense
+HY,Machinery-Gen Industrial
+HYAC,Finance-Blank Check
+HYB,Finance-Publ Inv Fd-Bond
+HYBB,Finance-ETF / ETN
+HYBL,Finance-ETF / ETN
+HYD,Finance-ETF / ETN
+HYDB,Finance-ETF / ETN
+HYDR,Finance-ETF / ETN
+HYDW,Finance-ETF / ETN
+HYEM,Finance-ETF / ETN
+HYFI,Finance-ETF / ETN
+HYFM,Machinery-Gen Industrial
+HYG,Finance-ETF / ETN
+HYGH,Finance-ETF / ETN
+HYGI,Finance-ETF / ETN
+HYGV,Finance-ETF / ETN
+HYGW,Finance-ETF / ETN
+HYHG,Finance-ETF / ETN
+HYI,Finance-Publ Inv Fd-Bond
+HYIN,Finance-ETF / ETN
+HYKE,Finance-ETF / ETN
+HYLB,Finance-ETF / ETN
+HYLG,Finance-ETF / ETN
+HYLN,Transportation-Equip Mfg
+HYLS,Finance-ETF / ETN
+HYMB,Finance-ETF / ETN
+HYMC,Mining-Gold/Silver/Gems
+HYMU,Finance-ETF / ETN
+HYPR,Medical-Systems/Equip
+HYRM,Finance-ETF / ETN
+HYS,Finance-ETF / ETN
+HYSA,Finance-ETF / ETN
+HYT,Finance-Publ Inv Fd-Bal
+HYTR,Finance-ETF / ETN
+HYUP,Finance-ETF / ETN
+HYW,Finance-Investment Mgmt
+HYXF,Finance-ETF / ETN
+HYXU,Finance-ETF / ETN
+HYZD,Finance-ETF / ETN
+HYZN,Trucks & Parts-Hvy Duty
+HZO,Retail-Leisure Products
+IAC,Internet-Content
+IAE,Finance-Publ Inv Fd-Glbl
+IAF,Finance-Publ Inv Fd-Glbl
+IAG,Mining-Gold/Silver/Gems
+IAGG,Finance-ETF / ETN
+IAI,Finance-ETF / ETN
+IAK,Finance-ETF / ETN
+IAPR,Finance-ETF / ETN
+IART,Medical-Products
+IAS,Comp Sftwr-Spec Enterprs
+IAT,Finance-ETF / ETN
+IAU,Finance-ETF / ETN
+IAUF,Finance-ETF / ETN
+IAUM,Finance-ETF / ETN
+IAUX,Mining-Gold/Silver/Gems
+IBAT,Finance-ETF / ETN
+IBB,Finance-ETF / ETN
+IBBQ,Finance-ETF / ETN
+IBCP,Banks-Midwest
+IBD,Finance-ETF / ETN
+IBDP,Finance-ETF / ETN
+IBDQ,Finance-ETF / ETN
+IBDR,Finance-ETF / ETN
+IBDRY,Utility-Electric Power
+IBDS,Finance-ETF / ETN
+IBDT,Finance-ETF / ETN
+IBDU,Finance-ETF / ETN
+IBDV,Finance-ETF / ETN
+IBDW,Finance-ETF / ETN
+IBDX,Finance-ETF / ETN
+IBDY,Finance-ETF / ETN
+IBEX,Computer-Tech Services
+IBHD,Finance-ETF / ETN
+IBHE,Finance-ETF / ETN
+IBHF,Finance-ETF / ETN
+IBHG,Finance-ETF / ETN
+IBHH,Finance-ETF / ETN
+IBHI,Finance-ETF / ETN
+IBHJ,Finance-ETF / ETN
+IBIA,Finance-ETF / ETN
+IBIB,Finance-ETF / ETN
+IBIC,Finance-ETF / ETN
+IBID,Finance-ETF / ETN
+IBIE,Finance-ETF / ETN
+IBIF,Finance-ETF / ETN
+IBIG,Finance-ETF / ETN
+IBIH,Finance-ETF / ETN
+IBII,Finance-ETF / ETN
+IBIJ,Finance-ETF / ETN
+IBIO,Medical-Biomed/Biotech
+IBIT,Finance-ETF / ETN
+IBKR,Finance-Invest Bnk/Bkrs
+IBLC,Finance-ETF / ETN
+IBM,Computer-Tech Services
+IBMM,Finance-ETF / ETN
+IBMN,Finance-ETF / ETN
+IBMO,Finance-ETF / ETN
+IBMP,Finance-ETF / ETN
+IBMQ,Finance-ETF / ETN
+IBMR,Finance-ETF / ETN
+IBN,Banks-Foreign
+IBND,Finance-ETF / ETN
+IBOC,Banks-West/Southwest
+IBOT,Finance-ETF / ETN
+IBP,Bldg-Maintenance & Svc
+IBRN,Finance-ETF / ETN
+IBRX,Medical-Biomed/Biotech
+IBTE,Finance-ETF / ETN
+IBTF,Finance-ETF / ETN
+IBTG,Finance-ETF / ETN
+IBTH,Finance-ETF / ETN
+IBTI,Finance-ETF / ETN
+IBTJ,Finance-ETF / ETN
+IBTK,Finance-ETF / ETN
+IBTL,Finance-ETF / ETN
+IBTM,Finance-ETF / ETN
+IBTO,Finance-ETF / ETN
+IBTX,Banks-West/Southwest
+IBUY,Finance-ETF / ETN
+ICAD,Medical-Systems/Equip
+ICAGY,Transportation-Airline
+ICAP,Finance-ETF / ETN
+ICCC,Medical-Products
+ICCH,Insurance-Prop/Cas/Titl
+ICCM,Medical-Systems/Equip
+ICCT,Computer Sftwr-Medical
+ICD,Oil&Gas-Drilling
+ICE,Financial Svcs-Specialty
+ICF,Finance-ETF / ETN
+ICFI,Comml Svcs-Consulting
+ICG,Elec-Semicondctor Fablss
+ICHR,Elec-Semiconductor Equip
+ICL,Chemicals-Agricultural
+ICLK,Internet-Content
+ICLN,Finance-ETF / ETN
+ICLO,Finance-ETF / ETN
+ICLR,Medical-Research Eqp/Svc
+ICMB,Finance-Investment Mgmt
+ICOP,Finance-ETF / ETN
+ICOW,Finance-ETF / ETN
+ICSH,Finance-ETF / ETN
+ICU,Medical-Biomed/Biotech
+ICUI,Medical-Products
+ICVT,Finance-ETF / ETN
+IDA,Utility-Electric Power
+IDAI,Security/Sfty
+IDAT,Finance-ETF / ETN
+IDCC,Elec-Misc Products
+IDE,Finance-Publ Inv Fd-Eqt
+IDEC,Finance-ETF / ETN
+IDEV,Finance-ETF / ETN
+IDEX,Internet-Content
+IDEXY,Retail-Apparel/Shoes/Acc
+IDGT,Finance-ETF / ETN
+IDHQ,Finance-ETF / ETN
+IDLB,Finance-ETF / ETN
+IDLV,Finance-ETF / ETN
+IDMO,Finance-ETF / ETN
+IDN,Security/Sfty
+IDNA,Finance-ETF / ETN
+IDOG,Finance-ETF / ETN
+IDR,Mining-Gold/Silver/Gems
+IDRV,Finance-ETF / ETN
+IDT,Telecom Svcs-Integrated
+IDU,Finance-ETF / ETN
+IDUB,Finance-ETF / ETN
+IDV,Finance-ETF / ETN
+IDVO,Finance-ETF / ETN
+IDWM,Media-Diversified
+IDX,Finance-ETF / ETN
+IDXX,Medical-Systems/Equip
+IDYA,Medical-Biomed/Biotech
+IE,Mining-Metal Ores
+IEDI,Finance-ETF / ETN
+IEF,Finance-ETF / ETN
+IEFA,Finance-ETF / ETN
+IEI,Finance-ETF / ETN
+IEMG,Finance-ETF / ETN
+IEO,Finance-ETF / ETN
+IEP,Diversified Operations
+IESC,Bldg-Maintenance & Svc
+IETC,Finance-ETF / ETN
+IEUR,Finance-ETF / ETN
+IEUS,Finance-ETF / ETN
+IEV,Finance-ETF / ETN
+IEX,Machinery-Gen Industrial
+IEZ,Finance-ETF / ETN
+IFBD,Computer Sftwr-Enterprse
+IFEB,Finance-ETF / ETN
+IFED,Finance-ETF / ETN
+IFF,Cosmetics/Personal Care
+IFGL,Finance-ETF / ETN
+IFIN,Finance-Blank Check
+IFN,Finance-Publ Inv Fd-Glbl
+IFRA,Finance-ETF / ETN
+IFRX,Medical-Biomed/Biotech
+IFS,Banks-Foreign
+IFV,Finance-ETF / ETN
+IG,Finance-ETF / ETN
+IGA,Finance-Publ Inv Fd-Eqt
+IGBH,Finance-ETF / ETN
+IGC,Medical-Biomed/Biotech
+IGD,Finance-Publ Inv Fd-Glbl
+IGE,Finance-ETF / ETN
+IGEB,Finance-ETF / ETN
+IGF,Finance-ETF / ETN
+IGHG,Finance-ETF / ETN
+IGI,Finance-Publ Inv Fd-Bond
+IGIB,Finance-ETF / ETN
+IGIC,Insurance-Prop/Cas/Titl
+IGLB,Finance-ETF / ETN
+IGLD,Finance-ETF / ETN
+IGM,Finance-ETF / ETN
+IGMS,Medical-Biomed/Biotech
+IGOV,Finance-ETF / ETN
+IGPT,Finance-ETF / ETN
+IGR,Finance-Publ Inv Fd-Eqt
+IGRO,Finance-ETF / ETN
+IGSB,Finance-ETF / ETN
+IGT,Leisure-Gaming/Equip
+IGTA,Finance-Blank Check
+IGTR,Finance-ETF / ETN
+IGV,Finance-ETF / ETN
+IH,Consumer Svcs-Education
+IHAK,Finance-ETF / ETN
+IHD,Finance-Publ Inv Fd-Eqt
+IHDG,Finance-ETF / ETN
+IHE,Finance-ETF / ETN
+IHF,Finance-ETF / ETN
+IHG,Leisure-Lodging
+IHI,Finance-ETF / ETN
+IHIT,Finance-Publ Inv Fd-Bond
+IHRT,Media-Radio/Tv
+IHS,Telecom-Infrastructure
+IHT,Finance-Property REIT
+IHTA,Finance-Publ Inv Fd-Bond
+IHY,Finance-ETF / ETN
+IHYF,Finance-ETF / ETN
+IIF,Finance-Publ Inv Fd-Glbl
+IIGD,Finance-ETF / ETN
+III,Comml Svcs-Consulting
+IIIN,Metal Proc & Fabrication
+IIIV,Finance-CrdtCard/PmtPr
+IIM,Finance-Publ Inv Fd-Bond
+IINN,Medical-Research Eqp/Svc
+IIPR,Finance-Property REIT
+IJAN,Finance-ETF / ETN
+IJH,Finance-ETF / ETN
+IJJ,Finance-ETF / ETN
+IJK,Finance-ETF / ETN
+IJR,Finance-ETF / ETN
+IJS,Finance-ETF / ETN
+IJT,Finance-ETF / ETN
+IJUL,Finance-ETF / ETN
+IKNA,Medical-Biomed/Biotech
+IKT,Medical-Biomed/Biotech
+ILAG,Retail-Home Furnishings
+ILCB,Finance-ETF / ETN
+ILCG,Finance-ETF / ETN
+ILCV,Finance-ETF / ETN
+ILDR,Finance-ETF / ETN
+ILF,Finance-ETF / ETN
+ILIT,Finance-ETF / ETN
+ILLMF,Comml Svcs-Advertising
+ILMN,Medical-Research Eqp/Svc
+ILPT,Finance-Property REIT
+ILTB,Finance-ETF / ETN
+IMAB,Medical-Biomed/Biotech
+IMAQ,Finance-Blank Check
+IMAR,Finance-ETF / ETN
+IMAX,Leisure-Movies & Related
+IMBIQ,Retail-Mail Order&Direct
+IMCB,Finance-ETF / ETN
+IMCC,Consumer Prod-Specialty
+IMCG,Finance-ETF / ETN
+IMCR,Medical-Biomed/Biotech
+IMCV,Finance-ETF / ETN
+IMFL,Finance-ETF / ETN
+IMKTA,Retail-Super/Mini Mkts
+IMMP,Medical-Biomed/Biotech
+IMMR,Elec-Misc Products
+IMMX,Medical-Biomed/Biotech
+IMNM,Medical-Biomed/Biotech
+IMNN,Medical-Biomed/Biotech
+IMO,Oil&Gas-Integrated
+IMOM,Finance-ETF / ETN
+IMOS,Elec-Semiconductor Mfg
+IMPLQ,Medical-Biomed/Biotech
+IMPM,Finance-Mrtg&Rel Svc
+IMPP,Oil&Gas-Transprt/Pipelne
+IMPUY,Mining-Gold/Silver/Gems
+IMRN,Medical-Biomed/Biotech
+IMRX,Medical-Biomed/Biotech
+IMSI,Finance-ETF / ETN
+IMTB,Finance-ETF / ETN
+IMTE,Computer-Tech Services
+IMTM,Finance-ETF / ETN
+IMTX,Medical-Biomed/Biotech
+IMUX,Medical-Biomed/Biotech
+IMVIQ,Medical-Biomed/Biotech
+IMVT,Medical-Biomed/Biotech
+IMXI,Financial Svcs-Specialty
+INAB,Medical-Biomed/Biotech
+INAQ,Finance-Blank Check
+INAV,Finance-ETF / ETN
+INBK,Banks-Midwest
+INBS,Medical-Products
+INBX,Medical-Biomed/Biotech
+INC,Finance-ETF / ETN
+INCM,Finance-ETF / ETN
+INCO,Finance-ETF / ETN
+INCR,Consumer Prod-Specialty
+INCY,Medical-Biomed/Biotech
+INDA,Finance-ETF / ETN
+INDB,Banks-Northeast
+INDE,Finance-ETF / ETN
+INDF,Finance-ETF / ETN
+INDI,Elec-Semicondctor Fablss
+INDL,Finance-ETF / ETN
+INDO,Oil&Gas-Intl Expl&Prod
+INDP,Medical-Biomed/Biotech
+INDS,Finance-ETF / ETN
+INDT,Real Estate Dvlpmt/Ops
+INDV,Medical-Ethical Drugs
+INDY,Finance-ETF / ETN
+INFA,Computer Sftwr-Enterprse
+INFIQ,Medical-Biomed/Biotech
+INFL,Finance-ETF / ETN
+INFN,Telecom-Fiber Optics
+INFR,Finance-ETF / ETN
+INFU,Medical-Services
+INFY,Computer-Tech Services
+ING,Banks-Foreign
+INGN,Medical-Products
+INGR,Food-Grain & Related
+INHD,Steel-Specialty Alloys
+INKM,Finance-ETF / ETN
+INKT,Medical-Biomed/Biotech
+INLX,Comp Sftwr-Spec Enterprs
+INM,Medical-Ethical Drugs
+INMB,Medical-Biomed/Biotech
+INMD,Medical-Systems/Equip
+INMU,Finance-ETF / ETN
+INN,Finance-Property REIT
+INNO,Finance-ETF / ETN
+INNV,Medical-Services
+INO,Medical-Biomed/Biotech
+INOD,Computer-Tech Services
+INQQ,Finance-ETF / ETN
+INRO,Finance-ETF / ETN
+INSE,Leisure-Services
+INSG,Telecom-Infrastructure
+INSI,Finance-Publ Inv Fd-Bond
+INSM,Medical-Biomed/Biotech
+INSP,Medical-Products
+INST,Computer Sftwr-Edu/Media
+INSW,Oil&Gas-Transprt/Pipelne
+INTA,Computer Sftwr-Financial
+INTC,Elec-Semiconductor Mfg
+INTE,Finance-Blank Check
+INTF,Finance-ETF / ETN
+INTG,Real Estate Dvlpmt/Ops
+INTJ,Comml Svcs-Advertising
+INTL,Finance-ETF / ETN
+INTR,Banks-Foreign
+INTS,Medical-Biomed/Biotech
+INTT,Elec-Misc Products
+INTU,Computer Sftwr-Financial
+INTZ,Computer Sftwr-Security
+INUV,Internet-Network Sltns
+INVA,Medical-Biomed/Biotech
+INVE,Computer Sftwr-Security
+INVH,Finance-Property REIT
+INVO,Medical-Services
+INVZ,Auto/Truck-Original Eqp
+INZY,Medical-Biomed/Biotech
+IOBT,Medical-Biomed/Biotech
+IOCT,Finance-ETF / ETN
+ION,Finance-ETF / ETN
+IONM,Medical-Systems/Equip
+IONQ,Computer-Hardware/Perip
+IONR,Mining-Metal Ores
+IONS,Medical-Biomed/Biotech
+IOO,Finance-ETF / ETN
+IOPP,Finance-ETF / ETN
+IOR,Real Estate Dvlpmt/Ops
+IOSP,Chemicals-Specialty
+IOT,Computer Sftwr-Enterprse
+IOVA,Medical-Biomed/Biotech
+IP,Paper & Paper Products
+IPA,Medical-Biomed/Biotech
+IPAC,Finance-ETF / ETN
+IPAR,Cosmetics/Personal Care
+IPAY,Finance-ETF / ETN
+IPDN,Internet-Content
+IPDP,Finance-ETF / ETN
+IPG,Comml Svcs-Advertising
+IPGP,Elec-Scientific/Msrng
+IPHA,Medical-Biomed/Biotech
+IPI,Chemicals-Agricultural
+IPKW,Finance-ETF / ETN
+IPO,Finance-ETF / ETN
+IPOS,Finance-ETF / ETN
+IPPP,Finance-ETF / ETN
+IPSC,Medical-Biomed/Biotech
+IPW,Retail-Internet
+IPWR,Electrical-Power/Equipmt
+IPX,Mining-Metal Ores
+IPXX,Finance-Blank Check
+IQ,Leisure-Movies & Related
+IQDE,Finance-ETF / ETN
+IQDF,Finance-ETF / ETN
+IQDG,Finance-ETF / ETN
+IQDY,Finance-ETF / ETN
+IQHI,Finance-ETF / ETN
+IQI,Finance-Publ Inv Fd-Bond
+IQIN,Finance-ETF / ETN
+IQLT,Finance-ETF / ETN
+IQM,Finance-ETF / ETN
+IQQQ,Finance-ETF / ETN
+IQRA,Finance-ETF / ETN
+IQSI,Finance-ETF / ETN
+IQSM,Finance-ETF / ETN
+IQSU,Finance-ETF / ETN
+IQV,Medical-Research Eqp/Svc
+IR,Machinery-Gen Industrial
+IRAA,Finance-Blank Check
+IRBA,Finance-ETF / ETN
+IRBO,Finance-ETF / ETN
+IRBT,Hsehold-Appliances/Wares
+IRDM,Telecom Svcs-Wireless
+IREN,Financial Svcs-Specialty
+IRET,Finance-ETF / ETN
+IRIX,Medical-Systems/Equip
+IRL,Finance-Publ Inv Fd-Glbl
+IRM,Comml Svcs-Document Mgmt
+IRMD,Medical-Systems/Equip
+IROH,Finance-Blank Check
+IRON,Medical-Biomed/Biotech
+IROQ,Finance-Savings & Loan
+IRRX,Finance-Blank Check
+IRS,Real Estate Dvlpmt/Ops
+IRT,Finance-Property REIT
+IRTC,Medical-Services
+IRTR,Finance-ETF / ETN
+IRVH,Finance-ETF / ETN
+IRWD,Medical-Biomed/Biotech
+ISCB,Finance-ETF / ETN
+ISCF,Finance-ETF / ETN
+ISCG,Finance-ETF / ETN
+ISCV,Finance-ETF / ETN
+ISD,Finance-Publ Inv Fd-Glbl
+ISDB,Finance-ETF / ETN
+ISDR,Computer Sftwr-Financial
+ISEE,Medical-Biomed/Biotech
+ISEP,Finance-ETF / ETN
+ISHG,Finance-ETF / ETN
+ISHP,Finance-ETF / ETN
+ISMD,Finance-ETF / ETN
+ISNPY,Banks-Foreign
+ISPC,Medical-Research Eqp/Svc
+ISPO,Leisure-Travel Booking
+ISPR,Consumer Prod-Specialty
+ISPY,Finance-ETF / ETN
+ISRA,Finance-ETF / ETN
+ISRG,Medical-Systems/Equip
+ISRL,Finance-Blank Check
+ISSC,Aerospace/Defense
+ISTB,Finance-ETF / ETN
+ISTR,Banks-Southeast
+ISUN,Energy-Solar
+ISVL,Finance-ETF / ETN
+ISWN,Finance-ETF / ETN
+ISZE,Finance-ETF / ETN
+IT,Comml Svcs-Market Rsrch
+ITA,Finance-ETF / ETN
+ITAN,Finance-ETF / ETN
+ITB,Finance-ETF / ETN
+ITCI,Medical-Biomed/Biotech
+ITDA,Finance-ETF / ETN
+ITDB,Finance-ETF / ETN
+ITDC,Finance-ETF / ETN
+ITDD,Finance-ETF / ETN
+ITDE,Finance-ETF / ETN
+ITDF,Finance-ETF / ETN
+ITDG,Finance-ETF / ETN
+ITDH,Finance-ETF / ETN
+ITDI,Finance-ETF / ETN
+ITEQ,Finance-ETF / ETN
+ITGR,Medical-Products
+ITHUF,Consumer Prod-Specialty
+ITI,Elec-Misc Products
+ITIC,Insurance-Prop/Cas/Titl
+ITM,Finance-ETF / ETN
+ITOCY,Diversified Operations
+ITOS,Medical-Biomed/Biotech
+ITOT,Finance-ETF / ETN
+ITP,Paper & Paper Products
+ITRG,Mining-Gold/Silver/Gems
+ITRI,Elec-Scientific/Msrng
+ITRM,Medical-Biomed/Biotech
+ITRN,Security/Sfty
+ITT,Machinery-Gen Industrial
+ITUB,Banks-Foreign
+ITW,Machinery-Gen Industrial
+IUS,Finance-ETF / ETN
+IUSB,Finance-ETF / ETN
+IUSG,Finance-ETF / ETN
+IUSV,Finance-ETF / ETN
+IVA,Medical-Biomed/Biotech
+IVAC,Elec-Semiconductor Equip
+IVAL,Finance-ETF / ETN
+IVCA,Finance-Blank Check
+IVCB,Finance-Blank Check
+IVCP,Finance-Blank Check
+IVDA,Security/Sfty
+IVE,Finance-ETF / ETN
+IVEG,Finance-ETF / ETN
+IVES,Finance-ETF / ETN
+IVLU,Finance-ETF / ETN
+IVOG,Finance-ETF / ETN
+IVOL,Finance-ETF / ETN
+IVOO,Finance-ETF / ETN
+IVOV,Finance-ETF / ETN
+IVP,Medical-Hospitals
+IVR,Finance-Mortgage REIT
+IVRA,Finance-ETF / ETN
+IVRS,Finance-ETF / ETN
+IVT,Finance-Property REIT
+IVV,Finance-ETF / ETN
+IVVB,Finance-ETF / ETN
+IVVD,Medical-Biomed/Biotech
+IVVM,Finance-ETF / ETN
+IVVW,Finance-ETF / ETN
+IVW,Finance-ETF / ETN
+IVZ,Finance-Investment Mgmt
+IWB,Finance-ETF / ETN
+IWC,Finance-ETF / ETN
+IWD,Finance-ETF / ETN
+IWDL,Finance-ETF / ETN
+IWF,Finance-ETF / ETN
+IWFG,Finance-ETF / ETN
+IWFH,Finance-ETF / ETN
+IWFL,Finance-ETF / ETN
+IWIN,Finance-ETF / ETN
+IWL,Finance-ETF / ETN
+IWLG,Finance-ETF / ETN
+IWM,Finance-ETF / ETN
+IWML,Finance-ETF / ETN
+IWMW,Finance-ETF / ETN
+IWMY,Finance-ETF / ETN
+IWN,Finance-ETF / ETN
+IWO,Finance-ETF / ETN
+IWP,Finance-ETF / ETN
+IWR,Finance-ETF / ETN
+IWS,Finance-ETF / ETN
+IWTR,Finance-ETF / ETN
+IWV,Finance-ETF / ETN
+IWX,Finance-ETF / ETN
+IWY,Finance-ETF / ETN
+IX,Finance-Consumer Loans
+IXAQ,Finance-Blank Check
+IXC,Finance-ETF / ETN
+IXG,Finance-ETF / ETN
+IXHL,Medical-Biomed/Biotech
+IXJ,Finance-ETF / ETN
+IXN,Finance-ETF / ETN
+IXP,Finance-ETF / ETN
+IXUS,Finance-ETF / ETN
+IYC,Finance-ETF / ETN
+IYE,Finance-ETF / ETN
+IYF,Finance-ETF / ETN
+IYG,Finance-ETF / ETN
+IYH,Finance-ETF / ETN
+IYJ,Finance-ETF / ETN
+IYK,Finance-ETF / ETN
+IYLD,Finance-ETF / ETN
+IYM,Finance-ETF / ETN
+IYR,Finance-ETF / ETN
+IYT,Finance-ETF / ETN
+IYW,Finance-ETF / ETN
+IYY,Finance-ETF / ETN
+IYZ,Finance-ETF / ETN
+IZEA,Internet-Content
+IZM,Retail-Internet
+IZRL,Finance-ETF / ETN
+J,Bldg-Heavy Construction
+JAAA,Finance-ETF / ETN
+JACK,Retail-Restaurants
+JAGX,Medical-Ethical Drugs
+JAKK,Leisure-Toys/Games/Hobby
+JAMF,Comp Sftwr-Spec Enterprs
+JAN,Retail-Consumer Elec
+JAND,Finance-ETF / ETN
+JANH,Finance-ETF / ETN
+JANJ,Finance-ETF / ETN
+JANP,Finance-ETF / ETN
+JANQ,Finance-ETF / ETN
+JANT,Finance-ETF / ETN
+JANW,Finance-ETF / ETN
+JANX,Medical-Biomed/Biotech
+JANZ,Finance-ETF / ETN
+JAPAY,Tobacco
+JAPSY,Transportation-Airline
+JAVA,Finance-ETF / ETN
+JAZZ,Medical-Ethical Drugs
+JBAXY,Finance-Investment Mgmt
+JBBB,Finance-ETF / ETN
+JBGS,Finance-Property REIT
+JBHT,Transportation-Truck
+JBI,Security/Sfty
+JBL,Elec-Contract Mfg
+JBLU,Transportation-Airline
+JBND,Finance-ETF / ETN
+JBSS,Food-Misc Preparation
+JBT,Machinery-Gen Industrial
+JCE,Finance-Publ Inv Fd-Eqt
+JCHI,Finance-ETF / ETN
+JCI,Diversified Operations
+JCPB,Finance-ETF / ETN
+JCPI,Finance-ETF / ETN
+JCSE,Machinery-Gen Industrial
+JCTCF,Retail/Whlsle-Bldg Prds
+JCTR,Finance-ETF / ETN
+JD,Retail-Internet
+JDOC,Finance-ETF / ETN
+JDST,Finance-ETF / ETN
+JDVI,Finance-ETF / ETN
+JEF,Finance-Invest Bnk/Bkrs
+JELD,Bldg-Constr Prds/Misc
+JEMA,Finance-ETF / ETN
+JEPI,Finance-ETF / ETN
+JEPQ,Finance-ETF / ETN
+JEPY,Finance-ETF / ETN
+JEQ,Finance-Publ Inv Fd-Glbl
+JETD,Finance-ETF / ETN
+JETS,Finance-ETF / ETN
+JETU,Finance-ETF / ETN
+JEWL,Retail/Whlsle-Jewelry
+JFBR,Retail-Internet
+JFIN,Financial Svcs-Specialty
+JFR,Finance-Publ Inv Fd-Bond
+JFU,Financial Svcs-Specialty
+JFWD,Finance-ETF / ETN
+JG,Computer Sftwr-Database
+JGH,Finance-Publ Inv Fd-Bond
+JGLO,Finance-ETF / ETN
+JGRO,Finance-ETF / ETN
+JHAA,Finance-Publ Inv Fd-Eqt
+JHAC,Finance-ETF / ETN
+JHCB,Finance-ETF / ETN
+JHDV,Finance-ETF / ETN
+JHEM,Finance-ETF / ETN
+JHG,Finance-Investment Mgmt
+JHI,Finance-Publ Inv Fd-Bond
+JHID,Finance-ETF / ETN
+JHMB,Finance-ETF / ETN
+JHMD,Finance-ETF / ETN
+JHML,Finance-ETF / ETN
+JHMM,Finance-ETF / ETN
+JHMU,Finance-ETF / ETN
+JHPI,Finance-ETF / ETN
+JHS,Finance-Publ Inv Fd-Bond
+JHSC,Finance-ETF / ETN
+JHX,Bldg-Constr Prds/Misc
+JIG,Finance-ETF / ETN
+JILL,Retail-Apparel/Shoes/Acc
+JIRE,Finance-ETF / ETN
+JIVE,Finance-ETF / ETN
+JJSF,Food-Packaged
+JKHY,Computer Sftwr-Financial
+JKS,Energy-Solar
+JL,Apparel-Clothing Mfg
+JLL,Real Estate Dvlpmt/Ops
+JLS,Finance-Publ Inv Fd-Bond
+JMBS,Finance-ETF / ETN
+JMEE,Finance-ETF / ETN
+JMHI,Finance-ETF / ETN
+JMIA,Retail-Internet
+JMM,Finance-Publ Inv Fd-Bond
+JMOM,Finance-ETF / ETN
+JMSB,Banks-Southeast
+JMSI,Finance-ETF / ETN
+JMST,Finance-ETF / ETN
+JMUB,Finance-ETF / ETN
+JNJ,Medical-Diversified
+JNK,Finance-ETF / ETN
+JNPR,Computer-Networking
+JNUG,Finance-ETF / ETN
+JNVR,Finance-Invest Bnk/Bkrs
+JOANQ,Retail-Specialty
+JOB,Comml Svcs-Staffing
+JOBY,Aerospace/Defense
+JOE,Real Estate Dvlpmt/Ops
+JOET,Finance-ETF / ETN
+JOF,Finance-Publ Inv Fd-Glbl
+JOJO,Finance-ETF / ETN
+JOUT,Leisure-Products
+JPAN,Finance-ETF / ETN
+JPC,Finance-Publ Inv Fd-Bal
+JPEF,Finance-ETF / ETN
+JPEM,Finance-ETF / ETN
+JPI,Finance-Publ Inv Fd-Eqt
+JPIB,Finance-ETF / ETN
+JPIE,Finance-ETF / ETN
+JPIN,Finance-ETF / ETN
+JPLD,Finance-ETF / ETN
+JPM,Banks-Money Center
+JPMB,Finance-ETF / ETN
+JPME,Finance-ETF / ETN
+JPMO,Finance-ETF / ETN
+JPRE,Finance-ETF / ETN
+JPS,Finance-Publ Inv Fd-Eqt
+JPSE,Finance-ETF / ETN
+JPST,Finance-ETF / ETN
+JPSV,Finance-ETF / ETN
+JPT,Finance-Publ Inv Fd-Bond
+JPUS,Finance-ETF / ETN
+JPXN,Finance-ETF / ETN
+JQC,Finance-Publ Inv Fd-Bond
+JQUA,Finance-ETF / ETN
+JRE,Finance-ETF / ETN
+JRI,Finance-Publ Inv Fd-Bond
+JRNY,Finance-ETF / ETN
+JRS,Finance-Publ Inv Fd-Eqt
+JRSH,Apparel-Clothing Mfg
+JRVR,Insurance-Prop/Cas/Titl
+JSCP,Finance-ETF / ETN
+JSI,Finance-ETF / ETN
+JSMD,Finance-ETF / ETN
+JSML,Finance-ETF / ETN
+JSPR,Medical-Biomed/Biotech
+JSTC,Finance-ETF / ETN
+JTAI,Comp Sftwr-Spec Enterprs
+JTEK,Finance-ETF / ETN
+JUCY,Finance-ETF / ETN
+JULD,Finance-ETF / ETN
+JULH,Finance-ETF / ETN
+JULJ,Finance-ETF / ETN
+JULQ,Finance-ETF / ETN
+JULT,Finance-ETF / ETN
+JULW,Finance-ETF / ETN
+JULZ,Finance-ETF / ETN
+JUNT,Finance-ETF / ETN
+JUNW,Finance-ETF / ETN
+JUNZ,Finance-ETF / ETN
+JUST,Finance-ETF / ETN
+JVA,Wholesale-Food
+JVAL,Finance-ETF / ETN
+JVSA,Finance-Blank Check
+JWEL,Retail-Department Stores
+JWN,Retail-Department Stores
+JWSM,Finance-Blank Check
+JXI,Finance-ETF / ETN
+JXJT,Apparel-Clothing Mfg
+JXN,Insurance-Diversified
+JYD,Transportation-Logistics
+JYNT,Medical-Services
+JZ,Consumer Svcs-Education
+JZXN,Retail/Whlsle-Automobile
+K,Food-Packaged
+KA,Medical-Biomed/Biotech
+KACL,Finance-Blank Check
+KAI,Machinery-Gen Industrial
+KALA,Medical-Biomed/Biotech
+KALL,Finance-ETF / ETN
+KALRQ,Agricultural Operations
+KALU,Metal Proc & Fabrication
+KALV,Medical-Biomed/Biotech
+KAMN,Aerospace/Defense
+KAOOY,Cosmetics/Personal Care
+KAPR,Finance-ETF / ETN
+KAR,Retail/Whlsle-Automobile
+KARB,Finance-ETF / ETN
+KARO,Comp Sftwr-Spec Enterprs
+KARS,Finance-ETF / ETN
+KAVL,Finance-Blank Check
+KB,Banks-Foreign
+KBA,Finance-ETF / ETN
+KBCSY,Banks-Foreign
+KBE,Finance-ETF / ETN
+KBH,Bldg-Resident/Comml
+KBNT,Comml Svcs-Advertising
+KBR,Comml Svcs-Consulting
+KBUF,Finance-ETF / ETN
+KBWB,Finance-ETF / ETN
+KBWD,Finance-ETF / ETN
+KBWP,Finance-ETF / ETN
+KBWR,Finance-ETF / ETN
+KBWY,Finance-ETF / ETN
+KC,Computer Sftwr-Enterprse
+KCCA,Finance-ETF / ETN
+KCDMY,Cosmetics/Personal Care
+KCE,Finance-ETF / ETN
+KCGI,Finance-Blank Check
+KD,Computer Sftwr-Enterprse
+KDDIY,Telecom Svcs-Wireless
+KDIV,Finance-ETF / ETN
+KDP,Beverages-Non-Alcoholic
+KDRN,Finance-ETF / ETN
+KE,Elec-Contract Mfg
+KEAT,Finance-ETF / ETN
+KELYA,Comml Svcs-Staffing
+KELYB,Comml Svcs-Staffing
+KEM,Finance-ETF / ETN
+KEMQ,Finance-ETF / ETN
+KEMX,Finance-ETF / ETN
+KEN,Energy-Alternative/Other
+KEP,Utility-Electric Power
+KEQU,Hsehold/Office Furniture
+KEUA,Finance-ETF / ETN
+KEX,Transportation-Ship
+KEY,Banks-Super Regional
+KEYS,Elec-Scientific/Msrng
+KF,Finance-Publ Inv Fd-Glbl
+KFFB,Finance-Savings & Loan
+KFRC,Comml Svcs-Staffing
+KFS,Insurance-Prop/Cas/Titl
+KFVG,Finance-ETF / ETN
+KFY,Comml Svcs-Staffing
+KGC,Mining-Gold/Silver/Gems
+KGEI,Oil&Gas-U S Expl&Prod
+KGRN,Finance-ETF / ETN
+KGS,Oil&Gas-Field Services
+KHC,Food-Packaged
+KHYB,Finance-ETF / ETN
+KIDS,Medical-Products
+KIE,Finance-ETF / ETN
+KIM,Finance-Property REIT
+KIND,Internet-Content
+KINS,Insurance-Brokers
+KIO,Finance-Publ Inv Fd-Bond
+KIQSF,Transportation-Equip Mfg
+KIRK,Retail-Home Furnishings
+KITT,Machinery-Mtl Hdlg/Autmn
+KJAN,Finance-ETF / ETN
+KJUL,Finance-ETF / ETN
+KKR,Finance-Investment Mgmt
+KLAC,Elec-Semiconductor Equip
+KLDO,Group not available
+KLDW,Finance-ETF / ETN
+KLG,Food-Packaged
+KLIC,Elec-Semiconductor Equip
+KLIP,Finance-ETF / ETN
+KLNE,Finance-ETF / ETN
+KLTR,Computer Sftwr-Enterprse
+KLXE,Oil&Gas-Field Services
+KLXY,Finance-ETF / ETN
+KMB,Cosmetics/Personal Care
+KMDA,Medical-Biomed/Biotech
+KMET,Finance-ETF / ETN
+KMI,Oil&Gas-Transprt/Pipelne
+KMLM,Finance-ETF / ETN
+KMPR,Insurance-Prop/Cas/Titl
+KMT,Machinery-Tools & Rel
+KMTUY,Machinery-Constr/Mining
+KMX,Retail/Whlsle-Automobile
+KN,Elec-Misc Products
+KNBWY,Beverages-Alcoholic
+KNCT,Finance-ETF / ETN
+KNDI,Auto Manufacturers
+KNF,Bldg-Cement/Concrt/Ag
+KNG,Finance-ETF / ETN
+KNGS,Finance-ETF / ETN
+KNGZ,Finance-ETF / ETN
+KNOP,Oil&Gas-Transprt/Pipelne
+KNOW,Finance-ETF / ETN
+KNSA,Medical-Biomed/Biotech
+KNSL,Insurance-Prop/Cas/Titl
+KNTE,Medical-Biomed/Biotech
+KNTK,Oil&Gas-Transprt/Pipelne
+KNW,Medical-Products
+KNX,Transportation-Truck
+KO,Beverages-Non-Alcoholic
+KOCG,Finance-ETF / ETN
+KOCT,Finance-ETF / ETN
+KOD,Medical-Biomed/Biotech
+KODK,Leisure-Products
+KOF,Beverages-Non-Alcoholic
+KOIN,Finance-ETF / ETN
+KOKU,Finance-ETF / ETN
+KOLD,Finance-ETF / ETN
+KOMP,Finance-ETF / ETN
+KONG,Finance-ETF / ETN
+KOOL,Group not available
+KOP,Chemicals-Specialty
+KOPN,Elec-Semiconductor Equip
+KORE,Computer Sftwr-Enterprse
+KORP,Finance-ETF / ETN
+KORU,Finance-ETF / ETN
+KOS,Oil&Gas-Intl Expl&Prod
+KOSS,Consumer Prod-Electronic
+KPLT,Retail-Internet
+KPOP,Finance-ETF / ETN
+KPRO,Finance-ETF / ETN
+KPRX,Medical-Biomed/Biotech
+KPTI,Medical-Biomed/Biotech
+KR,Retail-Super/Mini Mkts
+KRBN,Finance-ETF / ETN
+KRBP,Medical-Biomed/Biotech
+KRC,Finance-Property REIT
+KRE,Finance-ETF / ETN
+KREF,Finance-Mrtg&Rel Svc
+KRG,Finance-Property REIT
+KRKR,Internet-Content
+KRMA,Finance-ETF / ETN
+KRMD,Medical-Products
+KRNL,Finance-Blank Check
+KRNT,Machinery-Gen Industrial
+KRNY,Finance-Savings & Loan
+KRO,Chemicals-Specialty
+KRON,Medical-Biomed/Biotech
+KROP,Finance-ETF / ETN
+KROS,Medical-Biomed/Biotech
+KRP,Oil&Gas-U S Expl&Prod
+KRRO,Medical-Biomed/Biotech
+KRT,Containers/Packaging
+KRUS,Retail-Restaurants
+KRUZ,Finance-ETF / ETN
+KRYAY,Food-Misc Preparation
+KRYS,Medical-Biomed/Biotech
+KSA,Finance-ETF / ETN
+KSCP,Security/Sfty
+KSEA,Finance-ETF / ETN
+KSM,Finance-Publ Inv Fd-Bond
+KSPI,Finance-CrdtCard/PmtPr
+KSPN,Comml Svcs-Advertising
+KSS,Retail-Department Stores
+KSTR,Finance-ETF / ETN
+KT,Telecom Svcs- Foreign
+KTB,Apparel-Clothing Mfg
+KTCC,Elec-Contract Mfg
+KTEC,Finance-ETF / ETN
+KTF,Finance-Publ Inv Fd-Bond
+KTOS,Aerospace/Defense
+KTRA,Medical-Biomed/Biotech
+KTTA,Medical-Biomed/Biotech
+KUBTY,Machinery-Farm
+KUKE,Consumer Svcs-Education
+KULR,Elec-Semiconductor Equip
+KURA,Medical-Biomed/Biotech
+KURE,Finance-ETF / ETN
+KVAC,Finance-Blank Check
+KVHI,Telecom-Infrastructure
+KVLE,Finance-ETF / ETN
+KVSA,Finance-Blank Check
+KVUE,Cosmetics/Personal Care
+KVYO,Computer Sftwr-Enterprse
+KW,Real Estate Dvlpmt/Ops
+KWE,Aerospace/Defense
+KWEB,Finance-ETF / ETN
+KWR,Chemicals-Specialty
+KWT,Finance-ETF / ETN
+KXI,Finance-ETF / ETN
+KXIN,Retail/Whlsle-Automobile
+KYCH,Finance-Blank Check
+KYMR,Medical-Biomed/Biotech
+KYN,Finance-Publ Inv Fd-Eqt
+KYOCY,Elec-Misc Products
+KYTX,Medical-Biomed/Biotech
+KZIA,Medical-Biomed/Biotech
+KZR,Medical-Biomed/Biotech
+L,Insurance-Diversified
+LAAC,Mining-Metal Ores
+LAB,Medical-Systems/Equip
+LABD,Finance-ETF / ETN
+LABP,Medical-Biomed/Biotech
+LABU,Finance-ETF / ETN
+LAC,Mining-Metal Ores
+LAD,Retail/Whlsle-Automobile
+LADR,Finance-Mortgage REIT
+LAES,Elec-Semicondctor Fablss
+LAKE,Security/Sfty
+LALT,Finance-ETF / ETN
+LAMR,Comml Svcs-Advertising
+LANC,Food-Packaged
+LAND,Finance-Property REIT
+LANV,Apparel-Clothing Mfg
+LARK,Banks-Midwest
+LASE,Machinery-Gen Industrial
+LASR,Electronic-Parts
+LATG,Finance-Blank Check
+LAUR,Consumer Svcs-Education
+LAW,Computer Sftwr-Enterprse
+LAZ,Finance-Invest Bnk/Bkrs
+LAZR,Auto/Truck-Original Eqp
+LBAI,Banks-Northeast
+LBAY,Finance-ETF / ETN
+LBO,Finance-ETF / ETN
+LBPH,Medical-Biomed/Biotech
+LBRDA,Media-Diversified
+LBRDK,Media-Diversified
+LBRT,Oil&Gas-Field Services
+LBTYA,Telecom Svcs-Cable/Satl
+LBTYB,Telecom Svcs- Foreign
+LBTYK,Telecom Svcs-Cable/Satl
+LC,Financial Svcs-Specialty
+LCF,Finance-ETF / ETN
+LCFY,Computer Sftwr-Enterprse
+LCG,Finance-ETF / ETN
+LCID,Auto Manufacturers
+LCII,Bldg-Mobile/Mfg & Rv
+LCLG,Finance-ETF / ETN
+LCNB,Banks-Midwest
+LCR,Finance-ETF / ETN
+LCTD,Finance-ETF / ETN
+LCTU,Finance-ETF / ETN
+LCTX,Medical-Biomed/Biotech
+LCUT,Hsehold-Appliances/Wares
+LCW,Finance-Blank Check
+LDEM,Finance-ETF / ETN
+LDI,Finance-Mrtg&Rel Svc
+LDOS,Comml Svcs-Consulting
+LDP,Finance-Publ Inv Fd-Eqt
+LDSCY,Finance-Property REIT
+LDSF,Finance-ETF / ETN
+LDTC,Auto/Truck-Original Eqp
+LDUR,Finance-ETF / ETN
+LDWY,Comml Svcs-Advertising
+LE,Retail-Apparel/Shoes/Acc
+LEA,Auto/Truck-Original Eqp
+LEAD,Finance-ETF / ETN
+LECO,Machinery-Tools & Rel
+LEDS,Elec-Semiconductor Mfg
+LEE,Media-Newspapers
+LEG,Hsehold/Office Furniture
+LEGH,Finance-Property REIT
+LEGN,Medical-Biomed/Biotech
+LEGR,Finance-ETF / ETN
+LEGT,Finance-Blank Check
+LEJU,Internet-Content
+LEMB,Finance-ETF / ETN
+LEN,Bldg-Resident/Comml
+LENB,Bldg-Resident/Comml
+LENZ,Medical-Biomed/Biotech
+LEO,Finance-Publ Inv Fd-Bond
+LESL,Retail-Leisure Products
+LEU,Energy-Alternative/Other
+LEV,Auto Manufacturers
+LEVI,Apparel-Clothing Mfg
+LEXI,Finance-ETF / ETN
+LEXX,Medical-Ethical Drugs
+LFCBY,Medical-Systems/Equip
+LFCR,Medical-Ethical Drugs
+LFEQ,Finance-ETF / ETN
+LFLY,Consumer Prod-Specialty
+LFMD,Medical-Products
+LFST,Medical-Hospitals
+LFSWF,Consumer Prod-Specialty
+LFT,Finance-Mortgage REIT
+LFUS,Electronic-Parts
+LFVN,Cosmetics/Personal Care
+LFWD,Medical-Products
+LGCB,Retail-Internet
+LGCL,Computer-Tech Services
+LGFA,Leisure-Movies & Related
+LGFB,Leisure-Movies & Related
+LGH,Finance-ETF / ETN
+LGHL,Finance-Invest Bnk/Bkrs
+LGHT,Finance-ETF / ETN
+LGI,Finance-Publ Inv Fd-Bal
+LGIH,Bldg-Resident/Comml
+LGL,Machinery-Gen Industrial
+LGLV,Finance-ETF / ETN
+LGMK,Security/Sfty
+LGND,Medical-Biomed/Biotech
+LGO,Mining-Metal Ores
+LGOV,Finance-ETF / ETN
+LGRO,Finance-ETF / ETN
+LGVC,Finance-Blank Check
+LGVN,Medical-Biomed/Biotech
+LH,Medical-Services
+LHC,Finance-Blank Check
+LHX,Aerospace/Defense
+LI,Auto Manufacturers
+LIANY,Medical-Biomed/Biotech
+LICN,Comml Svcs-Consulting
+LICY,Pollution Control
+LIDR,Auto/Truck-Original Eqp
+LIFE,Medical-Biomed/Biotech
+LIFW,Computer Sftwr-Medical
+LII,Bldg-A/C & Heating Prds
+LILA,Telecom Svcs- Foreign
+LILAB,Telecom Svcs-Cable/Satl
+LILAK,Telecom Svcs- Foreign
+LILM,Aerospace/Defense
+LIN,Chemicals-Specialty
+LINC,Consumer Svcs-Education
+LIND,Leisure-Services
+LINK,Elec-Misc Products
+LIPO,Medical-Biomed/Biotech
+LIQT,Pollution Control
+LIT,Finance-ETF / ETN
+LITB,Retail-Internet
+LITE,Telecom-Fiber Optics
+LITM,Mining-Metal Ores
+LITP,Finance-ETF / ETN
+LIVE,Retail-Internet
+LIVN,Medical-Products
+LIXT,Medical-Biomed/Biotech
+LJAN,Finance-ETF / ETN
+LKCO,Internet-Content
+LKFN,Banks-Midwest
+LKNCY,Retail-Restaurants
+LKOR,Finance-ETF / ETN
+LKQ,Retail/Whlsle-Auto Parts
+LL,Retail/Whlsle-Bldg Prds
+LLAP,Aerospace/Defense
+LLY,Medical-Diversified
+LLYVA,Media-Diversified
+LLYVB,Media-Diversified
+LLYVK,Media-Diversified
+LMAT,Medical-Products
+LMB,Bldg-A/C & Heating Prds
+LMBS,Finance-ETF / ETN
+LMDXF,Medical-Systems/Equip
+LMFA,Financial Svcs-Specialty
+LMND,Insurance-Prop/Cas/Titl
+LMNR,Agricultural Operations
+LMPX,Group not available
+LMT,Aerospace/Defense
+LNC,Insurance-Life
+LND,Agricultural Operations
+LNG,Oil&Gas-Transprt/Pipelne
+LNGG,Finance-ETF / ETN
+LNGZ,Finance-ETF / ETN
+LNKB,Banks-Northeast
+LNN,Machinery-Farm
+LNSR,Medical-Systems/Equip
+LNSTY,Financial Svcs-Specialty
+LNT,Utility-Diversified
+LNTH,Medical-Products
+LNVGY,Computer-Hardware/Perip
+LNW,Leisure-Gaming/Equip
+LNZA,Chemicals-Specialty
+LOAN,Finance-Mortgage REIT
+LOB,Banks-Southeast
+LOBO,Auto Manufacturers
+LOCL,Agricultural Operations
+LOCO,Retail-Restaurants
+LOCT,Finance-ETF / ETN
+LODE,Mining-Gold/Silver/Gems
+LOGI,Computer-Hardware/Perip
+LOMA,Bldg-Cement/Concrt/Ag
+LONZ,Finance-ETF / ETN
+LOOP,Chemicals-Plastics
+LOPE,Consumer Svcs-Education
+LOPP,Finance-ETF / ETN
+LOT,Auto Manufacturers
+LOUP,Finance-ETF / ETN
+LOVE,Retail-Home Furnishings
+LOVLQ,Internet-Content
+LOW,Retail/Whlsle-Bldg Prds
+LOWV,Finance-ETF / ETN
+LPA,Finance-Property REIT
+LPCN,Medical-Biomed/Biotech
+LPG,Oil&Gas-Transprt/Pipelne
+LPL,Elec-Misc Products
+LPLA,Finance-Invest Bnk/Bkrs
+LPRO,Finance-Commercial Loans
+LPSN,Computer Sftwr-Enterprse
+LPTH,Telecom-Fiber Optics
+LPTV,Internet-Content
+LPTX,Medical-Biomed/Biotech
+LPX,Bldg-Wood Prds
+LQAI,Finance-ETF / ETN
+LQD,Finance-ETF / ETN
+LQDA,Medical-Biomed/Biotech
+LQDB,Finance-ETF / ETN
+LQDH,Finance-ETF / ETN
+LQDI,Finance-ETF / ETN
+LQDT,Retail-Internet
+LQDW,Finance-ETF / ETN
+LQIG,Finance-ETF / ETN
+LQR,Retail-Internet
+LRCX,Elec-Semiconductor Equip
+LRE,Finance-Property REIT
+LRFC,Finance-Investment Mgmt
+LRGC,Finance-ETF / ETN
+LRGE,Finance-ETF / ETN
+LRGF,Finance-ETF / ETN
+LRHC,Real Estate Dvlpmt/Ops
+LRLCY,Cosmetics/Personal Care
+LRMR,Medical-Generic Drugs
+LRN,Consumer Svcs-Education
+LRND,Finance-ETF / ETN
+LRNZ,Finance-ETF / ETN
+LSAF,Finance-ETF / ETN
+LSAK,Finance-CrdtCard/PmtPr
+LSAT,Finance-ETF / ETN
+LSBK,Finance-Savings & Loan
+LSCC,Elec-Semicondctor Fablss
+LSDI,Medical-Ethical Drugs
+LSEA,Bldg-Resident/Comml
+LSEQ,Finance-ETF / ETN
+LSF,Food-Packaged
+LSGR,Finance-ETF / ETN
+LSPD,Comp Sftwr-Spec Enterprs
+LSRCY,Elec-Semiconductor Equip
+LSST,Finance-ETF / ETN
+LSTA,Medical-Biomed/Biotech
+LSTR,Transportation-Truck
+LSXMA,Media-Diversified
+LSXMB,Media-Diversified
+LSXMK,Media-Diversified
+LTBR,Energy-Alternative/Other
+LTC,Finance-Property REIT
+LTCH,Security/Sfty
+LTCN,Finance-Publ Inv Fd-Eqt
+LTH,Leisure-Services
+LTL,Finance-ETF / ETN
+LTMAY,Transportation-Airline
+LTPZ,Finance-ETF / ETN
+LTRN,Medical-Biomed/Biotech
+LTRPA,Internet-Content
+LTRPB,Internet-Content
+LTRX,Computer-Networking
+LTRY,Computer Sftwr-Gaming
+LU,Financial Svcs-Specialty
+LUCD,Medical-Products
+LUCY,Retail-Specialty
+LUKOY,Oil&Gas-Integrated
+LULU,Retail-Apparel/Shoes/Acc
+LUMN,Telecom Svcs-Integrated
+LUMO,Medical-Biomed/Biotech
+LUNA,Elec-Scientific/Msrng
+LUNG,Medical-Products
+LUNR,Aerospace/Defense
+LUV,Transportation-Airline
+LUX,Finance-ETF / ETN
+LUXH,Real Estate Dvlpmt/Ops
+LUXX,Finance-ETF / ETN
+LVHD,Finance-ETF / ETN
+LVHI,Finance-ETF / ETN
+LVLU,Retail-Internet
+LVMUY,Apparel-Clothing Mfg
+LVO,Internet-Content
+LVOL,Finance-ETF / ETN
+LVOX,Computer Sftwr-Enterprse
+LVRO,Chemicals-Agricultural
+LVS,Leisure-Gaming/Equip
+LVTX,Medical-Biomed/Biotech
+LVWR,Auto Manufacturers
+LW,Food-Packaged
+LWAY,Food-Dairy Products
+LWLG,Elec-Contract Mfg
+LX,Finance-Consumer Loans
+LXEH,Consumer Svcs-Education
+LXEO,Medical-Biomed/Biotech
+LXFR,Chemicals-Specialty
+LXP,Finance-Property REIT
+LXRX,Medical-Biomed/Biotech
+LXU,Chemicals-Agricultural
+LYB,Chemicals-Basic
+LYEL,Medical-Biomed/Biotech
+LYFT,Leisure-Services
+LYG,Banks-Money Center
+LYRA,Medical-Biomed/Biotech
+LYT,Internet-Content
+LYTS,Bldg-Constr Prds/Misc
+LYV,Leisure-Services
+LZ,Internet-Content
+LZAGY,Chemicals-Specialty
+LZB,Retail-Home Furnishings
+LZM,Mining-Metal Ores
+M,Retail-Department Stores
+MA,Finance-CrdtCard/PmtPr
+MAA,Finance-Property REIT
+MAC,Finance-Property REIT
+MACA,Finance-Blank Check
+MACK,Medical-Biomed/Biotech
+MAG,Mining-Gold/Silver/Gems
+MAGA,Finance-ETF / ETN
+MAGG,Finance-ETF / ETN
+MAGQ,Finance-ETF / ETN
+MAGS,Finance-ETF / ETN
+MAGX,Finance-ETF / ETN
+MAIA,Medical-Biomed/Biotech
+MAIN,Finance-Investment Mgmt
+MAKX,Finance-ETF / ETN
+MAMA,Food-Meat Products
+MAMB,Finance-ETF / ETN
+MAMO,Group not available
+MAN,Comml Svcs-Staffing
+MANH,Computer Sftwr-Enterprse
+MANU,Leisure-Services
+MAPP,Finance-ETF / ETN
+MAPS,Computer Sftwr-Enterprse
+MAQC,Finance-Blank Check
+MAR,Leisure-Lodging
+MARA,Finance-Investment Mgmt
+MARB,Finance-ETF / ETN
+MARK,Internet-Content
+MARM,Finance-ETF / ETN
+MARPS,Oil&Gas-Royalty Trust
+MART,Finance-ETF / ETN
+MARW,Finance-ETF / ETN
+MARX,Finance-Blank Check
+MARZ,Finance-ETF / ETN
+MAS,Bldg-Constr Prds/Misc
+MASI,Medical-Systems/Equip
+MASS,Medical-Research Eqp/Svc
+MAT,Leisure-Toys/Games/Hobby
+MATH,Comml Svcs-Consulting
+MATV,Paper & Paper Products
+MATW,Funeral Svcs & Rel
+MATX,Transportation-Ship
+MAV,Finance-Publ Inv Fd-Bond
+MAX,Comml Svcs-Advertising
+MAXI,Finance-ETF / ETN
+MAXN,Energy-Solar
+MAYS,Real Estate Dvlpmt/Ops
+MAYT,Finance-ETF / ETN
+MAYW,Finance-ETF / ETN
+MAYZ,Finance-ETF / ETN
+MBAC,Finance-Blank Check
+MBB,Finance-ETF / ETN
+MBBB,Finance-ETF / ETN
+MBC,Hsehold-Appliances/Wares
+MBCC,Finance-ETF / ETN
+MBCN,Banks-Midwest
+MBGAF,Auto Manufacturers
+MBI,Insurance-Prop/Cas/Titl
+MBIN,Banks-Midwest
+MBIO,Medical-Biomed/Biotech
+MBLY,Elec-Semicondctor Fablss
+MBND,Finance-ETF / ETN
+MBNE,Finance-ETF / ETN
+MBOT,Medical-Biomed/Biotech
+MBOX,Finance-ETF / ETN
+MBRX,Medical-Biomed/Biotech
+MBS,Finance-ETF / ETN
+MBSD,Finance-ETF / ETN
+MBSF,Finance-ETF / ETN
+MBTC,Finance-Blank Check
+MBUU,Leisure-Products
+MBWM,Banks-Midwest
+MC,Finance-Invest Bnk/Bkrs
+MCAA,Finance-Blank Check
+MCAC,Finance-Blank Check
+MCAG,Finance-Blank Check
+MCB,Banks-Northeast
+MCBC,Banks-Midwest
+MCBS,Banks-Southeast
+MCD,Retail-Restaurants
+MCFT,Leisure-Products
+MCH,Finance-ETF / ETN
+MCHI,Finance-ETF / ETN
+MCHP,Elec-Semiconductor Mfg
+MCHS,Finance-ETF / ETN
+MCHX,Comml Svcs-Advertising
+MCI,Finance-Publ Inv Fd-Bond
+MCK,Medical-Whlsle Drg/Suppl
+MCKPF,Group not available
+MCLDF,Computer-Tech Services
+MCN,Finance-Publ Inv Fd-Eqt
+MCO,Comml Svcs-Market Rsrch
+MCOM,Leisure-Products
+MCR,Finance-Publ Inv Fd-Bond
+MCRB,Medical-Biomed/Biotech
+MCRI,Leisure-Gaming/Equip
+MCS,Leisure-Movies & Related
+MCSE,Finance-ETF / ETN
+MCVT,Finance-Investment Mgmt
+MCW,Retail/Whlsle-Automobile
+MCY,Insurance-Prop/Cas/Titl
+MD,Medical-Outpnt/Hm Care
+MDAI,Medical-Research Eqp/Svc
+MDB,Computer Sftwr-Database
+MDBH,Finance-Investment Mgmt
+MDC,Bldg-Resident/Comml
+MDCP,Finance-ETF / ETN
+MDEV,Finance-ETF / ETN
+MDGL,Medical-Biomed/Biotech
+MDGS,Medical-Systems/Equip
+MDIA,Media-Radio/Tv
+MDIV,Finance-ETF / ETN
+MDJH,Real Estate Dvlpmt/Ops
+MDLV,Finance-ETF / ETN
+MDLZ,Food-Confectionery
+MDNAF,Medical-Biomed/Biotech
+MDPL,Finance-ETF / ETN
+MDRR,Finance-Property REIT
+MDRX,Computer Sftwr-Medical
+MDT,Medical-Products
+MDU,Diversified Operations
+MDV,Finance-Property REIT
+MDVLQ,Medical-Services
+MDWD,Medical-Biomed/Biotech
+MDXG,Medical-Products
+MDXH,Medical-Biomed/Biotech
+MDY,Finance-ETF / ETN
+MDYG,Finance-ETF / ETN
+MDYV,Finance-ETF / ETN
+ME,Medical-Services
+MEAR,Finance-ETF / ETN
+MEC,Auto/Truck-Original Eqp
+MED,Cosmetics/Personal Care
+MEDI,Finance-ETF / ETN
+MEDP,Medical-Research Eqp/Svc
+MEDS,Medical-Whlsle Drg/Suppl
+MEDX,Finance-ETF / ETN
+MEG,Pollution Control
+MEGI,Finance-Publ Inv Fd-Eqt
+MEGL,Finance-Investment Mgmt
+MEI,Electronic-Parts
+MEIP,Medical-Biomed/Biotech
+MELI,Retail-Internet
+MEM,Finance-ETF / ETN
+MEME,Finance-ETF / ETN
+MEMS,Finance-ETF / ETN
+MEMX,Finance-ETF / ETN
+MEOA,Finance-Blank Check
+MEOH,Chemicals-Specialty
+MERC,Paper & Paper Products
+MESA,Transportation-Airline
+MESO,Medical-Biomed/Biotech
+MET,Insurance-Life
+META,Internet-Content
+METC,Energy-Coal
+METCB,Energy-Coal
+METV,Finance-ETF / ETN
+MEXX,Finance-ETF / ETN
+MFA,Finance-Mortgage REIT
+MFC,Insurance-Diversified
+MFD,Finance-Publ Inv Fd-Eqt
+MFDX,Finance-ETF / ETN
+MFEM,Finance-ETF / ETN
+MFG,Banks-Money Center
+MFH,Retail-Internet
+MFIC,Finance-Investment Mgmt
+MFIN,Finance-Commercial Loans
+MFLTY,Retail-Internet
+MFLX,Finance-ETF / ETN
+MFM,Finance-Publ Inv Fd-Bond
+MFUL,Finance-ETF / ETN
+MFUS,Finance-ETF / ETN
+MFV,Finance-Publ Inv Fd-Bond
+MG,Bldg-Maintenance & Svc
+MGA,Auto/Truck-Original Eqp
+MGAM,Leisure-Products
+MGC,Finance-ETF / ETN
+MGDDY,Auto/Truck-Tires & Misc
+MGEE,Utility-Diversified
+MGF,Finance-Publ Inv Fd-Bond
+MGIC,Computer-Tech Services
+MGIH,Paper & Paper Products
+MGK,Finance-ETF / ETN
+MGLD,Diversified Operations
+MGM,Leisure-Gaming/Equip
+MGMT,Finance-ETF / ETN
+MGNI,Computer Sftwr-Enterprse
+MGNR,Finance-ETF / ETN
+MGNX,Medical-Biomed/Biotech
+MGOL,Apparel-Clothing Mfg
+MGOV,Finance-ETF / ETN
+MGPI,Beverages-Alcoholic
+MGRC,Comml Svcs-Leasing
+MGRM,Medical-Systems/Equip
+MGRO,Group not available
+MGRX,Medical-Generic Drugs
+MGTX,Medical-Biomed/Biotech
+MGV,Finance-ETF / ETN
+MGX,Medical-Biomed/Biotech
+MGY,Oil&Gas-U S Expl&Prod
+MGYR,Finance-Savings & Loan
+MHD,Finance-Publ Inv Fd-Bond
+MHF,Finance-Publ Inv Fd-Bond
+MHH,Comml Svcs-Staffing
+MHI,Finance-Publ Inv Fd-Bond
+MHK,Bldg-Constr Prds/Misc
+MHLD,Insurance-Prop/Cas/Titl
+MHN,Finance-Publ Inv Fd-Bond
+MHO,Bldg-Resident/Comml
+MHUA,Medical-Supplies
+MI,Computer-Integrated Syst
+MICS,Consumer Prod-Electronic
+MID,Finance-ETF / ETN
+MIDD,Hsehold-Appliances/Wares
+MIDE,Finance-ETF / ETN
+MIDU,Finance-ETF / ETN
+MIELY,Diversified Operations
+MIG,Finance-ETF / ETN
+MIGI,Financial Svcs-Specialty
+MILN,Finance-ETF / ETN
+MIMOQ,Telecom-Infrastructure
+MIN,Finance-Publ Inv Fd-Bond
+MIND,Oil&Gas-Machinery/Equip
+MINM,Computer-Networking
+MINN,Finance-ETF / ETN
+MINO,Finance-ETF / ETN
+MINT,Finance-ETF / ETN
+MINV,Finance-ETF / ETN
+MIO,Finance-Publ Inv Fd-Glbl
+MIR,Machinery-Gen Industrial
+MIRA,Medical-Biomed/Biotech
+MIRM,Medical-Biomed/Biotech
+MISL,Finance-ETF / ETN
+MIST,Medical-Ethical Drugs
+MITA,Finance-Blank Check
+MITK,Comp Sftwr-Spec Enterprs
+MITQ,Leisure-Movies & Related
+MITSY,Diversified Operations
+MITT,Finance-Mortgage REIT
+MIY,Finance-Publ Inv Fd-Bond
+MJ,Finance-ETF / ETN
+MJNA,Consumer Prod-Specialty
+MJUS,Finance-ETF / ETN
+MKAM,Finance-ETF / ETN
+MKC,Food-Misc Preparation
+MKCV,Food-Misc Preparation
+MKFG,Computer-Hardware/Perip
+MKL,Insurance-Prop/Cas/Titl
+MKOR,Finance-ETF / ETN
+MKSI,Elec-Semiconductor Equip
+MKTAY,Bldg-Hand Tools
+MKTW,Computer Sftwr-Financial
+MKTX,Finance-Invest Bnk/Bkrs
+ML,Computer Sftwr-Financial
+MLAB,Medical-Systems/Equip
+MLCO,Leisure-Gaming/Equip
+MLEC,Medical-Biomed/Biotech
+MLGO,Computer-Tech Services
+MLI,Metal Proc & Fabrication
+MLKN,Hsehold/Office Furniture
+MLM,Bldg-Cement/Concrt/Ag
+MLN,Finance-ETF / ETN
+MLNK,Computer Sftwr-Financial
+MLP,Real Estate Dvlpmt/Ops
+MLPA,Finance-ETF / ETN
+MLPB,Finance-ETF / ETN
+MLPR,Finance-ETF / ETN
+MLPX,Finance-ETF / ETN
+MLR,Trucks & Parts-Hvy Duty
+MLSS,Medical-Products
+MLTX,Medical-Biomed/Biotech
+MLVF,Finance-Savings & Loan
+MLYS,Medical-Biomed/Biotech
+MMA,Leisure-Services
+MMAT,Metal Proc & Fabrication
+MMC,Insurance-Brokers
+MMCA,Finance-ETF / ETN
+MMD,Finance-Publ Inv Fd-Bond
+MMI,Real Estate Dvlpmt/Ops
+MMIN,Finance-ETF / ETN
+MMIT,Finance-ETF / ETN
+MMLG,Finance-ETF / ETN
+MMLP,Oil&Gas-Transprt/Pipelne
+MMM,Diversified Operations
+MMNFF,Consumer Prod-Specialty
+MMS,Comml Svcs-Consulting
+MMSB,Finance-ETF / ETN
+MMSC,Finance-ETF / ETN
+MMSI,Medical-Products
+MMT,Finance-Publ Inv Fd-Bond
+MMTM,Finance-ETF / ETN
+MMU,Finance-Publ Inv Fd-Bond
+MMV,Internet-Content
+MMYT,Leisure-Travel Booking
+MNA,Finance-ETF / ETN
+MNBD,Finance-ETF / ETN
+MNDO,Computer Sftwr-Enterprse
+MNDY,Computer Sftwr-Enterprse
+MNKD,Medical-Biomed/Biotech
+MNMD,Medical-Biomed/Biotech
+MNOV,Medical-Biomed/Biotech
+MNPR,Medical-Biomed/Biotech
+MNR,Oil&Gas-Integrated
+MNRO,Retail/Whlsle-Auto Parts
+MNSB,Banks-Southeast
+MNSO,Retail-Discount&Variety
+MNST,Beverages-Non-Alcoholic
+MNTK,Energy-Alternative/Other
+MNTL,Finance-ETF / ETN
+MNTN,Finance-Blank Check
+MNTS,Aerospace/Defense
+MNTX,Machinery-Gen Industrial
+MNY,Finance-Consumer Loans
+MO,Tobacco
+MOAT,Finance-ETF / ETN
+MOB,Computer Sftwr-Security
+MOBQ,Comml Svcs-Advertising
+MOBX,Elec-Semicondctor Fablss
+MOD,Bldg-A/C & Heating Prds
+MODD,Medical-Products
+MODG,Leisure-Products
+MODL,Finance-ETF / ETN
+MODN,Computer Sftwr-Enterprse
+MODV,Comml Svcs-Healthcare
+MOFG,Banks-Midwest
+MOGA,Aerospace/Defense
+MOGB,Aerospace/Defense
+MOGO,Finance-Consumer Loans
+MOGU,Retail-Internet
+MOH,Medical-Managed Care
+MOHR,Finance-ETF / ETN
+MOLN,Medical-Biomed/Biotech
+MOMO,Internet-Content
+MOND,Leisure-Travel Booking
+MOO,Finance-ETF / ETN
+MOOD,Finance-ETF / ETN
+MOON,Finance-ETF / ETN
+MOR,Medical-Biomed/Biotech
+MORF,Medical-Biomed/Biotech
+MORN,Comml Svcs-Market Rsrch
+MORT,Finance-ETF / ETN
+MOS,Chemicals-Agricultural
+MOTE,Finance-ETF / ETN
+MOTG,Finance-ETF / ETN
+MOTI,Finance-ETF / ETN
+MOTO,Finance-ETF / ETN
+MOTS,Medical-Supplies
+MOV,Retail/Whlsle-Jewelry
+MOVE,Medical-Products
+MP,Mining-Metal Ores
+MPA,Finance-Publ Inv Fd-Bond
+MPAA,Auto/Truck-Replace Parts
+MPAY,Finance-ETF / ETN
+MPB,Banks-Northeast
+MPC,Oil&Gas-Refining/Mktg
+MPLN,Computer Sftwr-Medical
+MPLX,Oil&Gas-Transprt/Pipelne
+MPRO,Finance-ETF / ETN
+MPTI,Aerospace/Defense
+MPU,Comml Svcs-Leasing
+MPV,Finance-Publ Inv Fd-Bond
+MPW,Finance-Property REIT
+MPWR,Elec-Semicondctor Fablss
+MPX,Leisure-Products
+MQ,Finance-CrdtCard/PmtPr
+MQBKY,Finance-Investment Mgmt
+MQT,Finance-Publ Inv Fd-Bond
+MQY,Finance-Publ Inv Fd-Bond
+MRAAY,Electronic-Parts
+MRAD,Finance-ETF / ETN
+MRAI,Medical-Managed Care
+MRAM,Elec-Semiconductor Mfg
+MRBK,Banks-Northeast
+MRC,Oil&Gas-Machinery/Equip
+MRCC,Finance-Investment Mgmt
+MRCP,Finance-ETF / ETN
+MRCY,Aerospace/Defense
+MRDB,Computer Sftwr-Database
+MREO,Medical-Biomed/Biotech
+MRGR,Finance-ETF / ETN
+MRIN,Computer Sftwr-Enterprse
+MRK,Medical-Ethical Drugs
+MRKR,Medical-Biomed/Biotech
+MRM,Leisure-Services
+MRMD,Consumer Prod-Specialty
+MRNA,Medical-Biomed/Biotech
+MRND,Finance-ETF / ETN
+MRNO,Finance-Property REIT
+MRNS,Medical-Biomed/Biotech
+MRNY,Finance-ETF / ETN
+MRO,Oil&Gas-Integrated
+MRSK,Finance-ETF / ETN
+MRSN,Medical-Biomed/Biotech
+MRT,Leisure-Services
+MRTN,Transportation-Truck
+MRUS,Medical-Biomed/Biotech
+MRVI,Medical-Biomed/Biotech
+MRVL,Elec-Semicondctor Fablss
+MS,Banks-Money Center
+MSA,Security/Sfty
+MSADY,Insurance-Diversified
+MSAI,Elec-Contract Mfg
+MSB,Mining-Metal Ores
+MSBI,Banks-Midwest
+MSC,Leisure-Gaming/Equip
+MSCI,Financial Svcs-Specialty
+MSD,Finance-Publ Inv Fd-Glbl
+MSDL,Finance-Commercial Loans
+MSEX,Utility-Water Supply
+MSFD,Finance-ETF / ETN
+MSFL,Finance-ETF / ETN
+MSFO,Finance-ETF / ETN
+MSFT,Computer Sftwr-Desktop
+MSFU,Finance-ETF / ETN
+MSFX,Finance-ETF / ETN
+MSFY,Finance-ETF / ETN
+MSGE,Leisure-Services
+MSGM,Computer Sftwr-Gaming
+MSGS,Leisure-Services
+MSI,Telecom-Consumer Prods
+MSM,Machinery-Tools & Rel
+MSMR,Finance-ETF / ETN
+MSN,Consumer Prod-Electronic
+MSOS,Finance-ETF / ETN
+MSOX,Finance-ETF / ETN
+MSS,Retail-Specialty
+MSSA,Finance-Blank Check
+MSSS,Finance-ETF / ETN
+MSTB,Finance-ETF / ETN
+MSTI,Finance-ETF / ETN
+MSTQ,Finance-ETF / ETN
+MSTR,Computer Sftwr-Database
+MSTY,Finance-ETF / ETN
+MSVB,Banks-Midwest
+MSVX,Finance-ETF / ETN
+MT,Steel-Producers
+MTA,Mining-Gold/Silver/Gems
+MTAL,Finance-Blank Check
+MTB,Banks-Northeast
+MTBA,Finance-ETF / ETN
+MTBL,Computer-Tech Services
+MTC,Finance-Investment Mgmt
+MTCH,Internet-Content
+MTD,Machinery-Gen Industrial
+MTDR,Oil&Gas-U S Expl&Prod
+MTEK,Computer Sftwr-Enterprse
+MTEM,Medical-Biomed/Biotech
+MTEX,Cosmetics/Personal Care
+MTG,Insurance-Prop/Cas/Titl
+MTGP,Finance-ETF / ETN
+MTH,Bldg-Resident/Comml
+MTLS,Machinery-Mtl Hdlg/Autmn
+MTN,Leisure-Services
+MTNB,Medical-Biomed/Biotech
+MTR,Oil&Gas-Royalty Trust
+MTRN,Metal Proc & Fabrication
+MTRX,Oil&Gas-Field Services
+MTSI,Elec-Semiconductor Mfg
+MTTR,Computer Sftwr-Design
+MTUL,Finance-ETF / ETN
+MTUM,Finance-ETF / ETN
+MTUS,Steel-Specialty Alloys
+MTVR,Finance-ETF / ETN
+MTW,Machinery-Constr/Mining
+MTX,Chemicals-Specialty
+MTZ,Bldg-Heavy Construction
+MU,Computer-Data Storage
+MUA,Finance-Publ Inv Fd-Bond
+MUB,Finance-ETF / ETN
+MUC,Finance-Publ Inv Fd-Bond
+MUE,Finance-Publ Inv Fd-Bond
+MUFG,Banks-Money Center
+MUI,Finance-Publ Inv Fd-Bond
+MUJ,Finance-Publ Inv Fd-Bond
+MULN,Auto Manufacturers
+MUNI,Finance-ETF / ETN
+MUR,Oil&Gas-Intl Expl&Prod
+MURA,Medical-Biomed/Biotech
+MURGY,Insurance-Diversified
+MUSA,Retail-Super/Mini Mkts
+MUSI,Finance-ETF / ETN
+MUSQ,Finance-ETF / ETN
+MUST,Finance-ETF / ETN
+MUX,Mining-Gold/Silver/Gems
+MVAL,Group not available
+MVBF,Banks-Southeast
+MVF,Finance-Publ Inv Fd-Bond
+MVFD,Finance-ETF / ETN
+MVFG,Finance-ETF / ETN
+MVIS,Elec-Misc Products
+MVLA,Computer-Hardware/Perip
+MVO,Oil&Gas-Royalty Trust
+MVPA,Finance-ETF / ETN
+MVPL,Finance-ETF / ETN
+MVPS,Finance-ETF / ETN
+MVRL,Finance-ETF / ETN
+MVST,Electrical-Power/Equipmt
+MVT,Finance-Publ Inv Fd-Bond
+MVV,Finance-ETF / ETN
+MWA,Bldg-Constr Prds/Misc
+MWG,Machinery-Mtl Hdlg/Autmn
+MX,Elec-Semiconductor Mfg
+MXC,Oil&Gas-U S Expl&Prod
+MXCT,Medical-Research Eqp/Svc
+MXE,Finance-Publ Inv Fd-Glbl
+MXF,Finance-Publ Inv Fd-Glbl
+MXI,Finance-ETF / ETN
+MXL,Elec-Semicondctor Fablss
+MYD,Finance-Publ Inv Fd-Bond
+MYE,Containers/Packaging
+MYFW,Banks-West/Southwest
+MYGN,Medical-Research Eqp/Svc
+MYI,Finance-Publ Inv Fd-Bond
+MYLD,Finance-ETF / ETN
+MYMD,Medical-Biomed/Biotech
+MYN,Finance-Publ Inv Fd-Bond
+MYNA,Telecom-Infrastructure
+MYND,Computer Sftwr-Edu/Media
+MYNZ,Medical-Biomed/Biotech
+MYO,Medical-Systems/Equip
+MYPS,Computer Sftwr-Gaming
+MYRG,Bldg-Maintenance & Svc
+MYSZ,Retail-Internet
+MYTAY,Telecom Svcs- Foreign
+MYTE,Retail-Internet
+MYY,Finance-ETF / ETN
+MZZ,Finance-ETF / ETN
+NA,Elec-Semicondctor Fablss
+NAAS,Energy-Alternative/Other
+NABL,Computer-Tech Services
+NABZY,Banks-Foreign
+NAC,Finance-Publ Inv Fd-Bond
+NACP,Finance-ETF / ETN
+NAD,Finance-Publ Inv Fd-Bond
+NAII,Cosmetics/Personal Care
+NAIL,Finance-ETF / ETN
+NAK,Mining-Metal Ores
+NAMS,Medical-Biomed/Biotech
+NAN,Finance-Publ Inv Fd-Bond
+NANC,Finance-ETF / ETN
+NANR,Finance-ETF / ETN
+NAOV,Medical-Products
+NAPA,Beverages-Alcoholic
+NAPR,Finance-ETF / ETN
+NARI,Medical-Products
+NAT,Oil&Gas-Transprt/Pipelne
+NATH,Retail-Restaurants
+NATL,Computer-Integrated Syst
+NATR,Cosmetics/Personal Care
+NAUT,Medical-Biomed/Biotech
+NAVB,Medical-Biomed/Biotech
+NAVI,Financial Svcs-Specialty
+NAZ,Finance-Publ Inv Fd-Bond
+NB,Mining-Metal Ores
+NBB,Finance-Publ Inv Fd-Bond
+NBBK,Banks-Northeast
+NBCC,Finance-ETF / ETN
+NBCE,Finance-ETF / ETN
+NBCM,Finance-ETF / ETN
+NBCT,Finance-ETF / ETN
+NBDS,Finance-ETF / ETN
+NBGR,Finance-ETF / ETN
+NBH,Finance-Publ Inv Fd-Bond
+NBHC,Banks-West/Southwest
+NBIX,Medical-Biomed/Biotech
+NBN,Banks-Northeast
+NBOS,Finance-ETF / ETN
+NBR,Oil&Gas-Drilling
+NBRVF,Medical-Biomed/Biotech
+NBSE,Medical-Biomed/Biotech
+NBSM,Finance-ETF / ETN
+NBST,Finance-Blank Check
+NBTB,Banks-Northeast
+NBTX,Medical-Biomed/Biotech
+NBXG,Finance-Publ Inv Fd-Eqt
+NBY,Medical-Biomed/Biotech
+NC,Energy-Coal
+NCA,Finance-Publ Inv Fd-Bond
+NCDL,Finance-Investment Mgmt
+NCL,Bldg-Constr Prds/Misc
+NCLH,Leisure-Services
+NCLTY,Retail-Home Furnishings
+NCMI,Comml Svcs-Advertising
+NCNA,Medical-Biomed/Biotech
+NCNC,Auto/Truck-Original Eqp
+NCNO,Computer Sftwr-Financial
+NCPB,Finance-ETF / ETN
+NCPL,Finance-Investment Mgmt
+NCRA,Machinery-Farm
+NCSM,Oil&Gas-Field Services
+NCTY,Computer Sftwr-Gaming
+NCV,Finance-Publ Inv Fd-Bal
+NCZ,Finance-Publ Inv Fd-Bond
+NDAQ,Financial Svcs-Specialty
+NDEKY,Elec-Misc Products
+NDIA,Finance-ETF / ETN
+NDIV,Finance-ETF / ETN
+NDLS,Retail-Restaurants
+NDMO,Finance-Publ Inv Fd-Bond
+NDP,Finance-Publ Inv Fd-Eqt
+NDRA,Medical-Systems/Equip
+NDSN,Machinery-Gen Industrial
+NDVG,Finance-ETF / ETN
+NE,Oil&Gas-Drilling
+NEA,Finance-Publ Inv Fd-Bond
+NEAR,Finance-ETF / ETN
+NECB,Finance-Savings & Loan
+NEE,Utility-Electric Power
+NEGG,Retail-Internet
+NEM,Mining-Gold/Silver/Gems
+NEN,Real Estate Dvlpmt/Ops
+NEO,Medical-Services
+NEOG,Medical-Products
+NEON,Elec-Misc Products
+NEOV,Energy-Solar
+NEP,Energy-Alternative/Other
+NEPH,Medical-Products
+NEPTF,Consumer Prod-Specialty
+NERD,Finance-ETF / ETN
+NERV,Medical-Biomed/Biotech
+NESR,Oil&Gas-Field Services
+NET,Computer Sftwr-Enterprse
+NETD,Finance-Blank Check
+NETL,Finance-ETF / ETN
+NETZ,Finance-ETF / ETN
+NEU,Chemicals-Specialty
+NEUE,Medical-Managed Care
+NEWP,Mining-Gold/Silver/Gems
+NEWT,Finance-Investment Mgmt
+NEXA,Mining-Gold/Silver/Gems
+NEXI,Medical-Biomed/Biotech
+NEXN,Computer Sftwr-Enterprse
+NEXOY,Computer Sftwr-Gaming
+NEXT,Utility-Gas Distribution
+NFBK,Finance-Savings & Loan
+NFE,Oil&Gas-Integrated
+NFG,Utility-Gas Distribution
+NFGC,Mining-Gold/Silver/Gems
+NFJ,Finance-Publ Inv Fd-Eqt
+NFLP,Finance-ETF / ETN
+NFLT,Finance-ETF / ETN
+NFLX,Leisure-Movies & Related
+NFLY,Finance-ETF / ETN
+NFRA,Finance-ETF / ETN
+NFTY,Finance-ETF / ETN
+NFYS,Finance-Blank Check
+NG,Mining-Gold/Silver/Gems
+NGD,Mining-Gold/Silver/Gems
+NGG,Utility-Diversified
+NGL,Oil&Gas-Refining/Mktg
+NGLOY,Mining-Metal Ores
+NGM,Medical-Biomed/Biotech
+NGMS,Computer Sftwr-Gaming
+NGNE,Medical-Biomed/Biotech
+NGS,Oil&Gas-Machinery/Equip
+NGVC,Retail-Super/Mini Mkts
+NGVT,Chemicals-Specialty
+NHC,Medical-Long-term Care
+NHI,Finance-Property REIT
+NHIQ,Computer Sftwr-Medical
+NHS,Finance-Publ Inv Fd-Bond
+NHTC,Cosmetics/Personal Care
+NHYDY,Metal Prds-Distributor
+NI,Utility-Diversified
+NIC,Banks-Midwest
+NICE,Computer Sftwr-Security
+NICK,Finance-Consumer Loans
+NID,Finance-Publ Inv Fd-Bond
+NIE,Finance-Publ Inv Fd-Bal
+NIKL,Finance-ETF / ETN
+NIM,Finance-Publ Inv Fd-Bond
+NINE,Oil&Gas-Field Services
+NIO,Auto Manufacturers
+NIQ,Finance-Publ Inv Fd-Bond
+NISN,Comml Svcs-Consulting
+NITO,Chemicals-Agricultural
+NIU,Leisure-Products
+NJAN,Finance-ETF / ETN
+NJDCY,Electrical-Power/Equipmt
+NJR,Utility-Gas Distribution
+NJUL,Finance-ETF / ETN
+NKE,Apparel-Shoes & Rel Mfg
+NKG,Finance-Publ Inv Fd-Bond
+NKGN,Medical-Biomed/Biotech
+NKLA,Auto Manufacturers
+NKSH,Banks-Southeast
+NKTR,Medical-Biomed/Biotech
+NKTX,Medical-Biomed/Biotech
+NKX,Finance-Publ Inv Fd-Bond
+NL,Hsehold/Office Furniture
+NLOP,Real Estate Dvlpmt/Ops
+NLR,Finance-ETF / ETN
+NLSP,Medical-Biomed/Biotech
+NLY,Finance-Mortgage REIT
+NMAI,Finance-Publ Inv Fd-Bal
+NMCO,Finance-Publ Inv Fd-Bond
+NMFC,Finance-Investment Mgmt
+NMG,Energy-Alternative/Other
+NMGX,Elec-Misc Products
+NMHI,Agricultural Operations
+NMI,Finance-Publ Inv Fd-Bond
+NMIH,Finance-Mrtg&Rel Svc
+NML,Finance-Publ Inv Fd-Eqt
+NMM,Transportation-Ship
+NMR,Finance-Invest Bnk/Bkrs
+NMRA,Medical-Biomed/Biotech
+NMRD,Medical-Products
+NMRK,Real Estate Dvlpmt/Ops
+NMS,Finance-Publ Inv Fd-Bond
+NMT,Finance-Publ Inv Fd-Bond
+NMTC,Medical-Biomed/Biotech
+NMTRQ,Medical-Biomed/Biotech
+NMZ,Finance-Publ Inv Fd-Bond
+NN,Consumer Prod-Electronic
+NNAG,Finance-Blank Check
+NNBR,Metal Proc & Fabrication
+NNDM,Elec-Misc Products
+NNI,Finance-Consumer Loans
+NNN,Finance-Property REIT
+NNOX,Medical-Systems/Equip
+NNVC,Medical-Biomed/Biotech
+NNY,Finance-Publ Inv Fd-Bond
+NOA,Oil&Gas-Field Services
+NOAH,Finance-Investment Mgmt
+NOBL,Finance-ETF / ETN
+NOC,Aerospace/Defense
+NOCT,Finance-ETF / ETN
+NODK,Insurance-Diversified
+NOG,Oil&Gas-U S Expl&Prod
+NOGNQ,Computer Sftwr-Enterprse
+NOK,Telecom-Infrastructure
+NOM,Finance-Publ Inv Fd-Bond
+NOMD,Food-Packaged
+NORW,Finance-ETF / ETN
+NOTE,Computer Sftwr-Enterprse
+NOTV,Medical-Research Eqp/Svc
+NOV,Oil&Gas-Machinery/Equip
+NOVA,Energy-Solar
+NOVNQ,Medical-Biomed/Biotech
+NOVT,Elec-Scientific/Msrng
+NOVV,Finance-Blank Check
+NOVZ,Finance-ETF / ETN
+NOW,Computer Sftwr-Enterprse
+NPAB,Finance-Blank Check
+NPCE,Medical-Products
+NPCT,Finance-Publ Inv Fd-Eqt
+NPFD,Finance-Publ Inv Fd-Eqt
+NPFI,Finance-ETF / ETN
+NPK,Aerospace/Defense
+NPNYY,Transportation-Logistics
+NPO,Machinery-Gen Industrial
+NPSCY,Steel-Producers
+NPSNY,Media-Diversified
+NPV,Finance-Publ Inv Fd-Bond
+NPWR,Energy-Alternative/Other
+NQP,Finance-Publ Inv Fd-Bond
+NR,Oil&Gas-Field Services
+NRBO,Medical-Biomed/Biotech
+NRC,Comml Svcs-Healthcare
+NRDBY,Banks-Foreign
+NRDE,Auto Manufacturers
+NRDS,Financial Svcs-Specialty
+NRDY,Computer Sftwr-Edu/Media
+NREF,Finance-Mortgage REIT
+NRES,Finance-ETF / ETN
+NRG,Utility-Diversified
+NRGD,Finance-ETF / ETN
+NRGU,Finance-ETF / ETN
+NRGV,Energy-Alternative/Other
+NRILY,Computer-Tech Services
+NRIM,Banks-West/Southwest
+NRIX,Medical-Biomed/Biotech
+NRK,Finance-Publ Inv Fd-Bond
+NRO,Finance-Publ Inv Fd-Eqt
+NRP,Energy-Coal
+NRSH,Finance-ETF / ETN
+NRSN,Medical-Biomed/Biotech
+NRT,Oil&Gas-Royalty Trust
+NRXP,Medical-Biomed/Biotech
+NRXS,Medical-Biomed/Biotech
+NS,Oil&Gas-Refining/Mktg
+NSA,Finance-Property REIT
+NSANY,Auto Manufacturers
+NSC,Transportation-Rail
+NSCR,Finance-ETF / ETN
+NSCS,Finance-ETF / ETN
+NSI,Finance-ETF / ETN
+NSIT,Wholesale-Electronics
+NSP,Comml Svcs-Outsourcing
+NSPR,Medical-Products
+NSRGY,Food-Packaged
+NSSC,Security/Sfty
+NSTB,Group not available
+NSTC,Finance-Blank Check
+NSTD,Finance-Blank Check
+NSTGQ,Medical-Research Eqp/Svc
+NSTS,Banks-Midwest
+NSYS,Elec-Contract Mfg
+NTAP,Computer-Data Storage
+NTB,Banks-Foreign
+NTBL,Medical-Biomed/Biotech
+NTCOY,Group not available
+NTCT,Computer Sftwr-Database
+NTDOY,Computer Sftwr-Gaming
+NTES,Computer Sftwr-Gaming
+NTG,Finance-Publ Inv Fd-Eqt
+NTGR,Computer-Networking
+NTIC,Chemicals-Basic
+NTIP,Elec-Misc Products
+NTLA,Medical-Biomed/Biotech
+NTNX,Computer Sftwr-Enterprse
+NTOIY,Oil&Gas-Refining/Mktg
+NTPIF,Group not available
+NTR,Chemicals-Agricultural
+NTRA,Medical-Research Eqp/Svc
+NTRB,Medical-Biomed/Biotech
+NTRP,Computer-Integrated Syst
+NTRS,Banks-Super Regional
+NTSE,Finance-ETF / ETN
+NTSI,Finance-ETF / ETN
+NTST,Finance-Property REIT
+NTSX,Finance-ETF / ETN
+NTTYY,Telecom Svcs- Foreign
+NTWK,Computer Sftwr-Financial
+NTZ,Hsehold/Office Furniture
+NTZG,Finance-ETF / ETN
+NU,Banks-Foreign
+NUAG,Finance-ETF / ETN
+NUBD,Finance-ETF / ETN
+NUDM,Finance-ETF / ETN
+NUDV,Finance-ETF / ETN
+NUE,Steel-Producers
+NUEM,Finance-ETF / ETN
+NUGO,Finance-ETF / ETN
+NUGT,Finance-ETF / ETN
+NUHY,Finance-ETF / ETN
+NUKK,Computer Sftwr-Financial
+NUKZ,Finance-ETF / ETN
+NULC,Finance-ETF / ETN
+NULG,Finance-ETF / ETN
+NULV,Finance-ETF / ETN
+NUMG,Finance-ETF / ETN
+NUMV,Finance-ETF / ETN
+NUO,Finance-Publ Inv Fd-Bond
+NURE,Finance-ETF / ETN
+NURO,Medical-Products
+NUS,Cosmetics/Personal Care
+NUSA,Finance-ETF / ETN
+NUSB,Finance-ETF / ETN
+NUSC,Finance-ETF / ETN
+NUSI,Finance-ETF / ETN
+NUTX,Medical-Hospitals
+NUV,Finance-Publ Inv Fd-Bond
+NUVB,Medical-Biomed/Biotech
+NUVL,Medical-Biomed/Biotech
+NUW,Finance-Publ Inv Fd-Bond
+NUWE,Medical-Products
+NUZE,Food-Packaged
+NVAC,Finance-Blank Check
+NVAX,Medical-Biomed/Biotech
+NVBT,Finance-ETF / ETN
+NVBW,Finance-ETF / ETN
+NVCR,Medical-Products
+NVCT,Medical-Biomed/Biotech
+NVD,Finance-ETF / ETN
+NVDA,Elec-Semicondctor Fablss
+NVDD,Finance-ETF / ETN
+NVDL,Finance-ETF / ETN
+NVDQ,Finance-ETF / ETN
+NVDS,Finance-ETF / ETN
+NVDU,Finance-ETF / ETN
+NVDX,Finance-ETF / ETN
+NVDY,Finance-ETF / ETN
+NVEC,Electronic-Parts
+NVEE,Comml Svcs-Consulting
+NVEI,Finance-CrdtCard/PmtPr
+NVFY,Hsehold/Office Furniture
+NVG,Finance-Publ Inv Fd-Bond
+NVGS,Oil&Gas-Transprt/Pipelne
+NVIR,Finance-ETF / ETN
+NVIVQ,Medical-Biomed/Biotech
+NVMI,Elec-Semiconductor Equip
+NVNI,Computer-Tech Services
+NVNO,Medical-Products
+NVO,Medical-Ethical Drugs
+NVOS,Medical-Services
+NVR,Bldg-Resident/Comml
+NVRI,Metal Proc & Fabrication
+NVRO,Medical-Systems/Equip
+NVS,Medical-Ethical Drugs
+NVST,Medical-Systems/Equip
+NVT,Electrical-Power/Equipmt
+NVTAQ,Medical-Services
+NVTS,Elec-Semicondctor Fablss
+NVVE,Comp Sftwr-Spec Enterprs
+NVX,Electrical-Power/Equipmt
+NVZMY,Chemicals-Specialty
+NWBI,Finance-Savings & Loan
+NWE,Utility-Diversified
+NWFL,Banks-Northeast
+NWG,Banks-Money Center
+NWGL,Bldg-Wood Prds
+NWL,Hsehold-Appliances/Wares
+NWLG,Finance-ETF / ETN
+NWLI,Insurance-Life
+NWN,Utility-Gas Distribution
+NWPX,Metal Proc & Fabrication
+NWS,Media-Newspapers
+NWSA,Media-Newspapers
+NWTN,Machinery-Mtl Hdlg/Autmn
+NWYF,Banks-Northeast
+NX,Bldg-Constr Prds/Misc
+NXC,Finance-Publ Inv Fd-Bond
+NXDT,Finance-Publ Inv Fd-Bond
+NXE,Mining-Metal Ores
+NXG,Finance-Publ Inv Fd-Eqt
+NXGL,Medical-Ethical Drugs
+NXJ,Finance-Publ Inv Fd-Bond
+NXL,Medical-Products
+NXN,Finance-Publ Inv Fd-Bond
+NXP,Finance-Publ Inv Fd-Bond
+NXPI,Elec-Semiconductor Mfg
+NXPL,Security/Sfty
+NXRT,Finance-Property REIT
+NXST,Media-Radio/Tv
+NXT,Energy-Solar
+NXTC,Medical-Biomed/Biotech
+NXTE,Finance-ETF / ETN
+NXTG,Finance-ETF / ETN
+NXTP,Leisure-Travel Booking
+NXTT,Computer-Tech Services
+NXU,Auto Manufacturers
+NYAX,Computer Sftwr-Financial
+NYC,Finance-Property REIT
+NYCB,Finance-Savings & Loan
+NYF,Finance-ETF / ETN
+NYMT,Finance-Mortgage REIT
+NYMXF,Medical-Biomed/Biotech
+NYT,Media-Newspapers
+NYXH,Medical-Products
+NZAC,Finance-ETF / ETN
+NZF,Finance-Publ Inv Fd-Bond
+NZUS,Finance-ETF / ETN
+O,Finance-Property REIT
+OABI,Medical-Biomed/Biotech
+OACP,Finance-ETF / ETN
+OAEM,Finance-ETF / ETN
+OAIA,Finance-ETF / ETN
+OAIB,Finance-ETF / ETN
+OAIM,Finance-ETF / ETN
+OAKU,Finance-Blank Check
+OALC,Finance-ETF / ETN
+OARK,Finance-ETF / ETN
+OB,Comml Svcs-Advertising
+OBDC,Finance-Investment Mgmt
+OBDE,Finance-Investment Mgmt
+OBE,Oil&Gas-Cdn Expl&Prod
+OBIL,Finance-ETF / ETN
+OBIO,Medical-Biomed/Biotech
+OBK,Banks-Southeast
+OBLG,Internet-Network Sltns
+OBND,Finance-ETF / ETN
+OBOR,Finance-ETF / ETN
+OBSEF,Medical-Biomed/Biotech
+OBT,Banks-Northeast
+OC,Bldg-Constr Prds/Misc
+OCAX,Finance-Blank Check
+OCC,Telecom-Fiber Optics
+OCCI,Finance-Investment Mgmt
+OCEA,Medical-Biomed/Biotech
+OCEN,Finance-ETF / ETN
+OCFC,Finance-Savings & Loan
+OCFT,Computer Sftwr-Financial
+OCG,Retail-Internet
+OCGN,Medical-Biomed/Biotech
+OCIO,Finance-ETF / ETN
+OCN,Finance-Mrtg&Rel Svc
+OCS,Medical-Biomed/Biotech
+OCSL,Finance-Investment Mgmt
+OCTD,Finance-ETF / ETN
+OCTH,Finance-ETF / ETN
+OCTJ,Finance-ETF / ETN
+OCTO,Diversified Operations
+OCTQ,Finance-ETF / ETN
+OCTT,Finance-ETF / ETN
+OCTW,Finance-ETF / ETN
+OCTZ,Finance-ETF / ETN
+OCUL,Medical-Biomed/Biotech
+OCUP,Medical-Biomed/Biotech
+OCX,Medical-Biomed/Biotech
+ODC,Consumer Prod-Specialty
+ODD,Cosmetics/Personal Care
+ODDS,Finance-ETF / ETN
+ODFL,Transportation-Truck
+ODP,Retail/Whlsle-Office Sup
+ODTC,Group not available
+ODV,Mining-Gold/Silver/Gems
+OEC,Chemicals-Specialty
+OEF,Finance-ETF / ETN
+OESX,Electrical-Power/Equipmt
+OEUR,Finance-ETF / ETN
+OFED,Finance-Savings & Loan
+OFG,Banks-Southeast
+OFIX,Medical-Products
+OFLX,Metal Proc & Fabrication
+OFOS,Finance-ETF / ETN
+OFS,Finance-Investment Mgmt
+OGE,Utility-Electric Power
+OGEN,Medical-Biomed/Biotech
+OGI,Consumer Prod-Specialty
+OGIG,Finance-ETF / ETN
+OGN,Medical-Generic Drugs
+OGS,Utility-Gas Distribution
+OHI,Finance-Property REIT
+OI,Containers/Packaging
+OIA,Finance-Publ Inv Fd-Bond
+OIGBQ,Energy-Alternative/Other
+OIH,Finance-ETF / ETN
+OII,Oil&Gas-Field Services
+OIL,Finance-ETF / ETN
+OILCF,Oil&Gas-U S Expl&Prod
+OILD,Finance-ETF / ETN
+OILK,Finance-ETF / ETN
+OILT,Finance-ETF / ETN
+OILU,Finance-ETF / ETN
+OIS,Oil&Gas-Field Services
+OKE,Oil&Gas-Transprt/Pipelne
+OKTA,Computer Sftwr-Security
+OKYO,Medical-Biomed/Biotech
+OLB,Finance-CrdtCard/PmtPr
+OLED,Elec-Misc Products
+OLK,Medical-Biomed/Biotech
+OLLI,Retail-Discount&Variety
+OLMA,Medical-Biomed/Biotech
+OLN,Chemicals-Specialty
+OLO,Retail-Internet
+OLP,Finance-Property REIT
+OLPX,Cosmetics/Personal Care
+OLYMY,Medical-Systems/Equip
+OM,Medical-Systems/Equip
+OMAB,Real Estate Dvlpmt/Ops
+OMC,Comml Svcs-Advertising
+OMCL,Medical-Systems/Equip
+OMER,Medical-Biomed/Biotech
+OMEX,Mining-Metal Ores
+OMF,Finance-Consumer Loans
+OMFL,Finance-ETF / ETN
+OMFS,Finance-ETF / ETN
+OMGA,Medical-Biomed/Biotech
+OMH,Retail-Internet
+OMI,Medical-Whlsle Drg/Suppl
+OMIC,Medical-Biomed/Biotech
+OMQS,Computer-Integrated Syst
+OMRNY,Machinery-Mtl Hdlg/Autmn
+ON,Elec-Semiconductor Mfg
+ONB,Banks-Midwest
+ONCO,Medical-Biomed/Biotech
+ONCSQ,Medical-Biomed/Biotech
+ONCT,Medical-Biomed/Biotech
+ONCY,Medical-Biomed/Biotech
+OND,Finance-ETF / ETN
+ONDS,Media-Radio/Tv
+ONEO,Finance-ETF / ETN
+ONEQ,Finance-ETF / ETN
+ONEV,Finance-ETF / ETN
+ONEW,Retail-Leisure Products
+ONEY,Finance-ETF / ETN
+ONFO,Computer-Tech Services
+ONL,Finance-Property REIT
+ONLN,Finance-ETF / ETN
+ONMD,Medical-Research Eqp/Svc
+ONOF,Finance-ETF / ETN
+ONON,Apparel-Shoes & Rel Mfg
+ONTF,Computer Sftwr-Enterprse
+ONTO,Elec-Semiconductor Equip
+ONTX,Medical-Biomed/Biotech
+ONVO,Medical-Systems/Equip
+ONYX,Finance-Blank Check
+OOMA,Telecom-Consumer Prods
+OOTO,Finance-ETF / ETN
+OP,Transportation-Ship
+OPAD,Real Estate Dvlpmt/Ops
+OPAL,Energy-Alternative/Other
+OPBK,Financial Svcs-Specialty
+OPCH,Medical-Services
+OPEN,Real Estate Dvlpmt/Ops
+OPER,Finance-ETF / ETN
+OPFI,Computer Sftwr-Financial
+OPGN,Medical-Services
+OPHC,Banks-Southeast
+OPHLY,Medical-Ethical Drugs
+OPI,Finance-Property REIT
+OPK,Medical-Biomed/Biotech
+OPOF,Banks-Southeast
+OPP,Finance-Publ Inv Fd-Bond
+OPRA,Internet-Content
+OPRT,Finance-Consumer Loans
+OPRX,Computer Sftwr-Medical
+OPT,Medical-Biomed/Biotech
+OPTN,Medical-Biomed/Biotech
+OPTT,Energy-Alternative/Other
+OPTX,Telecom-Fiber Optics
+OPXS,Aerospace/Defense
+OPY,Finance-Invest Bnk/Bkrs
+OR,Mining-Gold/Silver/Gems
+ORA,Energy-Alternative/Other
+ORAN,Telecom Svcs- Foreign
+ORC,Finance-Mortgage REIT
+ORCL,Computer Sftwr-Database
+ORGN,Energy-Alternative/Other
+ORGO,Medical-Products
+ORGS,Medical-Biomed/Biotech
+ORI,Insurance-Prop/Cas/Titl
+ORIC,Medical-Biomed/Biotech
+ORLA,Mining-Gold/Silver/Gems
+ORLY,Retail/Whlsle-Auto Parts
+ORMP,Medical-Biomed/Biotech
+ORN,Bldg-Heavy Construction
+ORRF,Banks-Northeast
+OSA,Medical-Products
+OSBC,Banks-Midwest
+OSCR,Insurance-Acc & Health
+OSCV,Finance-ETF / ETN
+OSEA,Finance-ETF / ETN
+OSG,Oil&Gas-Transprt/Pipelne
+OSI,Finance-Blank Check
+OSIS,Aerospace/Defense
+OSK,Trucks & Parts-Hvy Duty
+OSPN,Computer Sftwr-Security
+OSS,Computer-Hardware/Perip
+OST,Elec-Misc Products
+OSUR,Medical-Products
+OSW,Leisure-Services
+OTCM,Financial Svcs-Specialty
+OTEX,Computer Sftwr-Database
+OTIS,Machinery-Gen Industrial
+OTLK,Medical-Biomed/Biotech
+OTLY,Food-Dairy Products
+OTRK,Medical-Services
+OTSKY,Medical-Ethical Drugs
+OTTR,Diversified Operations
+OUNZ,Finance-ETF / ETN
+OUSA,Finance-ETF / ETN
+OUSM,Finance-ETF / ETN
+OUST,Auto/Truck-Original Eqp
+OUT,Finance-Property REIT
+OVB,Finance-ETF / ETN
+OVBC,Banks-Midwest
+OVCHY,Banks-Foreign
+OVF,Finance-ETF / ETN
+OVID,Medical-Biomed/Biotech
+OVL,Finance-ETF / ETN
+OVLH,Finance-ETF / ETN
+OVLY,Banks-West/Southwest
+OVM,Finance-ETF / ETN
+OVS,Finance-ETF / ETN
+OVT,Finance-ETF / ETN
+OVV,Oil&Gas-Intl Expl&Prod
+OWL,Finance-Investment Mgmt
+OWLT,Medical-Products
+OWNS,Finance-ETF / ETN
+OXBR,Insurance-Prop/Cas/Titl
+OXLC,Finance-Publ Inv Fd-Bond
+OXM,Apparel-Clothing Mfg
+OXSQ,Finance-Investment Mgmt
+OXY,Oil&Gas-Intl Expl&Prod
+OZK,Banks-Southeast
+PAA,Oil&Gas-Transprt/Pipelne
+PAAA,Finance-ETF / ETN
+PAAS,Mining-Gold/Silver/Gems
+PAB,Finance-ETF / ETN
+PABD,Finance-ETF / ETN
+PABU,Finance-ETF / ETN
+PAC,Real Estate Dvlpmt/Ops
+PACB,Medical-Systems/Equip
+PACK,Containers/Packaging
+PACW,Banks-West/Southwest
+PAG,Retail/Whlsle-Automobile
+PAGP,Oil&Gas-Transprt/Pipelne
+PAGS,Finance-CrdtCard/PmtPr
+PAHC,Medical-Ethical Drugs
+PAI,Finance-Publ Inv Fd-Bond
+PALC,Finance-ETF / ETN
+PALI,Medical-Biomed/Biotech
+PALL,Finance-ETF / ETN
+PALT,Computer Sftwr-Enterprse
+PAM,Utility-Electric Power
+PAMC,Finance-ETF / ETN
+PANL,Transportation-Ship
+PANW,Computer Sftwr-Security
+PAPI,Finance-ETF / ETN
+PAPL,Financial Svcs-Specialty
+PAPR,Finance-ETF / ETN
+PAR,Computer-Integrated Syst
+PARA,Media-Diversified
+PARAA,Media-Diversified
+PARR,Oil&Gas-Refining/Mktg
+PASG,Medical-Biomed/Biotech
+PATH,Computer Sftwr-Enterprse
+PATK,Bldg-Mobile/Mfg & Rv
+PAUG,Finance-ETF / ETN
+PAVE,Finance-ETF / ETN
+PAVM,Medical-Products
+PAVS,Cosmetics/Personal Care
+PAWZ,Finance-ETF / ETN
+PAX,Finance-Investment Mgmt
+PAXS,Finance-Publ Inv Fd-Glbl
+PAY,Finance-CrdtCard/PmtPr
+PAYC,Computer Sftwr-Enterprse
+PAYO,Finance-CrdtCard/PmtPr
+PAYS,Finance-CrdtCard/PmtPr
+PAYX,Comml Svcs-Outsourcing
+PB,Banks-West/Southwest
+PBA,Oil&Gas-Transprt/Pipelne
+PBBK,Banks-Northeast
+PBCRY,Banks-Foreign
+PBD,Finance-ETF / ETN
+PBDC,Finance-ETF / ETN
+PBE,Finance-ETF / ETN
+PBF,Oil&Gas-Refining/Mktg
+PBFB,Finance-ETF / ETN
+PBFS,Banks-Northeast
+PBH,Cosmetics/Personal Care
+PBHC,Finance-Savings & Loan
+PBI,Comml Svcs-Document Mgmt
+PBJ,Finance-ETF / ETN
+PBJA,Finance-ETF / ETN
+PBL,Finance-ETF / ETN
+PBLA,Medical-Biomed/Biotech
+PBM,Medical-Biomed/Biotech
+PBMR,Finance-ETF / ETN
+PBP,Finance-ETF / ETN
+PBPB,Retail-Restaurants
+PBR,Oil&Gas-Integrated
+PBRA,Oil&Gas-Integrated
+PBSFY,Media-Diversified
+PBT,Oil&Gas-Royalty Trust
+PBTP,Finance-ETF / ETN
+PBUS,Finance-ETF / ETN
+PBW,Finance-ETF / ETN
+PBYI,Medical-Biomed/Biotech
+PCAR,Trucks & Parts-Hvy Duty
+PCB,Banks-West/Southwest
+PCCE,Finance-ETF / ETN
+PCEF,Finance-ETF / ETN
+PCF,Finance-Publ Inv Fd-Bond
+PCG,Utility-Diversified
+PCGG,Finance-ETF / ETN
+PCH,Finance-Property REIT
+PCIG,Finance-ETF / ETN
+PCK,Finance-Publ Inv Fd-Bond
+PCLB,Banks-Southeast
+PCM,Finance-Publ Inv Fd-Bond
+PCN,Finance-Publ Inv Fd-Bond
+PCOR,Computer Sftwr-Enterprse
+PCQ,Finance-Publ Inv Fd-Bond
+PCRB,Finance-ETF / ETN
+PCRX,Medical-Biomed/Biotech
+PCSA,Medical-Ethical Drugs
+PCT,Chemicals-Plastics
+PCTI,Telecom-Cable/Satl Eqp
+PCTY,Computer Sftwr-Enterprse
+PCVX,Medical-Biomed/Biotech
+PCY,Finance-ETF / ETN
+PCYO,Utility-Water Supply
+PD,Computer Sftwr-Desktop
+PDBA,Finance-ETF / ETN
+PDBC,Finance-ETF / ETN
+PDCO,Medical-Supplies
+PDD,Retail-Internet
+PDEC,Finance-ETF / ETN
+PDEX,Medical-Products
+PDFS,Computer Sftwr-Design
+PDI,Finance-Publ Inv Fd-Glbl
+PDLB,Banks-Northeast
+PDM,Finance-Property REIT
+PDN,Finance-ETF / ETN
+PDO,Finance-Publ Inv Fd-Glbl
+PDP,Finance-ETF / ETN
+PDS,Oil&Gas-Drilling
+PDSB,Medical-Biomed/Biotech
+PDT,Finance-Publ Inv Fd-Eqt
+PDX,Finance-Publ Inv Fd-Glbl
+PEARQ,Computer Sftwr-Medical
+PEB,Finance-Property REIT
+PEBK,Banks-Southeast
+PEBO,Banks-Midwest
+PECO,Finance-Property REIT
+PED,Oil&Gas-U S Expl&Prod
+PEG,Utility-Diversified
+PEGA,Computer Sftwr-Financial
+PEGR,Finance-Blank Check
+PEGY,Energy-Solar
+PEJ,Finance-ETF / ETN
+PEMX,Finance-ETF / ETN
+PEN,Medical-Products
+PENN,Leisure-Gaming/Equip
+PEO,Finance-Publ Inv Fd-Eqt
+PEP,Food-Packaged
+PEPG,Medical-Biomed/Biotech
+PERF,Computer Sftwr-Enterprse
+PERI,Comml Svcs-Advertising
+PESI,Pollution Control
+PET,Computer Sftwr-Enterprse
+PETQ,Medical-Whlsle Drg/Suppl
+PETS,Retail-Internet
+PETV,Medical-Biomed/Biotech
+PETZ,Food-Packaged
+PEV,Auto/Truck-Original Eqp
+PEX,Finance-ETF / ETN
+PEXL,Finance-ETF / ETN
+PEY,Finance-ETF / ETN
+PEZ,Finance-ETF / ETN
+PFBC,Banks-West/Southwest
+PFC,Finance-Savings & Loan
+PFD,Finance-Publ Inv Fd-Eqt
+PFE,Medical-Ethical Drugs
+PFEB,Finance-ETF / ETN
+PFF,Finance-ETF / ETN
+PFFA,Finance-ETF / ETN
+PFFD,Finance-ETF / ETN
+PFFL,Finance-ETF / ETN
+PFFR,Finance-ETF / ETN
+PFFV,Finance-ETF / ETN
+PFG,Insurance-Diversified
+PFGC,Wholesale-Food
+PFI,Finance-ETF / ETN
+PFIE,Oil&Gas-Machinery/Equip
+PFIG,Finance-ETF / ETN
+PFIN,Bldg-Hand Tools
+PFIS,Banks-Northeast
+PFIX,Finance-ETF / ETN
+PFL,Finance-Publ Inv Fd-Bond
+PFLD,Finance-ETF / ETN
+PFLT,Finance-Investment Mgmt
+PFM,Finance-ETF / ETN
+PFMT,Financial Svcs-Specialty
+PFN,Finance-Publ Inv Fd-Bond
+PFO,Finance-Publ Inv Fd-Bal
+PFRL,Finance-ETF / ETN
+PFS,Banks-Northeast
+PFSI,Finance-Mrtg&Rel Svc
+PFTA,Finance-Investment Mgmt
+PFUT,Finance-ETF / ETN
+PFX,Finance-Investment Mgmt
+PFXF,Finance-ETF / ETN
+PG,Cosmetics/Personal Care
+PGC,Banks-Northeast
+PGEN,Medical-Biomed/Biotech
+PGF,Finance-ETF / ETN
+PGHY,Finance-ETF / ETN
+PGJ,Finance-ETF / ETN
+PGNY,Medical-Services
+PGP,Finance-Publ Inv Fd-Glbl
+PGR,Insurance-Prop/Cas/Titl
+PGRE,Finance-Property REIT
+PGRO,Finance-ETF / ETN
+PGRU,Real Estate Dvlpmt/Ops
+PGSS,Finance-Blank Check
+PGX,Finance-ETF / ETN
+PGY,Computer Sftwr-Financial
+PGZ,Finance-Publ Inv Fd-Bond
+PH,Machinery-Gen Industrial
+PHAR,Medical-Biomed/Biotech
+PHASQ,Group not available
+PHAT,Medical-Biomed/Biotech
+PHB,Finance-ETF / ETN
+PHCFF,Finance-Investment Mgmt
+PHD,Finance-Publ Inv Fd-Bond
+PHDG,Finance-ETF / ETN
+PHEQ,Finance-ETF / ETN
+PHG,Diversified Operations
+PHGE,Medical-Biomed/Biotech
+PHI,Telecom Svcs- Foreign
+PHIN,Auto/Truck-Original Eqp
+PHIO,Medical-Biomed/Biotech
+PHK,Finance-Publ Inv Fd-Bond
+PHM,Bldg-Resident/Comml
+PHO,Finance-ETF / ETN
+PHR,Computer Sftwr-Medical
+PHT,Finance-Publ Inv Fd-Bond
+PHUN,Computer-Tech Services
+PHVS,Medical-Biomed/Biotech
+PHX,Oil&Gas-U S Expl&Prod
+PHYD,Finance-ETF / ETN
+PHYL,Finance-ETF / ETN
+PHYS,Finance-ETF / ETN
+PHYT,Finance-Blank Check
+PI,Elec-Semicondctor Fablss
+PICB,Finance-ETF / ETN
+PICK,Finance-ETF / ETN
+PID,Finance-ETF / ETN
+PIE,Finance-ETF / ETN
+PIFI,Finance-ETF / ETN
+PII,Leisure-Products
+PIII,Medical-Outpnt/Hm Care
+PIK,Retail-Internet
+PILL,Finance-ETF / ETN
+PIM,Finance-Publ Inv Fd-Bond
+PIN,Finance-ETF / ETN
+PINC,Comml Svcs-Healthcare
+PINE,Finance-Property REIT
+PINK,Finance-ETF / ETN
+PINS,Internet-Content
+PIO,Finance-ETF / ETN
+PIPR,Finance-Invest Bnk/Bkrs
+PIRS,Medical-Biomed/Biotech
+PIT,Finance-ETF / ETN
+PIXY,Comml Svcs-Staffing
+PIZ,Finance-ETF / ETN
+PJAN,Finance-ETF / ETN
+PJBF,Finance-ETF / ETN
+PJFG,Finance-ETF / ETN
+PJFM,Finance-ETF / ETN
+PJFV,Finance-ETF / ETN
+PJIO,Finance-ETF / ETN
+PJP,Finance-ETF / ETN
+PJT,Finance-Investment Mgmt
+PJUL,Finance-ETF / ETN
+PJUN,Finance-ETF / ETN
+PK,Finance-Property REIT
+PKB,Finance-ETF / ETN
+PKBK,Banks-Northeast
+PKBO,Group not available
+PKE,Electronic-Parts
+PKG,Paper & Paper Products
+PKOH,Metal Prds-Distributor
+PKST,Finance-Property REIT
+PKW,Finance-ETF / ETN
+PKX,Steel-Producers
+PL,Telecom Svcs-Cable/Satl
+PLAB,Elec-Semiconductor Equip
+PLAG,Food-Misc Preparation
+PLAO,Finance-Blank Check
+PLAY,Retail-Restaurants
+PLBC,Banks-West/Southwest
+PLBY,Retail-Leisure Products
+PLCE,Retail-Apparel/Shoes/Acc
+PLD,Finance-Property REIT
+PLDR,Finance-ETF / ETN
+PLG,Mining-Gold/Silver/Gems
+PLL,Mining-Metal Ores
+PLMI,Finance-Blank Check
+PLMJ,Finance-Blank Check
+PLMR,Insurance-Diversified
+PLNH,Consumer Prod-Specialty
+PLNT,Leisure-Services
+PLOW,Auto/Truck-Tires & Misc
+PLPC,Telecom-Cable/Satl Eqp
+PLRX,Medical-Biomed/Biotech
+PLSE,Medical-Systems/Equip
+PLTK,Computer Sftwr-Gaming
+PLTM,Finance-ETF / ETN
+PLTN,Finance-Blank Check
+PLTR,Computer Sftwr-Enterprse
+PLUG,Energy-Alternative/Other
+PLUR,Medical-Biomed/Biotech
+PLUS,Computer-Tech Services
+PLX,Medical-Biomed/Biotech
+PLXS,Elec-Contract Mfg
+PLYA,Leisure-Lodging
+PLYM,Finance-Property REIT
+PM,Tobacco
+PMAR,Finance-ETF / ETN
+PMAY,Finance-ETF / ETN
+PMCB,Medical-Biomed/Biotech
+PMD,Medical-Services
+PMEC,Bldg-Maintenance & Svc
+PMF,Finance-Publ Inv Fd-Bond
+PMGM,Finance-Blank Check
+PML,Finance-Publ Inv Fd-Bond
+PMM,Finance-Publ Inv Fd-Bond
+PMN,Medical-Biomed/Biotech
+PMNT,Apparel-Clothing Mfg
+PMO,Finance-Publ Inv Fd-Bond
+PMT,Finance-Mortgage REIT
+PMTS,Finance-CrdtCard/PmtPr
+PMVCD,Group not available
+PMVP,Medical-Biomed/Biotech
+PMX,Finance-Publ Inv Fd-Bond
+PNBK,Banks-Northeast
+PNC,Banks-Super Regional
+PNF,Finance-Publ Inv Fd-Bond
+PNFP,Banks-Southeast
+PNGAY,Insurance-Diversified
+PNI,Finance-Publ Inv Fd-Bond
+PNM,Utility-Electric Power
+PNNT,Finance-Investment Mgmt
+PNOV,Finance-ETF / ETN
+PNQI,Finance-ETF / ETN
+PNR,Machinery-Gen Industrial
+PNRG,Oil&Gas-U S Expl&Prod
+PNST,Retail-Restaurants
+PNTG,Medical-Long-term Care
+PNW,Utility-Electric Power
+POAHY,Auto Manufacturers
+POAI,Medical-Products
+POCI,Medical-Products
+POCT,Finance-ETF / ETN
+PODC,Internet-Content
+PODD,Medical-Products
+POET,Elec-Semiconductor Mfg
+POLA,Electrical-Power/Equipmt
+POLCQ,Retail-Home Furnishings
+POOL,Retail-Leisure Products
+POR,Utility-Electric Power
+PORT,Finance-Blank Check
+POST,Food-Packaged
+POWA,Finance-ETF / ETN
+POWI,Elec-Semicondctor Fablss
+POWL,Electrical-Power/Equipmt
+POWW,Aerospace/Defense
+PP,Finance-ETF / ETN
+PPA,Finance-ETF / ETN
+PPBI,Banks-West/Southwest
+PPBT,Medical-Biomed/Biotech
+PPC,Food-Meat Products
+PPEM,Finance-ETF / ETN
+PPERY,Banks-Foreign
+PPG,Chemicals-Paints
+PPH,Finance-ETF / ETN
+PPHP,Finance-Blank Check
+PPI,Finance-ETF / ETN
+PPIE,Finance-ETF / ETN
+PPIH,Pollution Control
+PPL,Utility-Electric Power
+PPLT,Finance-ETF / ETN
+PPSI,Electrical-Power/Equipmt
+PPT,Finance-Publ Inv Fd-Bond
+PPTA,Mining-Gold/Silver/Gems
+PPTY,Finance-ETF / ETN
+PPYA,Finance-Blank Check
+PQDI,Finance-ETF / ETN
+PR,Oil&Gas-U S Expl&Prod
+PRA,Insurance-Prop/Cas/Titl
+PRAA,Financial Svcs-Specialty
+PRAE,Finance-ETF / ETN
+PRAX,Medical-Biomed/Biotech
+PRAY,Finance-ETF / ETN
+PRBM,Group not available
+PRCH,Computer-Tech Services
+PRCT,Medical-Systems/Equip
+PRDO,Consumer Svcs-Education
+PRE,Medical-Services
+PREF,Finance-ETF / ETN
+PRF,Finance-ETF / ETN
+PRFD,Finance-ETF / ETN
+PRFT,Computer-Tech Services
+PRFX,Medical-Generic Drugs
+PRFZ,Finance-ETF / ETN
+PRG,Retail-Home Furnishings
+PRGO,Medical-Generic Drugs
+PRGS,Computer Sftwr-Database
+PRI,Insurance-Life
+PRIM,Bldg-Heavy Construction
+PRK,Banks-Midwest
+PRKS,Leisure-Services
+PRLB,Machinery-Mtl Hdlg/Autmn
+PRLD,Medical-Biomed/Biotech
+PRLH,Finance-Blank Check
+PRM,Chemicals-Specialty
+PRME,Medical-Biomed/Biotech
+PRMN,Finance-ETF / ETN
+PRMW,Beverages-Non-Alcoholic
+PRN,Finance-ETF / ETN
+PRNDY,Beverages-Alcoholic
+PRNT,Finance-ETF / ETN
+PRO,Computer Sftwr-Enterprse
+PROC,Medical-Biomed/Biotech
+PROF,Medical-Systems/Equip
+PROK,Medical-Biomed/Biotech
+PROP,Oil&Gas-U S Expl&Prod
+PROV,Finance-Savings & Loan
+PRPH,Cosmetics/Personal Care
+PRPL,Hsehold/Office Furniture
+PRPO,Medical-Services
+PRQR,Medical-Biomed/Biotech
+PRSO,Elec-Semicondctor Fablss
+PRST,Machinery-Mtl Hdlg/Autmn
+PRT,Oil&Gas-Royalty Trust
+PRTA,Medical-Biomed/Biotech
+PRTC,Medical-Biomed/Biotech
+PRTG,Medical-Biomed/Biotech
+PRTH,Financial Svcs-Specialty
+PRTS,Retail/Whlsle-Auto Parts
+PRU,Insurance-Life
+PRVA,Computer Sftwr-Medical
+PRZO,Aerospace/Defense
+PSA,Finance-Property REIT
+PSBD,Finance-Investment Mgmt
+PSC,Finance-ETF / ETN
+PSCC,Finance-ETF / ETN
+PSCD,Finance-ETF / ETN
+PSCE,Finance-ETF / ETN
+PSCF,Finance-ETF / ETN
+PSCH,Finance-ETF / ETN
+PSCI,Finance-ETF / ETN
+PSCJ,Finance-ETF / ETN
+PSCM,Finance-ETF / ETN
+PSCQ,Finance-ETF / ETN
+PSCT,Finance-ETF / ETN
+PSCU,Finance-ETF / ETN
+PSCW,Finance-ETF / ETN
+PSCX,Finance-ETF / ETN
+PSDM,Finance-ETF / ETN
+PSEC,Finance-Investment Mgmt
+PSEP,Finance-ETF / ETN
+PSET,Finance-ETF / ETN
+PSF,Finance-Publ Inv Fd-Eqt
+PSFD,Finance-ETF / ETN
+PSFE,Finance-CrdtCard/PmtPr
+PSFF,Finance-ETF / ETN
+PSFJ,Finance-ETF / ETN
+PSFM,Finance-ETF / ETN
+PSFO,Finance-ETF / ETN
+PSH,Finance-ETF / ETN
+PSHG,Transportation-Ship
+PSI,Finance-ETF / ETN
+PSIL,Finance-ETF / ETN
+PSK,Finance-ETF / ETN
+PSL,Finance-ETF / ETN
+PSLV,Finance-ETF / ETN
+PSMD,Finance-ETF / ETN
+PSMJ,Finance-ETF / ETN
+PSMO,Finance-ETF / ETN
+PSMR,Finance-ETF / ETN
+PSMT,Retail-Major Disc Chains
+PSN,Computer Sftwr-Enterprse
+PSNL,Medical-Services
+PSNY,Auto Manufacturers
+PSO,Media-Books
+PSP,Finance-ETF / ETN
+PSQ,Finance-ETF / ETN
+PSQH,Internet-Content
+PSR,Finance-ETF / ETN
+PST,Finance-ETF / ETN
+PSTG,Computer-Data Storage
+PSTL,Finance-Property REIT
+PSTP,Finance-ETF / ETN
+PSTV,Medical-Biomed/Biotech
+PSTVY,Banks-Money Center
+PSTX,Medical-Biomed/Biotech
+PSWD,Finance-ETF / ETN
+PSX,Oil&Gas-Refining/Mktg
+PT,Computer-Tech Services
+PTA,Finance-ETF / ETN
+PTBD,Finance-ETF / ETN
+PTC,Computer Sftwr-Design
+PTCT,Medical-Biomed/Biotech
+PTEC,Finance-ETF / ETN
+PTEN,Oil&Gas-Drilling
+PTEU,Finance-ETF / ETN
+PTF,Finance-ETF / ETN
+PTGX,Medical-Ethical Drugs
+PTH,Finance-ETF / ETN
+PTIN,Finance-ETF / ETN
+PTIX,Medical-Biomed/Biotech
+PTL,Finance-ETF / ETN
+PTLC,Finance-ETF / ETN
+PTLO,Retail-Restaurants
+PTMC,Finance-ETF / ETN
+PTMN,Finance-Investment Mgmt
+PTN,Medical-Biomed/Biotech
+PTNQ,Finance-ETF / ETN
+PTON,Leisure-Services
+PTPI,Medical-Biomed/Biotech
+PTRB,Finance-ETF / ETN
+PTSI,Transportation-Truck
+PTVE,Containers/Packaging
+PTWO,Finance-Blank Check
+PTY,Finance-Publ Inv Fd-Bond
+PUBGY,Comml Svcs-Advertising
+PUBM,Comml Svcs-Advertising
+PUCK,Finance-Blank Check
+PUI,Finance-ETF / ETN
+PUK,Insurance-Life
+PULM,Medical-Biomed/Biotech
+PULS,Finance-ETF / ETN
+PULT,Finance-ETF / ETN
+PUMP,Oil&Gas-Field Services
+PUTD,Finance-ETF / ETN
+PUTW,Finance-ETF / ETN
+PVAL,Finance-ETF / ETN
+PVBC,Banks-Northeast
+PVH,Apparel-Clothing Mfg
+PVI,Finance-ETF / ETN
+PVL,Oil&Gas-Royalty Trust
+PW,Finance-Property REIT
+PWB,Finance-ETF / ETN
+PWER,Finance-ETF / ETN
+PWFL,Security/Sfty
+PWM,Finance-Investment Mgmt
+PWOD,Banks-Northeast
+PWP,Finance-Invest Bnk/Bkrs
+PWR,Bldg-Heavy Construction
+PWS,Finance-ETF / ETN
+PWSC,Consumer Svcs-Education
+PWUP,Finance-Blank Check
+PWV,Finance-ETF / ETN
+PWZ,Finance-ETF / ETN
+PX,Finance-Investment Mgmt
+PXD,Oil&Gas-U S Expl&Prod
+PXDT,Computer Sftwr-Enterprse
+PXE,Finance-ETF / ETN
+PXF,Finance-ETF / ETN
+PXH,Finance-ETF / ETN
+PXI,Finance-ETF / ETN
+PXJ,Finance-ETF / ETN
+PXLW,Elec-Semicondctor Fablss
+PXMD,Medical-Biomed/Biotech
+PXS,Transportation-Ship
+PY,Finance-ETF / ETN
+PYCR,Computer Sftwr-Enterprse
+PYLD,Finance-ETF / ETN
+PYN,Finance-Publ Inv Fd-Bond
+PYPD,Medical-Biomed/Biotech
+PYPL,Finance-CrdtCard/PmtPr
+PYPY,Finance-ETF / ETN
+PYRGF,Pollution Control
+PYXS,Medical-Biomed/Biotech
+PYZ,Finance-ETF / ETN
+PZA,Finance-ETF / ETN
+PZC,Finance-Publ Inv Fd-Bond
+PZG,Mining-Gold/Silver/Gems
+PZT,Finance-ETF / ETN
+PZZA,Retail-Restaurants
+QABA,Finance-ETF / ETN
+QAI,Finance-ETF / ETN
+QARP,Finance-ETF / ETN
+QAT,Finance-ETF / ETN
+QBTS,Computer Sftwr-Enterprse
+QCLN,Finance-ETF / ETN
+QCLR,Finance-ETF / ETN
+QCOM,Elec-Semicondctor Fablss
+QCON,Finance-ETF / ETN
+QCRH,Banks-Midwest
+QD,Finance-Consumer Loans
+QDEC,Finance-ETF / ETN
+QDEF,Finance-ETF / ETN
+QDEL,Medical-Products
+QDF,Finance-ETF / ETN
+QDIV,Finance-ETF / ETN
+QDPL,Finance-ETF / ETN
+QDRO,Finance-Blank Check
+QDTE,Finance-ETF / ETN
+QDYN,Finance-ETF / ETN
+QEFA,Finance-ETF / ETN
+QEMM,Finance-ETF / ETN
+QETA,Finance-Blank Check
+QFIN,Financial Svcs-Specialty
+QFLR,Finance-ETF / ETN
+QGEN,Medical-Products
+QGRO,Finance-ETF / ETN
+QGRW,Finance-ETF / ETN
+QH,Comml Svcs-Outsourcing
+QID,Finance-ETF / ETN
+QINT,Finance-ETF / ETN
+QIPT,Medical-Outpnt/Hm Care
+QIS,Finance-ETF / ETN
+QIWI,Finance-CrdtCard/PmtPr
+QJUN,Finance-ETF / ETN
+QLC,Finance-ETF / ETN
+QLD,Finance-ETF / ETN
+QLGN,Medical-Biomed/Biotech
+QLI,Medical-Generic Drugs
+QLTA,Finance-ETF / ETN
+QLTY,Finance-ETF / ETN
+QLV,Finance-ETF / ETN
+QLVD,Finance-ETF / ETN
+QLVE,Finance-ETF / ETN
+QLYS,Computer Sftwr-Security
+QMAR,Finance-ETF / ETN
+QMCO,Computer-Data Storage
+QMID,Finance-ETF / ETN
+QMOM,Finance-ETF / ETN
+QNCX,Medical-Biomed/Biotech
+QNGYQ,Group not available
+QNRX,Medical-Biomed/Biotech
+QNST,Comml Svcs-Advertising
+QOMO,Finance-Blank Check
+QOWZ,Finance-ETF / ETN
+QPFF,Finance-ETF / ETN
+QPX,Finance-ETF / ETN
+QQEW,Finance-ETF / ETN
+QQH,Finance-ETF / ETN
+QQJG,Finance-ETF / ETN
+QQMG,Finance-ETF / ETN
+QQQ,Finance-ETF / ETN
+QQQA,Finance-ETF / ETN
+QQQD,Finance-ETF / ETN
+QQQE,Finance-ETF / ETN
+QQQI,Finance-ETF / ETN
+QQQJ,Finance-ETF / ETN
+QQQM,Finance-ETF / ETN
+QQQN,Finance-ETF / ETN
+QQQS,Finance-ETF / ETN
+QQQU,Finance-ETF / ETN
+QQQX,Finance-Publ Inv Fd-Eqt
+QQQY,Finance-ETF / ETN
+QQXT,Finance-ETF / ETN
+QRFT,Finance-ETF / ETN
+QRHC,Pollution Control
+QRMI,Finance-ETF / ETN
+QRTEA,Retail-Mail Order&Direct
+QRTEB,Retail-Mail Order&Direct
+QRVO,Elec-Semiconductor Mfg
+QS,Auto/Truck-Original Eqp
+QSAM,Medical-Biomed/Biotech
+QSG,Computer Sftwr-Edu/Media
+QSI,Medical-Biomed/Biotech
+QSML,Finance-ETF / ETN
+QSPT,Finance-ETF / ETN
+QSR,Retail-Restaurants
+QSWN,Finance-ETF / ETN
+QTAP,Finance-ETF / ETN
+QTEC,Finance-ETF / ETN
+QTEKQ,Telecom-Infrastructure
+QTI,Medical-Products
+QTJA,Finance-ETF / ETN
+QTJL,Finance-ETF / ETN
+QTOC,Finance-ETF / ETN
+QTR,Finance-ETF / ETN
+QTRX,Medical-Products
+QTTB,Medical-Generic Drugs
+QTUM,Finance-ETF / ETN
+QTWO,Computer Sftwr-Financial
+QUAD,Comml Svcs-Document Mgmt
+QUAL,Finance-ETF / ETN
+QUBT,Computer-Tech Services
+QUIK,Elec-Semicondctor Fablss
+QULL,Finance-ETF / ETN
+QURE,Medical-Biomed/Biotech
+QUS,Finance-ETF / ETN
+QUVU,Finance-ETF / ETN
+QVAL,Finance-ETF / ETN
+QVML,Finance-ETF / ETN
+QVMM,Finance-ETF / ETN
+QVMS,Finance-ETF / ETN
+QVOY,Finance-ETF / ETN
+QWLD,Finance-ETF / ETN
+QYLD,Finance-ETF / ETN
+QYLE,Finance-ETF / ETN
+QYLG,Finance-ETF / ETN
+R,Comml Svcs-Leasing
+RA,Finance-Publ Inv Fd-Bond
+RAASY,Computer Sftwr-Enterprse
+RAAX,Finance-ETF / ETN
+RACE,Auto Manufacturers
+RACY,Finance-Blank Check
+RADCQ,Retail-Drug Stores
+RAFE,Finance-ETF / ETN
+RAIL,Transportation-Equip Mfg
+RAMP,Computer-Tech Services
+RAND,Finance-Investment Mgmt
+RANI,Medical-Biomed/Biotech
+RAPT,Medical-Biomed/Biotech
+RARE,Medical-Biomed/Biotech
+RATE,Finance-ETF / ETN
+RAVE,Retail-Restaurants
+RAVI,Finance-ETF / ETN
+RAYA,Electrical-Power/Equipmt
+RAYC,Finance-ETF / ETN
+RAYD,Finance-ETF / ETN
+RAYE,Finance-ETF / ETN
+RAYS,Finance-ETF / ETN
+RBA,Retail-Specialty
+RBB,Finance-Savings & Loan
+RBBN,Telecom-Infrastructure
+RBC,Metal Proc & Fabrication
+RBCAA,Banks-Southeast
+RBCN,Group not available
+RBKB,Finance-Commercial Loans
+RBLD,Finance-ETF / ETN
+RBLX,Computer Sftwr-Gaming
+RBOT,Computer Sftwr-Medical
+RBT,Comp Sftwr-Spec Enterprs
+RC,Finance-Mortgage REIT
+RCAC,Finance-Blank Check
+RCAT,Comp Sftwr-Spec Enterprs
+RCEL,Medical-Products
+RCFA,Finance-Blank Check
+RCG,Finance-Publ Inv Fd-Eqt
+RCI,Telecom Svcs- Foreign
+RCKT,Medical-Biomed/Biotech
+RCKY,Apparel-Shoes & Rel Mfg
+RCL,Leisure-Services
+RCM,Comml Svcs-Healthcare
+RCMT,Computer-Tech Services
+RCON,Oil&Gas-Machinery/Equip
+RCRT,Comml Svcs-Staffing
+RCRUY,Comml Svcs-Staffing
+RCS,Finance-Publ Inv Fd-Bond
+RCUS,Medical-Biomed/Biotech
+RDCM,Internet-Network Sltns
+RDDT,Internet-Content
+RDFI,Finance-ETF / ETN
+RDFN,Real Estate Dvlpmt/Ops
+RDHL,Medical-Biomed/Biotech
+RDI,Leisure-Movies & Related
+RDIB,Leisure-Movies & Related
+RDIV,Finance-ETF / ETN
+RDN,Finance-Mrtg&Rel Svc
+RDNT,Medical-Outpnt/Hm Care
+RDOG,Finance-ETF / ETN
+RDUS,Metal Proc & Fabrication
+RDVI,Finance-ETF / ETN
+RDVT,Comml Svcs-Outsourcing
+RDVWF,Internet-Network Sltns
+RDVY,Finance-ETF / ETN
+RDW,Aerospace/Defense
+RDWR,Computer-Networking
+RDY,Medical-Generic Drugs
+RDZN,Insurance-Prop/Cas/Titl
+REAI,Finance-ETF / ETN
+REAL,Retail-Internet
+REAX,Real Estate Dvlpmt/Ops
+REBN,Beverages-Non-Alcoholic
+RECS,Finance-ETF / ETN
+REE,Auto/Truck-Original Eqp
+REED,Beverages-Non-Alcoholic
+REET,Finance-ETF / ETN
+REFI,Finance-Mortgage REIT
+REFR,Elec-Misc Products
+REG,Finance-Property REIT
+REGL,Finance-ETF / ETN
+REGN,Medical-Biomed/Biotech
+REI,Oil&Gas-U S Expl&Prod
+REIT,Finance-ETF / ETN
+REK,Finance-ETF / ETN
+REKR,Comml Svcs-Consulting
+RELI,Insurance-Diversified
+RELL,Elec-Misc Products
+RELX,Comml Svcs-Market Rsrch
+RELY,Financial Svcs-Specialty
+REM,Finance-ETF / ETN
+REMX,Finance-ETF / ETN
+RENB,Medical-Biomed/Biotech
+RENE,Finance-Blank Check
+RENO,Group not available
+RENT,Retail-Internet
+RENW,Finance-ETF / ETN
+REPL,Medical-Biomed/Biotech
+REPX,Oil&Gas-U S Expl&Prod
+REPYY,Oil&Gas-Intl Expl&Prod
+RERE,Retail-Consumer Elec
+RES,Oil&Gas-Field Services
+RETL,Finance-ETF / ETN
+RETO,Bldg-Constr Prds/Misc
+REVB,Medical-Biomed/Biotech
+REVG,Bldg-Mobile/Mfg & Rv
+REVS,Finance-ETF / ETN
+REW,Finance-ETF / ETN
+REX,Energy-Alternative/Other
+REXR,Finance-Property REIT
+REYN,Containers/Packaging
+REZ,Finance-ETF / ETN
+REZI,Security/Sfty
+RF,Banks-Super Regional
+RFAC,Finance-Blank Check
+RFCI,Finance-ETF / ETN
+RFDA,Finance-ETF / ETN
+RFDI,Finance-ETF / ETN
+RFEM,Finance-ETF / ETN
+RFEU,Finance-ETF / ETN
+RFFC,Finance-ETF / ETN
+RFG,Finance-ETF / ETN
+RFI,Finance-Publ Inv Fd-Eqt
+RFIL,Telecom-Cable/Satl Eqp
+RFL,Finance-Investment Mgmt
+RFM,Finance-Publ Inv Fd-Bond
+RFMZ,Finance-Publ Inv Fd-Bond
+RFV,Finance-ETF / ETN
+RGA,Insurance-Life
+RGC,Medical-Biomed/Biotech
+RGCO,Utility-Gas Distribution
+RGEN,Medical-Products
+RGF,Food-Packaged
+RGLD,Mining-Gold/Silver/Gems
+RGLS,Medical-Biomed/Biotech
+RGNX,Medical-Biomed/Biotech
+RGP,Comml Svcs-Consulting
+RGR,Security/Sfty
+RGRX,Medical-Biomed/Biotech
+RGS,Retail-Specialty
+RGT,Finance-Publ Inv Fd-Eqt
+RGTI,Computer-Integrated Syst
+RGTPQ,Computer Sftwr-Medical
+RH,Retail-Home Furnishings
+RHCB,Finance-ETF / ETN
+RHE,Finance-Mortgage REIT
+RHHBY,Medical-Diversified
+RHI,Comml Svcs-Staffing
+RHP,Finance-Property REIT
+RHRX,Finance-ETF / ETN
+RHTX,Finance-ETF / ETN
+RIBT,Food-Grain & Related
+RICK,Leisure-Services
+RIET,Finance-ETF / ETN
+RIG,Oil&Gas-Drilling
+RIGL,Medical-Biomed/Biotech
+RIGS,Finance-ETF / ETN
+RILY,Finance-Invest Bnk/Bkrs
+RINC,Finance-ETF / ETN
+RINF,Finance-ETF / ETN
+RING,Finance-ETF / ETN
+RIO,Mining-Metal Ores
+RIOT,Financial Svcs-Specialty
+RISN,Finance-ETF / ETN
+RISR,Finance-ETF / ETN
+RITA,Finance-ETF / ETN
+RITM,Finance-Mortgage REIT
+RIV,Finance-Publ Inv Fd-Eqt
+RIVN,Auto Manufacturers
+RJF,Finance-Invest Bnk/Bkrs
+RJMG,Finance-ETF / ETN
+RKDA,Agricultural Operations
+RKLB,Aerospace/Defense
+RKT,Finance-Mrtg&Rel Svc
+RL,Apparel-Clothing Mfg
+RLAY,Medical-Biomed/Biotech
+RLGT,Transportation-Logistics
+RLI,Insurance-Prop/Cas/Titl
+RLJ,Finance-Property REIT
+RLMD,Medical-Biomed/Biotech
+RLTY,Finance-Publ Inv Fd-Bal
+RLX,Tobacco
+RLY,Finance-ETF / ETN
+RLYB,Medical-Biomed/Biotech
+RM,Finance-Consumer Loans
+RMAX,Real Estate Dvlpmt/Ops
+RMBI,Finance-Savings & Loan
+RMBL,Retail-Internet
+RMBS,Elec-Semicondctor Fablss
+RMCF,Food-Confectionery
+RMCO,Finance-Property REIT
+RMD,Medical-Products
+RMGC,Finance-Blank Check
+RMI,Finance-Publ Inv Fd-Eqt
+RMIF,Finance-ETF / ETN
+RMM,Finance-Publ Inv Fd-Eqt
+RMMZ,Finance-Publ Inv Fd-Bond
+RMNI,Computer-Tech Services
+RMR,Real Estate Dvlpmt/Ops
+RMT,Finance-Publ Inv Fd-Eqt
+RMTI,Medical-Products
+RNA,Medical-Biomed/Biotech
+RNAC,Medical-Biomed/Biotech
+RNAZ,Medical-Biomed/Biotech
+RNEM,Finance-ETF / ETN
+RNEW,Finance-ETF / ETN
+RNG,Computer Sftwr-Enterprse
+RNGR,Oil&Gas-Field Services
+RNLX,Medical-Services
+RNMC,Finance-ETF / ETN
+RNP,Finance-Publ Inv Fd-Eqt
+RNR,Insurance-Prop/Cas/Titl
+RNRG,Finance-ETF / ETN
+RNSC,Finance-ETF / ETN
+RNST,Banks-Southeast
+RNW,Energy-Alternative/Other
+RNWZ,Finance-ETF / ETN
+RNXT,Medical-Biomed/Biotech
+ROAD,Bldg-Heavy Construction
+ROAM,Finance-ETF / ETN
+ROBO,Finance-ETF / ETN
+ROBT,Finance-ETF / ETN
+ROCK,Metal Proc & Fabrication
+ROCL,Finance-Blank Check
+RODE,Finance-ETF / ETN
+RODM,Finance-ETF / ETN
+ROE,Finance-ETF / ETN
+ROG,Elec-Semiconductor Mfg
+ROIC,Finance-Property REIT
+ROII,Internet-Content
+ROIS,Finance-ETF / ETN
+ROIV,Medical-Biomed/Biotech
+ROK,Electrical-Power/Equipmt
+ROKT,Finance-ETF / ETN
+ROKU,Leisure-Movies & Related
+ROL,Bldg-Maintenance & Svc
+ROM,Finance-ETF / ETN
+ROMA,Comml Svcs-Consulting
+ROMO,Finance-ETF / ETN
+ROOF,Finance-ETF / ETN
+ROOT,Insurance-Prop/Cas/Titl
+ROP,Diversified Operations
+RORO,Finance-ETF / ETN
+ROSC,Finance-ETF / ETN
+ROST,Retail-Apparel/Shoes/Acc
+ROSYY,Telecom Svcs- Foreign
+ROUS,Finance-ETF / ETN
+ROYA,Finance-ETF / ETN
+RPAR,Finance-ETF / ETN
+RPAY,Finance-CrdtCard/PmtPr
+RPD,Computer Sftwr-Security
+RPG,Finance-ETF / ETN
+RPHM,Medical-Biomed/Biotech
+RPHS,Finance-ETF / ETN
+RPID,Medical-Research Eqp/Svc
+RPM,Chemicals-Paints
+RPRX,Medical-Biomed/Biotech
+RPTX,Medical-Biomed/Biotech
+RPV,Finance-ETF / ETN
+RQI,Finance-Publ Inv Fd-Eqt
+RR,Machinery-Mtl Hdlg/Autmn
+RRAC,Finance-Blank Check
+RRBI,Banks-Southeast
+RRC,Oil&Gas-U S Expl&Prod
+RRGB,Retail-Restaurants
+RRR,Leisure-Gaming/Equip
+RRX,Electrical-Power/Equipmt
+RS,Metal Proc & Fabrication
+RSBT,Finance-ETF / ETN
+RSEE,Finance-ETF / ETN
+RSF,Finance-Publ Inv Fd-Eqt
+RSG,Pollution Control
+RSHO,Finance-ETF / ETN
+RSI,Leisure-Gaming/Equip
+RSKD,Computer Sftwr-Enterprse
+RSLS,Medical-Products
+RSP,Finance-ETF / ETN
+RSPC,Finance-ETF / ETN
+RSPD,Finance-ETF / ETN
+RSPE,Finance-ETF / ETN
+RSPF,Finance-ETF / ETN
+RSPG,Finance-ETF / ETN
+RSPH,Finance-ETF / ETN
+RSPM,Finance-ETF / ETN
+RSPN,Finance-ETF / ETN
+RSPR,Finance-ETF / ETN
+RSPS,Finance-ETF / ETN
+RSPT,Finance-ETF / ETN
+RSPU,Finance-ETF / ETN
+RSSB,Finance-ETF / ETN
+RSSS,Comml Svcs-Market Rsrch
+RSST,Finance-ETF / ETN
+RSVR,Leisure-Movies & Related
+RTAI,Finance-ETF / ETN
+RTC,Chemicals-Plastics
+RTH,Finance-ETF / ETN
+RTO,Comml Svcs-Outsourcing
+RTX,Aerospace/Defense
+RUFF,Finance-ETF / ETN
+RULE,Finance-ETF / ETN
+RUM,Internet-Content
+RUN,Energy-Solar
+RUNN,Finance-ETF / ETN
+RUSHA,Retail/Whlsle-Automobile
+RUSHB,Retail/Whlsle-Automobile
+RVLPQ,Group not available
+RVLV,Retail-Apparel/Shoes/Acc
+RVMD,Medical-Biomed/Biotech
+RVNC,Medical-Biomed/Biotech
+RVNU,Finance-ETF / ETN
+RVP,Medical-Supplies
+RVPH,Medical-Biomed/Biotech
+RVRB,Finance-ETF / ETN
+RVSB,Finance-Savings & Loan
+RVSN,Computer Sftwr-Security
+RVT,Finance-Publ Inv Fd-Eqt
+RVTY,Medical-Research Eqp/Svc
+RVYL,Finance-CrdtCard/PmtPr
+RWAY,Finance-Commercial Loans
+RWJ,Finance-ETF / ETN
+RWK,Finance-ETF / ETN
+RWL,Finance-ETF / ETN
+RWM,Finance-ETF / ETN
+RWO,Finance-ETF / ETN
+RWOD,Finance-Blank Check
+RWR,Finance-ETF / ETN
+RWT,Finance-Property REIT
+RWX,Finance-ETF / ETN
+RXD,Finance-ETF / ETN
+RXI,Finance-ETF / ETN
+RXL,Finance-ETF / ETN
+RXO,Transportation-Truck
+RXRX,Medical-Biomed/Biotech
+RXST,Medical-Products
+RXT,Computer Sftwr-Enterprse
+RY,Banks-Money Center
+RYAAY,Transportation-Airline
+RYAM,Chemicals-Specialty
+RYAN,Insurance-Brokers
+RYDE,Leisure-Travel Booking
+RYI,Metal Prds-Distributor
+RYLD,Finance-ETF / ETN
+RYLG,Finance-ETF / ETN
+RYN,Finance-Property REIT
+RYSE,Finance-ETF / ETN
+RYTM,Medical-Biomed/Biotech
+RZG,Finance-ETF / ETN
+RZLT,Medical-Biomed/Biotech
+RZV,Finance-ETF / ETN
+S,Computer Sftwr-Security
+SA,Mining-Gold/Silver/Gems
+SAA,Finance-ETF / ETN
+SABA,Finance-Publ Inv Fd-Glbl
+SABR,Leisure-Travel Booking
+SABS,Medical-Biomed/Biotech
+SACH,Finance-Mortgage REIT
+SAEF,Finance-ETF / ETN
+SAFE,Finance-Mortgage REIT
+SAFT,Insurance-Prop/Cas/Titl
+SAGE,Medical-Biomed/Biotech
+SAGP,Finance-ETF / ETN
+SAH,Retail/Whlsle-Automobile
+SAI,Financial Svcs-Specialty
+SAIA,Transportation-Truck
+SAIC,Comml Svcs-Consulting
+SALM,Media-Radio/Tv
+SAM,Beverages-Alcoholic
+SAMG,Finance-Investment Mgmt
+SAMT,Finance-ETF / ETN
+SAN,Banks-Money Center
+SANA,Medical-Biomed/Biotech
+SAND,Mining-Gold/Silver/Gems
+SANG,Computer-Networking
+SANM,Elec-Contract Mfg
+SANW,Agricultural Operations
+SAP,Computer Sftwr-Enterprse
+SAR,Finance-Investment Mgmt
+SARK,Finance-ETF / ETN
+SASR,Banks-Northeast
+SATL,Aerospace/Defense
+SATO,Finance-ETF / ETN
+SATS,Telecom-Cable/Satl Eqp
+SATX,Telecom Svcs- Foreign
+SAUG,Finance-ETF / ETN
+SAVA,Medical-Biomed/Biotech
+SAVE,Transportation-Airline
+SB,Transportation-Ship
+SBAC,Finance-Property REIT
+SBB,Finance-ETF / ETN
+SBCF,Banks-Southeast
+SBET,Leisure-Gaming/Equip
+SBEV,Beverages-Alcoholic
+SBFG,Banks-Midwest
+SBFM,Medical-Biomed/Biotech
+SBGI,Media-Radio/Tv
+SBH,Retail-Specialty
+SBI,Finance-Publ Inv Fd-Bond
+SBIG,Consumer Prod-Specialty
+SBIO,Finance-ETF / ETN
+SBIT,Group not available
+SBLK,Transportation-Ship
+SBND,Finance-ETF / ETN
+SBNY,Banks-Northeast
+SBOW,Oil&Gas-U S Expl&Prod
+SBR,Oil&Gas-Royalty Trust
+SBRA,Finance-Property REIT
+SBS,Utility-Water Supply
+SBSI,Banks-West/Southwest
+SBSW,Mining-Gold/Silver/Gems
+SBT,Finance-Savings & Loan
+SBUX,Retail-Restaurants
+SBXC,Finance-Blank Check
+SCAP,Finance-ETF / ETN
+SCAQ,Finance-Blank Check
+SCC,Finance-ETF / ETN
+SCCO,Mining-Metal Ores
+SCD,Finance-Publ Inv Fd-Bal
+SCDL,Finance-ETF / ETN
+SCHA,Finance-ETF / ETN
+SCHB,Finance-ETF / ETN
+SCHC,Finance-ETF / ETN
+SCHD,Finance-ETF / ETN
+SCHE,Finance-ETF / ETN
+SCHF,Finance-ETF / ETN
+SCHG,Finance-ETF / ETN
+SCHH,Finance-ETF / ETN
+SCHI,Finance-ETF / ETN
+SCHJ,Finance-ETF / ETN
+SCHK,Finance-ETF / ETN
+SCHL,Media-Books
+SCHM,Finance-ETF / ETN
+SCHO,Finance-ETF / ETN
+SCHP,Finance-ETF / ETN
+SCHQ,Finance-ETF / ETN
+SCHR,Finance-ETF / ETN
+SCHV,Finance-ETF / ETN
+SCHW,Finance-Invest Bnk/Bkrs
+SCHX,Finance-ETF / ETN
+SCHY,Finance-ETF / ETN
+SCHYY,Leisure-Gaming/Equip
+SCHZ,Finance-ETF / ETN
+SCI,Funeral Svcs & Rel
+SCIO,Finance-ETF / ETN
+SCJ,Finance-ETF / ETN
+SCKT,Computer-Hardware/Perip
+SCL,Chemicals-Specialty
+SCLX,Medical-Biomed/Biotech
+SCLZ,Finance-ETF / ETN
+SCM,Finance-Investment Mgmt
+SCMB,Finance-ETF / ETN
+SCNI,Medical-Biomed/Biotech
+SCO,Finance-ETF / ETN
+SCOR,Comml Svcs-Market Rsrch
+SCPH,Medical-Biomed/Biotech
+SCPS,Group not available
+SCPX,Medical-Biomed/Biotech
+SCRD,Finance-ETF / ETN
+SCRM,Finance-Blank Check
+SCS,Hsehold/Office Furniture
+SCSC,Wholesale-Electronics
+SCTL,Medical-Biomed/Biotech
+SCVL,Retail-Apparel/Shoes/Acc
+SCWO,Pollution Control
+SCWX,Computer Sftwr-Security
+SCX,Bldg-Hand Tools
+SCYB,Finance-ETF / ETN
+SCYX,Medical-Biomed/Biotech
+SCZ,Finance-ETF / ETN
+SD,Oil&Gas-U S Expl&Prod
+SDA,Leisure-Services
+SDAC,Finance-Blank Check
+SDCCQ,Medical-Supplies
+SDCI,Finance-ETF / ETN
+SDCP,Finance-ETF / ETN
+SDD,Finance-ETF / ETN
+SDEM,Finance-ETF / ETN
+SDG,Finance-ETF / ETN
+SDGR,Medical-Research Eqp/Svc
+SDHC,Bldg-Resident/Comml
+SDHY,Finance-Publ Inv Fd-Bal
+SDIG,Financial Svcs-Specialty
+SDIV,Finance-ETF / ETN
+SDOG,Finance-ETF / ETN
+SDON,Finance-Blank Check
+SDOT,Retail-Restaurants
+SDOW,Finance-ETF / ETN
+SDP,Finance-ETF / ETN
+SDPI,Oil&Gas-Machinery/Equip
+SDRL,Oil&Gas-Drilling
+SDS,Finance-ETF / ETN
+SDSI,Finance-ETF / ETN
+SDVD,Finance-ETF / ETN
+SDVY,Finance-ETF / ETN
+SDY,Finance-ETF / ETN
+SE,Retail-Internet
+SEA,Finance-ETF / ETN
+SEAC,Telecom-Cable/Satl Eqp
+SEAT,Leisure-Travel Booking
+SEB,Diversified Operations
+SECD,Finance-ETF / ETN
+SECO,Retail-Internet
+SECT,Finance-ETF / ETN
+SEDA,Finance-Blank Check
+SEDG,Energy-Solar
+SEE,Containers/Packaging
+SEED,Agricultural Operations
+SEEL,Medical-Biomed/Biotech
+SEER,Medical-Biomed/Biotech
+SEF,Finance-ETF / ETN
+SEIC,Finance-Investment Mgmt
+SEIM,Finance-ETF / ETN
+SEIQ,Finance-ETF / ETN
+SEIV,Finance-ETF / ETN
+SEIX,Finance-ETF / ETN
+SELF,Finance-Property REIT
+SELV,Finance-ETF / ETN
+SELX,Electronic-Parts
+SEM,Medical-Hospitals
+SEMI,Finance-ETF / ETN
+SEMR,Internet-Content
+SENEA,Food-Packaged
+SENEB,Food-Packaged
+SENS,Medical-Products
+SEPA,Finance-Blank Check
+SEPT,Finance-ETF / ETN
+SEPW,Finance-ETF / ETN
+SEPZ,Finance-ETF / ETN
+SEQL,Medical-Services
+SER,Medical-Biomed/Biotech
+SERA,Medical-Services
+SES,Electrical-Power/Equipmt
+SESG,Finance-ETF / ETN
+SETH,Finance-ETF / ETN
+SETM,Finance-ETF / ETN
+SEVCQ,Auto Manufacturers
+SEVN,Finance-Mortgage REIT
+SEZL,Financial Svcs-Specialty
+SF,Finance-Invest Bnk/Bkrs
+SFBC,Banks-West/Southwest
+SFBS,Banks-Southeast
+SFEB,Finance-ETF / ETN
+SFES,Finance-Investment Mgmt
+SFIG,Finance-ETF / ETN
+SFIX,Retail-Internet
+SFL,Oil&Gas-Transprt/Pipelne
+SFLO,Finance-ETF / ETN
+SFLR,Finance-ETF / ETN
+SFM,Retail-Super/Mini Mkts
+SFNC,Banks-Southeast
+SFRT,Real Estate Dvlpmt/Ops
+SFST,Banks-Southeast
+SFTBY,Telecom Svcs- Foreign
+SFTGQ,Retail/Whlsle-Automobile
+SFWL,Transportation-Logistics
+SFY,Finance-ETF / ETN
+SFYF,Finance-ETF / ETN
+SFYX,Finance-ETF / ETN
+SG,Retail-Restaurants
+SGA,Media-Radio/Tv
+SGAPY,Telecom Svcs- Foreign
+SGBX,Metal Proc & Fabrication
+SGC,Comml Svcs-Outsourcing
+SGD,Real Estate Dvlpmt/Ops
+SGDJ,Finance-ETF / ETN
+SGDM,Finance-ETF / ETN
+SGE,Elec-Misc Products
+SGGFF,Finance-ETF / ETN
+SGH,Computer-Data Storage
+SGHC,Leisure-Gaming/Equip
+SGHT,Medical-Systems/Equip
+SGIOY,Medical-Ethical Drugs
+SGLC,Finance-ETF / ETN
+SGLY,Transportation-Logistics
+SGMA,Elec-Contract Mfg
+SGML,Mining-Metal Ores
+SGMO,Medical-Biomed/Biotech
+SGMT,Medical-Biomed/Biotech
+SGN,Computer Sftwr-Edu/Media
+SGOL,Finance-ETF / ETN
+SGOV,Finance-ETF / ETN
+SGRP,Comml Svcs-Advertising
+SGRY,Medical-Hospitals
+SGSOY,Comml Svcs-Consulting
+SGU,Oil&Gas-Refining/Mktg
+SH,Finance-ETF / ETN
+SHAG,Finance-ETF / ETN
+SHAK,Retail-Restaurants
+SHBI,Banks-Northeast
+SHC,Medical-Services
+SHCO,Leisure-Services
+SHCR,Computer Sftwr-Medical
+SHDG,Finance-ETF / ETN
+SHE,Finance-ETF / ETN
+SHECY,Chemicals-Specialty
+SHEL,Oil&Gas-Integrated
+SHEN,Telecom Svcs-Wireless
+SHFS,Comml Svcs-Outsourcing
+SHG,Banks-Foreign
+SHIM,Bldg-Heavy Construction
+SHIP,Transportation-Ship
+SHLD,Finance-ETF / ETN
+SHLS,Energy-Solar
+SHLT,Medical-Systems/Equip
+SHM,Finance-ETF / ETN
+SHNY,Finance-ETF / ETN
+SHO,Finance-Property REIT
+SHOC,Finance-ETF / ETN
+SHOO,Apparel-Shoes & Rel Mfg
+SHOP,Computer Sftwr-Enterprse
+SHOT,Medical-Biomed/Biotech
+SHPH,Medical-Biomed/Biotech
+SHPP,Finance-ETF / ETN
+SHPW,Machinery-Mtl Hdlg/Autmn
+SHRT,Finance-ETF / ETN
+SHRY,Finance-ETF / ETN
+SHTDY,Medical-Diversified
+SHUS,Finance-ETF / ETN
+SHV,Finance-ETF / ETN
+SHW,Chemicals-Paints
+SHWZ,Comml Svcs-Consulting
+SHY,Finance-ETF / ETN
+SHYD,Finance-ETF / ETN
+SHYF,Trucks & Parts-Hvy Duty
+SHYG,Finance-ETF / ETN
+SHYL,Finance-ETF / ETN
+SHZHY,Apparel-Clothing Mfg
+SIBN,Medical-Systems/Equip
+SICP,Banks-West/Southwest
+SID,Steel-Producers
+SIDU,Telecom-Cable/Satl Eqp
+SIEB,Finance-Invest Bnk/Bkrs
+SIEGY,Diversified Operations
+SIENQ,Medical-Products
+SIF,Aerospace/Defense
+SIFI,Finance-ETF / ETN
+SIFY,Telecom Svcs- Foreign
+SIG,Retail/Whlsle-Jewelry
+SIGA,Medical-Biomed/Biotech
+SIGI,Insurance-Prop/Cas/Titl
+SIHY,Finance-ETF / ETN
+SII,Finance-Investment Mgmt
+SIJ,Finance-ETF / ETN
+SIL,Finance-ETF / ETN
+SILC,Computer-Networking
+SILJ,Finance-ETF / ETN
+SILK,Medical-Products
+SILO,Medical-Biomed/Biotech
+SILV,Mining-Gold/Silver/Gems
+SILX,Finance-ETF / ETN
+SIM,Steel-Producers
+SIMO,Computer-Data Storage
+SIMS,Finance-ETF / ETN
+SING,Energy-Solar
+SINT,Medical-Products
+SIO,Finance-ETF / ETN
+SIRI,Telecom Svcs-Cable/Satl
+SISI,Medical-Biomed/Biotech
+SITC,Finance-Property REIT
+SITE,Retail/Whlsle-Bldg Prds
+SITM,Elec-Semicondctor Fablss
+SIVBQ,Banks-Super Regional
+SIVR,Finance-ETF / ETN
+SIX,Leisure-Services
+SIXA,Finance-ETF / ETN
+SIXF,Finance-ETF / ETN
+SIXH,Finance-ETF / ETN
+SIXJ,Finance-ETF / ETN
+SIXL,Finance-ETF / ETN
+SIXO,Finance-ETF / ETN
+SIXP,Finance-ETF / ETN
+SIXS,Finance-ETF / ETN
+SIZE,Finance-ETF / ETN
+SJ,Internet-Content
+SJB,Finance-ETF / ETN
+SJM,Food-Packaged
+SJNK,Finance-ETF / ETN
+SJR,Telecom Svcs-Cable/Satl
+SJT,Oil&Gas-Royalty Trust
+SJW,Utility-Water Supply
+SKE,Mining-Gold/Silver/Gems
+SKF,Finance-ETF / ETN
+SKGR,Finance-Blank Check
+SKHSY,Bldg-Resident/Comml
+SKIL,Consumer Svcs-Education
+SKIN,Cosmetics/Personal Care
+SKLZ,Leisure-Gaming/Equip
+SKM,Telecom Svcs- Foreign
+SKOR,Finance-ETF / ETN
+SKRE,Finance-ETF / ETN
+SKT,Finance-Property REIT
+SKWD,Insurance-Prop/Cas/Titl
+SKX,Apparel-Shoes & Rel Mfg
+SKY,Bldg-Mobile/Mfg & Rv
+SKYH,Bldg-Heavy Construction
+SKYT,Elec-Semiconductor Mfg
+SKYU,Finance-ETF / ETN
+SKYW,Transportation-Airline
+SKYX,Electrical-Power/Equipmt
+SKYY,Finance-ETF / ETN
+SLAB,Elec-Semicondctor Fablss
+SLAM,Finance-Blank Check
+SLB,Oil&Gas-Field Services
+SLCA,Chemicals-Specialty
+SLDB,Medical-Biomed/Biotech
+SLDP,Electrical-Power/Equipmt
+SLE,Internet-Content
+SLF,Insurance-Life
+SLG,Finance-Property REIT
+SLGL,Medical-Biomed/Biotech
+SLGN,Containers/Packaging
+SLHGF,Group not available
+SLI,Mining-Metal Ores
+SLM,Finance-Consumer Loans
+SLN,Medical-Biomed/Biotech
+SLNA,Leisure-Lodging
+SLND,Bldg-Heavy Construction
+SLNG,Oil&Gas-Integrated
+SLNH,Elec-Scientific/Msrng
+SLNO,Medical-Products
+SLP,Computer Sftwr-Medical
+SLQD,Finance-ETF / ETN
+SLQT,Insurance-Brokers
+SLRC,Finance-Investment Mgmt
+SLRN,Medical-Biomed/Biotech
+SLRX,Medical-Biomed/Biotech
+SLS,Medical-Biomed/Biotech
+SLV,Finance-ETF / ETN
+SLVM,Containers/Packaging
+SLVO,Finance-ETF / ETN
+SLVP,Finance-ETF / ETN
+SLX,Finance-ETF / ETN
+SLYG,Finance-ETF / ETN
+SLYV,Finance-ETF / ETN
+SM,Oil&Gas-U S Expl&Prod
+SMAR,Computer Sftwr-Enterprse
+SMAY,Finance-ETF / ETN
+SMB,Finance-ETF / ETN
+SMBC,Banks-Midwest
+SMBK,Banks-Southeast
+SMCAY,Machinery-Mtl Hdlg/Autmn
+SMCF,Finance-ETF / ETN
+SMCI,Computer-Hardware/Perip
+SMCO,Finance-ETF / ETN
+SMCP,Finance-ETF / ETN
+SMDD,Finance-ETF / ETN
+SMDV,Finance-ETF / ETN
+SMDY,Finance-ETF / ETN
+SMFG,Banks-Money Center
+SMFL,Cosmetics/Personal Care
+SMG,Chemicals-Agricultural
+SMH,Finance-ETF / ETN
+SMHB,Finance-ETF / ETN
+SMHI,Transportation-Ship
+SMI,Finance-ETF / ETN
+SMID,Bldg-Cement/Concrt/Ag
+SMIG,Finance-ETF / ETN
+SMIN,Finance-ETF / ETN
+SMIT,Group not available
+SMIZ,Finance-ETF / ETN
+SMLE,Finance-ETF / ETN
+SMLF,Finance-ETF / ETN
+SMLP,Oil&Gas-Transprt/Pipelne
+SMLR,Medical-Products
+SMLV,Finance-ETF / ETN
+SMMD,Finance-ETF / ETN
+SMMF,Banks-Southeast
+SMMT,Medical-Biomed/Biotech
+SMMU,Finance-ETF / ETN
+SMMV,Finance-ETF / ETN
+SMMYY,Mining-Metal Ores
+SMN,Finance-ETF / ETN
+SMNNY,Leisure-Products
+SMOG,Finance-ETF / ETN
+SMOT,Finance-ETF / ETN
+SMP,Auto/Truck-Replace Parts
+SMPL,Food-Confectionery
+SMPNY,Insurance-Prop/Cas/Titl
+SMR,Energy-Alternative/Other
+SMRI,Finance-ETF / ETN
+SMRT,Security/Sfty
+SMSEY,Apparel-Clothing Mfg
+SMSI,Internet-Network Sltns
+SMSMY,Metal Proc & Fabrication
+SMTC,Elec-Semicondctor Fablss
+SMTH,Finance-ETF / ETN
+SMTI,Medical-Products
+SMTSF,Group not available
+SMWB,Computer Sftwr-Database
+SMX,Internet-Network Sltns
+SMXT,Energy-Solar
+SN,Hsehold-Appliances/Wares
+SNA,Bldg-Hand Tools
+SNAL,Computer Sftwr-Gaming
+SNAP,Internet-Content
+SNAV,Finance-ETF / ETN
+SNAX,Food-Packaged
+SNBR,Retail-Home Furnishings
+SNCR,Computer Sftwr-Enterprse
+SNCY,Transportation-Airline
+SND,Chemicals-Specialty
+SNDA,Medical-Long-term Care
+SNDL,Consumer Prod-Specialty
+SNDR,Transportation-Logistics
+SNDX,Medical-Biomed/Biotech
+SNES,Medical-Biomed/Biotech
+SNEX,Finance-Invest Bnk/Bkrs
+SNFCA,Finance-Mrtg&Rel Svc
+SNGX,Medical-Biomed/Biotech
+SNN,Medical-Products
+SNOA,Medical-Products
+SNOV,Finance-ETF / ETN
+SNOW,Computer Sftwr-Enterprse
+SNPD,Finance-ETF / ETN
+SNPE,Finance-ETF / ETN
+SNPG,Finance-ETF / ETN
+SNPHY,Medical-Ethical Drugs
+SNPO,Security/Sfty
+SNPS,Computer Sftwr-Design
+SNPV,Finance-ETF / ETN
+SNPX,Medical-Biomed/Biotech
+SNSE,Medical-Biomed/Biotech
+SNSR,Finance-ETF / ETN
+SNT,Security/Sfty
+SNTG,Finance-Consumer Loans
+SNTI,Medical-Biomed/Biotech
+SNV,Banks-Southeast
+SNX,Wholesale-Electronics
+SNY,Medical-Ethical Drugs
+SO,Utility-Electric Power
+SOAR,Aerospace/Defense
+SOBKY,Telecom Svcs-Cable/Satl
+SOBR,Computer-Integrated Syst
+SOC,Oil&Gas-Integrated
+SOCL,Finance-ETF / ETN
+SOF,Finance-ETF / ETN
+SOFI,Finance-Consumer Loans
+SOFO,Computer Sftwr-Desktop
+SOGP,Internet-Content
+SOHO,Finance-Property REIT
+SOHU,Computer Sftwr-Gaming
+SOI,Chemicals-Specialty
+SOL,Energy-Solar
+SOLR,Finance-ETF / ETN
+SOLV,Medical-Products
+SOMLY,Security/Sfty
+SON,Containers/Packaging
+SOND,Leisure-Travel Booking
+SONM,Telecom-Consumer Prods
+SONN,Medical-Biomed/Biotech
+SONO,Consumer Prod-Electronic
+SONX,Medical-Systems/Equip
+SONY,Media-Diversified
+SOPA,Internet-Content
+SOPH,Medical-Biomed/Biotech
+SOR,Finance-Publ Inv Fd-Bal
+SOS,Financial Svcs-Specialty
+SOTGY,Electrical-Power/Equipmt
+SOTK,Machinery-Gen Industrial
+SOUN,Computer-Tech Services
+SOVF,Finance-ETF / ETN
+SOXL,Finance-ETF / ETN
+SOXQ,Finance-ETF / ETN
+SOXS,Finance-ETF / ETN
+SOXX,Finance-ETF / ETN
+SOYB,Finance-ETF / ETN
+SP,Comml Svcs-Outsourcing
+SPAB,Finance-ETF / ETN
+SPAM,Finance-ETF / ETN
+SPAQ,Finance-ETF / ETN
+SPAX,Finance-ETF / ETN
+SPB,Bldg-Constr Prds/Misc
+SPBC,Finance-ETF / ETN
+SPBO,Finance-ETF / ETN
+SPC,Finance-ETF / ETN
+SPCB,Security/Sfty
+SPCE,Aerospace/Defense
+SPCX,Finance-ETF / ETN
+SPCZ,Finance-ETF / ETN
+SPD,Finance-ETF / ETN
+SPDG,Finance-ETF / ETN
+SPDN,Finance-ETF / ETN
+SPDV,Finance-ETF / ETN
+SPDW,Finance-ETF / ETN
+SPE,Finance-Publ Inv Fd-Bond
+SPEC,Pollution Control
+SPEM,Finance-ETF / ETN
+SPEU,Finance-ETF / ETN
+SPFF,Finance-ETF / ETN
+SPFI,Banks-West/Southwest
+SPG,Finance-Property REIT
+SPGC,Leisure-Products
+SPGI,Comml Svcs-Market Rsrch
+SPGM,Finance-ETF / ETN
+SPGP,Finance-ETF / ETN
+SPH,Oil&Gas-Refining/Mktg
+SPHB,Finance-ETF / ETN
+SPHD,Finance-ETF / ETN
+SPHQ,Finance-ETF / ETN
+SPHR,Leisure-Services
+SPHY,Finance-ETF / ETN
+SPI,Energy-Solar
+SPIB,Finance-ETF / ETN
+SPIP,Finance-ETF / ETN
+SPIR,Aerospace/Defense
+SPKKY,Telecom Svcs- Foreign
+SPKL,Finance-Blank Check
+SPKX,Finance-ETF / ETN
+SPKY,Finance-ETF / ETN
+SPLB,Finance-ETF / ETN
+SPLG,Finance-ETF / ETN
+SPLP,Finance-Investment Mgmt
+SPLV,Finance-ETF / ETN
+SPMB,Finance-ETF / ETN
+SPMD,Finance-ETF / ETN
+SPMO,Finance-ETF / ETN
+SPMV,Finance-ETF / ETN
+SPNS,Computer-Tech Services
+SPNT,Insurance-Prop/Cas/Titl
+SPOK,Telecom Svcs-Wireless
+SPOT,Computer Sftwr-Edu/Media
+SPPJY,Paper & Paper Products
+SPPL,Computer-Integrated Syst
+SPPP,Finance-ETF / ETN
+SPQ,Finance-ETF / ETN
+SPR,Aerospace/Defense
+SPRB,Medical-Biomed/Biotech
+SPRC,Medical-Biomed/Biotech
+SPRE,Finance-ETF / ETN
+SPRO,Medical-Biomed/Biotech
+SPRU,Energy-Solar
+SPRX,Finance-ETF / ETN
+SPRY,Medical-Biomed/Biotech
+SPSB,Finance-ETF / ETN
+SPSC,Comp Sftwr-Spec Enterprs
+SPSK,Finance-ETF / ETN
+SPSM,Finance-ETF / ETN
+SPT,Computer Sftwr-Enterprse
+SPTE,Finance-ETF / ETN
+SPTI,Finance-ETF / ETN
+SPTL,Finance-ETF / ETN
+SPTM,Finance-ETF / ETN
+SPTN,Retail-Super/Mini Mkts
+SPTS,Finance-ETF / ETN
+SPUC,Finance-ETF / ETN
+SPUS,Finance-ETF / ETN
+SPUU,Finance-ETF / ETN
+SPVM,Finance-ETF / ETN
+SPVU,Finance-ETF / ETN
+SPWH,Retail-Leisure Products
+SPWO,Finance-ETF / ETN
+SPWR,Energy-Solar
+SPXB,Finance-ETF / ETN
+SPXC,Machinery-Gen Industrial
+SPXE,Finance-ETF / ETN
+SPXL,Finance-ETF / ETN
+SPXN,Finance-ETF / ETN
+SPXS,Finance-ETF / ETN
+SPXT,Finance-ETF / ETN
+SPXU,Finance-ETF / ETN
+SPXV,Finance-ETF / ETN
+SPXX,Finance-Publ Inv Fd-Eqt
+SPY,Finance-ETF / ETN
+SPYC,Finance-ETF / ETN
+SPYD,Finance-ETF / ETN
+SPYG,Finance-ETF / ETN
+SPYI,Finance-ETF / ETN
+SPYT,Finance-ETF / ETN
+SPYV,Finance-ETF / ETN
+SPYX,Finance-ETF / ETN
+SQ,Finance-CrdtCard/PmtPr
+SQEW,Finance-ETF / ETN
+SQFT,Finance-Property REIT
+SQLV,Finance-ETF / ETN
+SQM,Chemicals-Agricultural
+SQNS,Elec-Semicondctor Fablss
+SQQQ,Finance-ETF / ETN
+SQSP,Computer Sftwr-Enterprse
+SQY,Finance-ETF / ETN
+SQZB,Medical-Biomed/Biotech
+SR,Utility-Gas Distribution
+SRAD,Leisure-Gaming/Equip
+SRAX,Comml Svcs-Advertising
+SRBK,Banks-Northeast
+SRCE,Banks-Midwest
+SRCL,Pollution Control
+SRDX,Medical-Products
+SRE,Utility-Diversified
+SRET,Finance-ETF / ETN
+SRFM,Transportation-Airline
+SRG,Finance-Property REIT
+SRGHY,Retail-Super/Mini Mkts
+SRHQ,Finance-ETF / ETN
+SRHR,Finance-ETF / ETN
+SRI,Auto/Truck-Original Eqp
+SRL,Financial Svcs-Specialty
+SRLN,Finance-ETF / ETN
+SRM,Leisure-Toys/Games/Hobby
+SRNEQ,Medical-Biomed/Biotech
+SROI,Finance-ETF / ETN
+SRPT,Medical-Biomed/Biotech
+SRRK,Medical-Biomed/Biotech
+SRS,Finance-ETF / ETN
+SRTS,Medical-Systems/Equip
+SRTY,Finance-ETF / ETN
+SRV,Finance-Publ Inv Fd-Eqt
+SRVR,Finance-ETF / ETN
+SRZN,Medical-Biomed/Biotech
+SSB,Banks-Southeast
+SSBI,Finance-Savings & Loan
+SSBK,Banks-Southeast
+SSD,Bldg-Constr Prds/Misc
+SSDOY,Cosmetics/Personal Care
+SSFI,Finance-ETF / ETN
+SSG,Finance-ETF / ETN
+SSIC,Finance-Blank Check
+SSKN,Medical-Systems/Equip
+SSL,Oil&Gas-Refining/Mktg
+SSLY,Finance-ETF / ETN
+SSLZY,Oil&Gas-Intl Expl&Prod
+SSMXY,Medical-Systems/Equip
+SSNC,Computer Sftwr-Financial
+SSNT,Comml Svcs-Consulting
+SSO,Finance-ETF / ETN
+SSP,Media-Radio/Tv
+SSPX,Finance-ETF / ETN
+SSPY,Finance-ETF / ETN
+SSREY,Insurance-Diversified
+SSRM,Mining-Gold/Silver/Gems
+SSSS,Finance-Investment Mgmt
+SST,Comml Svcs-Advertising
+SSTI,Security/Sfty
+SSTK,Retail-Internet
+SSUMY,Diversified Operations
+SSUNF,Retail-Internet
+SSUS,Finance-ETF / ETN
+SSXU,Finance-ETF / ETN
+SSY,Medical-Hospitals
+SSYS,Machinery-Mtl Hdlg/Autmn
+ST,Elec-Misc Products
+STAA,Medical-Products
+STAB,Group not available
+STAF,Comml Svcs-Staffing
+STAG,Finance-Property REIT
+STAX,Finance-ETF / ETN
+STBA,Banks-Northeast
+STBFY,Beverages-Non-Alcoholic
+STBX,Computer Sftwr-Enterprse
+STC,Insurance-Prop/Cas/Titl
+STCE,Finance-ETF / ETN
+STCN,Computer Sftwr-Enterprse
+STE,Medical-Systems/Equip
+STEL,Banks-West/Southwest
+STEM,Comp Sftwr-Spec Enterprs
+STEP,Finance-Investment Mgmt
+STER,Computer Sftwr-Security
+STEW,Finance-Publ Inv Fd-Eqt
+STG,Consumer Svcs-Education
+STGW,Comml Svcs-Advertising
+STHO,Finance-Property REIT
+STI,Energy-Alternative/Other
+STIM,Medical-Biomed/Biotech
+STIP,Finance-ETF / ETN
+STIX,Computer Sftwr-Enterprse
+STK,Finance-Publ Inv Fd-Eqt
+STKH,Food-Meat Products
+STKL,Food-Packaged
+STKS,Retail-Restaurants
+STLA,Auto Manufacturers
+STLD,Steel-Producers
+STLG,Finance-ETF / ETN
+STM,Elec-Semiconductor Mfg
+STN,Comml Svcs-Consulting
+STNC,Finance-ETF / ETN
+STNE,Finance-CrdtCard/PmtPr
+STNG,Oil&Gas-Transprt/Pipelne
+STOK,Medical-Biomed/Biotech
+STOT,Finance-ETF / ETN
+STPZ,Finance-ETF / ETN
+STR,Oil&Gas-U S Expl&Prod
+STRA,Consumer Svcs-Education
+STRC,Elec-Misc Products
+STRL,Bldg-Heavy Construction
+STRM,Computer Sftwr-Medical
+STRO,Medical-Biomed/Biotech
+STRR,Medical-Systems/Equip
+STRS,Real Estate Dvlpmt/Ops
+STRT,Auto/Truck-Original Eqp
+STRV,Finance-ETF / ETN
+STRW,Finance-Property REIT
+STSS,Medical-Supplies
+STT,Finance-Investment Mgmt
+STTK,Medical-Biomed/Biotech
+STVN,Medical-Services
+STWD,Finance-Mortgage REIT
+STX,Computer-Data Storage
+STXD,Finance-ETF / ETN
+STXE,Finance-ETF / ETN
+STXG,Finance-ETF / ETN
+STXK,Finance-ETF / ETN
+STXS,Medical-Systems/Equip
+STXT,Finance-ETF / ETN
+STXV,Finance-ETF / ETN
+STZ,Beverages-Alcoholic
+SU,Oil&Gas-Integrated
+SUB,Finance-ETF / ETN
+SUGP,Security/Sfty
+SUHJY,Real Estate Dvlpmt/Ops
+SUI,Finance-Property REIT
+SUM,Bldg-Cement/Concrt/Ag
+SUN,Oil&Gas-Refining/Mktg
+SUNLQ,Finance-Consumer Loans
+SUNWQ,Energy-Solar
+SUP,Auto/Truck-Original Eqp
+SUPL,Finance-ETF / ETN
+SUPN,Medical-Biomed/Biotech
+SUPP,Finance-ETF / ETN
+SUPV,Banks-Foreign
+SURE,Finance-ETF / ETN
+SURG,Computer Sftwr-Enterprse
+SURI,Finance-ETF / ETN
+SUSA,Finance-ETF / ETN
+SUSB,Finance-ETF / ETN
+SUSC,Finance-ETF / ETN
+SUSL,Finance-ETF / ETN
+SUTNY,Banks-Money Center
+SUZ,Paper & Paper Products
+SVA,Medical-Biomed/Biotech
+SVAL,Finance-ETF / ETN
+SVC,Finance-Property REIT
+SVII,Finance-Blank Check
+SVIX,Finance-ETF / ETN
+SVM,Mining-Gold/Silver/Gems
+SVMH,Leisure-Products
+SVNDY,Retail-Super/Mini Mkts
+SVOL,Finance-ETF / ETN
+SVRA,Medical-Biomed/Biotech
+SVRE,Computer Sftwr-Security
+SVT,Aerospace/Defense
+SVV,Retail-Specialty
+SVVC,Finance-Publ Inv Fd-Eqt
+SVXY,Finance-ETF / ETN
+SWAG,Comml Svcs-Advertising
+SWAN,Finance-ETF / ETN
+SWAV,Medical-Systems/Equip
+SWBI,Security/Sfty
+SWDBY,Banks-Foreign
+SWGAY,Retail/Whlsle-Jewelry
+SWI,Computer Sftwr-Enterprse
+SWIM,Bldg-Constr Prds/Misc
+SWIN,Finance-Invest Bnk/Bkrs
+SWK,Bldg-Hand Tools
+SWKH,Comml Svcs-Consulting
+SWKS,Elec-Semiconductor Mfg
+SWN,Oil&Gas-U S Expl&Prod
+SWSS,Finance-Blank Check
+SWTX,Medical-Biomed/Biotech
+SWVL,Computer Sftwr-Enterprse
+SWX,Utility-Gas Distribution
+SWZ,Finance-Publ Inv Fd-Glbl
+SXC,Energy-Coal
+SXI,Machinery-Gen Industrial
+SXQG,Finance-ETF / ETN
+SXT,Food-Misc Preparation
+SXTC,Medical-Ethical Drugs
+SXTP,Medical-Ethical Drugs
+SXUS,Finance-ETF / ETN
+SY,Medical-Services
+SYBT,Banks-Southeast
+SYBX,Medical-Biomed/Biotech
+SYF,Finance-Savings & Loan
+SYII,Finance-ETF / ETN
+SYK,Medical-Products
+SYLD,Finance-ETF / ETN
+SYM,Machinery-Gen Industrial
+SYNA,Elec-Misc Products
+SYNB,Finance-ETF / ETN
+SYNX,Consumer Prod-Electronic
+SYPR,Elec-Contract Mfg
+SYRA,Medical-Services
+SYRE,Medical-Biomed/Biotech
+SYRS,Medical-Biomed/Biotech
+SYT,Real Estate Dvlpmt/Ops
+SYTA,Telecom-Consumer Prods
+SYUS,Finance-ETF / ETN
+SYY,Wholesale-Food
+SZK,Finance-ETF / ETN
+SZKMY,Auto Manufacturers
+SZNE,Finance-ETF / ETN
+T,Telecom Svcs-Integrated
+TAC,Utility-Electric Power
+TACK,Finance-ETF / ETN
+TACT,Computer-Hardware/Perip
+TAFI,Finance-ETF / ETN
+TAFL,Finance-ETF / ETN
+TAFM,Finance-ETF / ETN
+TAGG,Finance-ETF / ETN
+TAGS,Finance-ETF / ETN
+TAIL,Finance-ETF / ETN
+TAIT,Electronic-Parts
+TAK,Medical-Ethical Drugs
+TAL,Consumer Svcs-Education
+TALK,Medical-Services
+TALO,Oil&Gas-U S Expl&Prod
+TAN,Finance-ETF / ETN
+TANH,Chemicals-Specialty
+TAOP,Security/Sfty
+TAP,Beverages-Alcoholic
+TAPA,Beverages-Alcoholic
+TARA,Medical-Biomed/Biotech
+TARK,Finance-ETF / ETN
+TARO,Medical-Generic Drugs
+TARS,Medical-Biomed/Biotech
+TASK,Computer-Tech Services
+TAST,Retail-Restaurants
+TATT,Aerospace/Defense
+TATYY,Food-Grain & Related
+TAXF,Finance-ETF / ETN
+TAXX,Finance-ETF / ETN
+TAYD,Machinery-Gen Industrial
+TBBB,Retail-Major Disc Chains
+TBBK,Banks-Northeast
+TBCP,Finance-Blank Check
+TBF,Finance-ETF / ETN
+TBFC,Finance-ETF / ETN
+TBFG,Finance-ETF / ETN
+TBG,Finance-ETF / ETN
+TBI,Comml Svcs-Staffing
+TBIL,Finance-ETF / ETN
+TBIO,Medical-Research Eqp/Svc
+TBJL,Finance-ETF / ETN
+TBLA,Comml Svcs-Advertising
+TBLD,Finance-Publ Inv Fd-Glbl
+TBLL,Finance-ETF / ETN
+TBLT,Bldg-Hand Tools
+TBMC,Finance-Blank Check
+TBNK,Finance-Savings & Loan
+TBPH,Medical-Biomed/Biotech
+TBRG,Computer Sftwr-Medical
+TBT,Finance-ETF / ETN
+TBUX,Finance-ETF / ETN
+TBX,Finance-ETF / ETN
+TC,Retail/Whlsle-Automobile
+TCAF,Finance-ETF / ETN
+TCBC,Banks-Southeast
+TCBI,Banks-West/Southwest
+TCBK,Banks-West/Southwest
+TCBP,Medical-Biomed/Biotech
+TCBS,Banks-West/Southwest
+TCBX,Banks-West/Southwest
+TCEHY,Internet-Content
+TCFC,Banks-Northeast
+TCHI,Finance-ETF / ETN
+TCHP,Finance-ETF / ETN
+TCI,Real Estate Dvlpmt/Ops
+TCJH,Comml Svcs-Consulting
+TCMD,Medical-Products
+TCN,Real Estate Dvlpmt/Ops
+TCNNF,Consumer Prod-Specialty
+TCOA,Finance-Blank Check
+TCOM,Leisure-Travel Booking
+TCON,Medical-Biomed/Biotech
+TCPC,Finance-Investment Mgmt
+TCRT,Medical-Biomed/Biotech
+TCRX,Medical-Biomed/Biotech
+TCS,Retail-Home Furnishings
+TCTM,Consumer Svcs-Education
+TCX,Internet-Network Sltns
+TD,Banks-Money Center
+TDC,Computer Sftwr-Database
+TDCX,Comml Svcs-Outsourcing
+TDF,Finance-Publ Inv Fd-Glbl
+TDG,Aerospace/Defense
+TDI,Finance-ETF / ETN
+TDIV,Finance-ETF / ETN
+TDOC,Computer Sftwr-Medical
+TDS,Telecom Svcs-Wireless
+TDSB,Finance-ETF / ETN
+TDSC,Finance-ETF / ETN
+TDTF,Finance-ETF / ETN
+TDTT,Finance-ETF / ETN
+TDUP,Retail-Internet
+TDV,Finance-ETF / ETN
+TDVG,Finance-ETF / ETN
+TDVI,Finance-ETF / ETN
+TDW,Oil&Gas-Field Services
+TDY,Aerospace/Defense
+TEAF,Finance-Publ Inv Fd-Eqt
+TEAM,Comp Sftwr-Spec Enterprs
+TECB,Finance-ETF / ETN
+TECH,Medical-Research Eqp/Svc
+TECK,Mining-Metal Ores
+TECL,Finance-ETF / ETN
+TECS,Finance-ETF / ETN
+TEF,Telecom Svcs- Foreign
+TEI,Finance-Publ Inv Fd-Glbl
+TEL,Electronic-Parts
+TELA,Medical-Products
+TELL,Oil&Gas-Intl Expl&Prod
+TELNY,Telecom Svcs- Foreign
+TELO,Medical-Biomed/Biotech
+TEMP,Finance-ETF / ETN
+TENB,Computer Sftwr-Security
+TENK,Finance-Blank Check
+TENX,Medical-Biomed/Biotech
+TEO,Telecom Svcs- Foreign
+TEQI,Finance-ETF / ETN
+TER,Elec-Semiconductor Equip
+TERN,Medical-Biomed/Biotech
+TESS,Telecom-Consumer Prods
+TETE,Finance-Blank Check
+TEVA,Medical-Generic Drugs
+TEX,Machinery-Constr/Mining
+TEZNY,Utility-Electric Power
+TFC,Banks-Super Regional
+TFFP,Medical-Biomed/Biotech
+TFI,Finance-ETF / ETN
+TFII,Transportation-Truck
+TFIN,Banks-West/Southwest
+TFJL,Finance-ETF / ETN
+TFLO,Finance-ETF / ETN
+TFLR,Finance-ETF / ETN
+TFPM,Mining-Gold/Silver/Gems
+TFPN,Finance-ETF / ETN
+TFSL,Finance-Savings & Loan
+TFX,Medical-Products
+TG,Chemicals-Plastics
+TGAA,Finance-Blank Check
+TGAN,Elec-Semiconductor Mfg
+TGB,Mining-Metal Ores
+TGI,Aerospace/Defense
+TGL,Computer Sftwr-Enterprse
+TGLR,Finance-ETF / ETN
+TGLS,Bldg-Constr Prds/Misc
+TGNA,Media-Radio/Tv
+TGRT,Finance-ETF / ETN
+TGRW,Finance-ETF / ETN
+TGS,Oil&Gas-Transprt/Pipelne
+TGT,Retail-Major Disc Chains
+TGTX,Medical-Biomed/Biotech
+TH,Leisure-Lodging
+THAR,Medical-Biomed/Biotech
+THC,Medical-Hospitals
+THCH,Retail-Restaurants
+THCP,Finance-Blank Check
+THD,Finance-ETF / ETN
+THFF,Banks-Midwest
+THG,Insurance-Prop/Cas/Titl
+THLV,Finance-ETF / ETN
+THM,Mining-Gold/Silver/Gems
+THMO,Medical-Systems/Equip
+THNQ,Finance-ETF / ETN
+THO,Bldg-Mobile/Mfg & Rv
+THQ,Finance-Publ Inv Fd-Eqt
+THR,Bldg-A/C & Heating Prds
+THRD,Medical-Biomed/Biotech
+THRM,Auto/Truck-Original Eqp
+THRY,Comml Svcs-Advertising
+THS,Food-Packaged
+THTA,Finance-ETF / ETN
+THTX,Medical-Biomed/Biotech
+THW,Finance-Publ Inv Fd-Eqt
+THY,Finance-ETF / ETN
+THYF,Finance-ETF / ETN
+TIGO,Telecom Svcs- Foreign
+TIGR,Finance-Invest Bnk/Bkrs
+TIL,Medical-Biomed/Biotech
+TILE,Bldg-Constr Prds/Misc
+TILL,Finance-ETF / ETN
+TILT,Finance-ETF / ETN
+TIMB,Telecom Svcs- Foreign
+TIME,Finance-ETF / ETN
+TINT,Finance-ETF / ETN
+TINY,Finance-ETF / ETN
+TIOG,Financial Svcs-Specialty
+TIP,Finance-ETF / ETN
+TIPT,Financial Svcs-Specialty
+TIPX,Finance-ETF / ETN
+TIPZ,Finance-ETF / ETN
+TIRX,Insurance-Brokers
+TISI,Pollution Control
+TITN,Retail/Whlsle-Bldg Prds
+TIVC,Medical-Biomed/Biotech
+TIXT,Computer-Tech Services
+TJUL,Finance-ETF / ETN
+TJX,Retail-Apparel/Shoes/Acc
+TK,Oil&Gas-Transprt/Pipelne
+TKC,Telecom Svcs- Foreign
+TKLF,Cosmetics/Personal Care
+TKNO,Medical-Research Eqp/Svc
+TKO,Media-Diversified
+TKOMY,Insurance-Prop/Cas/Titl
+TKR,Metal Proc & Fabrication
+TLF,Retail-Apparel/Shoes/Acc
+TLGPY,Telecom Svcs- Foreign
+TLGY,Finance-Blank Check
+TLH,Finance-ETF / ETN
+TLIS,Medical-Research Eqp/Svc
+TLK,Telecom Svcs- Foreign
+TLLTF,Consumer Prod-Specialty
+TLPH,Medical-Biomed/Biotech
+TLRY,Consumer Prod-Specialty
+TLS,Computer Sftwr-Security
+TLSA,Medical-Biomed/Biotech
+TLSI,Medical-Biomed/Biotech
+TLT,Finance-ETF / ETN
+TLTD,Finance-ETF / ETN
+TLTE,Finance-ETF / ETN
+TLTW,Finance-ETF / ETN
+TLYS,Retail-Apparel/Shoes/Acc
+TM,Auto Manufacturers
+TMAT,Finance-ETF / ETN
+TMBRQ,Medical-Ethical Drugs
+TMC,Mining-Metal Ores
+TMCI,Medical-Systems/Equip
+TMDIF,Medical-Systems/Equip
+TMDV,Finance-ETF / ETN
+TMDX,Medical-Products
+TME,Internet-Content
+TMET,Finance-ETF / ETN
+TMF,Finance-ETF / ETN
+TMFC,Finance-ETF / ETN
+TMFE,Finance-ETF / ETN
+TMFG,Finance-ETF / ETN
+TMFM,Finance-ETF / ETN
+TMFS,Finance-ETF / ETN
+TMFX,Finance-ETF / ETN
+TMHC,Bldg-Resident/Comml
+TMO,Medical-Research Eqp/Svc
+TMP,Banks-Northeast
+TMPOQ,Machinery-Mtl Hdlg/Autmn
+TMQ,Mining-Metal Ores
+TMSL,Finance-ETF / ETN
+TMTC,Finance-Blank Check
+TMUS,Telecom Svcs-Wireless
+TMV,Finance-ETF / ETN
+TNA,Finance-ETF / ETN
+TNC,Machinery-Gen Industrial
+TNDM,Medical-Products
+TNET,Comml Svcs-Outsourcing
+TNGX,Medical-Biomed/Biotech
+TNK,Oil&Gas-Transprt/Pipelne
+TNL,Leisure-Services
+TNON,Medical-Products
+TNP,Oil&Gas-Transprt/Pipelne
+TNXP,Medical-Biomed/Biotech
+TNYA,Medical-Biomed/Biotech
+TOELY,Elec-Semiconductor Equip
+TOI,Medical-Hospitals
+TOK,Finance-ETF / ETN
+TOKE,Finance-ETF / ETN
+TOL,Bldg-Resident/Comml
+TOLL,Finance-ETF / ETN
+TOLZ,Finance-ETF / ETN
+TOMZ,Pollution Control
+TOON,Media-Diversified
+TOP,Finance-Invest Bnk/Bkrs
+TOPS,Oil&Gas-Transprt/Pipelne
+TORO,Transportation-Ship
+TOST,Finance-CrdtCard/PmtPr
+TOSYY,Electrical-Power/Equipmt
+TOTL,Finance-ETF / ETN
+TOTR,Finance-ETF / ETN
+TOUR,Leisure-Travel Booking
+TOUS,Finance-ETF / ETN
+TOVX,Medical-Biomed/Biotech
+TOWN,Banks-Southeast
+TPB,Tobacco
+TPC,Bldg-Heavy Construction
+TPCS,Metal Proc & Fabrication
+TPET,Oil&Gas-U S Expl&Prod
+TPG,Finance-Investment Mgmt
+TPH,Bldg-Resident/Comml
+TPHD,Finance-ETF / ETN
+TPHE,Finance-ETF / ETN
+TPHS,Real Estate Dvlpmt/Ops
+TPIC,Energy-Alternative/Other
+TPIF,Finance-ETF / ETN
+TPL,Oil&Gas-Royalty Trust
+TPLC,Finance-ETF / ETN
+TPLE,Finance-ETF / ETN
+TPMN,Finance-ETF / ETN
+TPOR,Finance-ETF / ETN
+TPR,Apparel-Clothing Mfg
+TPSC,Finance-ETF / ETN
+TPST,Medical-Biomed/Biotech
+TPVG,Finance-Investment Mgmt
+TPX,Hsehold/Office Furniture
+TPYP,Finance-ETF / ETN
+TPZ,Finance-Publ Inv Fd-Eqt
+TQQQ,Finance-ETF / ETN
+TR,Food-Confectionery
+TRAK,Comp Sftwr-Spec Enterprs
+TRC,Real Estate Dvlpmt/Ops
+TRDA,Medical-Biomed/Biotech
+TREE,Finance-Mrtg&Rel Svc
+TRES,Finance-ETF / ETN
+TREX,Bldg-Constr Prds/Misc
+TRFK,Finance-ETF / ETN
+TRFM,Finance-ETF / ETN
+TRGP,Oil&Gas-Refining/Mktg
+TRI,Comml Svcs-Market Rsrch
+TRIB,Medical-Products
+TRIN,Finance-Investment Mgmt
+TRIP,Leisure-Travel Booking
+TRIRF,Group not available
+TRIS,Finance-Blank Check
+TRKAQ,Comml Svcs-Advertising
+TRMB,Elec-Misc Products
+TRMD,Oil&Gas-Transprt/Pipelne
+TRMK,Banks-Southeast
+TRML,Medical-Biomed/Biotech
+TRN,Transportation-Equip Mfg
+TRND,Finance-ETF / ETN
+TRNO,Finance-Property REIT
+TRNR,Leisure-Services
+TRNS,Electronic-Parts
+TRON,Finance-Blank Check
+TROO,Elec-Misc Products
+TROW,Finance-Investment Mgmt
+TROX,Chemicals-Specialty
+TRP,Oil&Gas-Transprt/Pipelne
+TRS,Diversified Operations
+TRST,Finance-Savings & Loan
+TRT,Elec-Semiconductor Equip
+TRTL,Finance-Blank Check
+TRTX,Finance-Mrtg&Rel Svc
+TRTY,Finance-ETF / ETN
+TRU,Financial Svcs-Specialty
+TRUE,Internet-Content
+TRUG,Computer Sftwr-Gaming
+TRUP,Insurance-Acc & Health
+TRV,Insurance-Prop/Cas/Titl
+TRVG,Leisure-Travel Booking
+TRVI,Medical-Biomed/Biotech
+TRVN,Medical-Biomed/Biotech
+TRX,Mining-Gold/Silver/Gems
+TS,Steel-Producers
+TSAT,Telecom-Cable/Satl Eqp
+TSBK,Banks-West/Southwest
+TSBX,Medical-Biomed/Biotech
+TSCO,Retail/Whlsle-Bldg Prds
+TSDD,Finance-ETF / ETN
+TSE,Chemicals-Plastics
+TSEC,Finance-ETF / ETN
+TSEM,Elec-Semiconductor Mfg
+TSHA,Medical-Biomed/Biotech
+TSI,Finance-Publ Inv Fd-Bond
+TSL,Finance-ETF / ETN
+TSLA,Auto Manufacturers
+TSLH,Finance-ETF / ETN
+TSLL,Finance-ETF / ETN
+TSLP,Finance-ETF / ETN
+TSLQ,Finance-ETF / ETN
+TSLR,Finance-ETF / ETN
+TSLS,Finance-ETF / ETN
+TSLT,Finance-ETF / ETN
+TSLX,Finance-Commercial Loans
+TSLY,Finance-ETF / ETN
+TSLZ,Finance-ETF / ETN
+TSM,Elec-Semiconductor Mfg
+TSME,Finance-ETF / ETN
+TSN,Food-Meat Products
+TSNDF,Consumer Prod-Specialty
+TSPA,Finance-ETF / ETN
+TSPH,Group not available
+TSQ,Media-Radio/Tv
+TSRI,Computer-Tech Services
+TSVT,Medical-Biomed/Biotech
+TT,Bldg-A/C & Heating Prds
+TTAC,Finance-ETF / ETN
+TTAI,Finance-ETF / ETN
+TTC,Bldg-Hand Tools
+TTCFQ,Food-Packaged
+TTD,Comml Svcs-Advertising
+TTDKY,Electronic-Parts
+TTE,Oil&Gas-Integrated
+TTEC,Comml Svcs-Outsourcing
+TTEK,Pollution Control
+TTGT,Computer Sftwr-Enterprse
+TTI,Oil&Gas-Field Services
+TTMI,Elec-Contract Mfg
+TTNDY,Bldg-Hand Tools
+TTNP,Medical-Biomed/Biotech
+TTOO,Medical-Research Eqp/Svc
+TTP,Finance-Publ Inv Fd-Eqt
+TTSH,Retail/Whlsle-Bldg Prds
+TTT,Finance-ETF / ETN
+TTWO,Computer Sftwr-Gaming
+TU,Telecom Svcs- Foreign
+TUA,Finance-ETF / ETN
+TUEMQ,Group not available
+TUG,Finance-ETF / ETN
+TUGN,Finance-ETF / ETN
+TUP,Hsehold-Appliances/Wares
+TUR,Finance-ETF / ETN
+TURB,Electrical-Power/Equipmt
+TURN,Finance-Investment Mgmt
+TUSI,Finance-ETF / ETN
+TUSK,Oil&Gas-Field Services
+TUYA,Computer Sftwr-Enterprse
+TV,Media-Diversified
+TVAL,Finance-ETF / ETN
+TVGN,Medical-Biomed/Biotech
+TVTX,Medical-Biomed/Biotech
+TW,Financial Svcs-Specialty
+TWCB,Finance-Blank Check
+TWI,Auto/Truck-Tires & Misc
+TWIN,Transportation-Equip Mfg
+TWIO,Finance-ETF / ETN
+TWKS,Computer-Tech Services
+TWLO,Computer Sftwr-Enterprse
+TWLV,Finance-Blank Check
+TWM,Finance-ETF / ETN
+TWN,Finance-Publ Inv Fd-Glbl
+TWO,Finance-Mortgage REIT
+TWOU,Computer Sftwr-Edu/Media
+TWST,Medical-Biomed/Biotech
+TX,Steel-Producers
+TXG,Medical-Products
+TXMD,Medical-Ethical Drugs
+TXN,Elec-Semiconductor Mfg
+TXO,Oil&Gas-U S Expl&Prod
+TXRH,Retail-Restaurants
+TXS,Finance-ETF / ETN
+TXSS,Finance-ETF / ETN
+TXT,Aerospace/Defense
+TY,Finance-Publ Inv Fd-Eqt
+TYA,Finance-ETF / ETN
+TYD,Finance-ETF / ETN
+TYG,Finance-Publ Inv Fd-Eqt
+TYGO,Energy-Solar
+TYIDY,Auto Manufacturers
+TYL,Comp Sftwr-Spec Enterprs
+TYLD,Finance-ETF / ETN
+TYLG,Finance-ETF / ETN
+TYO,Finance-ETF / ETN
+TYRA,Medical-Biomed/Biotech
+TZA,Finance-ETF / ETN
+TZOO,Leisure-Travel Booking
+U,Computer Sftwr-Design
+UA,Apparel-Clothing Mfg
+UAA,Apparel-Clothing Mfg
+UAE,Finance-ETF / ETN
+UAL,Transportation-Airline
+UAMY,Mining-Metal Ores
+UAN,Chemicals-Agricultural
+UAPR,Finance-ETF / ETN
+UAUG,Finance-ETF / ETN
+UAVS,Machinery-Farm
+UBCP,Banks-Midwest
+UBER,Leisure-Services
+UBFO,Banks-West/Southwest
+UBND,Finance-ETF / ETN
+UBOH,Group not available
+UBOT,Finance-ETF / ETN
+UBR,Finance-ETF / ETN
+UBS,Banks-Money Center
+UBSI,Banks-Southeast
+UBT,Finance-ETF / ETN
+UBX,Medical-Biomed/Biotech
+UBXG,Comml Svcs-Advertising
+UCAR,Retail/Whlsle-Auto Parts
+UCBI,Banks-Southeast
+UCC,Finance-ETF / ETN
+UCIB,Finance-ETF / ETN
+UCL,Telecom Svcs- Foreign
+UCO,Finance-ETF / ETN
+UCON,Finance-ETF / ETN
+UCRD,Finance-ETF / ETN
+UCTT,Elec-Semiconductor Equip
+UCYB,Finance-ETF / ETN
+UDEC,Finance-ETF / ETN
+UDI,Finance-ETF / ETN
+UDIV,Finance-ETF / ETN
+UDMY,Computer Sftwr-Edu/Media
+UDN,Finance-ETF / ETN
+UDOW,Finance-ETF / ETN
+UDR,Finance-Property REIT
+UE,Finance-Property REIT
+UEC,Mining-Metal Ores
+UEIC,Consumer Prod-Electronic
+UEVM,Finance-ETF / ETN
+UFABQ,Auto/Truck-Original Eqp
+UFCS,Insurance-Prop/Cas/Titl
+UFEB,Finance-ETF / ETN
+UFI,Apparel-Clothing Mfg
+UFIV,Finance-ETF / ETN
+UFO,Finance-ETF / ETN
+UFPI,Bldg-Wood Prds
+UFPT,Containers/Packaging
+UG,Medical-Products
+UGA,Finance-ETF / ETN
+UGE,Finance-ETF / ETN
+UGI,Oil&Gas-Refining/Mktg
+UGL,Finance-ETF / ETN
+UGP,Oil&Gas-Refining/Mktg
+UGRO,Agricultural Operations
+UHAL,Comml Svcs-Leasing
+UHALB,Comml Svcs-Leasing
+UHG,Bldg-Resident/Comml
+UHS,Medical-Hospitals
+UHT,Finance-Property REIT
+UI,Telecom-Infrastructure
+UIS,Computer-Tech Services
+UITB,Finance-ETF / ETN
+UIVM,Finance-ETF / ETN
+UJAN,Finance-ETF / ETN
+UJB,Finance-ETF / ETN
+UJUL,Finance-ETF / ETN
+UJUN,Finance-ETF / ETN
+UK,Real Estate Dvlpmt/Ops
+UL,Food-Packaged
+ULBI,Consumer Prod-Specialty
+ULCC,Transportation-Airline
+ULE,Finance-ETF / ETN
+ULH,Transportation-Truck
+ULST,Finance-ETF / ETN
+ULTA,Retail-Specialty
+ULTR,Finance-ETF / ETN
+ULTY,Finance-ETF / ETN
+ULVM,Finance-ETF / ETN
+ULY,Computer Sftwr-Database
+UMAC,Aerospace/Defense
+UMAR,Finance-ETF / ETN
+UMAY,Finance-ETF / ETN
+UMBF,Banks-Midwest
+UMC,Elec-Semiconductor Mfg
+UMDD,Finance-ETF / ETN
+UMH,Finance-Property REIT
+UMI,Finance-ETF / ETN
+UMMA,Finance-ETF / ETN
+UNAM,Insurance-Prop/Cas/Titl
+UNB,Banks-Northeast
+UNCY,Medical-Biomed/Biotech
+UNF,Comml Svcs-Outsourcing
+UNFI,Wholesale-Food
+UNG,Finance-ETF / ETN
+UNH,Medical-Managed Care
+UNICY,Cosmetics/Personal Care
+UNIT,Finance-Property REIT
+UNIY,Finance-ETF / ETN
+UNL,Finance-ETF / ETN
+UNM,Insurance-Acc & Health
+UNOV,Finance-ETF / ETN
+UNP,Transportation-Rail
+UNTY,Banks-Northeast
+UOCT,Finance-ETF / ETN
+UONE,Media-Radio/Tv
+UONEK,Media-Radio/Tv
+UOVEY,Banks-Foreign
+UP,Leisure-Services
+UPAR,Finance-ETF / ETN
+UPBD,Comml Svcs-Leasing
+UPC,Medical-Biomed/Biotech
+UPGD,Finance-ETF / ETN
+UPGR,Finance-ETF / ETN
+UPHL,Medical-Long-term Care
+UPLD,Computer Sftwr-Enterprse
+UPMMY,Paper & Paper Products
+UPRO,Finance-ETF / ETN
+UPS,Transport-Air Freight
+UPST,Finance-Consumer Loans
+UPV,Finance-ETF / ETN
+UPW,Finance-ETF / ETN
+UPWK,Comml Svcs-Staffing
+UPXI,Consumer Prod-Specialty
+URA,Finance-ETF / ETN
+URBN,Retail-Apparel/Shoes/Acc
+URE,Finance-ETF / ETN
+URG,Mining-Metal Ores
+URGN,Medical-Biomed/Biotech
+URI,Comml Svcs-Leasing
+URNJ,Finance-ETF / ETN
+URNM,Finance-ETF / ETN
+UROY,Oil&Gas-Royalty Trust
+URTH,Finance-ETF / ETN
+URTY,Finance-ETF / ETN
+USA,Finance-Publ Inv Fd-Eqt
+USAC,Oil&Gas-Field Services
+USAI,Finance-ETF / ETN
+USAP,Steel-Specialty Alloys
+USAS,Mining-Gold/Silver/Gems
+USAU,Mining-Gold/Silver/Gems
+USB,Banks-Super Regional
+USBF,Finance-ETF / ETN
+USCA,Finance-ETF / ETN
+USCB,Banks-Southeast
+USCF,Finance-ETF / ETN
+USCI,Finance-ETF / ETN
+USCL,Finance-ETF / ETN
+USCT,Finance-Blank Check
+USD,Finance-ETF / ETN
+USDP,Transportation-Rail
+USDU,Finance-ETF / ETN
+USDX,Finance-ETF / ETN
+USE,Finance-ETF / ETN
+USEA,Transportation-Ship
+USEG,Oil&Gas-U S Expl&Prod
+USEP,Finance-ETF / ETN
+USEQ,Finance-ETF / ETN
+USFD,Wholesale-Food
+USFI,Finance-ETF / ETN
+USFR,Finance-ETF / ETN
+USG,Finance-ETF / ETN
+USGO,Mining-Gold/Silver/Gems
+USHY,Finance-ETF / ETN
+USIG,Finance-ETF / ETN
+USIN,Finance-ETF / ETN
+USIO,Finance-CrdtCard/PmtPr
+USL,Finance-ETF / ETN
+USLB,Finance-ETF / ETN
+USLM,Bldg-Cement/Concrt/Ag
+USM,Telecom Svcs-Wireless
+USMC,Finance-ETF / ETN
+USMF,Finance-ETF / ETN
+USML,Finance-ETF / ETN
+USMV,Finance-ETF / ETN
+USNA,Cosmetics/Personal Care
+USNZ,Finance-ETF / ETN
+USNZY,Steel-Producers
+USO,Finance-ETF / ETN
+USOI,Finance-ETF / ETN
+USPH,Medical-Outpnt/Hm Care
+USPX,Finance-ETF / ETN
+USRD,Finance-ETF / ETN
+USRT,Finance-ETF / ETN
+USSE,Finance-ETF / ETN
+USSG,Finance-ETF / ETN
+USSH,Finance-ETF / ETN
+UST,Finance-ETF / ETN
+USTB,Finance-ETF / ETN
+USVM,Finance-ETF / ETN
+USVN,Finance-ETF / ETN
+USVT,Finance-ETF / ETN
+USX,Transportation-Truck
+USXF,Finance-ETF / ETN
+UTEN,Finance-ETF / ETN
+UTES,Finance-ETF / ETN
+UTF,Finance-Publ Inv Fd-Eqt
+UTG,Finance-Publ Inv Fd-Eqt
+UTHR,Medical-Biomed/Biotech
+UTHY,Finance-ETF / ETN
+UTI,Consumer Svcs-Education
+UTL,Utility-Diversified
+UTMD,Medical-Products
+UTRE,Finance-ETF / ETN
+UTRN,Finance-ETF / ETN
+UTRS,Medical-Systems/Equip
+UTSI,Telecom-Infrastructure
+UTSL,Finance-ETF / ETN
+UTWO,Finance-ETF / ETN
+UTWY,Finance-ETF / ETN
+UTZ,Food-Packaged
+UUP,Finance-ETF / ETN
+UUU,Security/Sfty
+UUUU,Mining-Metal Ores
+UVE,Insurance-Prop/Cas/Titl
+UVIX,Finance-ETF / ETN
+UVSP,Banks-Northeast
+UVV,Tobacco
+UVXY,Finance-ETF / ETN
+UWM,Finance-ETF / ETN
+UWMC,Finance-Mrtg&Rel Svc
+UXI,Finance-ETF / ETN
+UXIN,Retail-Internet
+UYG,Finance-ETF / ETN
+UYLD,Finance-ETF / ETN
+UYM,Finance-ETF / ETN
+V,Finance-CrdtCard/PmtPr
+VABK,Banks-Southeast
+VABS,Finance-ETF / ETN
+VAC,Leisure-Services
+VAL,Oil&Gas-Drilling
+VALE,Mining-Metal Ores
+VALN,Medical-Biomed/Biotech
+VALQ,Finance-ETF / ETN
+VALU,Media-Periodicals
+VAMO,Finance-ETF / ETN
+VANI,Medical-Products
+VAPO,Medical-Products
+VATE,Steel-Specialty Alloys
+VAW,Finance-ETF / ETN
+VAXX,Medical-Biomed/Biotech
+VB,Finance-ETF / ETN
+VBF,Finance-Publ Inv Fd-Bond
+VBFC,Banks-Southeast
+VBIV,Medical-Biomed/Biotech
+VBK,Finance-ETF / ETN
+VBND,Finance-ETF / ETN
+VBNK,Banks-Foreign
+VBOC,Finance-Blank Check
+VBR,Finance-ETF / ETN
+VBTX,Banks-West/Southwest
+VC,Auto/Truck-Original Eqp
+VCAR,Finance-ETF / ETN
+VCEB,Finance-ETF / ETN
+VCEL,Medical-Biomed/Biotech
+VCIG,Comml Svcs-Consulting
+VCIT,Finance-ETF / ETN
+VCLN,Finance-ETF / ETN
+VCLT,Finance-ETF / ETN
+VCNX,Medical-Biomed/Biotech
+VCR,Finance-ETF / ETN
+VCRB,Finance-ETF / ETN
+VCSA,Leisure-Travel Booking
+VCSH,Finance-ETF / ETN
+VCTR,Finance-Investment Mgmt
+VCV,Finance-Publ Inv Fd-Bond
+VCXB,Finance-Blank Check
+VCYT,Medical-Research Eqp/Svc
+VDC,Finance-ETF / ETN
+VDE,Finance-ETF / ETN
+VEA,Finance-ETF / ETN
+VECO,Elec-Semiconductor Equip
+VEEE,Leisure-Products
+VEEV,Computer Sftwr-Medical
+VEGA,Finance-ETF / ETN
+VEGI,Finance-ETF / ETN
+VEGN,Finance-ETF / ETN
+VEL,Finance-Mrtg&Rel Svc
+VEMY,Finance-ETF / ETN
+VEOEY,Utility-Diversified
+VEON,Telecom Svcs- Foreign
+VERA,Medical-Biomed/Biotech
+VERB,Comp Sftwr-Spec Enterprs
+VERI,Comp Sftwr-Spec Enterprs
+VERO,Medical-Systems/Equip
+VERS,Finance-ETF / ETN
+VERU,Medical-Products
+VERV,Medical-Biomed/Biotech
+VERX,Computer Sftwr-Financial
+VERY,Insurance-Life
+VET,Oil&Gas-Cdn Expl&Prod
+VETZ,Finance-ETF / ETN
+VEU,Finance-ETF / ETN
+VEV,Trucks & Parts-Hvy Duty
+VFC,Apparel-Clothing Mfg
+VFF,Agricultural Operations
+VFH,Finance-ETF / ETN
+VFL,Finance-Publ Inv Fd-Bond
+VFLO,Finance-ETF / ETN
+VFMF,Finance-ETF / ETN
+VFMO,Finance-ETF / ETN
+VFMV,Finance-ETF / ETN
+VFQY,Finance-ETF / ETN
+VFS,Auto Manufacturers
+VFVA,Finance-ETF / ETN
+VGAS,Energy-Alternative/Other
+VGFCQ,Group not available
+VGI,Finance-Publ Inv Fd-Glbl
+VGIT,Finance-ETF / ETN
+VGK,Finance-ETF / ETN
+VGLT,Finance-ETF / ETN
+VGM,Finance-Publ Inv Fd-Bond
+VGR,Tobacco
+VGSH,Finance-ETF / ETN
+VGSR,Finance-ETF / ETN
+VGT,Finance-ETF / ETN
+VGZ,Mining-Gold/Silver/Gems
+VHAQ,Group not available
+VHC,Elec-Misc Products
+VHI,Chemicals-Specialty
+VHT,Finance-ETF / ETN
+VIA,Utility-Diversified
+VIAO,Elec-Misc Products
+VIAV,Telecom-Fiber Optics
+VICE,Finance-ETF / ETN
+VICI,Finance-Property REIT
+VICR,Electronic-Parts
+VIDI,Finance-ETF / ETN
+VIEW,Bldg-Constr Prds/Misc
+VIG,Finance-ETF / ETN
+VIGI,Finance-ETF / ETN
+VIGL,Medical-Biomed/Biotech
+VINC,Medical-Biomed/Biotech
+VINE,Beverages-Alcoholic
+VINO,Real Estate Dvlpmt/Ops
+VINP,Finance-Investment Mgmt
+VIOG,Finance-ETF / ETN
+VIOO,Finance-ETF / ETN
+VIOT,Hsehold-Appliances/Wares
+VIOV,Finance-ETF / ETN
+VIPS,Retail-Internet
+VIR,Medical-Biomed/Biotech
+VIRC,Hsehold/Office Furniture
+VIRI,Medical-Biomed/Biotech
+VIRS,Finance-ETF / ETN
+VIRT,Financial Svcs-Specialty
+VIRX,Medical-Biomed/Biotech
+VIS,Finance-ETF / ETN
+VISL,Elec-Misc Products
+VIST,Oil&Gas-Intl Expl&Prod
+VITL,Food-Meat Products
+VIV,Telecom Svcs- Foreign
+VIVE,Group not available
+VIVHY,Media-Diversified
+VIVK,Pollution Control
+VIXM,Finance-ETF / ETN
+VIXY,Finance-ETF / ETN
+VKI,Finance-Publ Inv Fd-Bond
+VKQ,Finance-Publ Inv Fd-Bond
+VKTX,Medical-Biomed/Biotech
+VLCN,Leisure-Products
+VLD,Machinery-Mtl Hdlg/Autmn
+VLEEY,Auto/Truck-Original Eqp
+VLGEA,Retail-Super/Mini Mkts
+VLN,Elec-Semicondctor Fablss
+VLO,Oil&Gas-Refining/Mktg
+VLRS,Transportation-Airline
+VLT,Finance-Publ Inv Fd-Bond
+VLTO,Pollution Control
+VLU,Finance-ETF / ETN
+VLUE,Finance-ETF / ETN
+VLY,Banks-Northeast
+VMAR,Leisure-Products
+VMAX,Finance-ETF / ETN
+VMBS,Finance-ETF / ETN
+VMC,Bldg-Cement/Concrt/Ag
+VMCA,Finance-Blank Check
+VMD,Medical-Whlsle Drg/Suppl
+VMEO,Computer Sftwr-Edu/Media
+VMI,Metal Proc & Fabrication
+VMO,Finance-Publ Inv Fd-Bond
+VMOT,Finance-ETF / ETN
+VMW,Comp Sftwr-Spec Enterprs
+VNAM,Finance-ETF / ETN
+VNCE,Apparel-Clothing Mfg
+VNDA,Medical-Biomed/Biotech
+VNET,Internet-Network Sltns
+VNLA,Finance-ETF / ETN
+VNM,Finance-ETF / ETN
+VNMC,Finance-ETF / ETN
+VNO,Finance-Property REIT
+VNOM,Oil&Gas-U S Expl&Prod
+VNQ,Finance-ETF / ETN
+VNQI,Finance-ETF / ETN
+VNRX,Medical-Products
+VNSE,Finance-ETF / ETN
+VNT,Machinery-Gen Industrial
+VO,Finance-ETF / ETN
+VOC,Oil&Gas-Royalty Trust
+VOD,Telecom Svcs- Foreign
+VOE,Finance-ETF / ETN
+VONE,Finance-ETF / ETN
+VONG,Finance-ETF / ETN
+VONV,Finance-ETF / ETN
+VOO,Finance-ETF / ETN
+VOOG,Finance-ETF / ETN
+VOOV,Finance-ETF / ETN
+VOR,Medical-Biomed/Biotech
+VOT,Finance-ETF / ETN
+VOTE,Finance-ETF / ETN
+VOX,Finance-ETF / ETN
+VOXR,Mining-Gold/Silver/Gems
+VOXX,Telecom-Consumer Prods
+VOYA,Insurance-Life
+VPC,Finance-ETF / ETN
+VPG,Elec-Scientific/Msrng
+VPL,Finance-ETF / ETN
+VPLS,Finance-ETF / ETN
+VPU,Finance-ETF / ETN
+VPV,Finance-Publ Inv Fd-Bond
+VQSSF,Computer Sftwr-Database
+VRA,Apparel-Clothing Mfg
+VRAR,Comp Sftwr-Spec Enterprs
+VRAX,Medical-Biomed/Biotech
+VRAYQ,Medical-Systems/Equip
+VRCA,Medical-Biomed/Biotech
+VRDN,Medical-Biomed/Biotech
+VRE,Finance-Property REIT
+VREX,Medical-Systems/Equip
+VRIG,Finance-ETF / ETN
+VRM,Retail/Whlsle-Automobile
+VRME,Security/Sfty
+VRNA,Medical-Biomed/Biotech
+VRNOF,Consumer Prod-Specialty
+VRNS,Computer Sftwr-Database
+VRNT,Computer Sftwr-Security
+VRP,Finance-ETF / ETN
+VRPX,Medical-Biomed/Biotech
+VRRM,Comp Sftwr-Spec Enterprs
+VRSK,Comml Svcs-Market Rsrch
+VRSN,Computer Sftwr-Security
+VRT,Electrical-Power/Equipmt
+VRTS,Finance-Investment Mgmt
+VRTX,Medical-Biomed/Biotech
+VS,Computer Sftwr-Desktop
+VSAC,Finance-Blank Check
+VSAT,Telecom-Infrastructure
+VSCO,Apparel-Clothing Mfg
+VSDA,Finance-ETF / ETN
+VSEC,Comml Svcs-Consulting
+VSGX,Finance-ETF / ETN
+VSH,Electronic-Parts
+VSHY,Finance-ETF / ETN
+VSLU,Finance-ETF / ETN
+VSME,Comml Svcs-Advertising
+VSMV,Finance-ETF / ETN
+VSS,Finance-ETF / ETN
+VST,Utility-Electric Power
+VSTA,Consumer Svcs-Education
+VSTE,Energy-Solar
+VSTM,Medical-Biomed/Biotech
+VSTO,Leisure-Products
+VSTS,Comml Svcs-Outsourcing
+VT,Finance-ETF / ETN
+VTAK,Medical-Systems/Equip
+VTC,Finance-ETF / ETN
+VTEB,Finance-ETF / ETN
+VTEC,Finance-ETF / ETN
+VTEI,Finance-ETF / ETN
+VTES,Finance-ETF / ETN
+VTEX,Comp Sftwr-Spec Enterprs
+VTGN,Medical-Biomed/Biotech
+VTHR,Finance-ETF / ETN
+VTI,Finance-ETF / ETN
+VTIP,Finance-ETF / ETN
+VTLE,Oil&Gas-U S Expl&Prod
+VTMX,Real Estate Dvlpmt/Ops
+VTN,Finance-Publ Inv Fd-Bond
+VTNR,Oil&Gas-Refining/Mktg
+VTOL,Oil&Gas-Field Services
+VTR,Finance-Property REIT
+VTRS,Medical-Generic Drugs
+VTRU,Consumer Svcs-Education
+VTS,Finance-Investment Mgmt
+VTSI,Computer Sftwr-Edu/Media
+VTV,Finance-ETF / ETN
+VTVT,Medical-Biomed/Biotech
+VTWG,Finance-ETF / ETN
+VTWO,Finance-ETF / ETN
+VTWV,Finance-ETF / ETN
+VTYX,Medical-Biomed/Biotech
+VUG,Finance-ETF / ETN
+VUSB,Finance-ETF / ETN
+VUSE,Finance-ETF / ETN
+VUZI,Consumer Prod-Specialty
+VV,Finance-ETF / ETN
+VVI,Comml Svcs-Advertising
+VVOS,Medical-Biomed/Biotech
+VVPR,Energy-Solar
+VVR,Finance-Publ Inv Fd-Bond
+VVV,Retail/Whlsle-Auto Parts
+VVX,Bldg-Maintenance & Svc
+VWAGY,Auto Manufacturers
+VWAPY,Auto Manufacturers
+VWDRY,Energy-Alternative/Other
+VWE,Beverages-Alcoholic
+VWI,Finance-ETF / ETN
+VWID,Finance-ETF / ETN
+VWO,Finance-ETF / ETN
+VWOB,Finance-ETF / ETN
+VXF,Finance-ETF / ETN
+VXRT,Medical-Biomed/Biotech
+VXUS,Finance-ETF / ETN
+VXX,Finance-ETF / ETN
+VXZ,Finance-ETF / ETN
+VYGR,Medical-Biomed/Biotech
+VYM,Finance-ETF / ETN
+VYMI,Finance-ETF / ETN
+VYNE,Medical-Biomed/Biotech
+VYNT,Medical-Services
+VYX,Computer-Integrated Syst
+VZ,Telecom Svcs-Integrated
+VZIO,Consumer Prod-Electronic
+VZLA,Mining-Gold/Silver/Gems
+W,Retail-Internet
+WAB,Transportation-Equip Mfg
+WABC,Banks-West/Southwest
+WABF,Finance-ETF / ETN
+WAFD,Banks-West/Southwest
+WAFU,Consumer Svcs-Education
+WAL,Banks-West/Southwest
+WALD,Cosmetics/Personal Care
+WANT,Finance-ETF / ETN
+WASH,Banks-Northeast
+WAT,Medical-Systems/Equip
+WATT,Elec-Misc Products
+WAVD,Computer-Tech Services
+WAVE,Utility-Electric Power
+WAVS,Finance-Blank Check
+WB,Internet-Content
+WBA,Retail-Drug Stores
+WBAT,Finance-ETF / ETN
+WBD,Media-Radio/Tv
+WBIF,Finance-ETF / ETN
+WBIG,Finance-ETF / ETN
+WBIL,Finance-ETF / ETN
+WBIY,Finance-ETF / ETN
+WBND,Finance-ETF / ETN
+WBRBY,Bldg-Constr Prds/Misc
+WBS,Banks-Northeast
+WBUY,Retail-Internet
+WBX,Auto/Truck-Original Eqp
+WCBR,Finance-ETF / ETN
+WCC,Electronic-Parts
+WCEO,Finance-ETF / ETN
+WCLD,Finance-ETF / ETN
+WCN,Pollution Control
+WD,Finance-Commercial Loans
+WDAY,Computer Sftwr-Enterprse
+WDC,Computer-Data Storage
+WDFC,Chemicals-Specialty
+WDH,Insurance-Brokers
+WDI,Finance-Publ Inv Fd-Bond
+WDIV,Finance-ETF / ETN
+WDNA,Finance-ETF / ETN
+WDS,Oil&Gas-Intl Expl&Prod
+WEA,Finance-Publ Inv Fd-Bond
+WEAT,Finance-ETF / ETN
+WEAV,Internet-Content
+WEBL,Finance-ETF / ETN
+WEBS,Finance-ETF / ETN
+WEC,Utility-Diversified
+WEED,Finance-ETF / ETN
+WEICY,Auto/Truck-Original Eqp
+WEIX,Finance-ETF / ETN
+WEJOF,Internet-Network Sltns
+WEL,Finance-Blank Check
+WELL,Finance-Property REIT
+WEN,Retail-Restaurants
+WERN,Transportation-Truck
+WES,Oil&Gas-Transprt/Pipelne
+WEST,Beverages-Non-Alcoholic
+WETH,Computer-Hardware/Perip
+WEWKQ,Real Estate Dvlpmt/Ops
+WEX,Finance-CrdtCard/PmtPr
+WEYS,Apparel-Shoes & Rel Mfg
+WF,Banks-Foreign
+WFC,Banks-Money Center
+WFCF,Comml Svcs-Consulting
+WFG,Bldg-Wood Prds
+WFH,Finance-ETF / ETN
+WFHY,Finance-ETF / ETN
+WFIG,Finance-ETF / ETN
+WFRD,Oil&Gas-Machinery/Equip
+WGMI,Finance-ETF / ETN
+WGO,Bldg-Mobile/Mfg & Rv
+WGS,Medical-Biomed/Biotech
+WH,Leisure-Lodging
+WHD,Oil&Gas-Machinery/Equip
+WHF,Finance-Investment Mgmt
+WHG,Finance-Investment Mgmt
+WHLM,Comml Svcs-Staffing
+WHLR,Finance-Property REIT
+WHR,Hsehold-Appliances/Wares
+WIA,Finance-Publ Inv Fd-Bond
+WILC,Wholesale-Food
+WIMI,Internet-Content
+WINA,Retail-Leisure Products
+WINC,Finance-ETF / ETN
+WING,Retail-Restaurants
+WINN,Finance-ETF / ETN
+WINT,Medical-Biomed/Biotech
+WINV,Finance-Blank Check
+WIP,Finance-ETF / ETN
+WIRE,Electrical-Power/Equipmt
+WISA,Elec-Misc Products
+WISE,Finance-ETF / ETN
+WISH,Retail-Internet
+WIT,Computer-Tech Services
+WIW,Finance-Publ Inv Fd-Bal
+WIX,Computer Sftwr-Enterprse
+WK,Computer Sftwr-Database
+WKC,Oil&Gas-Refining/Mktg
+WKEY,Elec-Semicondctor Fablss
+WKHS,Auto/Truck-Original Eqp
+WKME,Computer Sftwr-Enterprse
+WKSP,Auto/Truck-Replace Parts
+WLDN,Bldg-Heavy Construction
+WLDR,Finance-ETF / ETN
+WLDS,Consumer Prod-Electronic
+WLFC,Comml Svcs-Leasing
+WLGS,Electrical-Power/Equipmt
+WLK,Chemicals-Basic
+WLKP,Chemicals-Basic
+WLMSQ,Oil&Gas-Machinery/Equip
+WLTG,Finance-ETF / ETN
+WLY,Media-Books
+WLYB,Media-Books
+WM,Pollution Control
+WMB,Oil&Gas-Integrated
+WMG,Leisure-Services
+WMK,Retail-Super/Mini Mkts
+WMMVY,Retail-Major Disc Chains
+WMPN,Banks-Northeast
+WMS,Bldg-Constr Prds/Misc
+WMT,Retail-Major Disc Chains
+WNC,Transportation-Equip Mfg
+WNDY,Finance-ETF / ETN
+WNEB,Finance-Savings & Loan
+WNS,Comml Svcs-Outsourcing
+WNW,Retail-Internet
+WOLF,Elec-Semiconductor Mfg
+WOMN,Finance-ETF / ETN
+WOOD,Finance-ETF / ETN
+WOOF,Retail-Specialty
+WOR,Metal Proc & Fabrication
+WORX,Computer Sftwr-Medical
+WOW,Telecom Svcs-Cable/Satl
+WPC,Finance-Property REIT
+WPM,Mining-Gold/Silver/Gems
+WPP,Comml Svcs-Advertising
+WPRT,Trucks & Parts-Hvy Duty
+WPS,Finance-ETF / ETN
+WQGA,Finance-Blank Check
+WRAP,Security/Sfty
+WRB,Insurance-Prop/Cas/Titl
+WRBY,Retail-Specialty
+WRK,Paper & Paper Products
+WRLD,Finance-Consumer Loans
+WRN,Mining-Metal Ores
+WRND,Finance-ETF / ETN
+WRNT,Comml Svcs-Market Rsrch
+WS,Steel-Specialty Alloys
+WSBC,Banks-Southeast
+WSBF,Finance-Savings & Loan
+WSC,Comml Svcs-Leasing
+WSFS,Finance-Savings & Loan
+WSM,Retail-Home Furnishings
+WSO,Bldg-A/C & Heating Prds
+WSOB,Bldg-A/C & Heating Prds
+WSR,Finance-Property REIT
+WST,Medical-Supplies
+WT,Finance-Investment Mgmt
+WTAI,Finance-ETF / ETN
+WTBA,Banks-Midwest
+WTBN,Finance-ETF / ETN
+WTER,Beverages-Non-Alcoholic
+WTFC,Banks-Midwest
+WTI,Oil&Gas-U S Expl&Prod
+WTID,Finance-ETF / ETN
+WTIU,Finance-ETF / ETN
+WTKWY,Comml Svcs-Market Rsrch
+WTM,Insurance-Prop/Cas/Titl
+WTMA,Finance-Blank Check
+WTMF,Finance-ETF / ETN
+WTO,Telecom-Consumer Prods
+WTRE,Finance-ETF / ETN
+WTRG,Utility-Water Supply
+WTS,Bldg-Constr Prds/Misc
+WTTR,Utility-Water Supply
+WTV,Finance-ETF / ETN
+WTW,Insurance-Brokers
+WU,Financial Svcs-Specialty
+WUCT,Finance-ETF / ETN
+WUGI,Finance-ETF / ETN
+WULF,Chemicals-Specialty
+WVE,Medical-Biomed/Biotech
+WVFC,Group not available
+WVVI,Beverages-Alcoholic
+WW,Cosmetics/Personal Care
+WWD,Aerospace/Defense
+WWJD,Finance-ETF / ETN
+WWR,Mining-Metal Ores
+WWW,Apparel-Shoes & Rel Mfg
+WXXWY,Medical-Research Eqp/Svc
+WY,Finance-Property REIT
+WYNN,Leisure-Gaming/Equip
+WYY,Computer-Tech Services
+WZRD,Finance-ETF / ETN
+X,Steel-Producers
+XAIR,Medical-Systems/Equip
+XAR,Finance-ETF / ETN
+XAUG,Finance-ETF / ETN
+XB,Finance-ETF / ETN
+XBAP,Finance-ETF / ETN
+XBB,Finance-ETF / ETN
+XBI,Finance-ETF / ETN
+XBIL,Finance-ETF / ETN
+XBIO,Medical-Biomed/Biotech
+XBIT,Medical-Biomed/Biotech
+XBJA,Finance-ETF / ETN
+XBJL,Finance-ETF / ETN
+XBOC,Finance-ETF / ETN
+XBP,Financial Svcs-Specialty
+XC,Finance-ETF / ETN
+XCCC,Finance-ETF / ETN
+XCEM,Finance-ETF / ETN
+XCLR,Finance-ETF / ETN
+XCOR,Finance-ETF / ETN
+XCUR,Medical-Biomed/Biotech
+XDAP,Finance-ETF / ETN
+XDAT,Finance-ETF / ETN
+XDEC,Finance-ETF / ETN
+XDJA,Finance-ETF / ETN
+XDJL,Finance-ETF / ETN
+XDOC,Finance-ETF / ETN
+XDQQ,Finance-ETF / ETN
+XDSQ,Finance-ETF / ETN
+XDTE,Finance-ETF / ETN
+XEL,Utility-Diversified
+XELA,Computer Sftwr-Enterprse
+XELB,Retail-Apparel/Shoes/Acc
+XEMD,Finance-ETF / ETN
+XENE,Medical-Biomed/Biotech
+XERS,Medical-Biomed/Biotech
+XES,Finance-ETF / ETN
+XFEB,Finance-ETF / ETN
+XFIN,Finance-Blank Check
+XFIV,Finance-ETF / ETN
+XFIX,Finance-ETF / ETN
+XFLT,Finance-Publ Inv Fd-Bond
+XFLX,Finance-ETF / ETN
+XFOR,Medical-Biomed/Biotech
+XGN,Medical-Research Eqp/Svc
+XHB,Finance-ETF / ETN
+XHE,Finance-ETF / ETN
+XHLF,Finance-ETF / ETN
+XHR,Finance-Property REIT
+XHS,Finance-ETF / ETN
+XHYC,Finance-ETF / ETN
+XHYD,Finance-ETF / ETN
+XHYE,Finance-ETF / ETN
+XHYF,Finance-ETF / ETN
+XHYH,Finance-ETF / ETN
+XHYI,Finance-ETF / ETN
+XHYT,Finance-ETF / ETN
+XIACY,Telecom-Consumer Prods
+XIDE,Finance-ETF / ETN
+XIMR,Finance-ETF / ETN
+XIN,Bldg-Resident/Comml
+XISE,Finance-ETF / ETN
+XITK,Finance-ETF / ETN
+XJAN,Finance-ETF / ETN
+XJH,Finance-ETF / ETN
+XJR,Finance-ETF / ETN
+XJUL,Finance-ETF / ETN
+XJUN,Finance-ETF / ETN
+XLB,Finance-ETF / ETN
+XLC,Finance-ETF / ETN
+XLE,Finance-ETF / ETN
+XLF,Finance-ETF / ETN
+XLG,Finance-ETF / ETN
+XLI,Finance-ETF / ETN
+XLK,Finance-ETF / ETN
+XLO,Medical-Biomed/Biotech
+XLP,Finance-ETF / ETN
+XLRE,Finance-ETF / ETN
+XLSR,Finance-ETF / ETN
+XLU,Finance-ETF / ETN
+XLV,Finance-ETF / ETN
+XLY,Finance-ETF / ETN
+XMAR,Finance-ETF / ETN
+XME,Finance-ETF / ETN
+XMHQ,Finance-ETF / ETN
+XMLV,Finance-ETF / ETN
+XMMO,Finance-ETF / ETN
+XMPT,Finance-ETF / ETN
+XMTR,Machinery-Mtl Hdlg/Autmn
+XMVM,Finance-ETF / ETN
+XNAV,Finance-ETF / ETN
+XNCR,Medical-Biomed/Biotech
+XNET,Computer Sftwr-Edu/Media
+XNGSY,Utility-Gas Distribution
+XNNHQ,Aerospace/Defense
+XNOV,Finance-ETF / ETN
+XNTK,Finance-ETF / ETN
+XOCT,Finance-ETF / ETN
+XOM,Oil&Gas-Integrated
+XOMA,Medical-Biomed/Biotech
+XOMO,Finance-ETF / ETN
+XONE,Finance-ETF / ETN
+XOP,Finance-ETF / ETN
+XOS,Trucks & Parts-Hvy Duty
+XP,Finance-Invest Bnk/Bkrs
+XPEL,Auto/Truck-Replace Parts
+XPER,Elec-Semiconductor Mfg
+XPEV,Auto Manufacturers
+XPH,Finance-ETF / ETN
+XPL,Mining-Metal Ores
+XPND,Finance-ETF / ETN
+XPO,Transportation-Logistics
+XPOF,Leisure-Services
+XPON,Electrical-Power/Equipmt
+XPP,Finance-ETF / ETN
+XPRO,Oil&Gas-Field Services
+XRAY,Medical-Supplies
+XRLV,Finance-ETF / ETN
+XRLX,Finance-ETF / ETN
+XRMI,Finance-ETF / ETN
+XRT,Finance-ETF / ETN
+XRTX,Medical-Biomed/Biotech
+XRX,Computer-Hardware/Perip
+XSD,Finance-ETF / ETN
+XSEP,Finance-ETF / ETN
+XSHD,Finance-ETF / ETN
+XSHQ,Finance-ETF / ETN
+XSLV,Finance-ETF / ETN
+XSMO,Finance-ETF / ETN
+XSOE,Finance-ETF / ETN
+XSVM,Finance-ETF / ETN
+XSVN,Finance-ETF / ETN
+XSW,Finance-ETF / ETN
+XT,Finance-ETF / ETN
+XTAP,Finance-ETF / ETN
+XTEN,Finance-ETF / ETN
+XTIA,Computer Sftwr-Enterprse
+XTJA,Finance-ETF / ETN
+XTJL,Finance-ETF / ETN
+XTKG,Computer Sftwr-Enterprse
+XTL,Finance-ETF / ETN
+XTLB,Medical-Biomed/Biotech
+XTN,Finance-ETF / ETN
+XTNT,Medical-Products
+XTOC,Finance-ETF / ETN
+XTR,Finance-ETF / ETN
+XTRE,Finance-ETF / ETN
+XTWO,Finance-ETF / ETN
+XTWY,Finance-ETF / ETN
+XUSP,Finance-ETF / ETN
+XVOL,Finance-ETF / ETN
+XVV,Finance-ETF / ETN
+XWEL,Cosmetics/Personal Care
+XXCH,Finance-ETF / ETN
+XXII,Tobacco
+XXXX,Finance-ETF / ETN
+XYF,Financial Svcs-Specialty
+XYL,Machinery-Tools & Rel
+XYLD,Finance-ETF / ETN
+XYLE,Finance-ETF / ETN
+XYLG,Finance-ETF / ETN
+YAHOY,Retail-Internet
+YALA,Internet-Content
+YALL,Finance-ETF / ETN
+YANG,Finance-ETF / ETN
+YARIY,Chemicals-Agricultural
+YASKY,Electrical-Power/Equipmt
+YBTC,Finance-ETF / ETN
+YCBD,Consumer Prod-Specialty
+YCL,Finance-ETF / ETN
+YCS,Finance-ETF / ETN
+YDEC,Finance-ETF / ETN
+YEAR,Finance-ETF / ETN
+YELLQ,Transportation-Truck
+YELP,Internet-Content
+YETI,Leisure-Products
+YEXT,Comp Sftwr-Spec Enterprs
+YGFGF,Food-Grain & Related
+YGMZ,Transportation-Truck
+YHGJ,Consumer Prod-Specialty
+YI,Retail-Drug Stores
+YIBO,Computer-Hardware/Perip
+YINN,Finance-ETF / ETN
+YJ,Retail-Internet
+YJUN,Finance-ETF / ETN
+YLD,Finance-ETF / ETN
+YLDE,Finance-ETF / ETN
+YMAB,Medical-Biomed/Biotech
+YMAG,Finance-ETF / ETN
+YMAR,Finance-ETF / ETN
+YMAX,Finance-ETF / ETN
+YMM,Internet-Content
+YNDX,Internet-Content
+YOLO,Finance-ETF / ETN
+YORW,Utility-Water Supply
+YOSH,Retail-Restaurants
+YOTA,Finance-Blank Check
+YOU,Security/Sfty
+YPF,Oil&Gas-Integrated
+YQ,Consumer Svcs-Education
+YRD,Computer Sftwr-Financial
+YS,Medical-Biomed/Biotech
+YSEP,Finance-ETF / ETN
+YSG,Cosmetics/Personal Care
+YTEN,Agricultural Operations
+YTRA,Leisure-Travel Booking
+YUM,Retail-Restaurants
+YUMC,Retail-Restaurants
+YUMY,Finance-ETF / ETN
+YVRLF,Leisure-Toys/Games/Hobby
+YXI,Finance-ETF / ETN
+YY,Internet-Content
+YYY,Finance-ETF / ETN
+Z,Internet-Content
+ZALT,Finance-ETF / ETN
+ZAPP,Auto Manufacturers
+ZBAO,Group not available
+ZBH,Medical-Products
+ZBRA,Elec-Misc Products
+ZCAR,Leisure-Services
+ZCMD,Internet-Content
+ZD,Internet-Content
+ZDGE,Computer Sftwr-Edu/Media
+ZDPY,Real Estate Dvlpmt/Ops
+ZECP,Finance-ETF / ETN
+ZENV,Computer Sftwr-Enterprse
+ZEO,Energy-Solar
+ZEPP,Consumer Prod-Electronic
+ZETA,Computer Sftwr-Database
+ZEUS,Metal Prds-Distributor
+ZEVY,Auto Manufacturers
+ZFOX,Computer Sftwr-Security
+ZG,Internet-Content
+ZGN,Apparel-Clothing Mfg
+ZH,Internet-Content
+ZHDG,Finance-ETF / ETN
+ZI,Computer Sftwr-Enterprse
+ZIG,Finance-ETF / ETN
+ZIM,Transportation-Ship
+ZIMV,Medical-Products
+ZION,Banks-West/Southwest
+ZIP,Internet-Content
+ZIVB,Finance-ETF / ETN
+ZIVO,Medical-Research Eqp/Svc
+ZJYL,Medical-Systems/Equip
+ZKH,Retail-Internet
+ZKIN,Steel-Producers
+ZLAB,Medical-Biomed/Biotech
+ZLS,Finance-Blank Check
+ZM,Computer Sftwr-Enterprse
+ZNTL,Medical-Biomed/Biotech
+ZOM,Medical-Biomed/Biotech
+ZPTA,Finance-Blank Check
+ZROZ,Finance-ETF / ETN
+ZS,Computer Sftwr-Security
+ZSB,Finance-ETF / ETN
+ZSC,Finance-ETF / ETN
+ZSL,Finance-ETF / ETN
+ZTAX,Finance-ETF / ETN
+ZTEK,Medical-Biomed/Biotech
+ZTEN,Finance-ETF / ETN
+ZTO,Transportation-Logistics
+ZTR,Finance-Publ Inv Fd-Bal
+ZTRE,Finance-ETF / ETN
+ZTS,Medical-Ethical Drugs
+ZTWO,Finance-ETF / ETN
+ZUMZ,Retail-Apparel/Shoes/Acc
+ZUO,Comp Sftwr-Spec Enterprs
+ZURA,Medical-Biomed/Biotech
+ZVIA,Beverages-Non-Alcoholic
+ZVOI,Group not available
+ZVRA,Medical-Biomed/Biotech
+ZVSA,Medical-Biomed/Biotech
+ZWS,Machinery-Gen Industrial
+ZYME,Medical-Biomed/Biotech
+ZYXI,Medical-Products
+ZZZ,Finance-ETF / ETN
+VRAI,Finance-ETF / ETN

--- a/backend/scripts/seed_ibd_industry_groups.py
+++ b/backend/scripts/seed_ibd_industry_groups.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Seed the ibd_industry_groups table from the bundled canonical CSV."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.database import SessionLocal
+from app.services.ibd_industry_service import IBDIndustryService
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed ibd_industry_groups from a CSV file.",
+    )
+    parser.add_argument(
+        "--csv-path",
+        default=None,
+        help="Optional override path for the source CSV.",
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Replace any existing ibd_industry_groups rows instead of only seeding empty tables.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    with SessionLocal() as db:
+        if args.replace:
+            loaded = IBDIndustryService.load_from_csv(db, args.csv_path)
+            print(f"Replaced IBD industry mappings with {loaded} rows")
+            return 0
+
+        loaded = IBDIndustryService.seed_if_empty(db, args.csv_path)
+        if loaded > 0:
+            print(f"Seeded IBD industry mappings with {loaded} rows")
+        else:
+            print("IBD industry mappings already present; no changes made")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_ibd_industry_service.py
+++ b/backend/tests/unit/test_ibd_industry_service.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.industry import IBDIndustryGroup
+from app.services.ibd_industry_service import IBDIndustryService
+
+
+def _make_session_factory(tmp_path: Path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'ibd-industry.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def test_seed_if_empty_loads_mappings_when_table_empty(tmp_path):
+    session_factory = _make_session_factory(tmp_path)
+    csv_path = tmp_path / "ibd_industry_group.csv"
+    csv_path.write_text(
+        "AAPL,Computer-Hardware/Peripherals\nMSFT,Computer-Software/Desktop\n",
+        encoding="utf-8",
+    )
+
+    with session_factory() as db:
+        loaded = IBDIndustryService.seed_if_empty(db, str(csv_path))
+        rows = db.query(IBDIndustryGroup).order_by(IBDIndustryGroup.symbol).all()
+
+    assert loaded == 2
+    assert [(row.symbol, row.industry_group) for row in rows] == [
+        ("AAPL", "Computer-Hardware/Peripherals"),
+        ("MSFT", "Computer-Software/Desktop"),
+    ]
+
+
+def test_seed_if_empty_is_noop_when_rows_already_exist(tmp_path):
+    session_factory = _make_session_factory(tmp_path)
+    csv_path = tmp_path / "ibd_industry_group.csv"
+    csv_path.write_text("MSFT,Should-Not-Replace\n", encoding="utf-8")
+
+    with session_factory() as db:
+        db.add(IBDIndustryGroup(symbol="AAPL", industry_group="Existing-Group"))
+        db.commit()
+
+        loaded = IBDIndustryService.seed_if_empty(db, str(csv_path))
+        rows = db.query(IBDIndustryGroup).order_by(IBDIndustryGroup.symbol).all()
+
+    assert loaded == 0
+    assert [(row.symbol, row.industry_group) for row in rows] == [
+        ("AAPL", "Existing-Group"),
+    ]

--- a/docs/INSTALL_DOCKER.md
+++ b/docs/INSTALL_DOCKER.md
@@ -174,7 +174,7 @@ docker-compose up -d backend
 docker-compose up -d celery-worker celery-datafetch celery-userscans celery-beat frontend db-backup
 ```
 
-Fresh installs now auto-seed `ibd_industry_groups` from the bundled canonical CSV on backend startup when the table is empty.
+Fresh installs now auto-seed `ibd_industry_groups` from the bundled canonical CSV on backend startup when the table is empty. That seed lives outside the `/app/data` bind mount so it remains visible in Docker.
 If you already have an existing database with an empty `ibd_industry_groups` table, repair it with:
 ```bash
 docker-compose run --rm backend python scripts/seed_ibd_industry_groups.py


### PR DESCRIPTION
## Summary
- add a bundled canonical IBD industry group CSV outside the Docker data volume
- seed ibd_industry_groups automatically on non-desktop startup when the table is empty
- add a manual repair script and focused tests for empty vs already-seeded databases

## Validation
- /Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest /Users/admin/StockScreenClaude/backend/tests/unit/test_ibd_industry_service.py
- DATABASE_URL=sqlite:////tmp/ibd_seed_smoke.db /Users/admin/StockScreenClaude/backend/venv/bin/python -c "from app.database import init_db; init_db()"
- DATABASE_URL=sqlite:////tmp/ibd_seed_smoke.db /Users/admin/StockScreenClaude/backend/venv/bin/python /Users/admin/StockScreenClaude/backend/scripts/seed_ibd_industry_groups.py
- sqlite3 /tmp/ibd_seed_smoke.db "SELECT COUNT(*), COUNT(DISTINCT industry_group) FROM ibd_industry_groups;"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
