### PR TITLE
Peer comparison, digest, validation & UI polish

### DIFF
--- a/frontend/src/components/Layout/Layout.jsx
+++ b/frontend/src/components/Layout/Layout.jsx
@@ -71,8 +71,8 @@ function Layout({ children }) {
 
   const navItems = [
     { path: '/', label: 'Routine' },
-    { path: '/scan', label: 'Bulk Scanner' },
-    { path: '/breadth', label: 'Market Breadth' },
+    { path: '/scan', label: 'Scanner' },
+    { path: '/breadth', label: 'Breadth' },
     { path: '/groups', label: 'Group Rankings' },
     { path: '/digest', label: 'Digest' },
     { path: '/validation', label: 'Validation' },

--- a/frontend/src/components/MarketScan/ThemeTable.jsx
+++ b/frontend/src/components/MarketScan/ThemeTable.jsx
@@ -113,31 +113,27 @@ function ThemeTable({ themeData, onRefresh }) {
                 {/* Subgroup Header Row */}
                 <TableRow
                   sx={{
-                    bgcolor: (theme) => theme.palette.mode === 'dark'
-                      ? 'rgba(31, 151, 244, 0.22)'
-                      : 'rgba(31, 151, 244, 0.18)',
+                    bgcolor: '#1F97F4',
+                    color: '#fff',
                     cursor: 'pointer',
                     '&:hover': {
-                      bgcolor: (theme) => theme.palette.mode === 'dark'
-                        ? 'rgba(31, 151, 244, 0.32)'
-                        : 'rgba(31, 151, 244, 0.28)',
+                      bgcolor: '#3AA3F6',
                     },
                   }}
                   onClick={() => toggleGroup(subgroup.id, isCollapsed)}
                 >
                   <TableCell sx={{ p: 0, px: 0.5, width: 28 }}>
-                    <IconButton size="small" sx={{ p: 0.25 }}>
+                    <IconButton size="small" sx={{ p: 0.25, color: 'inherit' }}>
                       {isCollapsed ? <ExpandMoreIcon fontSize="small" /> : <ExpandLessIcon fontSize="small" />}
                     </IconButton>
                   </TableCell>
-                  <TableCell colSpan={4 + PRICE_PERIODS.length} sx={{ py: 0.5 }}>
-                    <Typography variant="subtitle2" fontWeight={600}>
+                  <TableCell colSpan={4 + PRICE_PERIODS.length} sx={{ py: 0.5, color: 'inherit' }}>
+                    <Typography variant="subtitle2" fontWeight={600} color="inherit">
                       {subgroup.name}
                       <Typography
                         component="span"
                         variant="caption"
-                        color="text.secondary"
-                        sx={{ ml: 1 }}
+                        sx={{ ml: 1, color: 'rgba(255, 255, 255, 0.8)' }}
                       >
                         ({subgroup.stocks.length} stocks)
                       </Typography>


### PR DESCRIPTION
## Summary
- **Peer comparison modal** on standalone stock page
- **Daily digest** service with theme alerts and market summary (tranche 3)
- **Validation loop** service for scan result verification
- **UI polish**: solid blue theme subgroup rows, shorter nav labels (Scanner, Breadth)
- Static site workflow runs on Saturdays; degrades gracefully when breadth/groups unavailable

## Test plan
- [ ] Verify peer comparison modal opens from stock page
- [ ] Check digest endpoint returns data (`GET /api/v1/digest/daily`)
- [ ] Check validation endpoint (`GET /api/v1/validation/results`)
- [ ] Confirm theme subgroup rows are solid blue on Routine → Themes
- [ ] Confirm nav shows "Scanner" and "Breadth" labels
- [ ] Run `pytest tests/unit/` for backend coverage
- [ ] Run `npm run test:run` for frontend coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified navigation menu labels for Scanner and Breadth sections.
  * Enhanced table header styling with updated color scheme and improved text contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->