### PR TITLE
feat(llm): add Minimax M2.7 as default extraction provider

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -58,6 +58,11 @@ ZAI_API_KEY=
 ZAI_API_KEYS=
 ZAI_API_BASE=https://api.z.ai/api/paas/v4
 
+# Minimax - International API (default for theme extraction)
+# Get key at: https://platform.minimax.io
+MINIMAX_API_KEY=
+MINIMAX_API_BASE=https://api.minimax.io/v1
+
 # Groq - Fast inference, free tier available (recommended for start)
 # Get key at: https://console.groq.com
 GROQ_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ python scripts/cleanup_orphaned_scans.py   # Clean up stale scans, VACUUM DB
   - Benchmark (SPY): 24h TTL with distributed locking to prevent thundering herd
 
 **LLM Integration** (`services/chatbot/`):
-- Multi-provider support: Groq, DeepSeek, Together AI, OpenRouter, Gemini
+- Multi-provider support: Minimax, Groq, DeepSeek, Together AI, OpenRouter, Gemini
 - Agent orchestrator with tool executor pattern
 - Research mode with web search (Tavily, Serper, DuckDuckGo)
 
@@ -245,7 +245,7 @@ const BASE_PATH = '/api/v1/user-themes';
 - `CORS_ORIGINS` - Comma-separated allowed origins (for production)
 
 **LLM routing** (optional):
-- `LLM_DEFAULT_PROVIDER` - Primary provider: groq, deepseek, together_ai, openrouter, gemini
+- `LLM_DEFAULT_PROVIDER` - Primary provider: groq, minimax, deepseek, together_ai, openrouter, gemini
 - `LLM_CHATBOT_MODEL`, `LLM_RESEARCH_MODEL` - Model overrides (LiteLLM format)
 - `LLM_FALLBACK_ENABLED` - Enable automatic provider fallback
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,11 @@ ZAI_API_KEY=
 ZAI_API_KEYS=
 ZAI_API_BASE=https://api.z.ai/api/paas/v4
 
+# Minimax - International API (default for theme extraction)
+# Get key at: https://platform.minimax.io
+MINIMAX_API_KEY=
+MINIMAX_API_BASE=https://api.minimax.io/v1
+
 # Groq - Fast inference, free tier available (recommended)
 # Get key at: https://console.groq.com
 GROQ_API_KEY=

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -52,6 +52,8 @@ class Settings(BaseSettings):
     zai_api_key: str = ""  # For Z.AI GLM models via OpenAI-compatible endpoint
     zai_api_keys: str = ""  # For Z.AI GLM models (multiple keys, comma-separated)
     zai_api_base: str = "https://api.z.ai/api/paas/v4"  # Z.AI OpenAI-compatible base URL
+    minimax_api_key: str = ""  # Minimax international API
+    minimax_api_base: str = "https://api.minimax.io/v1"  # Minimax OpenAI-compatible base URL
     groq_api_key: str = ""  # For LLM via Groq (single key, backward compatible)
     groq_api_keys: str = ""  # For LLM via Groq (multiple keys, comma-separated)
     deepseek_api_key: str = ""  # For LLM via DeepSeek (cost-effective fallback)

