### PR TITLE
refactor(backend): migrate legacy root scripts to runtime session factory

### DIFF
--- a/backend/app/db_migrations/theme_taxonomy_migration.py
+++ b/backend/app/db_migrations/theme_taxonomy_migration.py
@@ -56,7 +56,8 @@ def migrate_theme_taxonomy(engine) -> dict[str, Any]:
                         WHEN is_l1 = {true_literal} THEN 1
                         ELSE 2
                     END
-                    WHERE taxonomy_level IS NULL
+                    WHERE (is_l1 = {true_literal} AND taxonomy_level != 1)
+                       OR (is_l1 != {true_literal} AND taxonomy_level != 2)
                     """
                 )
             )

--- a/backend/app/db_migrations/theme_taxonomy_migration.py
+++ b/backend/app/db_migrations/theme_taxonomy_migration.py
@@ -12,7 +12,8 @@ from ..infra.db.portability import column_names, dialect_name, index_names
 logger = logging.getLogger(__name__)
 
 THEME_TABLE = "theme_clusters"
-PARENT_CLUSTER_INDEX = "idx_theme_clusters_parent_cluster_id"
+PARENT_CLUSTER_INDEX = "ix_theme_clusters_parent_cluster_id"
+LEGACY_PARENT_CLUSTER_INDEX = "idx_theme_clusters_parent_cluster_id"
 IS_L1_INDEX = "idx_theme_clusters_is_l1"
 
 
@@ -47,8 +48,9 @@ def migrate_theme_taxonomy(engine) -> dict[str, Any]:
             if column in columns:
                 continue
             try:
-                conn.execute(text(statement))
-                stats["columns_added"].append(column)
+                with conn.begin_nested():
+                    conn.execute(text(statement))
+                    stats["columns_added"].append(column)
             except SQLAlchemyError:
                 # Another process may have applied the same ALTER between check and execute.
                 if column not in column_names(conn, THEME_TABLE):
@@ -63,14 +65,24 @@ def migrate_theme_taxonomy(engine) -> dict[str, Any]:
                         WHEN COALESCE(is_l1, {false_literal}) = {true_literal} THEN 1
                         ELSE 2
                     END
-                    WHERE (COALESCE(is_l1, {false_literal}) = {true_literal} AND taxonomy_level != 1)
-                       OR (COALESCE(is_l1, {false_literal}) != {true_literal} AND taxonomy_level != 2)
+                    WHERE (
+                        COALESCE(is_l1, {false_literal}) = {true_literal}
+                        AND (taxonomy_level IS NULL OR taxonomy_level != 1)
+                    )
+                    OR (
+                        COALESCE(is_l1, {false_literal}) != {true_literal}
+                        AND (taxonomy_level IS NULL OR taxonomy_level != 2)
+                    )
                     """
                 )
             )
 
         existing_indexes = index_names(conn, THEME_TABLE)
