### PR TITLE
feat(static-site): fix breadth page and add group detail sparklines

### DIFF
--- a/backend/app/schemas/groups.py
+++ b/backend/app/schemas/groups.py
@@ -64,6 +64,11 @@ class ConstituentStock(BaseModel):
     sales_growth_yy: Optional[float] = Field(None, description="Sales growth year-over-year %")
     composite_score: Optional[float] = Field(None, description="Composite screener score")
     stage: Optional[int] = Field(None, description="Weinstein stage (1-4)")
+    price_sparkline_data: Optional[list] = Field(None, description="30-day normalized price trend")
+    price_trend: Optional[int] = Field(None, description="Price trend: -1=down, 0=flat, 1=up")
+    price_change_1d: Optional[float] = Field(None, description="1-day price change %")
+    rs_sparkline_data: Optional[list] = Field(None, description="30-day RS ratio trend")
+    rs_trend: Optional[int] = Field(None, description="RS trend: -1=declining, 0=flat, 1=improving")
 
 
 class GroupDetailResponse(BaseModel):

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -636,6 +636,11 @@ class IBDGroupRankService:
                     'sales_growth_yy': r.sales_growth_yy,
                     'composite_score': r.composite_score,
                     'stage': r.stage,
+                    'price_sparkline_data': r.price_sparkline_data,
+                    'price_trend': r.price_trend,
+                    'price_change_1d': r.price_change_1d,
+                    'rs_sparkline_data': r.rs_sparkline_data,
+                    'rs_trend': r.rs_trend,
                 })
 
             logger.info(f"Found {len(stocks)} stocks for group {industry_group}")

--- a/backend/app/tasks/breadth_tasks.py
+++ b/backend/app/tasks/breadth_tasks.py
@@ -27,7 +27,7 @@ from .data_fetch_lock import serialized_data_fetch
 
 logger = logging.getLogger(__name__)
 TRANSIENT_TASK_EXCEPTIONS = (ConnectionError, TimeoutError, OSError)
