### PR TITLE
feat: add peer comparison modal to standalone stock page

### DIFF
--- a/backend/app/api/v1/stocks.py
+++ b/backend/app/api/v1/stocks.py
@@ -740,6 +740,42 @@ async def get_stock_decision_dashboard(
     }
 
 
+@router.get("/{symbol}/peers", response_model=list[ScanResultItem])
+async def get_stock_peers(
+    symbol: str,
+    peer_type: str = Query("industry", pattern="^(industry|sector)$"),
+    uow=Depends(get_uow),
+):
+    """Get industry/sector peers from the latest published feature run."""
+    from ...domain.scanning.models import PeerType
+
+    symbol = symbol.upper()
+    pt = PeerType(peer_type)
+
+    with uow:
+        latest_run = uow.feature_runs.get_latest_published()
+        if latest_run is None:
+            raise HTTPException(status_code=404, detail="No published feature run available")
+
+        item = uow.feature_store.get_by_symbol_for_run(
+            latest_run.id, symbol, include_sparklines=False, include_setup_payload=False,
+        )
+        if item is None:
+            raise HTTPException(status_code=404, detail=f"Symbol {symbol} not found in latest feature run")
+
+        field_key = "ibd_industry_group" if pt == PeerType.INDUSTRY else "gics_sector"
+        group_value = (item.extended_fields or {}).get(field_key)
+        if not group_value or not str(group_value).strip():
+            return []
+
+        if pt == PeerType.INDUSTRY:
+            peers = uow.feature_store.get_peers_by_industry_for_run(latest_run.id, group_value)
+        else:
+            peers = uow.feature_store.get_peers_by_sector_for_run(latest_run.id, group_value)
+
+    return [ScanResultItem.from_domain(p) for p in peers]
+
+
 @router.get("/{symbol}/history", response_model=list[StockPriceHistoryPoint])
 async def get_price_history(symbol: str, period: str = "6mo"):
     return _load_price_history(symbol, period)

--- a/frontend/src/api/stocks.js
+++ b/frontend/src/api/stocks.js
@@ -187,3 +187,16 @@ export const getStockDecisionDashboard = async (symbol) => {
   const response = await apiClient.get(`/v1/stocks/${symbol}/decision-dashboard`);
   return response.data;
 };
+
+/**
+ * Get industry/sector peers from the latest published feature run.
+ * @param {string} symbol - Stock ticker symbol
+ * @param {string} [peerType='industry'] - 'industry' or 'sector'
+ * @returns {Promise<Array>} Peer stock items
+ */
+export const getStockPeers = async (symbol, peerType = 'industry') => {
+  const response = await apiClient.get(`/v1/stocks/${symbol}/peers`, {
+    params: { peer_type: peerType },
+  });
+  return response.data;
+};

--- a/frontend/src/components/Scan/PeerComparisonModal.jsx
+++ b/frontend/src/components/Scan/PeerComparisonModal.jsx
@@ -24,31 +24,22 @@ import CloseIcon from '@mui/icons-material/Close';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import { useQuery } from '@tanstack/react-query';
 import apiClient from '../../api/client';
+import { getStockPeers } from '../../api/stocks';
 import RSSparkline from './RSSparkline';
 import AddToWatchlistMenu from '../common/AddToWatchlistMenu';
+import { getStageColor } from '../../utils/colorUtils';
 
 /**
- * Fetch peer stocks for a symbol
+ * Fetch peer stocks — scan-based when scanId is provided, standalone otherwise.
  */
 const fetchPeers = async (scanId, symbol) => {
-  const response = await apiClient.get(
-    `/v1/scans/${scanId}/peers/${symbol}`
-  );
-  return response.data;
+  if (scanId) {
+    const response = await apiClient.get(`/v1/scans/${scanId}/peers/${symbol}`);
+    return response.data;
+  }
+  return getStockPeers(symbol);
 };
 
