### PR TITLE
feat(static-site): enhance home, breadth, and groups pages

### DIFF
--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 import json
+import logging
 from pathlib import Path
 import shutil
 from typing import Any
@@ -24,6 +25,8 @@ from app.services.price_cache_service import PriceCacheService
 from app.services.ui_snapshot_service import UISnapshotService
 
 
+logger = logging.getLogger(__name__)
+
 STATIC_SITE_SCHEMA_VERSION = "static-site-v1"
 SCAN_BUNDLE_SCHEMA_VERSION = "static-scan-v1"
 CHART_BUNDLE_SCHEMA_VERSION = "static-charts-v1"
@@ -33,6 +36,7 @@ STATIC_CHART_PERIOD = "6mo"
 STATIC_CHART_PERIOD_DAYS = 180
 STATIC_CHART_LOOKUP_BATCH_SIZE = 250
 STATIC_DEFAULT_SCAN_FILTERS = {"minVolume": 100_000_000}
+STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
 
 _DEFAULT_KEY_MARKETS = (
     {"symbol": "SPY", "display_name": "S&P 500 ETF"},
@@ -464,6 +468,17 @@ class StaticSiteExportService:
                     f"{expected_as_of_date.isoformat()} (latest ranking date: {ranking_date})."
                 ),
             )
+        group_details: dict[str, Any] = {}
+        for row in rankings:
+            group_name = row["industry_group"]
+            try:
+                group_details[group_name] = service.get_group_history(
+                    db, group_name, days=STATIC_GROUP_DETAIL_HISTORY_DAYS,
+                )
+            except Exception:
+                logger.warning("Failed to export detail for group %s", group_name, exc_info=True)
+                db.rollback()
+
         return {
             "schema_version": STATIC_SITE_SCHEMA_VERSION,
             "generated_at": generated_at,
@@ -480,6 +495,7 @@ class StaticSiteExportService:
                     gainers=[GroupRankResponse(**row) for row in movers.get("gainers", [])],
                     losers=[GroupRankResponse(**row) for row in movers.get("losers", [])],
                 ).model_dump(mode="json"),
+                "group_details": group_details,
             },
         }
 

--- a/frontend/src/App.static.test.jsx
+++ b/frontend/src/App.static.test.jsx
@@ -227,11 +227,11 @@ describe('App static mode', () => {
     });
   }, 10000);
 
-  it('locks the breadth view to the exported range in the static route', async () => {
+  it('offers 1M and 3M ranges on the breadth page in the static route', async () => {
     await renderStaticAppAtHash('#/breadth');
 
     expect(await screen.findByRole('heading', { name: 'Market Breadth' })).toBeInTheDocument();
     expect(screen.getByTestId('breadth-chart-ranges')).toHaveTextContent('1M');
-    expect(screen.getByTestId('breadth-chart-ranges')).not.toHaveTextContent('3M');
+    expect(screen.getByTestId('breadth-chart-ranges')).toHaveTextContent('3M');
   }, 10000);
 });

