### PR TITLE
fix(ui-snapshot): sanitize non-finite payload values (StockScreenClaude-08lo)

### DIFF
--- a/backend/app/services/ui_snapshot_service.py
+++ b/backend/app/services/ui_snapshot_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
+import math
 import json
 import logging
 from threading import Lock
@@ -852,6 +853,11 @@ def _json_safe(value: Any) -> Any:
         return [_json_safe(item) for item in value]
     if isinstance(value, (datetime, date)):
         return value.isoformat()
+    if isinstance(value, float):
+        # Postgres JSON/JSONB rejects non-finite numbers. Coerce NaN/Inf to null.
+        if not math.isfinite(value):
+            return None
+        return value
     return value
 
 

--- a/backend/tests/unit/test_ui_snapshot_service.py
+++ b/backend/tests/unit/test_ui_snapshot_service.py
@@ -308,6 +308,44 @@ def test_ui_snapshot_publish_coerces_nested_dates_to_json_safe_strings():
     assert json.loads(json.dumps(snapshot.payload)) == snapshot.payload
 
 
+def test_ui_snapshot_publish_coerces_non_finite_numbers_to_null():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    service = UISnapshotService(Session)
+
+    with Session() as db:
+        snapshot = service._publish(  # noqa: SLF001 - persistence semantics
+            db=db,
+            view_key="test_view",
+            variant_key="default",
+            source_revision="rev-non-finite",
+            payload={
+                "ratio_5day": float("nan"),
+                "ratio_10day": float("inf"),
+                "nested": {
+                    "value": float("-inf"),
+                    "ok": 1.25,
+                },
+                "series": [1.0, float("nan"), 2.0],
+            },
+        )
+        row = db.query(UIViewSnapshot).filter(
+            UIViewSnapshot.view_key == "test_view",
+            UIViewSnapshot.variant_key == "default",
+            UIViewSnapshot.source_revision == "rev-non-finite",
+        ).one()
+
+    assert snapshot.payload["ratio_5day"] is None
+    assert snapshot.payload["ratio_10day"] is None
+    assert snapshot.payload["nested"]["value"] is None
+    assert snapshot.payload["nested"]["ok"] == 1.25
+    assert snapshot.payload["series"] == [1.0, None, 2.0]
+    assert row.payload_json["ratio_5day"] is None
+    assert row.payload_json["nested"]["value"] is None
+    assert json.loads(json.dumps(snapshot.payload)) == snapshot.payload
+
+
 def test_ui_snapshot_service_resets_corrupt_cache_tables_and_retries():
     engine = create_engine("sqlite:///:memory:")
     Session = sessionmaker(bind=engine)


### PR DESCRIPTION
## Summary
- fixes `StockScreenClaude-08lo`
- sanitizes non-finite floats (`NaN`, `+Inf`, `-Inf`) in UI snapshot payloads before JSON persistence
- adds regression coverage for nested/list payload coercion behavior

## Why
Restored breadth/history data can contain non-finite numeric values, which breaks snapshot JSON persistence paths.

## Changes
- `backend/app/services/ui_snapshot_service.py`
  - `_json_safe` now coerces non-finite float values to `null`
- `backend/tests/unit/test_ui_snapshot_service.py`
  - adds `test_ui_snapshot_publish_coerces_non_finite_numbers_to_null`

## Validation
- Added unit regression test for non-finite sanitization behavior.
- Full suite was not run in this environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot serialization to properly handle non-finite floating-point values (NaN, Infinity, -Infinity) by converting them to null, ensuring reliable payload serialization.

* **Tests**
  * Added comprehensive tests for snapshot serialization with non-finite number edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->