### PR TITLE
fix(static-site): unblock breadth and group rankings in CI export

### DIFF
--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -176,6 +176,7 @@ class BenchmarkCacheService:
             }
 
             df = pd.DataFrame(data)
+            df['Date'] = pd.to_datetime(df['Date'])
             df.set_index('Date', inplace=True)
 
             logger.debug(f"Retrieved SPY {period} from database ({len(df)} rows)")

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -22,6 +22,7 @@ from .benchmark_cache_service import BenchmarkCacheService
 from ..scanners.criteria.relative_strength import RelativeStrengthCalculator
 
 logger = logging.getLogger(__name__)
+CACHE_MISS_TOLERANCE_RATIO = 0.05  # Allow up to 5% cache misses in cache-only group ranking runs
 
 
 class IncompleteGroupRankingCacheError(RuntimeError):
@@ -104,11 +105,19 @@ class IBDGroupRankService:
             )
         )
 
-        if require_complete_cache and (
-            not prefetch_stats.get("spy_cached")
-            or prefetch_stats.get("cache_miss_symbols", 0) > 0
-        ):
-            raise IncompleteGroupRankingCacheError(prefetch_stats)
+        if require_complete_cache:
+            if not prefetch_stats.get("spy_cached"):
+                raise IncompleteGroupRankingCacheError(prefetch_stats)
+            cache_miss_symbols = prefetch_stats.get("cache_miss_symbols", 0)
+            target_symbols = prefetch_stats.get("target_symbols", 0)
+            miss_ratio = cache_miss_symbols / target_symbols if target_symbols > 0 else 0.0
+            if miss_ratio > CACHE_MISS_TOLERANCE_RATIO:
+                raise IncompleteGroupRankingCacheError(prefetch_stats)
+            if cache_miss_symbols > 0:
+                logger.warning(
+                    "Cache-only group ranking run has %d cache misses out of %d symbols (%.1f%%) -- within tolerance",
+                    cache_miss_symbols, target_symbols, miss_ratio * 100,
+                )
 
         if spy_data is None or spy_data.empty:
             logger.error("Failed to get SPY benchmark data")

--- a/backend/app/tasks/breadth_tasks.py
+++ b/backend/app/tasks/breadth_tasks.py
@@ -94,7 +94,7 @@ def _validate_same_day_cache_only_breadth_metrics(metrics: dict) -> Optional[str
             f"(cache_misses={cache_misses}, total={total_scanned}, "
             f"ratio={cache_misses / total_scanned:.1%}, limit={CACHE_MISS_TOLERANCE_RATIO:.0%})"
         )
