### PR TITLE
fix(backend): make legacy verification queries postgres-safe

### DIFF
--- a/backend/app/db_migrations/theme_cluster_identity_migration.py
+++ b/backend/app/db_migrations/theme_cluster_identity_migration.py
@@ -111,7 +111,7 @@ def verify_theme_cluster_identity_schema(engine) -> dict[str, Any]:
                       SELECT pipeline, canonical_key, COUNT(*) c
                       FROM theme_clusters
                       GROUP BY pipeline, canonical_key
-                      HAVING c > 1
+                      HAVING COUNT(*) > 1
                     ) d
                     """
                 )

--- a/backend/app/db_migrations/theme_pipeline_state_migration.py
+++ b/backend/app/db_migrations/theme_pipeline_state_migration.py
@@ -127,7 +127,7 @@ def verify_theme_pipeline_state_schema(engine) -> dict[str, Any]:
                       SELECT content_item_id, pipeline, COUNT(*) c
                       FROM content_item_pipeline_state
                       GROUP BY content_item_id, pipeline
-                      HAVING c > 1
+                      HAVING COUNT(*) > 1
                     ) d
                     """
                 )

--- a/backend/tests/unit/test_legacy_runtime_migrations.py
+++ b/backend/tests/unit/test_legacy_runtime_migrations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from sqlalchemy import create_engine, text
 
+from app.db_migrations.theme_cluster_identity_migration import verify_theme_cluster_identity_schema
+from app.db_migrations.theme_pipeline_state_migration import verify_theme_pipeline_state_schema
 from app.db_migrations.universe_migration import _ensure_indexes, migrate_scan_universe_schema_and_backfill
 from app.infra.db.legacy_runtime_migrations import (
     _THEME_MERGE_SAFETY_REQUIRED_COLUMNS,
@@ -207,4 +209,131 @@ def test_verify_theme_lifecycle_schema_accepts_equivalent_index_shapes():
     assert verification["ok"] is True
     assert verification["theme_clusters"]["missing_indexes"] == []
     assert verification["theme_lifecycle_transitions"]["missing_indexes"] == []
+    engine.dispose()
+
+
+def test_verify_theme_pipeline_state_schema_counts_duplicate_rows():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE content_item_pipeline_state (
+                    id INTEGER PRIMARY KEY,
+                    content_item_id INTEGER NOT NULL,
+                    pipeline TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    attempt_count INTEGER NOT NULL DEFAULT 0,
+                    error_code TEXT,
+                    error_message TEXT,
+                    last_attempt_at TEXT,
+                    processed_at TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX idx_cips_pipeline_status_last_attempt
+                ON content_item_pipeline_state(pipeline, status, last_attempt_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX idx_cips_pipeline_status_created
+                ON content_item_pipeline_state(pipeline, status, created_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX idx_cips_content_item_pipeline_status
+                ON content_item_pipeline_state(content_item_id, pipeline, status)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX idx_cips_error_code
+                ON content_item_pipeline_state(error_code)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE INDEX idx_cips_updated_at
+                ON content_item_pipeline_state(updated_at)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO content_item_pipeline_state
+                    (id, content_item_id, pipeline, status, attempt_count, created_at, updated_at)
+                VALUES
+                    (1, 42, 'technical', 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                    (2, 42, 'fundamental', 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                    (3, 42, 'fundamental', 'pending', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """
+            )
+        )
+
+    verification = verify_theme_pipeline_state_schema(engine)
+
+    assert verification["duplicate_rows"] == 1
+    engine.dispose()
+
+
+def test_verify_theme_cluster_identity_schema_counts_duplicate_pipeline_keys():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE theme_clusters (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    canonical_key TEXT NOT NULL,
+                    display_name TEXT NOT NULL,
+                    aliases TEXT,
+                    description TEXT,
+                    pipeline TEXT NOT NULL,
+                    category TEXT,
+                    is_emerging INTEGER,
+                    first_seen_at TEXT,
+                    last_seen_at TEXT,
+                    discovery_source TEXT,
+                    is_active INTEGER,
+                    is_validated INTEGER,
+                    created_at TEXT,
+                    updated_at TEXT
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO theme_clusters
+                    (id, name, canonical_key, display_name, pipeline, created_at, updated_at)
+                VALUES
+                    (1, 'AI Infra', 'ai-infra', 'AI Infra', 'technical', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                    (2, 'AI Infra 2', 'ai-infra', 'AI Infra', 'fundamental', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                    (3, 'AI Infra 3', 'ai-infra', 'AI Infra', 'fundamental', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """
+            )
+        )
+
+    verification = verify_theme_cluster_identity_schema(engine)
+
+    assert verification["duplicate_pipeline_keys"] == 1
     engine.dispose()


### PR DESCRIPTION
## Summary
- make legacy theme migration verification queries portable to PostgreSQL by avoiding `HAVING` alias references
- cover the duplicate-detection verification paths in legacy runtime migration unit tests
- unblock backend startup during legacy schema reconciliation on Postgres deployments

## Testing
- `DATABASE_URL=postgresql://user:pass@localhost/test backend/venv/bin/python -m pytest backend/tests/unit/test_legacy_runtime_migrations.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated duplicate-detection logic in database migrations to use equivalent SQL syntax while maintaining the same verification behavior.

* **Tests**
  * Added new unit tests to verify schema integrity checks for theme pipeline state and cluster identity validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->