-        if PARENT_CLUSTER_INDEX not in existing_indexes:
+        has_parent_cluster_index = (
+            PARENT_CLUSTER_INDEX in existing_indexes
+            or LEGACY_PARENT_CLUSTER_INDEX in existing_indexes
+        )
+        if not has_parent_cluster_index:
             conn.execute(
                 text(
                     f"""

--- a/backend/app/db_migrations/theme_taxonomy_migration.py
+++ b/backend/app/db_migrations/theme_taxonomy_migration.py
@@ -1,0 +1,88 @@
+"""Idempotent migration for theme taxonomy schema on theme_clusters."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import text
+
+from ..infra.db.portability import column_names, dialect_name, index_names
+
+logger = logging.getLogger(__name__)
+
+THEME_TABLE = "theme_clusters"
+PARENT_CLUSTER_INDEX = "idx_theme_clusters_parent_cluster_id"
+IS_L1_INDEX = "idx_theme_clusters_is_l1"
+
+
+def migrate_theme_taxonomy(engine) -> dict[str, Any]:
+    """Ensure L1/L2 taxonomy columns exist on ``theme_clusters``."""
+    stats: dict[str, Any] = {
+        "columns_added": [],
+        "indexes_ensured": [],
+    }
+
+    with engine.connect() as conn:
+        columns = column_names(conn, THEME_TABLE)
+        if not columns:
+            logger.warning("Table %s not found; skipping taxonomy migration", THEME_TABLE)
+            return stats
+
+        is_postgres = dialect_name(conn) == "postgresql"
+        timestamp_type = "TIMESTAMP WITH TIME ZONE" if is_postgres else "DATETIME"
+        true_literal = "TRUE" if is_postgres else "1"
+
+        add_statements = {
+            "parent_cluster_id": f"ALTER TABLE {THEME_TABLE} ADD COLUMN parent_cluster_id INTEGER",
+            "is_l1": f"ALTER TABLE {THEME_TABLE} ADD COLUMN is_l1 BOOLEAN NOT NULL DEFAULT FALSE",
+            "taxonomy_level": f"ALTER TABLE {THEME_TABLE} ADD COLUMN taxonomy_level INTEGER NOT NULL DEFAULT 2",
+            "l1_assignment_method": f"ALTER TABLE {THEME_TABLE} ADD COLUMN l1_assignment_method VARCHAR(20)",
+            "l1_assignment_confidence": f"ALTER TABLE {THEME_TABLE} ADD COLUMN l1_assignment_confidence FLOAT",
+            "l1_assigned_at": f"ALTER TABLE {THEME_TABLE} ADD COLUMN l1_assigned_at {timestamp_type}",
+        }
+
+        for column, statement in add_statements.items():
+            if column in columns:
+                continue
+            conn.execute(text(statement))
+            stats["columns_added"].append(column)
+
+        if "taxonomy_level" in column_names(conn, THEME_TABLE):
+            conn.execute(
+                text(
+                    f"""
+                    UPDATE {THEME_TABLE}
+                    SET taxonomy_level = CASE
+                        WHEN is_l1 = {true_literal} THEN 1
+                        ELSE 2
+                    END
+                    WHERE taxonomy_level IS NULL
+                    """
+                )
+            )
+
+        existing_indexes = index_names(conn, THEME_TABLE)
+        if PARENT_CLUSTER_INDEX not in existing_indexes:
+            conn.execute(
+                text(
+                    f"""
+                    CREATE INDEX IF NOT EXISTS {PARENT_CLUSTER_INDEX}
+                    ON {THEME_TABLE}(parent_cluster_id)
+                    """
+                )
+            )
+        if IS_L1_INDEX not in existing_indexes:
+            conn.execute(
+                text(
+                    f"""
+                    CREATE INDEX IF NOT EXISTS {IS_L1_INDEX}
+                    ON {THEME_TABLE}(is_l1)
+                    """
+                )
+            )
+
+        stats["indexes_ensured"] = [PARENT_CLUSTER_INDEX, IS_L1_INDEX]
+        conn.commit()
+
+    logger.info("Theme taxonomy migration completed: %s", stats)
+    return stats

--- a/backend/app/db_migrations/theme_taxonomy_migration.py
+++ b/backend/app/db_migrations/theme_taxonomy_migration.py
@@ -32,6 +32,7 @@ def migrate_theme_taxonomy(engine) -> dict[str, Any]:
         is_postgres = dialect_name(conn) == "postgresql"
         timestamp_type = "TIMESTAMP WITH TIME ZONE" if is_postgres else "DATETIME"
         true_literal = "TRUE" if is_postgres else "1"
+        false_literal = "FALSE" if is_postgres else "0"
 
         add_statements = {
             "parent_cluster_id": f"ALTER TABLE {THEME_TABLE} ADD COLUMN parent_cluster_id INTEGER",
@@ -59,11 +60,11 @@ def migrate_theme_taxonomy(engine) -> dict[str, Any]:
                     f"""
                     UPDATE {THEME_TABLE}
                     SET taxonomy_level = CASE
-                        WHEN is_l1 = {true_literal} THEN 1
+                        WHEN COALESCE(is_l1, {false_literal}) = {true_literal} THEN 1
                         ELSE 2
                     END
-                    WHERE (is_l1 = {true_literal} AND taxonomy_level != 1)
-                       OR (is_l1 != {true_literal} AND taxonomy_level != 2)
+                    WHERE (COALESCE(is_l1, {false_literal}) = {true_literal} AND taxonomy_level != 1)
+                       OR (COALESCE(is_l1, {false_literal}) != {true_literal} AND taxonomy_level != 2)
                     """
                 )
             )

--- a/backend/app/db_migrations/theme_taxonomy_migration.py
+++ b/backend/app/db_migrations/theme_taxonomy_migration.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 
 from ..infra.db.portability import column_names, dialect_name, index_names
 
@@ -44,8 +45,13 @@ def migrate_theme_taxonomy(engine) -> dict[str, Any]:
         for column, statement in add_statements.items():
             if column in columns:
                 continue
-            conn.execute(text(statement))
-            stats["columns_added"].append(column)
+            try:
+                conn.execute(text(statement))
+                stats["columns_added"].append(column)
+            except SQLAlchemyError:
+                # Another process may have applied the same ALTER between check and execute.
+                if column not in column_names(conn, THEME_TABLE):
+                    raise
 
         if "taxonomy_level" in column_names(conn, THEME_TABLE):
             conn.execute(

--- a/backend/app/wiring/bootstrap.py
+++ b/backend/app/wiring/bootstrap.py
@@ -112,6 +112,9 @@ class RuntimeServices:
         self._stock_data_provider: DataPrepStockDataProvider | None = None
         self._scan_orchestrator: ScanOrchestrator | None = None
 
+    def session_factory(self) -> SessionFactory:
+        return self._session_factory
+
     def job_backend(self) -> JobBackend:
         if self._job_backend is None:
             with self._init_lock:
@@ -496,6 +499,11 @@ def get_task_dispatcher() -> TaskDispatcher:
 def get_ui_snapshot_service() -> UISnapshotService:
     """Return the process-scoped UI bootstrap snapshot publisher."""
     return _resolve_runtime_services().ui_snapshot_service()
+
+
+def get_session_factory() -> SessionFactory:
+    """Return runtime-bound SQLAlchemy session factory."""
+    return _resolve_runtime_services().session_factory()
 
 
 def get_cache_bundle() -> CacheBundle:

--- a/backend/scripts/backfill_l1_taxonomy.py
+++ b/backend/scripts/backfill_l1_taxonomy.py
@@ -16,9 +16,10 @@ from datetime import datetime
 # Add backend directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from app.database import SessionLocal, engine
+from app.database import engine
 from app.db_migrations.theme_taxonomy_migration import migrate_theme_taxonomy
 from app.services.theme_taxonomy_service import ThemeTaxonomyService
+from app.wiring.bootstrap import get_session_factory, initialize_process_runtime_services
 
 
 def main():
@@ -43,7 +44,8 @@ def main():
     else:
         print("  Schema already up to date.")
 
-    db = SessionLocal()
+    initialize_process_runtime_services()
+    db = get_session_factory()()
     try:
         service = ThemeTaxonomyService(db, pipeline=args.pipeline)
 

--- a/backend/scripts/backfill_l1_taxonomy.py
+++ b/backend/scripts/backfill_l1_taxonomy.py
@@ -16,7 +16,6 @@ from datetime import datetime
 # Add backend directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from app.database import engine
 from app.db_migrations.theme_taxonomy_migration import migrate_theme_taxonomy
 from app.services.theme_taxonomy_service import ThemeTaxonomyService
 from app.wiring.bootstrap import get_session_factory, initialize_process_runtime_services
@@ -35,18 +34,18 @@ def main():
     print(f"Time: {datetime.now().isoformat()}")
     print("=" * 60)
 
-    # Ensure taxonomy columns exist (migration normally runs on app startup,
-    # but this script bypasses FastAPI lifespan)
-    print("\n[Pre-flight] Ensuring taxonomy schema...")
-    migration_result = migrate_theme_taxonomy(engine)
-    if migration_result["columns_added"]:
-        print(f"  Added columns: {migration_result['columns_added']}")
-    else:
-        print("  Schema already up to date.")
-
     initialize_process_runtime_services()
     db = get_session_factory()()
     try:
+        # Ensure taxonomy columns exist (migration normally runs on app startup,
+        # but this script bypasses FastAPI lifespan)
+        print("\n[Pre-flight] Ensuring taxonomy schema...")
+        migration_result = migrate_theme_taxonomy(db.get_bind())
+        if migration_result["columns_added"]:
+            print(f"  Added columns: {migration_result['columns_added']}")
+        else:
+            print("  Schema already up to date.")
+
         service = ThemeTaxonomyService(db, pipeline=args.pipeline)
 
         # Phase 1-3: Full assignment pipeline

--- a/backend/scripts/backfill_l1_taxonomy.py
+++ b/backend/scripts/backfill_l1_taxonomy.py
@@ -39,7 +39,10 @@ def main():
     try:
         # Ensure taxonomy columns exist (migration normally runs on app startup,
         # but this script bypasses FastAPI lifespan)
-        print("\n[Pre-flight] Ensuring taxonomy schema...")
+        print(
+            "\n[Pre-flight] Ensuring taxonomy schema..."
+            + (" (schema-only changes may still be applied in --dry-run)" if args.dry_run else "")
+        )
         migration_result = migrate_theme_taxonomy(db.get_bind())
         if migration_result["columns_added"]:
             print(f"  Added columns: {migration_result['columns_added']}")
@@ -123,7 +126,7 @@ def main():
 
         print("\n" + "=" * 60)
         if args.dry_run:
-            print("DRY RUN complete. No changes made. Run without --dry-run to apply.")
+            print("DRY RUN complete. No assignment changes made (schema pre-flight may still apply).")
         else:
             print("BACKFILL COMPLETE.")
         print("=" * 60)

--- a/backend/scripts/backfill_silent_failures.py
+++ b/backend/scripts/backfill_silent_failures.py
@@ -22,8 +22,11 @@ from pathlib import Path
 # Add backend to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.database import SessionLocal
 from app.services.theme_extraction_service import ThemeExtractionService
+from app.wiring.bootstrap import (
+    get_session_factory,
+    initialize_process_runtime_services,
+)
 
 
 def main():
@@ -32,7 +35,8 @@ def main():
     parser.add_argument("--max-age-days", type=int, default=30, help="Max age of items to check (default: 30)")
     args = parser.parse_args()
 
-    db = SessionLocal()
+    initialize_process_runtime_services()
+    db = get_session_factory()()
 
     try:
         pipelines = ["technical", "fundamental"]

--- a/backend/scripts/backfill_theme_aliases.py
+++ b/backend/scripts/backfill_theme_aliases.py
@@ -11,8 +11,11 @@ from pathlib import Path
 # Add backend to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.database import SessionLocal  # noqa: E402
 from app.services.theme_alias_backfill_service import ThemeAliasBackfillService  # noqa: E402
+from app.wiring.bootstrap import (  # noqa: E402
+    get_session_factory,
+    initialize_process_runtime_services,
+)
 
 
 def _default_report_path() -> Path:
@@ -55,7 +58,8 @@ def main() -> None:
             print("Aborted.")
             return
 
-    db = SessionLocal()
+    initialize_process_runtime_services()
+    db = get_session_factory()()
     try:
         service = ThemeAliasBackfillService(db)
         report = service.run(

--- a/backend/scripts/backfill_theme_pipeline_state.py
+++ b/backend/scripts/backfill_theme_pipeline_state.py
@@ -20,9 +20,12 @@ from pathlib import Path
 # Add backend to path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.database import SessionLocal
 from app.services.theme_pipeline_state_backfill_service import (  # noqa: E402
     ThemePipelineStateBackfillService,
+)
+from app.wiring.bootstrap import (  # noqa: E402
+    get_session_factory,
+    initialize_process_runtime_services,
 )
 
 
@@ -134,7 +137,8 @@ def main() -> None:
             print("Aborted.")
             return
 
-    db = SessionLocal()
+    initialize_process_runtime_services()
+    db = get_session_factory()()
     service = ThemePipelineStateBackfillService(db)
 
     cursor = start_cursor

--- a/backend/scripts/cleanup_orphaned_scans.py
+++ b/backend/scripts/cleanup_orphaned_scans.py
@@ -25,8 +25,8 @@ sys.path.insert(0, str(backend_dir))
 
 import logging
 from datetime import datetime, timedelta
-from app.database import SessionLocal
 from app.models.scan_result import Scan, ScanResult
+from app.wiring.bootstrap import get_session_factory, initialize_process_runtime_services
 from sqlalchemy import func, text
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -74,7 +74,8 @@ def main(skip_confirmation: bool = False, do_vacuum: bool = False):
     print("ORPHANED SCAN DATA CLEANUP")
     print("=" * 80)
 
-    db = SessionLocal()
+    initialize_process_runtime_services()
+    db = get_session_factory()()
 
     try:
         # Show current state

--- a/backend/scripts/cleanup_orphaned_scans.py
+++ b/backend/scripts/cleanup_orphaned_scans.py
@@ -162,14 +162,20 @@ def main(skip_confirmation: bool = False, do_vacuum: bool = False):
         print(f"  {'TOTAL':<15}: {total_scans_after:>5} scans, {total_results_after:>8} results")
         print(f"\n  Deleted: {total_scans_before - total_scans_after} scans, {total_results_before - total_results_after} results")
 
-        # Close session before space reclamation
+        # Close session before space reclamation.
+        # Derive maintenance target from the same runtime-bound session bind.
+        database_url = str(db.get_bind().url)
         db.close()
 
         # Get database path
-        from app.config import settings
         import sqlite3
 
-        db_path = settings.database_url.replace("sqlite:///", "")
+        if not database_url.startswith("sqlite:///"):
+            raise RuntimeError(
+                "cleanup_orphaned_scans.py only supports sqlite databases; "
+                f"resolved runtime DB URL is {database_url}"
+            )
+        db_path = database_url.replace("sqlite:///", "", 1)
         size_before = os.path.getsize(db_path) / (1024 * 1024)  # MB
 
         # Show WAL file size

--- a/backend/scripts/cleanup_orphaned_scans.py
+++ b/backend/scripts/cleanup_orphaned_scans.py
@@ -164,7 +164,9 @@ def main(skip_confirmation: bool = False, do_vacuum: bool = False):
 
         # Close session before space reclamation.
         # Derive maintenance target from the same runtime-bound session bind.
-        database_url = str(db.get_bind().url)
+        bind_url = db.get_bind().url
+        database_url = bind_url.render_as_string(hide_password=False)
+        safe_database_url = bind_url.render_as_string(hide_password=True)
         db.close()
 
         # Get database path
@@ -173,7 +175,7 @@ def main(skip_confirmation: bool = False, do_vacuum: bool = False):
         if not database_url.startswith("sqlite:///"):
             raise RuntimeError(
                 "cleanup_orphaned_scans.py only supports sqlite databases; "
-                f"resolved runtime DB URL is {database_url}"
+                f"resolved runtime DB URL is {safe_database_url}"
             )
         db_path = database_url.replace("sqlite:///", "", 1)
         size_before = os.path.getsize(db_path) / (1024 * 1024)  # MB

--- a/backend/tests/unit/test_backfill_theme_aliases_script.py
+++ b/backend/tests/unit/test_backfill_theme_aliases_script.py
@@ -19,11 +19,13 @@ def _args(**overrides) -> argparse.Namespace:
 
 @patch("scripts.backfill_theme_aliases._save_json")
 @patch("scripts.backfill_theme_aliases.ThemeAliasBackfillService")
-@patch("scripts.backfill_theme_aliases.SessionLocal")
+@patch("scripts.backfill_theme_aliases.get_session_factory")
+@patch("scripts.backfill_theme_aliases.initialize_process_runtime_services")
 @patch("scripts.backfill_theme_aliases._build_parser")
 def test_main_writes_report_for_dry_run(
     mock_build_parser,
-    mock_session_local,
+    mock_initialize_runtime,
+    mock_get_session_factory,
     mock_service_cls,
     mock_save_json,
 ):
@@ -32,7 +34,8 @@ def test_main_writes_report_for_dry_run(
     mock_build_parser.return_value = parser
 
     db = MagicMock()
-    mock_session_local.return_value = db
+    session_factory = MagicMock(return_value=db)
+    mock_get_session_factory.return_value = session_factory
 
     service = MagicMock()
     service.run.return_value = {
@@ -51,6 +54,9 @@ def test_main_writes_report_for_dry_run(
 
     script.main()
 
+    mock_initialize_runtime.assert_called_once_with()
+    mock_get_session_factory.assert_called_once_with()
+    session_factory.assert_called_once_with()
     mock_save_json.assert_called_once()
     saved_path = mock_save_json.call_args.args[0]
     assert str(saved_path) == "/tmp/theme_alias_backfill_report.json"
@@ -59,11 +65,13 @@ def test_main_writes_report_for_dry_run(
 
 @patch("scripts.backfill_theme_aliases._save_json")
 @patch("scripts.backfill_theme_aliases.ThemeAliasBackfillService")
-@patch("scripts.backfill_theme_aliases.SessionLocal")
+@patch("scripts.backfill_theme_aliases.get_session_factory")
+@patch("scripts.backfill_theme_aliases.initialize_process_runtime_services")
 @patch("scripts.backfill_theme_aliases._build_parser")
 def test_main_calls_service_with_mention_limit(
     mock_build_parser,
-    mock_session_local,
+    mock_initialize_runtime,
+    mock_get_session_factory,
     mock_service_cls,
     mock_save_json,
 ):
@@ -72,7 +80,8 @@ def test_main_calls_service_with_mention_limit(
     mock_build_parser.return_value = parser
 
     db = MagicMock()
-    mock_session_local.return_value = db
+    session_factory = MagicMock(return_value=db)
+    mock_get_session_factory.return_value = session_factory
 
     service = MagicMock()
     service.run.return_value = {
@@ -91,5 +100,8 @@ def test_main_calls_service_with_mention_limit(
 
     script.main()
 
+    mock_initialize_runtime.assert_called_once_with()
+    mock_get_session_factory.assert_called_once_with()
+    session_factory.assert_called_once_with()
     service.run.assert_called_once_with(dry_run=False, mention_limit=100)
     mock_save_json.assert_called_once()

--- a/backend/tests/unit/test_backfill_theme_pipeline_state_script.py
+++ b/backend/tests/unit/test_backfill_theme_pipeline_state_script.py
@@ -58,11 +58,13 @@ def _summary_payload():
 
 @patch("scripts.backfill_theme_pipeline_state._save_checkpoint")
 @patch("scripts.backfill_theme_pipeline_state.ThemePipelineStateBackfillService")
-@patch("scripts.backfill_theme_pipeline_state.SessionLocal")
+@patch("scripts.backfill_theme_pipeline_state.get_session_factory")
+@patch("scripts.backfill_theme_pipeline_state.initialize_process_runtime_services")
 @patch("scripts.backfill_theme_pipeline_state._build_parser")
 def test_main_dry_run_skips_checkpoint_and_report_writes(
     mock_build_parser,
-    mock_session_local,
+    mock_initialize_runtime,
+    mock_get_session_factory,
     mock_service_cls,
     mock_save_checkpoint,
 ):
@@ -71,7 +73,8 @@ def test_main_dry_run_skips_checkpoint_and_report_writes(
     mock_build_parser.return_value = parser
 
     db = MagicMock()
-    mock_session_local.return_value = db
+    session_factory = MagicMock(return_value=db)
+    mock_get_session_factory.return_value = session_factory
 
     service = MagicMock()
     service.process_chunk.side_effect = [
@@ -83,17 +86,22 @@ def test_main_dry_run_skips_checkpoint_and_report_writes(
 
     script.main()
 
+    mock_initialize_runtime.assert_called_once_with()
+    mock_get_session_factory.assert_called_once_with()
+    session_factory.assert_called_once_with()
     mock_save_checkpoint.assert_not_called()
     db.close.assert_called_once()
 
 
 @patch("scripts.backfill_theme_pipeline_state._save_checkpoint")
 @patch("scripts.backfill_theme_pipeline_state.ThemePipelineStateBackfillService")
-@patch("scripts.backfill_theme_pipeline_state.SessionLocal")
+@patch("scripts.backfill_theme_pipeline_state.get_session_factory")
+@patch("scripts.backfill_theme_pipeline_state.initialize_process_runtime_services")
 @patch("scripts.backfill_theme_pipeline_state._build_parser")
 def test_main_non_dry_run_writes_checkpoint_and_report(
     mock_build_parser,
-    mock_session_local,
+    mock_initialize_runtime,
+    mock_get_session_factory,
     mock_service_cls,
     mock_save_checkpoint,
 ):
@@ -102,7 +110,8 @@ def test_main_non_dry_run_writes_checkpoint_and_report(
     mock_build_parser.return_value = parser
 
     db = MagicMock()
-    mock_session_local.return_value = db
+    session_factory = MagicMock(return_value=db)
+    mock_get_session_factory.return_value = session_factory
 
     service = MagicMock()
     service.process_chunk.side_effect = [
@@ -114,6 +123,9 @@ def test_main_non_dry_run_writes_checkpoint_and_report(
 
     script.main()
 
+    mock_initialize_runtime.assert_called_once_with()
+    mock_get_session_factory.assert_called_once_with()
+    session_factory.assert_called_once_with()
     # One write for checkpoint progress, one for final report.
     assert mock_save_checkpoint.call_count == 2
     first_path = mock_save_checkpoint.call_args_list[0].args[0]


### PR DESCRIPTION
## Summary
- migrate legacy root maintenance scripts to runtime/container-owned session wiring
- replace direct `SessionLocal()` creation with:
  - `initialize_process_runtime_services()`
  - `get_session_factory()()`
- update script unit tests to patch runtime/session-factory seams
- add `get_session_factory()` provider in `bootstrap` so scripts can resolve runtime-bound session factories through wiring

## Files
- `backend/scripts/backfill_theme_aliases.py`
- `backend/scripts/backfill_silent_failures.py`
- `backend/scripts/backfill_theme_pipeline_state.py`
- `backend/scripts/cleanup_orphaned_scans.py`
- `backend/scripts/backfill_l1_taxonomy.py`
- `backend/app/wiring/bootstrap.py`
- `backend/tests/unit/test_backfill_theme_aliases_script.py`
- `backend/tests/unit/test_backfill_theme_pipeline_state_script.py`

## Validation
- `cd backend && DATABASE_URL=postgresql://user:pass@localhost/stockscanner /Users/admin/StockScreenClaude/backend/venv/bin/pytest tests/unit/test_backfill_theme_aliases_script.py tests/unit/test_backfill_theme_pipeline_state_script.py -q`
- Result: `4 passed`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Backend processes and maintenance scripts now use a unified runtime session factory for database access and initialization.
* **New Features**
  * Added an idempotent taxonomy migration that ensures required columns and indexes and backfills taxonomy levels when needed.
* **Bug Fixes**
  * More consistent migration application, clearer dry-run messaging, and safer SQLite maintenance handling.
* **Tests**
  * Unit tests updated to validate the new initialization and session-factory wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->