### PR TITLE
feat(mcp): expand to 12 tools + Streamable HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Full reference: **[Environment Variables](docs/ENVIRONMENT.md)**
 - **Market breadth** dashboard with StockBee-style indicators and historical trends
 - **197 IBD industry groups** ranked by relative strength with movers and constituent analysis
 - **Watchlists** with RS/price sparklines, multi-period change bars, and drag-and-drop organization
-- **MCP integration** for AI copilot workflows with 8 tools ([details](docs/MCP_INTEGRATION.md))
+- **MCP integration** for AI copilot workflows with 12 tools via stdio and Streamable HTTP ([details](docs/MCP_INTEGRATION.md))
 - **TradingView-style charts** with candlestick OHLC and technical overlays
 - **CSV export** for scan results
 - **Dark and light mode** UI

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -128,6 +128,9 @@ MCP_SERVER_NAME=stockscreen-market-copilot
 # Keep false unless you explicitly want MCP clients to modify watchlists
 MCP_WATCHLIST_WRITES_ENABLED=false
 
+# Enable the Streamable HTTP MCP transport at /mcp (disable to keep stdio-only)
+MCP_HTTP_ENABLED=true
+
 # -----------------------------------------------------------------------------
 # REDIS / CELERY
 # -----------------------------------------------------------------------------

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -256,6 +256,7 @@ class Settings(BaseSettings):
     # Hermes / MCP integration
     mcp_server_name: str = "stockscreen-market-copilot"
     mcp_watchlist_writes_enabled: bool = False
+    mcp_http_enabled: bool = True
 
     @field_validator('cache_warm_hour')
     @classmethod

--- a/backend/app/interfaces/mcp/__init__.py
+++ b/backend/app/interfaces/mcp/__init__.py
@@ -1,5 +1,6 @@
 """Hermes-facing MCP server package for StockScreenClaude."""
 
+from .http_transport import mcp_router
 from .market_copilot import MarketCopilotService
 
-__all__ = ["MarketCopilotService"]
+__all__ = ["MarketCopilotService", "mcp_router"]

--- a/backend/app/interfaces/mcp/http_transport.py
+++ b/backend/app/interfaces/mcp/http_transport.py
@@ -7,9 +7,11 @@ same ``MarketCopilotMcpServer`` that powers the stdio transport.
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any
 
 from fastapi import APIRouter, Request, Response
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 
 from app.config import settings
@@ -25,13 +27,16 @@ mcp_router = APIRouter(tags=["mcp"])
 # Lazy singleton — created on first request so the router can be imported at
 # module level without requiring a live database connection.
 _server: MarketCopilotMcpServer | None = None
+_server_lock = threading.Lock()
 
 
 def _get_server() -> MarketCopilotMcpServer:
     global _server
     if _server is None:
-        service = MarketCopilotService(SessionLocal, settings)
-        _server = MarketCopilotMcpServer(service, transport=None)
+        with _server_lock:
+            if _server is None:
+                service = MarketCopilotService(SessionLocal, settings)
+                _server = MarketCopilotMcpServer(service, transport=None)
     return _server
 
 
@@ -56,7 +61,7 @@ async def mcp_post(request: Request) -> Response:
         )
 
     server = _get_server()
-    response = server._handle_message(body)
+    response = await run_in_threadpool(server.dispatch, body)
 
     if response is None:
         # Notification — no response required per JSON-RPC spec.

--- a/backend/app/interfaces/mcp/http_transport.py
+++ b/backend/app/interfaces/mcp/http_transport.py
@@ -48,13 +48,24 @@ async def mcp_post(request: Request) -> Response:
     instance, and returns the JSON-RPC response.
     """
     try:
-        body: dict[str, Any] = await request.json()
+        body = await request.json()
     except Exception:
         return JSONResponse(
             content={
                 "jsonrpc": "2.0",
                 "id": None,
                 "error": {"code": -32700, "message": "Parse error: invalid JSON"},
+            },
+            status_code=200,
+            media_type="application/json",
+        )
+
+    if not isinstance(body, dict):
+        return JSONResponse(
+            content={
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request: expected a JSON object, not array or scalar"},
             },
             status_code=200,
             media_type="application/json",

--- a/backend/app/interfaces/mcp/http_transport.py
+++ b/backend/app/interfaces/mcp/http_transport.py
@@ -1,0 +1,81 @@
+"""Streamable HTTP transport for the MCP server (spec 2025-03-26).
+
+Mounts as a FastAPI router at ``/mcp`` and delegates JSON-RPC dispatch to the
+same ``MarketCopilotMcpServer`` that powers the stdio transport.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse
+
+from app.config import settings
+from app.database import SessionLocal
+
+from .market_copilot import MarketCopilotService
+from .server import MarketCopilotMcpServer
+
+logger = logging.getLogger(__name__)
+
+mcp_router = APIRouter(tags=["mcp"])
+
+# Lazy singleton — created on first request so the router can be imported at
+# module level without requiring a live database connection.
+_server: MarketCopilotMcpServer | None = None
+
+
+def _get_server() -> MarketCopilotMcpServer:
+    global _server
+    if _server is None:
+        service = MarketCopilotService(SessionLocal, settings)
+        _server = MarketCopilotMcpServer(service, transport=None)
+    return _server
+
+
+@mcp_router.post("/")
+async def mcp_post(request: Request) -> Response:
+    """Handle a JSON-RPC request over HTTP (Streamable HTTP transport).
+
+    Accepts a single JSON-RPC message, dispatches via the shared server
+    instance, and returns the JSON-RPC response.
+    """
+    try:
+        body: dict[str, Any] = await request.json()
+    except Exception:
+        return JSONResponse(
+            content={
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error: invalid JSON"},
+            },
+            status_code=200,
+            media_type="application/json",
+        )
+
+    server = _get_server()
+    response = server._handle_message(body)
+
+    if response is None:
+        # Notification — no response required per JSON-RPC spec.
+        return Response(status_code=202)
+
+    return JSONResponse(content=response, media_type="application/json")
+
+
+@mcp_router.get("/")
+async def mcp_sse() -> Response:
+    """SSE keepalive endpoint (placeholder).
+
+    The Streamable HTTP spec allows GET for server-initiated events.
+    We don't push events, so this returns 405 for now.
+    """
+    return Response(status_code=405)
+
+
+@mcp_router.delete("/")
+async def mcp_session_teardown() -> Response:
+    """Session teardown (no-op for stateless server)."""
+    return Response(status_code=200)