-CACHE_MISS_TOLERANCE_RATIO = 0.05  # Allow up to 5% cache misses in cache-only breadth runs
+CACHE_MISS_TOLERANCE_RATIO = 0.10  # Allow up to 10% — breadth scans the full universe including delisted tickers
 _ALLOW_SAME_DAY_BREADTH_WARMUP_BYPASS: ContextVar[bool] = ContextVar(
     "allow_same_day_breadth_warmup_bypass",
     default=False,

--- a/frontend/src/pages/GroupRankingsPage.jsx
+++ b/frontend/src/pages/GroupRankingsPage.jsx
@@ -52,6 +52,8 @@ import {
   ReferenceLine,
 } from 'recharts';
 import { useRuntime } from '../contexts/RuntimeContext';
+import PriceSparkline from '../components/Scan/PriceSparkline';
+import RSSparkline from '../components/Scan/RSSparkline';
 
 // Helper to format rank change with color
 const RankChangeCell = ({ value }) => {
@@ -304,6 +306,8 @@ const GroupDetailModal = ({ group, open, onClose }) => {
                     <TableHead>
                       <TableRow>
                         <TableCell>Sym</TableCell>
+                        <TableCell align="center" sx={{ p: '2px' }}>Price 30d</TableCell>
+                        <TableCell align="center" sx={{ p: '2px' }}>RS 30d</TableCell>
                         <TableCell align="right">Price</TableCell>
                         <TableCell align="right">RS</TableCell>
                         <TableCell align="right">1M</TableCell>
@@ -320,6 +324,24 @@ const GroupDetailModal = ({ group, open, onClose }) => {
                         <TableRow key={stock.symbol} hover>
                           <TableCell sx={{ fontWeight: 600 }}>
                             {stock.symbol}
+                          </TableCell>
+                          <TableCell align="center" sx={{ p: '2px' }}>
+                            <PriceSparkline
+                              data={stock.price_sparkline_data}
+                              trend={stock.price_trend}
+                              change1d={stock.price_change_1d}
+                              width={80}
+                              height={22}
+                              showChange={false}
+                            />
+                          </TableCell>
+                          <TableCell align="center" sx={{ p: '2px' }}>
+                            <RSSparkline
+                              data={stock.rs_sparkline_data}
+                              trend={stock.rs_trend}
+                              width={60}
+                              height={20}
+                            />
                           </TableCell>
                           <TableCell align="right" sx={{ fontFamily: 'monospace' }}>
                             {stock.price?.toFixed(2) || '-'}

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -26,6 +26,8 @@ import {
   ReferenceLine,
 } from 'recharts';
 import RankChangeCell from '../components/shared/RankChangeCell';
+import PriceSparkline from '../components/Scan/PriceSparkline';
+import RSSparkline from '../components/Scan/RSSparkline';
 
 function StaticGroupDetailModal({ group, detail, open, onClose }) {
   const chartData = useMemo(() => {
@@ -160,6 +162,8 @@ function StaticGroupDetailModal({ group, detail, open, onClose }) {
                     <TableHead>
                       <TableRow>
                         <TableCell>Sym</TableCell>
+                        <TableCell align="center" sx={{ p: '2px' }}>Price 30d</TableCell>
+                        <TableCell align="center" sx={{ p: '2px' }}>RS 30d</TableCell>
                         <TableCell align="right">Price</TableCell>
                         <TableCell align="right">RS</TableCell>
                         <TableCell align="right">1M</TableCell>
@@ -175,6 +179,24 @@ function StaticGroupDetailModal({ group, detail, open, onClose }) {
                       {detail.stocks.map((stock) => (
                         <TableRow key={stock.symbol} hover>
                           <TableCell sx={{ fontWeight: 600 }}>{stock.symbol}</TableCell>
+                          <TableCell align="center" sx={{ p: '2px' }}>
+                            <PriceSparkline
+                              data={stock.price_sparkline_data}
+                              trend={stock.price_trend}
+                              change1d={stock.price_change_1d}
+                              width={80}
+                              height={22}
+                              showChange={false}
+                            />
+                          </TableCell>
+                          <TableCell align="center" sx={{ p: '2px' }}>
+                            <RSSparkline
+                              data={stock.rs_sparkline_data}
+                              trend={stock.rs_trend}
+                              width={60}
+                              height={20}
+                            />
+                          </TableCell>
                           <TableCell align="right" sx={{ fontFamily: 'monospace' }}>
                             {stock.price?.toFixed(2) || '-'}
                           </TableCell>


### PR DESCRIPTION
## Summary
- Fix empty breadth page in static site builds by raising cache miss tolerance from 5% to 10% — breadth scans the full universe (~9774 stocks) including delisted tickers, unlike group rankings (~7276)
- Add Price 30d and RS 30d sparkline columns to the group detail constituent stocks table in both dynamic and static modes
- Include sparkline fields in `_get_constituent_stocks()` backend response (data already on ScanResult model, just wasn't being returned)

## Root Cause (Breadth)
Build log: `cache_misses=510, total=9774, ratio=5.2%, limit=5%`. The 510 missed tickers are delisted stocks (AACPU, ACGCU, etc.) that will never have cached price data. The 9208 successfully scanned stocks produced valid breadth data that was discarded due to the tight tolerance.

## Test plan
- [x] `pytest backend/tests/unit/test_breadth_tasks.py` — 6 passed
- [x] `npm run build` — clean build, no errors
- [x] `npm run lint` — 0 errors, 38 pre-existing warnings (no new ones)
- [ ] Verify next static site build produces non-empty breadth page
- [ ] Open Group Rankings → click a group → verify sparkline columns render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 30-day price sparklines and 1‑day price change indicators to constituent stock tables for richer price context.
  * Added 30-day relative-strength (RS) sparklines to constituent stock tables for enhanced performance comparison.

* **Improvements**
  * Relaxed cache-validation tolerance to reduce false rejects on cache-only breadth checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->