--- a/backend/app/services/llm/__init__.py
+++ b/backend/app/services/llm/__init__.py
@@ -66,6 +66,7 @@ from .config import (
     GROQ_LLAMA_70B,
     GROQ_MIXTRAL,
     DEEPSEEK_CHAT,
+    MINIMAX_M27,
     OLLAMA_QWEN3_14B,
     OLLAMA_LLAMA3_8B,
     OLLAMA_MISTRAL_7B,
@@ -111,6 +112,7 @@ __all__ = [
     "GROQ_LLAMA_70B",
     "GROQ_MIXTRAL",
     "DEEPSEEK_CHAT",
+    "MINIMAX_M27",
     # Local model configs (Ollama)
     "OLLAMA_QWEN3_14B",
     "OLLAMA_LLAMA3_8B",

--- a/backend/app/services/llm/config.py
+++ b/backend/app/services/llm/config.py
@@ -107,6 +107,13 @@ ZAI_GLM_47_FLASH = ModelConfig(
     max_tokens=4000,
 )
 
+# Minimax Models (native LiteLLM support)
+MINIMAX_M27 = ModelConfig(
+    model_id="minimax/MiniMax-M2.7",
+    temperature=0.2,
+    max_tokens=4000,
+)
+
 # Together AI Models
 TOGETHER_LLAMA_70B = ModelConfig(
     model_id="together_ai/meta-llama/Llama-3-70b-chat-hf",
@@ -158,8 +165,9 @@ RESEARCH_PRESET = ModelPreset(
 
 # Theme extraction - needs structured output (JSON)
 EXTRACTION_PRESET = ModelPreset(
-    primary=ZAI_GLM_47_FLASH,
+    primary=MINIMAX_M27,
     fallbacks=[
+        ZAI_GLM_47_FLASH,
         GROQ_QWEN3_32B,
     ]
 )
@@ -202,6 +210,7 @@ PROVIDER_ENV_VARS = {
     "deepseek": "DEEPSEEK_API_KEY",
     "together_ai": "TOGETHER_API_KEY",  # Also: TOGETHERAI_API_KEY
     "openrouter": "OPENROUTER_API_KEY",
+    "minimax": "MINIMAX_API_KEY",
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "ollama": "OLLAMA_API_BASE",  # Default: http://localhost:11434
@@ -213,6 +222,9 @@ PROVIDER_ENV_VARS = {
 # =============================================================================
 
 AVAILABLE_MODELS = [
+    # Cloud models (Minimax)
+    {"id": "minimax/MiniMax-M2.7", "name": "MiniMax M2.7 (Minimax)", "provider": "minimax", "category": "cloud"},
+
     # Cloud models (Z.AI)
     {"id": "openai/glm-4.7-flash", "name": "GLM-4.7-Flash (Z.AI)", "provider": "zai", "category": "cloud"},
 

--- a/backend/app/services/llm/llm_service.py
+++ b/backend/app/services/llm/llm_service.py
@@ -135,6 +135,20 @@ class LLMService:
         if openrouter_key:
             os.environ["OPENROUTER_API_KEY"] = openrouter_key
 
+        # Minimax — cache resolved values for per-request use
+        self._minimax_api_key = getattr(settings, "minimax_api_key", None) or os.environ.get("MINIMAX_API_KEY")
+        self._minimax_api_base = (
+            getattr(settings, "minimax_api_base", None)
+            or os.environ.get("MINIMAX_API_BASE")
+            or "https://api.minimax.io/v1"
+        )
+        if self._minimax_api_key:
+            os.environ["MINIMAX_API_KEY"] = self._minimax_api_key
+        elif self.preset.primary.model_id.startswith("minimax/"):
+            logger.warning(
+                "MINIMAX_API_KEY not set — extraction will fall back to next provider in chain"
+            )
+
     async def completion(
         self,
         messages: List[Dict[str, Any]],
@@ -253,6 +267,11 @@ class LLMService:
         """Return True when a model should route through the Z.AI OpenAI-compatible endpoint."""
         return model.startswith("openai/glm-")
 
+    @staticmethod
+    def _is_minimax_model(model: str) -> bool:
+        """Return True when a model should route through the Minimax endpoint."""
+        return model.startswith("minimax/")
+
     def _resolve_fallback_models(self, *, primary_model: str, allow_fallbacks: bool) -> List[str]:
         """Resolve fallback models for a request, excluding duplicates of the active model."""
         if not allow_fallbacks:
@@ -289,21 +308,29 @@ class LLMService:
         provider_name, key_manager = self._get_provider_key_manager(model)
         provider_key = None
 
+        is_zai = self._is_zai_model(model)
+        is_minimax = self._is_minimax_model(model)
+
         if key_manager and len(key_manager) > 0:
             provider_key = key_manager.get_key()
-        elif self._is_zai_model(model):
+        elif is_zai:
             provider_key = getattr(settings, "zai_api_key", None) or os.environ.get("ZAI_API_KEY")
+        elif is_minimax:
+            provider_key = self._minimax_api_key
+            provider_name = "minimax"
 
         if provider_key:
             params["api_key"] = provider_key
 
-        if self._is_zai_model(model):
+        if is_zai:
             zai_base = (
                 getattr(settings, "zai_api_base", None)
                 or os.environ.get("ZAI_API_BASE")
                 or _ZAI_API_BASE_DEFAULT
             )
             params["api_base"] = zai_base
+        elif is_minimax:
+            params["api_base"] = self._minimax_api_base
 
         return provider_name, provider_key, key_manager
 

--- a/backend/app/services/theme_extraction_service.py
+++ b/backend/app/services/theme_extraction_service.py
@@ -183,7 +183,7 @@ class ThemeExtractionService:
         "models/gemini-2.5-flash",
     ]
     DEFAULT_EXTRACTION_MAX_TOKENS = 2000
-    ZAI_EXTRACTION_MAX_TOKENS = 4000
+    HIGH_EXTRACTION_MAX_TOKENS = 4000
     PROCESSABLE_STATUSES = {"pending", "failed_retryable"}
     TICKER_FALSE_POSITIVES = {
         "A", "I", "AI", "CEO", "CFO", "IPO", "ETF", "NYSE", "SEC", "FDA",
@@ -496,14 +496,13 @@ class ThemeExtractionService:
         # Use configured model if set
         model_override = self.configured_model if self.configured_model else None
         active_model = model_override or self.llm.preset.primary.model_id
-        # Keep Z.AI as the primary model for every extraction request, but allow the
-        # shared LLM service to fall through to Groq if a single request exhausts its
-        # Z.AI retries. The next request still starts from Z.AI because the active
-        # model selection here is unchanged.
+        # Minimax M2.7 is the primary extraction model, with Z.AI and Groq as
+        # fallbacks. Each request starts from the primary; fallbacks only activate
+        # if the primary exhausts its retries for that single request.
         allow_fallbacks = True
         max_tokens = (
-            self.ZAI_EXTRACTION_MAX_TOKENS
-            if LLMService._is_zai_model(active_model)
+            self.HIGH_EXTRACTION_MAX_TOKENS
+            if LLMService._is_minimax_model(active_model) or LLMService._is_zai_model(active_model)
             else self.DEFAULT_EXTRACTION_MAX_TOKENS
         )
 

--- a/backend/tests/unit/test_minimax_llm_routing.py
+++ b/backend/tests/unit/test_minimax_llm_routing.py
@@ -1,0 +1,46 @@
+"""Tests for Minimax model routing and provider overrides."""
+
+from __future__ import annotations
+
+from app.services.llm.groq_key_manager import GroqKeyManager
+from app.services.llm.zai_key_manager import ZAIKeyManager
+from app.services.llm.llm_service import LLMService
+
+
+def test_is_minimax_model_detects_minimax_prefix() -> None:
+    assert LLMService._is_minimax_model("minimax/MiniMax-M2.7") is True
+    assert LLMService._is_minimax_model("minimax/MiniMax-M2.5") is True
+
+
+def test_is_minimax_model_rejects_non_minimax() -> None:
+    assert LLMService._is_minimax_model("groq/qwen/qwen3-32b") is False
+    assert LLMService._is_minimax_model("openai/glm-4.7-flash") is False
+    assert LLMService._is_minimax_model("deepseek/deepseek-chat") is False
+
+
+def test_apply_provider_overrides_injects_minimax_api_key_and_base() -> None:
+    service = LLMService.__new__(LLMService)
+    service._groq_key_manager = GroqKeyManager(keys=[])
+    service._zai_key_manager = ZAIKeyManager(keys=[])
+    service._minimax_api_key = "test-minimax-key"
+    service._minimax_api_base = "https://api.minimax.io/v1"
+    params = {"model": "minimax/MiniMax-M2.7"}
+
+    service._apply_provider_overrides(params)
+
+    assert params["api_key"] == "test-minimax-key"
+    assert params["api_base"] == "https://api.minimax.io/v1"
+
+
+def test_apply_provider_overrides_does_not_affect_non_minimax_models() -> None:
+    service = LLMService.__new__(LLMService)
+    service._groq_key_manager = GroqKeyManager(keys=[])
+    service._zai_key_manager = ZAIKeyManager(keys=[])
+    service._minimax_api_key = "test-minimax-key"
+    service._minimax_api_base = "https://api.minimax.io/v1"
+    params = {"model": "groq/qwen/qwen3-32b"}
+
+    service._apply_provider_overrides(params)
+
+    assert "api_key" not in params
+    assert "api_base" not in params

--- a/backend/tests/unit/test_zai_llm_routing.py
+++ b/backend/tests/unit/test_zai_llm_routing.py
@@ -23,11 +23,14 @@ def _llm_json_response(payload: str):
     )
 
 
-def test_extraction_preset_defaults_to_zai_glm_flash() -> None:
+def test_extraction_preset_defaults_to_minimax_m27() -> None:
     preset = get_preset_for_use_case("extraction")
 
-    assert preset.primary.model_id == "openai/glm-4.7-flash"
-    assert [model.model_id for model in preset.fallbacks] == ["groq/qwen/qwen3-32b"]
+    assert preset.primary.model_id == "minimax/MiniMax-M2.7"
+    assert [model.model_id for model in preset.fallbacks] == [
+        "openai/glm-4.7-flash",
+        "groq/qwen/qwen3-32b",
+    ]
 
 
 def test_apply_provider_overrides_injects_zai_api_key_and_base(monkeypatch) -> None:
@@ -85,13 +88,13 @@ def test_try_generate_litellm_enables_fallbacks_for_configured_zai_model() -> No
     kwargs = service.llm.completion.await_args.kwargs
     assert kwargs["model"] == "openai/glm-4.7-flash"
     assert kwargs["allow_fallbacks"] is True
-    assert kwargs["max_tokens"] == ThemeExtractionService.ZAI_EXTRACTION_MAX_TOKENS
+    assert kwargs["max_tokens"] == ThemeExtractionService.HIGH_EXTRACTION_MAX_TOKENS
 
 
-def test_try_generate_litellm_enables_fallbacks_for_default_zai_model() -> None:
+def test_try_generate_litellm_enables_fallbacks_for_default_minimax_model() -> None:
     service = ThemeExtractionService.__new__(ThemeExtractionService)
     service.llm = SimpleNamespace(
-        preset=SimpleNamespace(primary=SimpleNamespace(model_id="openai/glm-4.7-flash")),
+        preset=SimpleNamespace(primary=SimpleNamespace(model_id="minimax/MiniMax-M2.7")),
         completion=AsyncMock(return_value=_llm_json_response("[]")),
     )
     service.pipeline_config = None
@@ -103,7 +106,7 @@ def test_try_generate_litellm_enables_fallbacks_for_default_zai_model() -> None:
     kwargs = service.llm.completion.await_args.kwargs
     assert kwargs["model"] is None
     assert kwargs["allow_fallbacks"] is True
-    assert kwargs["max_tokens"] == ThemeExtractionService.ZAI_EXTRACTION_MAX_TOKENS
+    assert kwargs["max_tokens"] == ThemeExtractionService.HIGH_EXTRACTION_MAX_TOKENS
 
 
 def test_try_generate_litellm_keeps_default_token_budget_for_non_zai_model() -> None:
@@ -123,14 +126,14 @@ def test_try_generate_litellm_keeps_default_token_budget_for_non_zai_model() -> 
     assert kwargs["max_tokens"] == ThemeExtractionService.DEFAULT_EXTRACTION_MAX_TOKENS
 
 
-def test_resolve_fallback_models_uses_qwen_for_non_zai_override() -> None:
+def test_resolve_fallback_models_uses_full_chain_for_non_preset_override() -> None:
     service = LLMService.__new__(LLMService)
     service.preset = get_preset_for_use_case("extraction")
 
     assert service._resolve_fallback_models(
         primary_model="deepseek/deepseek-chat",
         allow_fallbacks=True,
-    ) == ["groq/qwen/qwen3-32b"]
+    ) == ["openai/glm-4.7-flash", "groq/qwen/qwen3-32b"]
 
 
 def test_resolve_fallback_models_dedupes_primary_model() -> None:
@@ -140,4 +143,4 @@ def test_resolve_fallback_models_dedupes_primary_model() -> None:
     assert service._resolve_fallback_models(
         primary_model="groq/qwen/qwen3-32b",
         allow_fallbacks=True,
-    ) == []
+    ) == ["openai/glm-4.7-flash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       - ZAI_API_KEY=${ZAI_API_KEY:-}
       - ZAI_API_KEYS=${ZAI_API_KEYS:-}
       - ZAI_API_BASE=${ZAI_API_BASE:-https://api.z.ai/api/paas/v4}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+      - MINIMAX_API_BASE=${MINIMAX_API_BASE:-https://api.minimax.io/v1}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}
@@ -120,6 +122,8 @@ services:
       - ZAI_API_KEY=${ZAI_API_KEY:-}
       - ZAI_API_KEYS=${ZAI_API_KEYS:-}
       - ZAI_API_BASE=${ZAI_API_BASE:-https://api.z.ai/api/paas/v4}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+      - MINIMAX_API_BASE=${MINIMAX_API_BASE:-https://api.minimax.io/v1}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}
@@ -178,6 +182,8 @@ services:
       - ZAI_API_KEY=${ZAI_API_KEY:-}
       - ZAI_API_KEYS=${ZAI_API_KEYS:-}
       - ZAI_API_BASE=${ZAI_API_BASE:-https://api.z.ai/api/paas/v4}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+      - MINIMAX_API_BASE=${MINIMAX_API_BASE:-https://api.minimax.io/v1}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}
@@ -236,6 +242,8 @@ services:
       - ZAI_API_KEY=${ZAI_API_KEY:-}
       - ZAI_API_KEYS=${ZAI_API_KEYS:-}
       - ZAI_API_BASE=${ZAI_API_BASE:-https://api.z.ai/api/paas/v4}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+      - MINIMAX_API_BASE=${MINIMAX_API_BASE:-https://api.minimax.io/v1}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -16,6 +16,7 @@ At least one LLM provider key is required for the AI chatbot. Scanning and other
 | Together AI | `TOGETHER_API_KEY` | [api.together.xyz](https://api.together.xyz) | Wide model selection |
 | OpenRouter | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) | 100+ models, unified billing |
 | Z.AI | `ZAI_API_KEY` | [platform.z.ai](https://platform.z.ai) | GLM models |
+| Minimax | `MINIMAX_API_KEY` | [platform.minimax.io](https://platform.minimax.io) | Default for theme extraction |
 
 Multiple keys for load balancing: `GROQ_API_KEYS=key1,key2,key3` (comma-separated).
 
@@ -38,7 +39,7 @@ Enables research mode in the chatbot.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LLM_DEFAULT_PROVIDER` | `groq` | Primary provider: groq, zai, deepseek, together_ai, openrouter, gemini |
+| `LLM_DEFAULT_PROVIDER` | `groq` | Primary provider: groq, minimax, zai, deepseek, together_ai, openrouter, gemini |
 | `LLM_CHATBOT_MODEL` | `groq/qwen-qwen3-32b` | Model for chatbot (LiteLLM format: provider/model) |
 | `LLM_RESEARCH_MODEL` | `groq/qwen-qwen3-32b` | Model for research agents |
 | `LLM_FALLBACK_ENABLED` | `true` | Enable automatic fallback to other providers on failure |


### PR DESCRIPTION
## Summary

- Adds **Minimax M2.7** as a new LLM provider via LiteLLM's native `minimax/` prefix
- Makes Minimax the **default primary model for theme extraction**, replacing Z.AI GLM-4.7-Flash
- Z.AI demoted to first fallback, Groq Qwen3 32B remains second fallback
- Extraction fallback chain: `Minimax M2.7 → Z.AI GLM-4.7-Flash → Groq Qwen3 32B → Gemini (external)`

### Changes across 12 files

**Core integration (4 files):**
- `settings.py` — `MINIMAX_API_KEY` + `MINIMAX_API_BASE` settings
- `llm/config.py` — `MINIMAX_M27` ModelConfig, updated `EXTRACTION_PRESET`, `PROVIDER_ENV_VARS`, `AVAILABLE_MODELS`
- `llm/llm_service.py` — `_is_minimax_model()`, cached key/base resolution, provider overrides
- `llm/__init__.py` — export `MINIMAX_M27`

**Theme extraction (1 file):**
- `theme_extraction_service.py` — token budget delegates to `_is_minimax_model()`/`_is_zai_model()` instead of a separate prefix tuple

**Env & Docker (4 files):**
- `backend/.env.example`, `.env.docker.example` — Minimax env vars documented
- `docker-compose.yml` — `MINIMAX_API_KEY`/`MINIMAX_API_BASE` in all 4 service blocks

**Docs (2 files):**
- `CLAUDE.md`, `docs/ENVIRONMENT.md` — Minimax added to provider lists

**Tests (2 files):**
- `test_zai_llm_routing.py` — updated assertions for new extraction preset chain
- `test_minimax_llm_routing.py` (new) — prefix detection, provider override injection

## Test plan

- [x] Smoke-tested `minimax/MiniMax-M2.7` via LiteLLM with real API key — confirmed slug, response, and usage tracking
- [x] All 22 LLM-related unit tests pass (`test_zai_llm_routing`, `test_minimax_llm_routing`, `test_llm_quota_failfast`, `test_llm_config_api`, `test_settings_llm_keys`, `test_zai_env_docs`)
- [ ] Set `MINIMAX_API_KEY` in `.env`, start backend, verify `GET /api/v1/config/llm` shows Minimax in available models
- [ ] Run theme extraction batch and confirm requests route through Minimax

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Minimax as a supported LLM provider for theme extraction.
  * Minimax M2.7 is now the primary extraction model with Groq and Z.AI as fallbacks.

* **Documentation**
  * Updated environment and configuration guides to include Minimax provider setup and required API credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->