--- a/backend/app/interfaces/mcp/market_copilot.py
+++ b/backend/app/interfaces/mcp/market_copilot.py
@@ -846,6 +846,7 @@ class MarketCopilotService:
 
         ranking_date_str = rankings[0].get("date")
         ranking_date = date.fromisoformat(ranking_date_str) if ranking_date_str else None
+        rank_change_key = f"rank_change_{args.period}"
         top_rankings = [
             {
                 "industry_group": r["industry_group"],
@@ -853,7 +854,7 @@ class MarketCopilotService:
                 "avg_rs_rating": r.get("avg_rs_rating"),
                 "num_stocks": r.get("num_stocks"),
                 "top_symbol": r.get("top_symbol"),
-                "rank_change_1w": r.get("rank_change_1w"),
+                "rank_change": r.get(rank_change_key),
             }
             for r in rankings
         ]

--- a/backend/app/interfaces/mcp/market_copilot.py
+++ b/backend/app/interfaces/mcp/market_copilot.py
@@ -864,7 +864,7 @@ class MarketCopilotService:
             f"Showing {args.period} movers ({len(movers.get('gainers', []))} gainers, {len(movers.get('losers', []))} losers).",
             facts=[
                 self._fact("ranking_date", str(ranking_date), "ibd_group_ranks"),
-                self._fact("total_groups", len(rankings), "ibd_group_ranks"),
+                self._fact("returned_groups", len(rankings), "ibd_group_ranks"),
                 self._fact("top_group", rankings[0]["industry_group"], "ibd_group_ranks", ranking_date),
             ],
             citations=[self._citation("ibd_group_ranks", "Group Rankings", f"ibd_group_ranks:{ranking_date}", ranking_date)],

--- a/backend/app/interfaces/mcp/market_copilot.py
+++ b/backend/app/interfaces/mcp/market_copilot.py
@@ -829,7 +829,7 @@ class MarketCopilotService:
         from app.services.ibd_group_rank_service import IBDGroupRankService
 
         with self._session_scope() as db:
-            service = IBDGroupRankService()
+            service = IBDGroupRankService.get_instance()
             rankings = service.get_current_rankings(db, limit=args.limit)
             movers = service.get_rank_movers(db, period=args.period, limit=min(args.limit, 10))
 
@@ -886,6 +886,7 @@ class MarketCopilotService:
                 .filter(StockUniverse.symbol == args.symbol, StockUniverse.is_active.is_(True))
                 .first()
             )
+            run = self._latest_published_run(db) if args.include_technicals else None
 
         if stock is None:
             return self._envelope(
@@ -904,32 +905,29 @@ class MarketCopilotService:
             "sector": stock.sector,
             "industry": stock.industry,
             "market_cap": stock.market_cap,
-            "exchange": getattr(stock, "exchange", None),
+            "exchange": stock.exchange,
         }
 
         technicals = None
-        if args.include_technicals:
-            with self._session_scope() as db:
-                run = self._latest_published_run(db)
-            if run is not None:
-                with self._uow_scope() as uow:
-                    row = uow.feature_store.get_by_symbol_for_run(
-                        run.id,
-                        args.symbol,
-                        include_sparklines=False,
-                        include_setup_payload=False,
-                    )
-                if row is not None:
-                    extended = getattr(row, "extended_fields", {}) or {}
-                    technicals = {
-                        "run_id": run.id,
-                        "as_of_date": run.as_of_date.isoformat(),
-                        "composite_score": row.composite_score,
-                        "overall_rating": row.rating,
-                        "rs_rating": extended.get("rs_rating"),
-                        "stage": extended.get("stage"),
-                        "current_price": row.current_price,
-                    }
+        if run is not None:
+            with self._uow_scope() as uow:
+                row = uow.feature_store.get_by_symbol_for_run(
+                    run.id,
+                    args.symbol,
+                    include_sparklines=False,
+                    include_setup_payload=False,
+                )
+            if row is not None:
+                extended = getattr(row, "extended_fields", {}) or {}
+                technicals = {
+                    "run_id": run.id,
+                    "as_of_date": run.as_of_date.isoformat(),
+                    "composite_score": row.composite_score,
+                    "overall_rating": row.rating,
+                    "rs_rating": extended.get("rs_rating"),
+                    "stage": extended.get("stage"),
+                    "current_price": row.current_price,
+                }
 
         facts = [
             self._fact("symbol", stock.symbol, "stock_universe"),
@@ -1001,8 +999,6 @@ class MarketCopilotService:
             service = DigestService()
             digest = service.get_daily_digest(db, as_of_date=args.as_of_date)
 
-        digest_data = digest.model_dump(mode="json")
-
         return self._envelope(
             f"Daily digest as of {digest.as_of_date}. "
             f"Market stance: {digest.market.stance}. "
@@ -1026,7 +1022,7 @@ class MarketCopilotService:
                     "theme_metrics": digest.freshness.latest_theme_metrics_date,
                 }.items() if v is not None},
             ),
-            digest=digest_data,
+            digest=digest.model_dump(mode="json"),
         )
 
     def _find_candidates_for_run(self, run_id: int, args: FindCandidatesArgs) -> list[dict[str, Any]]:

--- a/backend/app/interfaces/mcp/market_copilot.py
+++ b/backend/app/interfaces/mcp/market_copilot.py
@@ -26,11 +26,15 @@ from app.use_cases.feature_store.compare_runs import CompareFeatureRunsUseCase, 
 from app.use_cases.scanning.explain_stock import ExplainStockUseCase
 
 from .models import (
+    BreadthSnapshotArgs,
     CandidateFilters,
     CompareFeatureRunsArgs,
+    DailyDigestArgs,
     ExplainSymbolArgs,
     FindCandidatesArgs,
+    GroupRankingsArgs,
     MarketOverviewArgs,
+    StockLookupArgs,
     TaskStatusArgs,
     ThemeStateArgs,
     ToolCitation,
@@ -125,6 +129,30 @@ class MarketCopilotService:
                     description="Add symbols to an existing watchlist when MCP watchlist writes are explicitly enabled.",
                     args_model=WatchlistAddArgs,
                     handler=self._watchlist_add,
+                ),
+                ToolSpec(
+                    name="group_rankings",
+                    description="Get current IBD industry group rankings and biggest rank movers over a configurable period (1w, 1m, 3m, 6m).",
+                    args_model=GroupRankingsArgs,
+                    handler=self._group_rankings,
+                ),
+                ToolSpec(
+                    name="stock_lookup",
+                    description="Look up a stock by symbol and return universe info, fundamentals, and optionally RS rating and stage from the latest feature run.",
+                    args_model=StockLookupArgs,
+                    handler=self._stock_lookup,
+                ),
+                ToolSpec(
+                    name="breadth_snapshot",
+                    description="Return recent market breadth snapshots (up/down 4%+ counts and ratios) for the last N trading days.",
+                    args_model=BreadthSnapshotArgs,
+                    handler=self._breadth_snapshot,
+                ),
+                ToolSpec(
+                    name="daily_digest",
+                    description="Return the full daily digest including market stance, leaders, themes, watchlist highlights, and risk notes.",
+                    args_model=DailyDigestArgs,
+                    handler=self._daily_digest,
                 ),
             )
         }
@@ -795,6 +823,210 @@ class MarketCopilotService:
             added=added,
             skipped=skipped,
             writes_enabled=True,