-    if cache_misses > 0:
+    if cache_misses > 0 and total_scanned > 0:
         logger.warning(
             "Cache-only breadth run has %d cache misses out of %d stocks (%.1f%%) -- within tolerance",
             cache_misses, total_scanned, cache_misses / total_scanned * 100,

--- a/backend/app/tasks/breadth_tasks.py
+++ b/backend/app/tasks/breadth_tasks.py
@@ -27,6 +27,7 @@ from .data_fetch_lock import serialized_data_fetch
 
 logger = logging.getLogger(__name__)
 TRANSIENT_TASK_EXCEPTIONS = (ConnectionError, TimeoutError, OSError)
+CACHE_MISS_TOLERANCE_RATIO = 0.05  # Allow up to 5% cache misses in cache-only breadth runs
 _ALLOW_SAME_DAY_BREADTH_WARMUP_BYPASS: ContextVar[bool] = ContextVar(
     "allow_same_day_breadth_warmup_bypass",
     default=False,
@@ -77,25 +78,26 @@ def _validate_same_day_cache_only_breadth(price_cache, metrics: dict) -> Optiona
         except ValueError:
             return "Cache warmup metadata timestamp is invalid"
 
-    cache_misses = int(metrics.get("cache_miss_stocks", 0) or 0)
-    errors = int(metrics.get("error_stocks", 0) or 0)
-    if cache_misses > 0 or errors > 0:
-        return (
-            f"Cache-only breadth run is incomplete "
-            f"(cache_misses={cache_misses}, errors={errors})"
-        )
-
-    return None
+    return _validate_same_day_cache_only_breadth_metrics(metrics)
 
 
 def _validate_same_day_cache_only_breadth_metrics(metrics: dict) -> Optional[str]:
     """Validate cache completeness without requiring Redis warmup metadata."""
     cache_misses = int(metrics.get("cache_miss_stocks", 0) or 0)
     errors = int(metrics.get("error_stocks", 0) or 0)
-    if cache_misses > 0 or errors > 0:
+    total_scanned = int(metrics.get("total_stocks_scanned", 0) or 0)
+    if errors > 0:
+        return f"Cache-only breadth run has errors (errors={errors})"
+    if total_scanned > 0 and cache_misses / total_scanned > CACHE_MISS_TOLERANCE_RATIO:
         return (
-            f"Cache-only breadth run is incomplete "
-            f"(cache_misses={cache_misses}, errors={errors})"
+            f"Cache-only breadth run exceeds miss tolerance "
+            f"(cache_misses={cache_misses}, total={total_scanned}, "
+            f"ratio={cache_misses / total_scanned:.1%}, limit={CACHE_MISS_TOLERANCE_RATIO:.0%})"
+        )
+    if cache_misses > 0:
+        logger.warning(
+            "Cache-only breadth run has %d cache misses out of %d stocks (%.1f%%) -- within tolerance",
+            cache_misses, total_scanned, cache_misses / total_scanned * 100,
         )
     return None
 

--- a/backend/app/tasks/breadth_tasks.py
+++ b/backend/app/tasks/breadth_tasks.py
@@ -87,7 +87,7 @@ def _validate_same_day_cache_only_breadth_metrics(metrics: dict) -> Optional[str
     errors = int(metrics.get("error_stocks", 0) or 0)
     total_scanned = int(metrics.get("total_stocks_scanned", 0) or 0)
     skipped = int(metrics.get("skipped_stocks", 0) or 0)
-    total_attempted = total_scanned + skipped + cache_misses
+    total_attempted = total_scanned + skipped
     if errors > 0:
         return f"Cache-only breadth run has errors (errors={errors})"
     if total_attempted == 0:

--- a/backend/app/tasks/breadth_tasks.py
+++ b/backend/app/tasks/breadth_tasks.py
@@ -86,18 +86,23 @@ def _validate_same_day_cache_only_breadth_metrics(metrics: dict) -> Optional[str
     cache_misses = int(metrics.get("cache_miss_stocks", 0) or 0)
     errors = int(metrics.get("error_stocks", 0) or 0)
     total_scanned = int(metrics.get("total_stocks_scanned", 0) or 0)
+    skipped = int(metrics.get("skipped_stocks", 0) or 0)
+    total_attempted = total_scanned + skipped + cache_misses
     if errors > 0:
         return f"Cache-only breadth run has errors (errors={errors})"
-    if total_scanned > 0 and cache_misses / total_scanned > CACHE_MISS_TOLERANCE_RATIO:
+    if total_attempted == 0:
+        return "Cache-only breadth run processed no stocks"
+    miss_ratio = cache_misses / total_attempted
+    if miss_ratio > CACHE_MISS_TOLERANCE_RATIO:
         return (
             f"Cache-only breadth run exceeds miss tolerance "
-            f"(cache_misses={cache_misses}, total={total_scanned}, "
-            f"ratio={cache_misses / total_scanned:.1%}, limit={CACHE_MISS_TOLERANCE_RATIO:.0%})"
+            f"(cache_misses={cache_misses}, total={total_attempted}, "
+            f"ratio={miss_ratio:.1%}, limit={CACHE_MISS_TOLERANCE_RATIO:.0%})"
         )
-    if cache_misses > 0 and total_scanned > 0:
+    if cache_misses > 0:
         logger.warning(
             "Cache-only breadth run has %d cache misses out of %d stocks (%.1f%%) -- within tolerance",
-            cache_misses, total_scanned, cache_misses / total_scanned * 100,
+            cache_misses, total_attempted, miss_ratio * 100,
         )
     return None
 


### PR DESCRIPTION
## Summary
- **Fix DatetimeIndex bug** in `BenchmarkCacheService._get_from_database()` — added missing `pd.to_datetime()` conversion that caused group history backfill to crash on all 69 dates with `'Index' object has no attribute 'date'`
- **Replace zero-tolerance cache miss rejection** with 5% ratio-based thresholds in both breadth and group rankings validators — unavoidable cache misses (3.5% breadth, 0.3% groups) in CI without Redis now pass within tolerance
- **Deduplicate breadth validation** — `_validate_same_day_cache_only_breadth` now delegates to `_validate_same_day_cache_only_breadth_metrics` instead of duplicating its logic

Ref: https://github.com/xang1234/stock-screener/actions/runs/23997402206

## Test plan
- [x] All 23 existing unit tests pass (`test_breadth_tasks`, `test_group_rank_service`, `test_group_rank_tasks`)
- [x] Existing rejection test (50% miss rate) still correctly triggers `IncompleteGroupRankingCacheError`
- [x] Existing refuse-to-publish tests still pass at the task level
- [ ] Re-run static site workflow to verify breadth.json and groups.json are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured cached data uses consistent datetime-based indexes for reliable date queries and comparisons.
  * Relaxed cache validation to tolerate small, non-actionable data gaps (5% tolerance), reducing unnecessary failures.
  * When misses are within tolerance, the system now logs a warning with summary metrics instead of failing outright.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->