-/**
- * Get color for stock stage
- */
-const getStageColor = (stage) => {
-  switch (stage) {
-    case 1: return '#9e9e9e'; // Gray
-    case 2: return '#4caf50'; // Green
-    case 3: return '#ff9800'; // Orange
-    case 4: return '#f44336'; // Red
-    default: return '#9e9e9e';
-  }
-};
 
 /**
  * Peer Comparison Modal
@@ -56,9 +47,10 @@ const getStageColor = (stage) => {
  */
 function PeerComparisonModal({ open, onClose, scanId, symbol, onOpenChart }) {
   const { data: peers, isLoading, error } = useQuery({
-    queryKey: ['peers', scanId, symbol],
+    queryKey: ['peers', scanId || 'standalone', symbol],
     queryFn: () => fetchPeers(scanId, symbol),
-    enabled: open && !!scanId && !!symbol,
+    enabled: open && !!symbol,
+    staleTime: 10 * 60 * 1000,
   });
 
   const [sortBy, setSortBy] = useState('composite_score');

--- a/frontend/src/components/Stock/StockDetails.jsx
+++ b/frontend/src/components/Stock/StockDetails.jsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Link as RouterLink, useParams } from 'react-router-dom';
+import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
 import {
   Accordion,
   AccordionDetails,
@@ -28,6 +28,7 @@ import { getStockDecisionDashboard } from '../../api/stocks';
 import CandlestickChart from '../Charts/CandlestickChart';
 import StockMetricsSidebar from '../Scan/StockMetricsSidebar';
 import AddToWatchlistMenu from '../common/AddToWatchlistMenu';
+import PeerComparisonModal from '../Scan/PeerComparisonModal';
 import { getGroupRankColor, getStageColor } from '../../utils/colorUtils';
 import {
   formatLargeNumber,
@@ -129,6 +130,8 @@ function InfoBox({ label, value }) {
 
 function StockDetails() {
   const { ticker: symbol } = useParams();
+  const navigate = useNavigate();
+  const [peerModalOpen, setPeerModalOpen] = useState(false);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['stockDecisionDashboard', symbol],
@@ -274,6 +277,7 @@ function StockDetails() {
         <StockMetricsSidebar
           stockData={(data.chart?.chart_data?.source !== 'unavailable' && data.chart?.chart_data) || null}
           fundamentals={sidebarFundamentals}
+          onViewPeers={() => setPeerModalOpen(true)}
         />
         <Box sx={{ flex: 1, overflow: 'hidden', bgcolor: 'background.paper' }}>
           <CandlestickChart
@@ -513,6 +517,16 @@ function StockDetails() {
           </AccordionDetails>
         </Accordion>
       </Box>
+
+      <PeerComparisonModal
+        open={peerModalOpen}
+        onClose={() => setPeerModalOpen(false)}
+        symbol={data.symbol}
+        onOpenChart={(sym) => {
+          setPeerModalOpen(false);
+          navigate(`/stocks/${encodeURIComponent(sym)}`);
+        }}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- **New backend endpoint** `GET /v1/stocks/{symbol}/peers` — fetches industry/sector peers from the latest published feature run without requiring a scan ID
- **Dual-mode PeerComparisonModal** — now works both from scan results (with `scanId`) and standalone stock pages (without). Also removes duplicate `getStageColor` in favor of shared `colorUtils` import, and adds `staleTime` to prevent redundant re-fetches
- **Stock page wiring** — passes `onViewPeers` to `StockMetricsSidebar` and renders `PeerComparisonModal`; clicking a peer's chart icon navigates to `/stocks/{peer}`

## Test plan
- [ ] Navigate to `/stocks/NVDA` and verify the "View Industry Peers" button appears in the sidebar
- [ ] Click button — verify PeerComparisonModal opens with sortable peer table
- [ ] Click a peer's chart icon — verify navigation to `/stocks/{peer}`
- [ ] Open scan results, click a stock, click "View Industry Peers" — verify scan-based modal still works (regression)
- [ ] Test `curl http://localhost:8000/api/v1/stocks/NVDA/peers | jq length` returns peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to view stock peers based on industry or sector classification
  * Peer comparison now accessible from individual stock detail pages
  * Support for both industry group and sector peer types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->