+        )
+
+    def _group_rankings(self, args: GroupRankingsArgs) -> ToolEnvelope:
+        from app.services.ibd_group_rank_service import IBDGroupRankService
+
+        with self._session_scope() as db:
+            service = IBDGroupRankService()
+            rankings = service.get_current_rankings(db, limit=args.limit)
+            movers = service.get_rank_movers(db, period=args.period, limit=min(args.limit, 10))
+
+        if not rankings:
+            return self._envelope(
+                "No IBD group ranking data is available.",
+                facts=[],
+                citations=[],
+                next_actions=["Run a group ranking calculation before using group_rankings."],
+                freshness=self._freshness(),
+                rankings=[],
+                movers={"gainers": [], "losers": []},
+            )
+
+        ranking_date = rankings[0].get("date")
+        top_rankings = [
+            {
+                "industry_group": r["industry_group"],
+                "rank": r["rank"],
+                "avg_rs_rating": r.get("avg_rs_rating"),
+                "num_stocks": r.get("num_stocks"),
+                "top_symbol": r.get("top_symbol"),
+                "rank_change_1w": r.get("rank_change_1w"),
+            }
+            for r in rankings
+        ]
+
+        return self._envelope(
+            f"Top {len(top_rankings)} IBD group rankings as of {ranking_date}. "
+            f"Showing {args.period} movers ({len(movers.get('gainers', []))} gainers, {len(movers.get('losers', []))} losers).",
+            facts=[
+                self._fact("ranking_date", str(ranking_date), "ibd_group_ranks"),
+                self._fact("total_groups", len(rankings), "ibd_group_ranks"),
+                self._fact("top_group", rankings[0]["industry_group"], "ibd_group_ranks", ranking_date),
+            ],
+            citations=[self._citation("ibd_group_ranks", "Group Rankings", f"ibd_group_ranks:{ranking_date}", ranking_date)],
+            next_actions=[
+                "Use find_candidates with industry_group filter to drill into a top-ranked group.",
+                "Use explain_symbol for the top_symbol in a leading group.",
+            ],
+            freshness=self._freshness(as_of_date=ranking_date, ibd_group_ranks=str(ranking_date)),
+            rankings=top_rankings,
+            movers={
+                "period": movers.get("period", args.period),
+                "gainers": movers.get("gainers", []),
+                "losers": movers.get("losers", []),
+            },
+        )
+
+    def _stock_lookup(self, args: StockLookupArgs) -> ToolEnvelope:
+        with self._session_scope() as db:
+            stock = (
+                db.query(StockUniverse)
+                .filter(StockUniverse.symbol == args.symbol, StockUniverse.is_active.is_(True))
+                .first()
+            )
+
+        if stock is None:
+            return self._envelope(
+                f"Symbol {args.symbol!r} was not found in the active stock universe.",
+                facts=[],
+                citations=[],
+                next_actions=["Verify the ticker symbol or check if it was delisted."],
+                freshness=self._freshness(),
+                stock=None,
+                technicals=None,
+            )
+
+        stock_info = {
+            "symbol": stock.symbol,
+            "name": stock.name,
+            "sector": stock.sector,
+            "industry": stock.industry,
+            "market_cap": stock.market_cap,
+            "exchange": getattr(stock, "exchange", None),
+        }
+
+        technicals = None
+        if args.include_technicals:
+            with self._session_scope() as db:
+                run = self._latest_published_run(db)
+            if run is not None:
+                with self._uow_scope() as uow:
+                    row = uow.feature_store.get_by_symbol_for_run(
+                        run.id,
+                        args.symbol,
+                        include_sparklines=False,
+                        include_setup_payload=False,
+                    )
+                if row is not None:
+                    extended = getattr(row, "extended_fields", {}) or {}
+                    technicals = {
+                        "run_id": run.id,
+                        "as_of_date": run.as_of_date.isoformat(),
+                        "composite_score": row.composite_score,
+                        "overall_rating": row.rating,
+                        "rs_rating": extended.get("rs_rating"),
+                        "stage": extended.get("stage"),
+                        "current_price": row.current_price,
+                    }
+
+        facts = [
+            self._fact("symbol", stock.symbol, "stock_universe"),
+            self._fact("name", stock.name, "stock_universe"),
+            self._fact("sector", stock.sector, "stock_universe"),
+        ]
+        citations = [self._citation("stock_universe", stock.symbol, f"stock_universe:{stock.symbol}")]
+        if technicals:
+            facts.append(self._fact("composite_score", technicals["composite_score"], "feature_runs", technicals["as_of_date"]))
+
+        return self._envelope(
+            f"{stock.symbol} ({stock.name}) — {stock.sector} / {stock.industry}."
+            + (f" Score {technicals['composite_score']}, RS {technicals['rs_rating']}, Stage {technicals['stage']}." if technicals else ""),
+            facts=facts,
+            citations=citations,
+            next_actions=["Use explain_symbol for a detailed breakdown." if technicals else "Run a feature snapshot to get technicals."],
+            freshness=self._freshness(
+                as_of_date=technicals["as_of_date"] if technicals else None,
+                stock_universe="current",
+                **({"feature_run": technicals["as_of_date"]} if technicals else {}),
+            ),
+            stock=stock_info,
+            technicals=technicals,
+        )
+
+    def _breadth_snapshot(self, args: BreadthSnapshotArgs) -> ToolEnvelope:
+        with self._session_scope() as db:
+            rows = (
+                db.query(MarketBreadth)
+                .order_by(desc(MarketBreadth.date))
+                .limit(args.days)
+                .all()
+            )
+
+        if not rows:
+            return self._envelope(
+                "No market breadth data is available.",
+                facts=[],
+                citations=[],
+                next_actions=["Run a breadth calculation to populate breadth data."],
+                freshness=self._freshness(),
+                snapshots=[],
+            )
+
+        snapshots = [self._breadth_record(row) for row in rows]
+        latest = rows[0]
+
+        return self._envelope(
+            f"Market breadth for the last {len(snapshots)} trading days. "
+            f"Latest ({latest.date.isoformat()}): {latest.stocks_up_4pct} up 4%+, {latest.stocks_down_4pct} down 4%+, "
+            f"5-day ratio {latest.ratio_5day}.",
+            facts=[
+                self._fact("latest_date", latest.date.isoformat(), "market_breadth", latest.date),
+                self._fact("days_returned", len(snapshots), "market_breadth"),
+                self._fact("latest_ratio_5day", latest.ratio_5day, "market_breadth", latest.date),
+            ],
+            citations=[self._citation("market_breadth", "Breadth Data", f"market_breadth:{latest.date.isoformat()}", latest.date)],
+            next_actions=[
+                "Use market_overview for a fuller picture including feature runs and alerts.",
+            ],
+            freshness=self._freshness(as_of_date=latest.date, market_breadth=str(latest.date)),
+            snapshots=snapshots,
+        )
+
+    def _daily_digest(self, args: DailyDigestArgs) -> ToolEnvelope:
+        from app.services.digest_service import DigestService
+
+        with self._session_scope() as db:
+            service = DigestService()
+            digest = service.get_daily_digest(db, as_of_date=args.as_of_date)
+
+        digest_data = digest.model_dump(mode="json")
+
+        return self._envelope(
+            f"Daily digest as of {digest.as_of_date}. "
+            f"Market stance: {digest.market.stance}. "
+            f"{len(digest.leaders)} leaders, {len(digest.risks)} risk notes.",
+            facts=[
+                self._fact("as_of_date", digest.as_of_date, "digest"),
+                self._fact("market_stance", digest.market.stance, "digest", digest.as_of_date),
+                self._fact("leader_count", len(digest.leaders), "digest", digest.as_of_date),
+            ],
+            citations=[self._citation("digest", "Daily Digest", f"digest:{digest.as_of_date}", digest.as_of_date)],
+            next_actions=[
+                "Use find_candidates to drill into the leaders list.",
+                "Use theme_state for deeper theme analysis.",
+            ],
+            freshness=self._freshness(
+                as_of_date=digest.as_of_date,
+                digest=str(digest.as_of_date),
+                **{k: v for k, v in {
+                    "feature_run": digest.freshness.latest_feature_as_of_date,
+                    "market_breadth": digest.freshness.latest_breadth_date,
+                    "theme_metrics": digest.freshness.latest_theme_metrics_date,
+                }.items() if v is not None},
+            ),
+            digest=digest_data,
         )
 
     def _find_candidates_for_run(self, run_id: int, args: FindCandidatesArgs) -> list[dict[str, Any]]:

--- a/backend/app/interfaces/mcp/market_copilot.py
+++ b/backend/app/interfaces/mcp/market_copilot.py
@@ -844,7 +844,8 @@ class MarketCopilotService:
                 movers={"gainers": [], "losers": []},
             )
 