--- a/frontend/src/components/shared/RankChangeCell.jsx
+++ b/frontend/src/components/shared/RankChangeCell.jsx
@@ -1,0 +1,22 @@
+import { Box } from '@mui/material';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+
+const RankChangeCell = ({ value, justifyContent = 'flex-end' }) => {
+  if (value === null || value === undefined) {
+    return <Box sx={{ color: 'text.secondary', fontFamily: 'monospace' }}>-</Box>;
+  }
+  const color = value > 0 ? 'success.main' : value < 0 ? 'error.main' : 'text.secondary';
+  const prefix = value > 0 ? '+' : '';
+  return (
+    <Box display="flex" alignItems="center" justifyContent={justifyContent} sx={{ fontFamily: 'monospace' }}>
+      {value > 0 && <TrendingUpIcon sx={{ fontSize: 12, mr: 0.25, color }} />}
+      {value < 0 && <TrendingDownIcon sx={{ fontSize: 12, mr: 0.25, color }} />}
+      <Box component="span" sx={{ color, fontWeight: value !== 0 ? 600 : 400, fontSize: '11px' }}>
+        {prefix}{value}
+      </Box>
+    </Box>
+  );
+};
+
+export default RankChangeCell;

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -1,0 +1,252 @@
+import { useMemo } from 'react';
+import {
+  Box,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Grid,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from 'recharts';
+import RankChangeCell from '../components/shared/RankChangeCell';
+
+function StaticGroupDetailModal({ group, detail, open, onClose }) {
+  const chartData = useMemo(() => {
+    if (!detail?.history) return [];
+    return [...detail.history].reverse().map((item) => {
+      const d = new Date(item.date);
+      const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+      return {
+        date: item.date,
+        rank: item.rank,
+        displayDate: `${months[d.getMonth()]} '${String(d.getFullYear()).slice(2)}`,
+      };
+    });
+  }, [detail?.history]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6">{group}</Typography>
+          <IconButton onClick={onClose} size="small">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        {!detail ? (
+          <Typography color="text.secondary">No data available</Typography>
+        ) : (
+          <Box>
+            {/* Current Stats */}
+            <Grid container spacing={2} mb={3}>
+              <Grid item xs={3}>
+                <Box textAlign="center">
+                  <Typography variant="h4">{detail.current_rank}</Typography>
+                  <Typography variant="caption" color="text.secondary">Current Rank</Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={3}>
+                <Box textAlign="center">
+                  <Typography variant="h4">{detail.current_avg_rs?.toFixed(1)}</Typography>
+                  <Typography variant="caption" color="text.secondary">Avg RS Rating</Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={3}>
+                <Box textAlign="center">
+                  <Typography variant="h4">{detail.num_stocks}</Typography>
+                  <Typography variant="caption" color="text.secondary">Stocks</Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={3}>
+                <Box textAlign="center">
+                  <Typography variant="body1">{detail.top_symbol || '-'}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Top Stock (RS: {detail.top_rs_rating?.toFixed(1) || '-'})
+                  </Typography>
+                </Box>
+              </Grid>
+            </Grid>
+
+            {/* Rank History Chart */}
+            {chartData.length > 0 && (
+              <Box mb={3}>
+                <Typography variant="subtitle2" gutterBottom>Rank History</Typography>
+                <Box sx={{ width: '100%', height: 220, bgcolor: 'background.paper', borderRadius: 1, p: 1 }}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={chartData} margin={{ top: 5, right: 20, left: 10, bottom: 25 }}>
+                      <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                      <XAxis
+                        dataKey="displayDate"
+                        tick={{ fontSize: 11 }}
+                        interval={Math.floor(chartData.length / 6)}
+                        angle={-45}
+                        textAnchor="end"
+                        height={50}
+                      />
+                      <YAxis
+                        scale="log"
+                        domain={[1, 200]}
+                        reversed
+                        tick={{ fontSize: 10 }}
+                        tickFormatter={(value) => value}
+                        ticks={[1, 5, 10, 20, 50, 100, 197]}
+                      />
+                      <RechartsTooltip
+                        contentStyle={{
+                          backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                          border: 'none',
+                          borderRadius: 4,
+                          fontSize: 12,
+                        }}
+                        labelStyle={{ color: '#fff' }}
+                        itemStyle={{ color: '#fff' }}
+                        formatter={(value) => [`Rank: ${value}`, '']}
+                        labelFormatter={(label, payload) => payload?.[0]?.payload?.date || label}
+                      />
+                      <ReferenceLine y={20} stroke="#4caf50" strokeDasharray="3 3" opacity={0.5} />
+                      <ReferenceLine y={177} stroke="#f44336" strokeDasharray="3 3" opacity={0.5} />
+                      <Line type="monotone" dataKey="rank" stroke="#2196f3" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </Box>
+              </Box>
+            )}
+
+            {/* Rank Changes */}
+            <Typography variant="subtitle2" gutterBottom>Rank Changes</Typography>
+            <Grid container spacing={2} mb={3}>
+              {[
+                { label: '1 Week', key: 'rank_change_1w' },
+                { label: '1 Month', key: 'rank_change_1m' },
+                { label: '3 Months', key: 'rank_change_3m' },
+                { label: '6 Months', key: 'rank_change_6m' },
+              ].map(({ label, key }) => (
+                <Grid item xs={3} key={key}>
+                  <Box textAlign="center" p={1} bgcolor="action.hover" borderRadius={1}>
+                    <RankChangeCell value={detail[key]} justifyContent="center" />
+                    <Typography variant="caption" color="text.secondary">{label}</Typography>
+                  </Box>
+                </Grid>
+              ))}
+            </Grid>
+
+            {/* Constituent Stocks Table */}
+            {detail.stocks && detail.stocks.length > 0 && (
+              <Box mb={2}>
+                <Box sx={{ fontSize: '12px', fontWeight: 600, mb: 0.5 }}>
+                  Constituent Stocks ({detail.stocks.length})
+                </Box>
+                <TableContainer sx={{ maxHeight: 300 }}>
+                  <Table size="small" stickyHeader>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Sym</TableCell>
+                        <TableCell align="right">Price</TableCell>
+                        <TableCell align="right">RS</TableCell>
+                        <TableCell align="right">1M</TableCell>
+                        <TableCell align="right">3M</TableCell>
+                        <TableCell align="right">EPS Q</TableCell>
+                        <TableCell align="right">EPS Y</TableCell>
+                        <TableCell align="right">Sls Q</TableCell>
+                        <TableCell align="right">Sls Y</TableCell>
+                        <TableCell align="center">Stg</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {detail.stocks.map((stock) => (
+                        <TableRow key={stock.symbol} hover>
+                          <TableCell sx={{ fontWeight: 600 }}>{stock.symbol}</TableCell>
+                          <TableCell align="right" sx={{ fontFamily: 'monospace' }}>
+                            {stock.price?.toFixed(2) || '-'}
+                          </TableCell>
+                          <TableCell align="right" sx={{
+                            fontFamily: 'monospace', fontWeight: 600,
+                            color: stock.rs_rating >= 80 ? 'success.main' : stock.rs_rating <= 30 ? 'error.main' : 'text.primary',
+                          }}>
+                            {stock.rs_rating?.toFixed(0) || '-'}
+                          </TableCell>
+                          <TableCell align="right" sx={{ fontFamily: 'monospace' }}>
+                            {stock.rs_rating_1m?.toFixed(0) || '-'}
+                          </TableCell>
+                          <TableCell align="right" sx={{ fontFamily: 'monospace' }}>
+                            {stock.rs_rating_3m?.toFixed(0) || '-'}
+                          </TableCell>
+                          {['eps_growth_qq', 'eps_growth_yy', 'sales_growth_qq', 'sales_growth_yy'].map((field) => (
+                            <TableCell key={field} align="right" sx={{
+                              fontFamily: 'monospace',
+                              color: stock[field] > 0 ? 'success.main' : stock[field] < 0 ? 'error.main' : 'text.secondary',
+                            }}>
+                              {stock[field] != null ? `${stock[field] > 0 ? '+' : ''}${stock[field].toFixed(0)}%` : '-'}
+                            </TableCell>
+                          ))}
+                          <TableCell align="center">
+                            <Box component="span" sx={{
+                              backgroundColor: stock.stage === 2 ? 'success.main' : 'grey.400',
+                              color: 'white', padding: '1px 4px', borderRadius: '2px', fontSize: '10px', fontWeight: 500,
+                            }}>
+                              S{stock.stage || '-'}
+                            </Box>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Box>
+            )}
+
+            {/* History Table */}
+            {detail.history && detail.history.length > 0 && (
+              <>
+                <Box sx={{ fontSize: '12px', fontWeight: 600, mb: 0.5 }}>Rank History</Box>
+                <TableContainer sx={{ maxHeight: 180 }}>
+                  <Table size="small" stickyHeader>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Date</TableCell>
+                        <TableCell align="right">Rank</TableCell>
+                        <TableCell align="right">Avg RS</TableCell>
+                        <TableCell align="right">Stocks</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {detail.history.slice(0, 20).map((row) => (
+                        <TableRow key={row.date} hover>
+                          <TableCell sx={{ fontFamily: 'monospace' }}>{row.date}</TableCell>
+                          <TableCell align="right" sx={{ fontFamily: 'monospace' }}>{row.rank}</TableCell>
+                          <TableCell align="right" sx={{ fontFamily: 'monospace' }}>{row.avg_rs_rating?.toFixed(1)}</TableCell>
+                          <TableCell align="right" sx={{ fontFamily: 'monospace' }}>{row.num_stocks || '-'}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default StaticGroupDetailModal;

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -31,12 +31,12 @@ function StaticGroupDetailModal({ group, detail, open, onClose }) {
   const chartData = useMemo(() => {
     if (!detail?.history) return [];
     return [...detail.history].reverse().map((item) => {
-      const d = new Date(item.date);
+      const [year, month] = item.date.split('-');
       const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
       return {
         date: item.date,
         rank: item.rank,
-        displayDate: `${months[d.getMonth()]} '${String(d.getFullYear()).slice(2)}`,
+        displayDate: `${months[parseInt(month, 10) - 1]} '${year.slice(2)}`,
       };
     });
   }, [detail?.history]);
@@ -235,7 +235,7 @@ function StaticGroupDetailModal({ group, detail, open, onClose }) {
                         <TableRow key={row.date} hover>
                           <TableCell sx={{ fontFamily: 'monospace' }}>{row.date}</TableCell>
                           <TableCell align="right" sx={{ fontFamily: 'monospace' }}>{row.rank}</TableCell>
-                          <TableCell align="right" sx={{ fontFamily: 'monospace' }}>{row.avg_rs_rating?.toFixed(1)}</TableCell>
+                          <TableCell align="right" sx={{ fontFamily: 'monospace' }}>{row.avg_rs_rating?.toFixed(1) ?? '-'}</TableCell>
                           <TableCell align="right" sx={{ fontFamily: 'monospace' }}>{row.num_stocks || '-'}</TableCell>
                         </TableRow>
                       ))}

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -46,7 +46,7 @@ function StaticGroupDetailModal({ group, detail, open, onClose }) {
       <DialogTitle>
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <Typography variant="h6">{group}</Typography>
-          <IconButton onClick={onClose} size="small">
+          <IconButton onClick={onClose} size="small" aria-label="Close group detail">
             <CloseIcon />
           </IconButton>
         </Box>
@@ -180,7 +180,9 @@ function StaticGroupDetailModal({ group, detail, open, onClose }) {
                           </TableCell>
                           <TableCell align="right" sx={{
                             fontFamily: 'monospace', fontWeight: 600,
-                            color: stock.rs_rating >= 80 ? 'success.main' : stock.rs_rating <= 30 ? 'error.main' : 'text.primary',
+                            color: stock.rs_rating == null ? 'text.primary'
+                              : stock.rs_rating >= 80 ? 'success.main'
+                              : stock.rs_rating <= 30 ? 'error.main' : 'text.primary',
                           }}>
                             {stock.rs_rating?.toFixed(0) || '-'}
                           </TableCell>

--- a/frontend/src/static/pages/StaticBreadthPage.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Alert,
@@ -40,6 +40,17 @@ function StaticBreadthPage() {
   });
   const [timeRange, setTimeRange] = useState('1M');
 
+  const rangeDays = { '1M': 31, '3M': 90 };
+  const payload = breadthQuery.data?.payload || {};
+  const filteredChartData = useMemo(() => {
+    const allData = payload.chart_data || payload.history_90d || [];
+    return allData.slice(-(rangeDays[timeRange] || 31));
+  }, [payload.chart_data, payload.history_90d, timeRange]);
+  const filteredSpyData = useMemo(() => {
+    const allSpy = payload.spy_overlay || [];
+    return allSpy.slice(-(rangeDays[timeRange] || 31));
+  }, [payload.spy_overlay, timeRange]);
+
   if (manifestQuery.isLoading || breadthQuery.isLoading) {
     return (
       <Box display="flex" justifyContent="center" py={8}>
@@ -56,7 +67,6 @@ function StaticBreadthPage() {
     return <Alert severity="info">{breadthQuery.data?.message || 'No breadth snapshot is available.'}</Alert>;
   }
 
-  const payload = breadthQuery.data?.payload || {};
   const current = payload.current || {};
   const history = payload.history_90d || [];
 
@@ -85,8 +95,8 @@ function StaticBreadthPage() {
       </Grid>
 
       <BreadthChart
-        breadthData={payload.chart_data || []}
-        spyData={payload.spy_overlay || []}
+        breadthData={filteredChartData}
+        spyData={filteredSpyData}
         isLoading={false}
         error={null}
         timeRange={timeRange}

--- a/frontend/src/static/pages/StaticBreadthPage.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Alert,
@@ -37,6 +38,7 @@ function StaticBreadthPage() {
     enabled: Boolean(manifestQuery.data?.pages?.breadth?.path),
     staleTime: Infinity,
   });
+  const [timeRange, setTimeRange] = useState('1M');
 
   if (manifestQuery.isLoading || breadthQuery.isLoading) {
     return (
@@ -87,9 +89,9 @@ function StaticBreadthPage() {
         spyData={payload.spy_overlay || []}
         isLoading={false}
         error={null}
-        timeRange="1M"
-        onTimeRangeChange={() => {}}
-        availableRanges={['1M']}
+        timeRange={timeRange}
+        onTimeRangeChange={setTimeRange}
+        availableRanges={['1M', '3M']}
       />
 
       <Paper sx={{ p: 2 }}>

--- a/frontend/src/static/pages/StaticGroupsPage.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Alert,
@@ -14,6 +15,8 @@ import {
   Typography,
 } from '@mui/material';
 import { useStaticManifest, fetchStaticJson } from '../dataClient';
+import StaticGroupDetailModal from '../StaticGroupDetailModal';
+import RankChangeCell from '../../components/shared/RankChangeCell';
 
 function MoversCard({ title, rows }) {
   return (
@@ -27,6 +30,7 @@ function MoversCard({ title, rows }) {
             <TableRow>
               <TableCell>Group</TableCell>
               <TableCell align="right">Rank</TableCell>
+              <TableCell align="right">Change</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -34,6 +38,9 @@ function MoversCard({ title, rows }) {
               <TableRow key={`${title}-${row.industry_group}`}>
                 <TableCell>{row.industry_group}</TableCell>
                 <TableCell align="right">{row.rank}</TableCell>
+                <TableCell align="right">
+                  <RankChangeCell value={row.rank_change_3m} />
+                </TableCell>
               </TableRow>
             ))}
           </TableBody>
@@ -51,6 +58,7 @@ function StaticGroupsPage() {
     enabled: Boolean(manifestQuery.data?.pages?.groups?.path),
     staleTime: Infinity,
   });
+  const [selectedGroup, setSelectedGroup] = useState(null);
 
   if (manifestQuery.isLoading || groupsQuery.isLoading) {
     return (
@@ -72,6 +80,7 @@ function StaticGroupsPage() {
   const rankings = payload.rankings?.rankings || [];
   const movers = payload.movers || {};
   const moversPeriod = payload.movers_period || movers.period || '3m';
+  const groupDetails = payload.group_details || {};
 
   return (
     <Box>
@@ -99,31 +108,49 @@ function StaticGroupsPage() {
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell align="right">Rank</TableCell>
+                <TableCell align="center">Rank</TableCell>
                 <TableCell>Group</TableCell>
-                <TableCell align="right">Avg RS</TableCell>
-                <TableCell align="right">Stocks</TableCell>
+                <TableCell align="center">Avg RS</TableCell>
+                <TableCell align="center">Stocks</TableCell>
                 <TableCell align="right">1W</TableCell>
                 <TableCell align="right">1M</TableCell>
                 <TableCell align="right">3M</TableCell>
+                <TableCell align="right">6M</TableCell>
+                <TableCell>Top Stock</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {rankings.slice(0, 50).map((row) => (
-                <TableRow key={row.industry_group}>
-                  <TableCell align="right">{row.rank}</TableCell>
+              {rankings.map((row) => (
+                <TableRow
+                  key={row.industry_group}
+                  hover
+                  onClick={() => setSelectedGroup(row.industry_group)}
+                  sx={{ cursor: 'pointer' }}
+                >
+                  <TableCell align="center" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>{row.rank}</TableCell>
                   <TableCell>{row.industry_group}</TableCell>
-                  <TableCell align="right">{row.avg_rs_rating?.toFixed?.(1) ?? '-'}</TableCell>
-                  <TableCell align="right">{row.num_stocks}</TableCell>
-                  <TableCell align="right">{row.rank_change_1w ?? '-'}</TableCell>
-                  <TableCell align="right">{row.rank_change_1m ?? '-'}</TableCell>
-                  <TableCell align="right">{row.rank_change_3m ?? '-'}</TableCell>
+                  <TableCell align="center" sx={{ fontFamily: 'monospace' }}>{row.avg_rs_rating?.toFixed?.(1) ?? '-'}</TableCell>
+                  <TableCell align="center" sx={{ fontFamily: 'monospace' }}>{row.num_stocks}</TableCell>
+                  <TableCell align="right"><RankChangeCell value={row.rank_change_1w} /></TableCell>
+                  <TableCell align="right"><RankChangeCell value={row.rank_change_1m} /></TableCell>
+                  <TableCell align="right"><RankChangeCell value={row.rank_change_3m} /></TableCell>
+                  <TableCell align="right"><RankChangeCell value={row.rank_change_6m} /></TableCell>
+                  <TableCell sx={{ fontWeight: 500, color: 'text.secondary', fontSize: '12px' }}>
+                    {row.top_symbol || '-'}
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
         </TableContainer>
       </Paper>
+
+      <StaticGroupDetailModal
+        group={selectedGroup}
+        detail={selectedGroup ? groupDetails[selectedGroup] : null}
+        open={!!selectedGroup}
+        onClose={() => setSelectedGroup(null)}
+      />
     </Box>
   );
 }

--- a/frontend/src/static/pages/StaticGroupsPage.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.jsx
@@ -125,6 +125,13 @@ function StaticGroupsPage() {
                   key={row.industry_group}
                   hover
                   onClick={() => setSelectedGroup(row.industry_group)}
+                  tabIndex={0}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setSelectedGroup(row.industry_group);
+                    }
+                  }}
                   sx={{ cursor: 'pointer' }}
                 >
                   <TableCell align="center" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>{row.rank}</TableCell>

--- a/frontend/src/static/pages/StaticGroupsPage.test.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.test.jsx
@@ -95,6 +95,6 @@ describe('StaticGroupsPage', () => {
     expect(screen.getByText('Top Losers (3M)')).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: '3M' })).toBeInTheDocument();
     expect(screen.getAllByText('Semiconductors').length).toBeGreaterThan(0);
-    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('+7')).toBeInTheDocument();
   });
 });

--- a/frontend/src/static/pages/StaticHomePage.jsx
+++ b/frontend/src/static/pages/StaticHomePage.jsx
@@ -1,3 +1,4 @@
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Alert,
@@ -14,6 +15,11 @@ import {
   Typography,
 } from '@mui/material';
 import { useStaticManifest, fetchStaticJson } from '../dataClient';
+import { useStaticChartIndex } from '../chartClient';
+import PriceSparkline from '../../components/Scan/PriceSparkline';
+import RSSparkline from '../../components/Scan/RSSparkline';
+import StaticChartViewerModal from '../StaticChartViewerModal';
+import { getGroupRankColor } from '../../utils/colorUtils';
 
 const formatNumber = (value, digits = 0) => {
   if (value == null) return '-';
@@ -49,6 +55,20 @@ function StaticHomePage() {
     enabled: Boolean(manifestQuery.data?.pages?.home?.path),
     staleTime: Infinity,
   });
+  const chartIndexQuery = useStaticChartIndex(manifestQuery.data?.assets?.charts?.path);
+
+  const [chartModalOpen, setChartModalOpen] = useState(false);
+  const [selectedChartSymbol, setSelectedChartSymbol] = useState(null);
+
+  const topResults = homeQuery.data?.scan_summary?.top_results || [];
+  const topGroups = homeQuery.data?.top_groups || [];
+
+  const chartEntries = useMemo(() => chartIndexQuery.data?.symbols || [], [chartIndexQuery.data]);
+  const chartEnabledSymbols = useMemo(() => new Set(chartEntries.map((e) => e.symbol)), [chartEntries]);
+  const navigationSymbols = useMemo(
+    () => topResults.map((r) => r.symbol).filter((s) => chartEnabledSymbols.has(s)),
+    [topResults, chartEnabledSymbols],
+  );
 
   if (manifestQuery.isLoading || homeQuery.isLoading) {
     return (
@@ -68,8 +88,13 @@ function StaticHomePage() {
 
   const home = homeQuery.data;
   const freshness = home?.freshness || {};
-  const topResults = home?.scan_summary?.top_results || [];
-  const topGroups = home?.top_groups || [];
+
+  const handleRowClick = (symbol) => {
+    if (chartEnabledSymbols.has(symbol)) {
+      setSelectedChartSymbol(symbol);
+      setChartModalOpen(true);
+    }
+  };
 
   return (
     <Box>
@@ -126,66 +151,115 @@ function StaticHomePage() {
         ))}
       </Grid>
 
-      <Grid container spacing={2}>
-        <Grid item xs={12} lg={7}>
-          <Paper sx={{ p: 2, height: '100%' }}>
-            <Typography variant="h6" gutterBottom>
-              Top Scan Candidates
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-              Default view uses dollar volume &gt; $100M.
-            </Typography>
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Symbol</TableCell>
-                    <TableCell align="right">Score</TableCell>
-                    <TableCell align="right">Price</TableCell>
-                    <TableCell>Rating</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {topResults.map((row) => (
-                    <TableRow key={row.symbol}>
-                      <TableCell sx={{ fontWeight: 600 }}>{row.symbol}</TableCell>
-                      <TableCell align="right">{formatNumber(row.composite_score, 1)}</TableCell>
-                      <TableCell align="right">{row.current_price != null ? `$${formatNumber(row.current_price, 2)}` : '-'}</TableCell>
-                      <TableCell>{row.rating}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Paper>
-        </Grid>
+      <Paper sx={{ p: 2, mb: 3 }}>
+        <Typography variant="h6" gutterBottom>
+          Top Scan Candidates
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          Default view uses dollar volume &gt; $100M. Click a row for details.
+        </Typography>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell align="center">Symbol</TableCell>
+                <TableCell align="center">Score</TableCell>
+                <TableCell align="center">Price</TableCell>
+                <TableCell align="center">Rating</TableCell>
+                <TableCell align="center">Price Trend</TableCell>
+                <TableCell align="center">RS Trend</TableCell>
+                <TableCell align="center">IBD Group</TableCell>
+                <TableCell align="center">Grp Rank</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {topResults.map((row) => (
+                <TableRow
+                  key={row.symbol}
+                  hover
+                  onClick={() => handleRowClick(row.symbol)}
+                  sx={{ cursor: chartEnabledSymbols.has(row.symbol) ? 'pointer' : 'default' }}
+                >
+                  <TableCell align="center" sx={{ fontWeight: 600 }}>{row.symbol}</TableCell>
+                  <TableCell align="center">{formatNumber(row.composite_score, 1)}</TableCell>
+                  <TableCell align="center">{row.current_price != null ? `$${formatNumber(row.current_price, 2)}` : '-'}</TableCell>
+                  <TableCell align="center">{row.rating}</TableCell>
+                  <TableCell align="center">
+                    {row.price_sparkline_data ? (
+                      <Box display="flex" justifyContent="center">
+                        <PriceSparkline
+                          data={row.price_sparkline_data}
+                          trend={row.price_trend}
+                          change1d={row.price_change_1d}
+                          industry={row.ibd_industry_group}
+                          width={100}
+                          height={28}
+                        />
+                      </Box>
+                    ) : '-'}
+                  </TableCell>
+                  <TableCell align="center">
+                    {row.rs_sparkline_data ? (
+                      <Box display="flex" justifyContent="center">
+                        <RSSparkline
+                          data={row.rs_sparkline_data}
+                          trend={row.rs_trend}
+                          width={60}
+                          height={20}
+                        />
+                      </Box>
+                    ) : '-'}
+                  </TableCell>
+                  <TableCell align="center" sx={{
+                    color: 'text.secondary', fontSize: '12px',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 140,
+                  }}>
+                    {row.ibd_industry_group || '-'}
+                  </TableCell>
+                  <TableCell align="center" sx={{
+                    fontFamily: 'monospace', fontWeight: row.ibd_group_rank && row.ibd_group_rank <= 20 ? 600 : 400,
+                    color: getGroupRankColor(row.ibd_group_rank),
+                  }}>
+                    {row.ibd_group_rank ?? '-'}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
 
-        <Grid item xs={12} lg={5}>
-          <Paper sx={{ p: 2, height: '100%' }}>
-            <Typography variant="h6" gutterBottom>
-              Leading Groups
-            </Typography>
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Group</TableCell>
-                    <TableCell align="right">Rank</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {topGroups.map((group) => (
-                    <TableRow key={group.industry_group}>
-                      <TableCell>{group.industry_group}</TableCell>
-                      <TableCell align="right">{group.rank}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Paper>
-        </Grid>
-      </Grid>
+      <Paper sx={{ p: 2 }}>
+        <Typography variant="h6" gutterBottom>
+          Leading Groups
+        </Typography>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Group</TableCell>
+                <TableCell align="right">Rank</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {topGroups.map((group) => (
+                <TableRow key={group.industry_group}>
+                  <TableCell>{group.industry_group}</TableCell>
+                  <TableCell align="right">{group.rank}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      <StaticChartViewerModal
+        open={chartModalOpen}
+        onClose={() => setChartModalOpen(false)}
+        initialSymbol={selectedChartSymbol}
+        chartIndex={chartIndexQuery.data}
+        navigationSymbols={navigationSymbols}
+      />
     </Box>
   );
 }

--- a/frontend/src/static/pages/StaticHomePage.jsx
+++ b/frontend/src/static/pages/StaticHomePage.jsx
@@ -156,7 +156,7 @@ function StaticHomePage() {
           Top Scan Candidates
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-          Default view uses dollar volume &gt; $100M. Click a row for details.
+          Default view uses dollar volume &gt; $100M. Click a row for chart details.
         </Typography>
         <TableContainer>
           <Table size="small">
@@ -176,8 +176,16 @@ function StaticHomePage() {
               {topResults.map((row) => (
                 <TableRow
                   key={row.symbol}
-                  hover
+                  hover={chartEnabledSymbols.has(row.symbol)}
+                  tabIndex={chartEnabledSymbols.has(row.symbol) ? 0 : -1}
                   onClick={() => handleRowClick(row.symbol)}
+                  onKeyDown={(event) => {
+                    if (!chartEnabledSymbols.has(row.symbol)) return;
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      handleRowClick(row.symbol);
+                    }
+                  }}
                   sx={{ cursor: chartEnabledSymbols.has(row.symbol) ? 'pointer' : 'default' }}
                 >
                   <TableCell align="center" sx={{ fontWeight: 600 }}>{row.symbol}</TableCell>


### PR DESCRIPTION
## Summary
- **Home page**: Added price/RS sparklines, IBD Group and Group Rank columns to the top scan candidates table. All columns center-aligned. Rows are clickable to open the chart detail modal with keyboard navigation (Space: next, Shift+Space: previous, Esc: close).
- **Groups page**: Added red/green trending arrows via shared `RankChangeCell` component, 6M rank change column, Top Stock column. Expanded to show all 197 groups (was 50). Clicking a group opens a detail popup with rank history chart, constituent stocks table, and rank changes — matching the dynamic page.
- **Breadth page**: Added interactive 1M/3M time range toggle (was locked to 1M only).
- **Backend**: Exports `group_details` (rank history + constituent stocks) for all groups in `groups.json`.
- **Shared component**: Extracted `RankChangeCell` to `components/shared/` (was duplicated in 3 files). Uses existing `getGroupRankColor` utility for rank coloring.

## Test plan
- [x] Frontend build succeeds (`npm run build`)
- [x] All 22 static site tests pass (`vitest run src/static/ src/App.static.test.jsx`)
- [x] Updated `StaticGroupsPage.test.jsx` for `RankChangeCell` prefix rendering (`+7` instead of `7`)
- [x] Updated `App.static.test.jsx` breadth range test to expect 3M available
- [ ] Visual verification: deploy static site and check all 3 pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group detail modal with rank history, constituent stocks, and rank-change metrics.
  * Breadth chart adds a 3-month range option.
  * Rank change cells and columns added across groups and movers (1W, 1M, 3M, 6M); rows are clickable/keyboard-accessible to open details.
  * Home page gains chart-view modal, sparklines, and colored group-rank indicators.

* **Bug Fixes / Chores**
  * Static export now includes per-group detail history with improved logging and error resilience.

* **Tests**
  * Updated static-mode tests to expect 3M and formatted rank-change output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->