-        ranking_date = rankings[0].get("date")
+        ranking_date_str = rankings[0].get("date")
+        ranking_date = date.fromisoformat(ranking_date_str) if ranking_date_str else None
         top_rankings = [
             {
                 "industry_group": r["industry_group"],
@@ -870,7 +871,7 @@ class MarketCopilotService:
                 "Use find_candidates with industry_group filter to drill into a top-ranked group.",
                 "Use explain_symbol for the top_symbol in a leading group.",
             ],
-            freshness=self._freshness(as_of_date=ranking_date, ibd_group_ranks=str(ranking_date)),
+            freshness=self._freshness(as_of_date=ranking_date, ibd_group_ranks=ranking_date_str or ""),
             rankings=top_rankings,
             movers={
                 "period": movers.get("period", args.period),
@@ -929,6 +930,7 @@ class MarketCopilotService:
                     "current_price": row.current_price,
                 }
 
+        run_date = run.as_of_date if run is not None else None
         facts = [
             self._fact("symbol", stock.symbol, "stock_universe"),
             self._fact("name", stock.name, "stock_universe"),
@@ -936,7 +938,7 @@ class MarketCopilotService:
         ]
         citations = [self._citation("stock_universe", stock.symbol, f"stock_universe:{stock.symbol}")]
         if technicals:
-            facts.append(self._fact("composite_score", technicals["composite_score"], "feature_runs", technicals["as_of_date"]))
+            facts.append(self._fact("composite_score", technicals["composite_score"], "feature_runs", run_date))
 
         return self._envelope(
             f"{stock.symbol} ({stock.name}) — {stock.sector} / {stock.industry}."
@@ -945,9 +947,9 @@ class MarketCopilotService:
             citations=citations,
             next_actions=["Use explain_symbol for a detailed breakdown." if technicals else "Run a feature snapshot to get technicals."],
             freshness=self._freshness(
-                as_of_date=technicals["as_of_date"] if technicals else None,
+                as_of_date=run_date,
                 stock_universe="current",
-                **({"feature_run": technicals["as_of_date"]} if technicals else {}),
+                **({"feature_run": run_date.isoformat()} if run_date else {}),
             ),
             stock=stock_info,
             technicals=technicals,
@@ -999,23 +1001,25 @@ class MarketCopilotService:
             service = DigestService()
             digest = service.get_daily_digest(db, as_of_date=args.as_of_date)
 
+        digest_date = date.fromisoformat(digest.as_of_date) if digest.as_of_date else None
+
         return self._envelope(
             f"Daily digest as of {digest.as_of_date}. "
             f"Market stance: {digest.market.stance}. "
             f"{len(digest.leaders)} leaders, {len(digest.risks)} risk notes.",
             facts=[
                 self._fact("as_of_date", digest.as_of_date, "digest"),
-                self._fact("market_stance", digest.market.stance, "digest", digest.as_of_date),
-                self._fact("leader_count", len(digest.leaders), "digest", digest.as_of_date),
+                self._fact("market_stance", digest.market.stance, "digest", digest_date),
+                self._fact("leader_count", len(digest.leaders), "digest", digest_date),
             ],
-            citations=[self._citation("digest", "Daily Digest", f"digest:{digest.as_of_date}", digest.as_of_date)],
+            citations=[self._citation("digest", "Daily Digest", f"digest:{digest.as_of_date}", digest_date)],
             next_actions=[
                 "Use find_candidates to drill into the leaders list.",
                 "Use theme_state for deeper theme analysis.",
             ],
             freshness=self._freshness(
-                as_of_date=digest.as_of_date,
-                digest=str(digest.as_of_date),
+                as_of_date=digest_date,
+                digest=digest.as_of_date or "",
                 **{k: v for k, v in {
                     "feature_run": digest.freshness.latest_feature_as_of_date,
                     "market_breadth": digest.freshness.latest_breadth_date,

--- a/backend/app/interfaces/mcp/models.py
+++ b/backend/app/interfaces/mcp/models.py
@@ -168,7 +168,10 @@ class StockLookupArgs(BaseModel):
     @field_validator("symbol")
     @classmethod
     def normalize_symbol(cls, value: str) -> str:
-        return value.strip().upper()
+        normalized = value.strip().upper()
+        if not normalized:
+            raise ValueError("symbol must contain at least one non-whitespace character")
+        return normalized
 
 
 class BreadthSnapshotArgs(BaseModel):

--- a/backend/app/interfaces/mcp/models.py
+++ b/backend/app/interfaces/mcp/models.py
@@ -150,3 +150,34 @@ class WatchlistAddArgs(BaseModel):
         if not normalized:
             raise ValueError("symbols must include at least one non-empty ticker")
         return normalized
+
+
+class GroupRankingsArgs(BaseModel):
+    """Arguments for group_rankings."""
+
+    limit: int = Field(20, ge=1, le=197)
+    period: Literal["1w", "1m", "3m", "6m"] = "1w"
+
+
+class StockLookupArgs(BaseModel):
+    """Arguments for stock_lookup."""
+
+    symbol: str = Field(..., min_length=1, max_length=10)
+    include_technicals: bool = False
+
+    @field_validator("symbol")
+    @classmethod
+    def normalize_symbol(cls, value: str) -> str:
+        return value.strip().upper()
+
+
+class BreadthSnapshotArgs(BaseModel):
+    """Arguments for breadth_snapshot."""
+
+    days: int = Field(5, ge=1, le=30)
+
+
+class DailyDigestArgs(BaseModel):
+    """Arguments for daily_digest."""
+
+    as_of_date: date | None = None

--- a/backend/app/interfaces/mcp/server.py
+++ b/backend/app/interfaces/mcp/server.py
@@ -93,6 +93,10 @@ class MarketCopilotMcpServer:
             if response is not None:
                 self._transport.write_message(response)
 
+    def dispatch(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        """Dispatch a JSON-RPC message and return the response (or None for notifications)."""
+        return self._handle_message(message)
+
     def _handle_message(self, message: dict[str, Any]) -> dict[str, Any] | None:
         method = message.get("method")
         request_id = message.get("id")

--- a/backend/app/interfaces/mcp/server.py
+++ b/backend/app/interfaces/mcp/server.py
@@ -95,7 +95,12 @@ class MarketCopilotMcpServer:
 
     def dispatch(self, message: dict[str, Any]) -> dict[str, Any] | None:
         """Dispatch a JSON-RPC message and return the response (or None for notifications)."""
-        return self._handle_message(message)
+        if not isinstance(message, dict):
+            return self._error_response(None, -32600, "Invalid Request")
+        try:
+            return self._handle_message(message)
+        except Exception:
+            return self._error_response(message.get("id"), -32603, "Internal error")
 
     def _handle_message(self, message: dict[str, Any]) -> dict[str, Any] | None:
         method = message.get("method")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -496,8 +496,16 @@ app.include_router(api_router, prefix="/api/v1")
 
 # Mount MCP Streamable HTTP transport (JSON-RPC over HTTP)
 if settings.mcp_http_enabled:
+    from fastapi import Depends
+
     from .interfaces.mcp import mcp_router
-    app.include_router(mcp_router, prefix="/mcp")
+    from .services.server_auth import require_server_session
+
+    app.include_router(
+        mcp_router,
+        prefix="/mcp",
+        dependencies=[Depends(require_server_session)],
+    )
 
 
 @app.get("/{full_path:path}", include_in_schema=False)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -402,6 +402,7 @@ def _is_reserved_frontend_path(path: str) -> bool:
         "livez",
         "readyz",
         "health",
+        "mcp",
     )
     return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in reserved_prefixes)
 
@@ -492,6 +493,11 @@ async def health_check():
 # Include API routers
 from .api.v1.router import router as api_router
 app.include_router(api_router, prefix="/api/v1")
+
+# Mount MCP Streamable HTTP transport (JSON-RPC over HTTP)
+if settings.mcp_http_enabled:
+    from .interfaces.mcp import mcp_router
+    app.include_router(mcp_router, prefix="/mcp")
 
 
 @app.get("/{full_path:path}", include_in_schema=False)

--- a/backend/tests/helpers/mcp_fixture.py
+++ b/backend/tests/helpers/mcp_fixture.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer, StockFeatureDaily
+from app.models.industry import IBDGroupRank
 from app.models.market_breadth import MarketBreadth
 from app.models.stock_universe import StockUniverse
 from app.models.task_execution import TaskExecutionHistory
@@ -28,6 +29,7 @@ _TABLES = (
     ThemeAlert,
     MarketBreadth,
     TaskExecutionHistory,
+    IBDGroupRank,
 )
 
 
@@ -216,15 +218,75 @@ def seed_market_copilot_data(session_factory: sessionmaker) -> None:
             )
         )
 
-        session.add(
-            MarketBreadth(
-                date=date(2026, 3, 29),
-                stocks_up_4pct=128,
-                stocks_down_4pct=34,
-                ratio_5day=1.82,
-                ratio_10day=1.54,
-                total_stocks_scanned=4081,
-            )
+        session.add_all(
+            [
+                MarketBreadth(
+                    date=date(2026, 3, 29),
+                    stocks_up_4pct=128,
+                    stocks_down_4pct=34,
+                    ratio_5day=1.82,
+                    ratio_10day=1.54,
+                    total_stocks_scanned=4081,
+                ),
+                MarketBreadth(
+                    date=date(2026, 3, 28),
+                    stocks_up_4pct=112,
+                    stocks_down_4pct=41,
+                    ratio_5day=1.70,
+                    ratio_10day=1.48,
+                    total_stocks_scanned=4075,
+                ),
+                MarketBreadth(
+                    date=date(2026, 3, 27),
+                    stocks_up_4pct=98,
+                    stocks_down_4pct=52,
+                    ratio_5day=1.55,
+                    ratio_10day=1.42,
+                    total_stocks_scanned=4070,
+                ),
+            ]
+        )
+
+        # IBD Group Rankings (2 groups, 2 dates for mover calculation)
+        session.add_all(
+            [
+                IBDGroupRank(
+                    industry_group="Semiconductors",
+                    date=date(2026, 3, 29),
+                    rank=1,
+                    avg_rs_rating=91.0,
+                    num_stocks=25,
+                    top_symbol="NVDA",
+                    top_rs_rating=95.0,
+                ),
+                IBDGroupRank(
+                    industry_group="Cybersecurity",
+                    date=date(2026, 3, 29),
+                    rank=2,
+                    avg_rs_rating=87.0,
+                    num_stocks=15,
+                    top_symbol="PANW",
+                    top_rs_rating=91.0,
+                ),
+                IBDGroupRank(
+                    industry_group="Semiconductors",
+                    date=date(2026, 3, 22),
+                    rank=3,
+                    avg_rs_rating=85.0,
+                    num_stocks=25,
+                    top_symbol="NVDA",
+                    top_rs_rating=92.0,
+                ),
+                IBDGroupRank(
+                    industry_group="Cybersecurity",
+                    date=date(2026, 3, 22),
+                    rank=5,
+                    avg_rs_rating=80.0,
+                    num_stocks=15,
+                    top_symbol="PANW",
+                    top_rs_rating=87.0,
+                ),
+            ]
         )
         session.add_all(
             [

--- a/backend/tests/integration/test_mcp_server_integration.py
+++ b/backend/tests/integration/test_mcp_server_integration.py
@@ -102,36 +102,39 @@ class TestMcpHttpTransport:
 
     @pytest_asyncio.fixture()
     async def client(self, tmp_path):
-        """Create an httpx client backed by the FastAPI app with seeded test data."""
+        """Create an httpx client with an isolated FastAPI app and seeded test data."""
+        from types import SimpleNamespace
+
+        from fastapi import FastAPI
+
+        from app.interfaces.mcp.http_transport import mcp_router
+        from app.interfaces.mcp.market_copilot import MarketCopilotService
+        from app.interfaces.mcp.server import MarketCopilotMcpServer
+        import app.interfaces.mcp.http_transport as http_mod
+
         database_path = tmp_path / "mcp-http.sqlite3"
         database_url = f"sqlite:///{database_path}"
 
         session_factory, test_engine = create_mcp_test_session_factory(database_url)
         seed_market_copilot_data(session_factory)
 
-        # Patch SessionLocal and settings before importing the http_transport module
-        # so the lazy singleton picks up the test database.
-        import app.interfaces.mcp.http_transport as http_mod
-
-        from app.interfaces.mcp.market_copilot import MarketCopilotService
-        from app.interfaces.mcp.server import MarketCopilotMcpServer
-        from types import SimpleNamespace
-
         test_settings = SimpleNamespace(
             mcp_server_name="test-mcp-http",
             mcp_watchlist_writes_enabled=False,
-            mcp_http_enabled=True,
         )
         test_service = MarketCopilotService(session_factory, test_settings)
         test_server = MarketCopilotMcpServer(test_service, transport=None)
 
-        # Override the lazy singleton
+        # Override the lazy singleton so the router uses our test server
         original_server = http_mod._server
         http_mod._server = test_server
 
-        from app.main import app
+        # Build an isolated app with only the MCP router — avoids dependency
+        # on app.main's import-time MCP_HTTP_ENABLED gate.
+        test_app = FastAPI()
+        test_app.include_router(mcp_router, prefix="/mcp")
 
-        transport = httpx.ASGITransport(app=app)
+        transport = httpx.ASGITransport(app=test_app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             yield client
 
@@ -207,6 +210,12 @@ class TestMcpHttpTransport:
         )
         body = resp.json()
         assert body["error"]["code"] == -32700
+
+    async def test_non_dict_body_returns_invalid_request(self, client):
+        resp = await client.post("/mcp/", json=[1, 2, 3])
+        body = resp.json()
+        assert body["error"]["code"] == -32600
+        assert "not array" in body["error"]["message"]
 
     async def test_delete_returns_200(self, client):
         resp = await client.delete("/mcp/")

--- a/backend/tests/integration/test_mcp_server_integration.py
+++ b/backend/tests/integration/test_mcp_server_integration.py
@@ -6,8 +6,6 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
-
 import httpx
 import pytest
 import pytest_asyncio

--- a/backend/tests/integration/test_mcp_server_integration.py
+++ b/backend/tests/integration/test_mcp_server_integration.py
@@ -1,4 +1,4 @@
-"""Integration test for the stdio MCP server transport."""
+"""Integration tests for the stdio and HTTP MCP server transports."""
 
 from __future__ import annotations
 
@@ -6,6 +6,11 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+import pytest_asyncio
 
 from tests.helpers.mcp_fixture import create_mcp_test_session_factory, seed_market_copilot_data
 from tests.helpers.mcp_stdio import read_mcp_message, write_mcp_message
@@ -91,3 +96,124 @@ def test_mcp_server_lists_tools_and_serves_market_overview(tmp_path):
     finally:
         process.terminate()
         process.wait(timeout=5)
+
+
+@pytest.mark.asyncio
+class TestMcpHttpTransport:
+    """Integration tests for the Streamable HTTP MCP transport."""
+
+    @pytest_asyncio.fixture()
+    async def client(self, tmp_path):
+        """Create an httpx client backed by the FastAPI app with seeded test data."""
+        database_path = tmp_path / "mcp-http.sqlite3"
+        database_url = f"sqlite:///{database_path}"
+
+        session_factory, test_engine = create_mcp_test_session_factory(database_url)
+        seed_market_copilot_data(session_factory)
+
+        # Patch SessionLocal and settings before importing the http_transport module
+        # so the lazy singleton picks up the test database.
+        import app.interfaces.mcp.http_transport as http_mod
+
+        from app.interfaces.mcp.market_copilot import MarketCopilotService
+        from app.interfaces.mcp.server import MarketCopilotMcpServer
+        from types import SimpleNamespace
+
+        test_settings = SimpleNamespace(
+            mcp_server_name="test-mcp-http",
+            mcp_watchlist_writes_enabled=False,
+            mcp_http_enabled=True,
+        )
+        test_service = MarketCopilotService(session_factory, test_settings)
+        test_server = MarketCopilotMcpServer(test_service, transport=None)
+
+        # Override the lazy singleton
+        original_server = http_mod._server
+        http_mod._server = test_server
+
+        from app.main import app
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+
+        http_mod._server = original_server
+
+    async def test_initialize_returns_capabilities(self, client):
+        resp = await client.post(
+            "/mcp/",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pytest-http", "version": "1.0"},
+                },
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["result"]["capabilities"]["tools"]["listChanged"] is False
+        assert "name" in body["result"]["serverInfo"]
+
+    async def test_tools_list_returns_12_tools(self, client):
+        resp = await client.post(
+            "/mcp/",
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {},
+            },
+        )
+        body = resp.json()
+        tool_names = {t["name"] for t in body["result"]["tools"]}
+        assert len(tool_names) == 12
+        assert "group_rankings" in tool_names
+        assert "stock_lookup" in tool_names
+        assert "breadth_snapshot" in tool_names
+        assert "daily_digest" in tool_names
+
+    async def test_tool_call_market_overview(self, client):
+        resp = await client.post(
+            "/mcp/",
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "market_overview", "arguments": {}},
+            },
+        )
+        body = resp.json()
+        structured = body["result"]["structuredContent"]
+        assert "Published feature run 2" in structured["summary"]
+
+    async def test_notification_returns_202(self, client):
+        resp = await client.post(
+            "/mcp/",
+            json={
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            },
+        )
+        assert resp.status_code == 202
+
+    async def test_invalid_json_returns_parse_error(self, client):
+        resp = await client.post(
+            "/mcp/",
+            content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        body = resp.json()
+        assert body["error"]["code"] == -32700
+
+    async def test_delete_returns_200(self, client):
+        resp = await client.delete("/mcp/")
+        assert resp.status_code == 200
+
+    async def test_get_returns_405(self, client):
+        resp = await client.get("/mcp/")
+        assert resp.status_code == 405

--- a/backend/tests/integration/test_mcp_server_integration.py
+++ b/backend/tests/integration/test_mcp_server_integration.py
@@ -129,16 +129,18 @@ class TestMcpHttpTransport:
         original_server = http_mod._server
         http_mod._server = test_server
 
-        # Build an isolated app with only the MCP router — avoids dependency
-        # on app.main's import-time MCP_HTTP_ENABLED gate.
-        test_app = FastAPI()
-        test_app.include_router(mcp_router, prefix="/mcp")
+        try:
+            # Build an isolated app with only the MCP router — avoids dependency
+            # on app.main's import-time MCP_HTTP_ENABLED gate.
+            test_app = FastAPI()
+            test_app.include_router(mcp_router, prefix="/mcp")
 
-        transport = httpx.ASGITransport(app=test_app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-            yield client
-
-        http_mod._server = original_server
+            transport = httpx.ASGITransport(app=test_app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                yield client
+        finally:
+            http_mod._server = original_server
+            test_engine.dispose()
 
     async def test_initialize_returns_capabilities(self, client):
         resp = await client.post(

--- a/backend/tests/unit/test_mcp_market_copilot.py
+++ b/backend/tests/unit/test_mcp_market_copilot.py
@@ -44,6 +44,10 @@ def test_lists_expected_tools(read_only_service):
         "theme_state",
         "task_status",
         "watchlist_add",
+        "group_rankings",
+        "stock_lookup",
+        "breadth_snapshot",
+        "daily_digest",
     }
 
 
@@ -177,6 +181,70 @@ def test_watchlist_add_writes_when_enabled(session_factory):
     snapshot = _tool_payload(service.call_tool("watchlist_snapshot", {"watchlist": "Leaders"}))
     symbols = [row["symbol"] for row in snapshot["items"]]
     assert symbols == ["NVDA", "MSFT"]
+
+
+def test_stock_lookup_returns_universe_info(read_only_service):
+    payload = _tool_payload(read_only_service.call_tool("stock_lookup", {"symbol": "nvda"}))
+
+    assert payload["stock"]["symbol"] == "NVDA"
+    assert payload["stock"]["name"] == "NVIDIA Corporation"
+    assert payload["stock"]["sector"] == "Information Technology"
+    assert payload["technicals"] is None
+
+
+def test_stock_lookup_with_technicals(read_only_service):
+    payload = _tool_payload(
+        read_only_service.call_tool(
+            "stock_lookup",
+            {"symbol": "NVDA", "include_technicals": True},
+        )
+    )
+
+    assert payload["stock"]["symbol"] == "NVDA"
+    assert payload["technicals"] is not None
+    assert payload["technicals"]["composite_score"] == 92.0
+    assert payload["technicals"]["rs_rating"] == 95
+
+
+def test_stock_lookup_unknown_symbol(read_only_service):
+    payload = _tool_payload(read_only_service.call_tool("stock_lookup", {"symbol": "ZZZZ"}))
+
+    assert payload["stock"] is None
+    assert "not found" in payload["summary"]
+
+
+def test_breadth_snapshot_returns_multiple_days(read_only_service):
+    payload = _tool_payload(read_only_service.call_tool("breadth_snapshot", {"days": 5}))
+
+    assert len(payload["snapshots"]) == 3  # only 3 seeded
+    assert payload["snapshots"][0]["date"] == "2026-03-29"
+    assert payload["snapshots"][1]["date"] == "2026-03-28"
+
+
+def test_breadth_snapshot_default_days(read_only_service):
+    payload = _tool_payload(read_only_service.call_tool("breadth_snapshot", {}))
+
+    assert len(payload["snapshots"]) >= 1
+    assert payload["facts"][0]["key"] == "latest_date"
+
+
+def test_group_rankings_returns_rankings(read_only_service):
+    payload = _tool_payload(
+        read_only_service.call_tool("group_rankings", {"limit": 10, "period": "1w"})
+    )
+
+    assert len(payload["rankings"]) == 2
+    assert payload["rankings"][0]["industry_group"] == "Semiconductors"
+    assert payload["rankings"][0]["rank"] == 1
+
+
+def test_daily_digest_returns_envelope(read_only_service):
+    payload = _tool_payload(read_only_service.call_tool("daily_digest", {}))
+
+    assert "digest" in payload
+    assert payload["digest"]["as_of_date"] is not None
+    assert payload["digest"]["market"]["stance"] is not None
+    assert "Daily digest" in payload["summary"]
 
 
 def test_invalid_sort_field_returns_tool_error(read_only_service):


### PR DESCRIPTION
## Summary

- **4 new MCP tools**: `group_rankings`, `stock_lookup`, `breadth_snapshot`, `daily_digest` — expanding coverage from 8 to 12 tools
- **Streamable HTTP transport**: MCP server now reachable at `POST /mcp` (JSON-RPC over HTTP) alongside existing stdio, gated by `MCP_HTTP_ENABLED` (default: true)
- **Quality hardening**: consolidated DB sessions, thread-safe lazy singleton with `run_in_threadpool`, public `dispatch()` API on `MarketCopilotMcpServer`, fixed silent date-type bugs in `_fact`/`_freshness` helpers

## New tools

| Tool | Description | Service/Source |
|------|-------------|----------------|
| `group_rankings` | IBD industry group rankings + rank movers | `IBDGroupRankService` |
| `stock_lookup` | Stock universe info + optional technicals | `StockUniverse` + feature store |
| `breadth_snapshot` | N-day market breadth history | `MarketBreadth` |
| `daily_digest` | Full daily digest (stance, leaders, themes, risks) | `DigestService` |

## HTTP transport

- `POST /mcp/` — JSON-RPC request/response
- `GET /mcp/` — 405 (SSE placeholder)
- `DELETE /mcp/` — session teardown (no-op)
- Sync DB work offloaded via `run_in_threadpool` to avoid blocking the event loop
- Lazy singleton with double-checked locking (`threading.Lock`)

## Test plan

- [x] 20 unit tests passing (`test_mcp_market_copilot.py`) — tool count, all 4 new handlers, edge cases
- [x] 8 integration tests passing (`test_mcp_server_integration.py`) — stdio + 7 HTTP transport tests
- [x] Full unit suite (374/375 pass, 1 pre-existing flaky test unrelated)
- [ ] Manual smoke test: `curl -X POST http://localhost:8000/mcp/ -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Streamable HTTP MCP transport (can be enabled/disabled).
  * Four new MCP tools: group rankings, stock lookup, market breadth snapshot, and daily digest.
  * Docs updated: MCP capabilities now list 12 tools and mention stdio + Streamable HTTP transports.

* **Chores**
  * Expanded test coverage for the HTTP transport and the new MCP tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->