### PR TITLE
ASIA E3: market-aware benchmark/calendar architecture and scheduler de-hardcoding

### DIFF
--- a/backend/app/api/v1/cache.py
+++ b/backend/app/api/v1/cache.py
@@ -83,7 +83,7 @@ async def get_cache_statistics():
     Get comprehensive cache statistics.
 
     Returns:
-        Cache statistics including Redis status, SPY cache, price cache, and memory usage
+        Cache statistics including Redis status, benchmark cache, price cache, and memory usage
     """
     try:
         cache_manager = CacheManager()
@@ -115,9 +115,9 @@ async def get_market_status():
 @router.post("/warm/spy")
 async def warm_spy_benchmark_cache(background_tasks: BackgroundTasks):
     """
-    Warm SPY benchmark cache.
+    Warm benchmark cache for active markets.
 
-    This endpoint triggers background warming of the SPY benchmark data.
+    Compatibility endpoint name; task warms benchmarks for active markets.
 
     Returns:
         Task information
@@ -128,14 +128,14 @@ async def warm_spy_benchmark_cache(background_tasks: BackgroundTasks):
 
         return TaskResponse(
             task_id=task.id,
-            message="SPY cache warming task queued",
+            message="Benchmark cache warming task queued",
             status="queued"
         )
 
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Error queuing SPY cache warming: {str(e)}"
+            detail=f"Error queuing benchmark cache warming: {str(e)}"
         )
 
 
@@ -384,16 +384,16 @@ async def get_cache_health():
     """
     Get cache health status with unified state indicator.
 
-    This is the NEW primary endpoint for cache status. It uses SPY as a proxy
+    This is the NEW primary endpoint for cache status. It uses US benchmark cache as a proxy
     for overall cache health (O(1) check) and includes warmup metadata for
     detecting partial failures.
 
     Returns one of 6 states:
-    - fresh: Cache is up to date (SPY has expected date + last warmup complete)
+    - fresh: Cache is up to date (US benchmark has expected date + last warmup complete)
     - updating: Refresh task is currently running
     - stuck: Task running but no progress for >30 minutes
     - partial: Last warmup incomplete (some symbols failed)
-    - stale: SPY missing expected trading date
+    - stale: Benchmark missing expected trading date
     - error: Redis unavailable or other error
 
     Returns:
@@ -438,7 +438,7 @@ async def smart_refresh(request: SmartRefreshRequest):
     - full: Full universe, force re-fetch everything (~2 hours)
 
     Key features:
-    - Always warms SPY first (required for RS calculations)
+    - Always warms market benchmarks first (required for RS calculations)
     - Fetches symbols in market cap order (high cap first)
     - Prevents double-refresh (returns existing task info if running)
 
@@ -519,7 +519,7 @@ async def get_dashboard_cache_statistics():
 
     This endpoint aggregates cache health metrics from all cache services:
     - Fundamentals cache (Redis + DB)
-    - Price/technical data cache (SPY + symbols)
+    - Price/technical data cache (benchmarks + symbols)
     - Market status
 
     Returns:
@@ -576,11 +576,12 @@ async def get_dashboard_cache_statistics():
         cache_manager = CacheManager()
         price_stats = cache_manager.get_cache_stats()
 
-        # Extract SPY cache info (corrected key names)
-        spy_cache = price_stats.get('spy_cache', {})
-        spy_cached = spy_cache.get('2y_cached', False)
-        spy_ttl_seconds = spy_cache.get('2y_ttl', 0)
-        spy_ttl = (spy_ttl_seconds / 3600) if spy_ttl_seconds else 0  # Convert seconds to hours
+        # Extract US benchmark cache info (with legacy SPY fallback key)
+        benchmark_cache = price_stats.get('benchmark_cache', {})
+        us_benchmark = benchmark_cache.get('US') or price_stats.get('spy_cache', {})
+        us_benchmark_cached = us_benchmark.get('2y_cached', False)
+        us_benchmark_ttl_seconds = us_benchmark.get('2y_ttl', 0)
+        us_benchmark_ttl = (us_benchmark_ttl_seconds / 3600) if us_benchmark_ttl_seconds else 0
 
         # Get market status
         market_status = {
@@ -600,9 +601,9 @@ async def get_dashboard_cache_statistics():
                 "hit_rate": fundamentals_stats.get('hit_rate', 0)
             },
             "prices": {
-                "spy_cached": spy_cached,
+                "spy_cached": us_benchmark_cached,
                 "spy_last_update": "N/A",  # Could be enhanced to extract last update date
-                "spy_ttl_hours": round(spy_ttl, 1),
+                "spy_ttl_hours": round(us_benchmark_ttl, 1),
                 "total_symbols_cached": price_stats.get('price_cache', {}).get('symbols_cached', 0),
                 "last_warmup": "N/A"  # Could track last warmup timestamp
             },

--- a/backend/app/scanners/base_screener.py
+++ b/backend/app/scanners/base_screener.py
@@ -105,6 +105,11 @@ class StockData:
     earnings_history: Optional[pd.DataFrame] = None  # Historical earnings data
 
     # Additional metadata
+    market: Optional[str] = None
+    exchange: Optional[str] = None
+    currency: Optional[str] = None
+    timezone: Optional[str] = None
+    local_code: Optional[str] = None
     fetch_errors: Dict[str, str] = field(default_factory=dict)  # Any errors during fetch
 
     def has_sufficient_data(self, min_days: int = 100) -> bool:

--- a/backend/app/scanners/data_preparation.py
+++ b/backend/app/scanners/data_preparation.py
@@ -165,7 +165,8 @@ class DataPreparationLayer:
         if requirements.needs_benchmark:
             try:
                 benchmark_data = self._fetch_with_retry(
-                    self.benchmark_cache.get_spy_data,
+                    self.benchmark_cache.get_benchmark_data,
+                    market=identity.market,
                     period=requirements.price_period,
                 )
                 if benchmark_data is None or benchmark_data.empty:
@@ -280,18 +281,22 @@ class DataPreparationLayer:
             else {}
         )
 
-        # Get benchmark data once (shared by all stocks)
-        benchmark_data = None
+        # Get benchmark data once per market (shared by symbols in that market)
+        benchmark_data_by_market: dict[str, pd.DataFrame | None] = {}
         all_errors: dict[str, str] = {}
         if requirements.needs_benchmark:
-            try:
-                benchmark_data = self._fetch_with_retry(
-                    self.benchmark_cache.get_spy_data,
-                    period=requirements.price_period,
-                )
-            except Exception as e:
-                logger.warning(f"Error fetching benchmark data: {e}")
-                all_errors["<bulk>/benchmark_data"] = str(e)
+            unique_markets = sorted({identity.market for identity in identities})
+            for market in unique_markets:
+                try:
+                    benchmark_data_by_market[market] = self._fetch_with_retry(
+                        self.benchmark_cache.get_benchmark_data,
+                        market=market,
+                        period=requirements.price_period,
+                    )
+                except Exception as e:
+                    logger.warning("Error fetching benchmark data for market %s: %s", market, e)
+                    all_errors[f"<bulk>/benchmark_data:{market}"] = str(e)
+                    benchmark_data_by_market[market] = None
 
         # Build StockData for each symbol
         results = {}
@@ -362,7 +367,11 @@ class DataPreparationLayer:
             results[symbol] = StockData(
                 symbol=symbol,
                 price_data=price_data if price_data is not None else pd.DataFrame(),
-                benchmark_data=benchmark_data if benchmark_data is not None else pd.DataFrame(),
+                benchmark_data=(
+                    benchmark_data_by_market.get(identity.market)
+                    if requirements.needs_benchmark
+                    else None
+                ) or pd.DataFrame(),
                 fundamentals=fundamentals,
                 quarterly_growth=quarterly_growth,
                 earnings_history=earnings_history,

--- a/backend/app/scanners/data_preparation.py
+++ b/backend/app/scanners/data_preparation.py
@@ -288,11 +288,17 @@ class DataPreparationLayer:
             unique_markets = sorted({identity.market for identity in identities})
             for market in unique_markets:
                 try:
-                    benchmark_data_by_market[market] = self._fetch_with_retry(
+                    benchmark_data = self._fetch_with_retry(
                         self.benchmark_cache.get_benchmark_data,
                         market=market,
                         period=requirements.price_period,
                     )
+                    if benchmark_data is None or benchmark_data.empty:
+                        logger.warning("No benchmark data returned for market %s", market)
+                        all_errors[f"<bulk>/benchmark_data:{market}"] = "No benchmark data returned"
+                        benchmark_data_by_market[market] = None
+                    else:
+                        benchmark_data_by_market[market] = benchmark_data
                 except Exception as e:
                     logger.warning("Error fetching benchmark data for market %s: %s", market, e)
                     all_errors[f"<bulk>/benchmark_data:{market}"] = str(e)
@@ -369,6 +375,10 @@ class DataPreparationLayer:
                 if requirements.needs_benchmark
                 else None
             )
+            if requirements.needs_benchmark and (
+                market_benchmark_data is None or market_benchmark_data.empty
+            ):
+                fetch_errors["benchmark_data"] = f"No benchmark data returned for market {identity.market}"
             results[symbol] = StockData(
                 symbol=symbol,
                 price_data=price_data if price_data is not None else pd.DataFrame(),

--- a/backend/app/scanners/data_preparation.py
+++ b/backend/app/scanners/data_preparation.py
@@ -17,6 +17,7 @@ from ..services.benchmark_cache_service import BenchmarkCacheService
 from ..services.fundamentals_cache_service import FundamentalsCacheService
 from ..services.price_cache_service import PriceCacheService
 from ..services.rate_limiter import RateLimitTimeoutError
+from ..services.security_master_service import SecurityMasterResolver, security_master_resolver
 from ..wiring.bootstrap import get_rate_limiter, get_yfinance_service
 
 logger = logging.getLogger(__name__)
@@ -49,6 +50,11 @@ class DataPreparationLayer:
         self._retry_base_delay = retry_base_delay
         self._yfinance_service = get_yfinance_service()
         self._rate_limiter = get_rate_limiter()
+        self._security_master = security_master_resolver
+
+    def _resolve_identity(self, symbol: str):
+        resolver = getattr(self, "_security_master", None) or SecurityMasterResolver()
+        return resolver.resolve_identity(symbol=symbol)
 
     def _is_transient(self, exc: Exception) -> bool:
         """Classify whether an exception is transient (worth retrying)."""
@@ -116,6 +122,8 @@ class DataPreparationLayer:
         Returns:
             StockData object with all fetched data
         """
+        identity = self._resolve_identity(symbol)
+        normalized_symbol = identity.normalized_symbol
         fetch_errors = {}
 
         # 1. Fetch price data (always needed)
@@ -124,25 +132,32 @@ class DataPreparationLayer:
         try:
             # Check cache first (no rate limiting)
             # Note: get_historical_data() handles Redis → DB fallback internally and ensures sufficient data
-            price_data = self.price_cache.get_historical_data(symbol, period=requirements.price_period)
+            price_data = self.price_cache.get_historical_data(
+                normalized_symbol,
+                period=requirements.price_period,
+            )
 
             if price_data is None or price_data.empty:
                 # Cache miss or insufficient - fetch directly
                 # (yfinance_service has its own rate limiter)
-                logger.debug(f"Cache MISS for {symbol} - fetching from yfinance")
+                logger.debug(f"Cache MISS for {normalized_symbol} - fetching from yfinance")
                 price_data = self._fetch_with_retry(
                     self._yfinance_service.get_historical_data,
-                    symbol,
+                    normalized_symbol,
                     period=requirements.price_period,
                     use_cache=False,  # Already checked cache
                 )
             else:
-                logger.debug(f"Cache HIT for {symbol} ({len(price_data)} days) - no rate limiting")
+                logger.debug(
+                    "Cache HIT for %s (%d days) - no rate limiting",
+                    normalized_symbol,
+                    len(price_data),
+                )
 
             if price_data is None or price_data.empty:
                 fetch_errors["price_data"] = "No price data returned"
         except Exception as e:
-            logger.error(f"Error fetching price data for {symbol}: {e}")
+            logger.error(f"Error fetching price data for {normalized_symbol}: {e}")
             fetch_errors["price_data"] = str(e)
 
         # 2. Fetch benchmark data (if needed)
@@ -166,13 +181,13 @@ class DataPreparationLayer:
                 # Use cache service instead of direct API call (no rate limiting needed - cache handles it)
                 fundamentals = self._fetch_with_retry(
                     self.fundamentals_cache.get_fundamentals,
-                    symbol,
+                    normalized_symbol,
                     force_refresh=False,  # Use cache by default
                 )
                 if fundamentals is None:
                     fetch_errors["fundamentals"] = "No fundamental data returned"
             except Exception as e:
-                logger.warning(f"Error fetching fundamentals for {symbol}: {e}")
+                logger.warning(f"Error fetching fundamentals for {normalized_symbol}: {e}")
                 fetch_errors["fundamentals"] = str(e)
 
         # 4. Extract quarterly growth from fundamentals (consolidated cache)
@@ -193,17 +208,22 @@ class DataPreparationLayer:
 
         # Create StockData container
         stock_data = StockData(
-            symbol=symbol,
+            symbol=normalized_symbol,
             price_data=price_data if price_data is not None else pd.DataFrame(),
             benchmark_data=benchmark_data if benchmark_data is not None else pd.DataFrame(),
             fundamentals=fundamentals,
             quarterly_growth=quarterly_growth,
             earnings_history=earnings_history,
+            market=identity.market,
+            exchange=identity.exchange,
+            currency=identity.currency,
+            timezone=identity.timezone,
+            local_code=identity.local_code,
             fetch_errors=fetch_errors
         )
 
         if not allow_partial and fetch_errors:
-            raise DataFetchError(symbol, fetch_errors, partial_data=stock_data)
+            raise DataFetchError(normalized_symbol, fetch_errors, partial_data=stock_data)
 
         return stock_data
 
@@ -238,15 +258,27 @@ class DataPreparationLayer:
             return {}
 
         logger.info(f"Preparing data for {len(symbols)} symbols using bulk cache operations")
+        identities = [self._resolve_identity(symbol) for symbol in symbols]
+        normalized_symbols = [identity.normalized_symbol for identity in identities]
+        identity_by_symbol = {
+            identity.normalized_symbol: identity for identity in identities
+        }
 
         # PHASE 3 OPTIMIZATION: Bulk cache lookups using Redis pipelines
         # Instead of N individual Redis calls, make 2 pipeline calls (1 per cache type)
         # Get cached data for all symbols in parallel
         # Price data is always needed (no needs_price_data flag)
         # IMPORTANT: Pass period so get_many() can fall back to database if Redis only has 30 days
-        cached_prices = self.price_cache.get_many(symbols, period=requirements.price_period)
+        cached_prices = self.price_cache.get_many(
+            normalized_symbols,
+            period=requirements.price_period,
+        )
         # Fundamentals cache now includes quarterly growth data (consolidated)
-        cached_fundamentals = self.fundamentals_cache.get_many(symbols) if requirements.needs_fundamentals else {}
+        cached_fundamentals = (
+            self.fundamentals_cache.get_many(normalized_symbols)
+            if requirements.needs_fundamentals
+            else {}
+        )
 
         # Get benchmark data once (shared by all stocks)
         benchmark_data = None
@@ -263,8 +295,9 @@ class DataPreparationLayer:
 
         # Build StockData for each symbol
         results = {}
-        for symbol in symbols:
+        for symbol in normalized_symbols:
             fetch_errors = {}
+            identity = identity_by_symbol[symbol]
 
             # Get price data (from cache or fetch)
             # Note: get_many() already handles sufficiency checks and database fallback
@@ -333,6 +366,11 @@ class DataPreparationLayer:
                 fundamentals=fundamentals,
                 quarterly_growth=quarterly_growth,
                 earnings_history=earnings_history,
+                market=identity.market,
+                exchange=identity.exchange,
+                currency=identity.currency,
+                timezone=identity.timezone,
+                local_code=identity.local_code,
                 fetch_errors=fetch_errors
             )
 

--- a/backend/app/scanners/data_preparation.py
+++ b/backend/app/scanners/data_preparation.py
@@ -260,7 +260,8 @@ class DataPreparationLayer:
             return {}
 
         logger.info(f"Preparing data for {len(symbols)} symbols using bulk cache operations")
-        requested_keys = [self._security_master.normalize_symbol(symbol) for symbol in symbols]
+        resolver = getattr(self, "_security_master", None) or SecurityMasterResolver()
+        requested_keys = [resolver.normalize_symbol(symbol) for symbol in symbols]
         identities = [self._resolve_identity(symbol) for symbol in symbols]
         canonical_symbols = [identity.canonical_symbol for identity in identities]
         unique_canonical_symbols = list(dict.fromkeys(canonical_symbols))

--- a/backend/app/scanners/data_preparation.py
+++ b/backend/app/scanners/data_preparation.py
@@ -124,6 +124,7 @@ class DataPreparationLayer:
         """
         identity = self._resolve_identity(symbol)
         normalized_symbol = identity.normalized_symbol
+        canonical_symbol = identity.canonical_symbol
         fetch_errors = {}
 
         # 1. Fetch price data (always needed)
@@ -133,7 +134,7 @@ class DataPreparationLayer:
             # Check cache first (no rate limiting)
             # Note: get_historical_data() handles Redis → DB fallback internally and ensures sufficient data
             price_data = self.price_cache.get_historical_data(
-                normalized_symbol,
+                canonical_symbol,
                 period=requirements.price_period,
             )
 
@@ -143,7 +144,7 @@ class DataPreparationLayer:
                 logger.debug(f"Cache MISS for {normalized_symbol} - fetching from yfinance")
                 price_data = self._fetch_with_retry(
                     self._yfinance_service.get_historical_data,
-                    normalized_symbol,
+                    canonical_symbol,
                     period=requirements.price_period,
                     use_cache=False,  # Already checked cache
                 )
@@ -182,7 +183,7 @@ class DataPreparationLayer:
                 # Use cache service instead of direct API call (no rate limiting needed - cache handles it)
                 fundamentals = self._fetch_with_retry(
                     self.fundamentals_cache.get_fundamentals,
-                    normalized_symbol,
+                    canonical_symbol,
                     force_refresh=False,  # Use cache by default
                 )
                 if fundamentals is None:
@@ -209,7 +210,7 @@ class DataPreparationLayer:
 
         # Create StockData container
         stock_data = StockData(
-            symbol=normalized_symbol,
+            symbol=canonical_symbol,
             price_data=price_data if price_data is not None else pd.DataFrame(),
             benchmark_data=benchmark_data if benchmark_data is not None else pd.DataFrame(),
             fundamentals=fundamentals,
@@ -224,7 +225,7 @@ class DataPreparationLayer:
         )
 
         if not allow_partial and fetch_errors:
-            raise DataFetchError(normalized_symbol, fetch_errors, partial_data=stock_data)
+            raise DataFetchError(canonical_symbol, fetch_errors, partial_data=stock_data)
 
         return stock_data
 
@@ -260,9 +261,9 @@ class DataPreparationLayer:
 
         logger.info(f"Preparing data for {len(symbols)} symbols using bulk cache operations")
         identities = [self._resolve_identity(symbol) for symbol in symbols]
-        normalized_symbols = [identity.normalized_symbol for identity in identities]
+        canonical_symbols = [identity.canonical_symbol for identity in identities]
         identity_by_symbol = {
-            identity.normalized_symbol: identity for identity in identities
+            identity.canonical_symbol: identity for identity in identities
         }
 
         # PHASE 3 OPTIMIZATION: Bulk cache lookups using Redis pipelines
@@ -271,12 +272,12 @@ class DataPreparationLayer:
         # Price data is always needed (no needs_price_data flag)
         # IMPORTANT: Pass period so get_many() can fall back to database if Redis only has 30 days
         cached_prices = self.price_cache.get_many(
-            normalized_symbols,
+            canonical_symbols,
             period=requirements.price_period,
         )
         # Fundamentals cache now includes quarterly growth data (consolidated)
         cached_fundamentals = (
-            self.fundamentals_cache.get_many(normalized_symbols)
+            self.fundamentals_cache.get_many(canonical_symbols)
             if requirements.needs_fundamentals
             else {}
         )
@@ -306,7 +307,7 @@ class DataPreparationLayer:
 
         # Build StockData for each symbol
         results = {}
-        for symbol in normalized_symbols:
+        for symbol in canonical_symbols:
             fetch_errors = {}
             identity = identity_by_symbol[symbol]
 

--- a/backend/app/scanners/data_preparation.py
+++ b/backend/app/scanners/data_preparation.py
@@ -364,14 +364,19 @@ class DataPreparationLayer:
             earnings_history = None
 
             # Create StockData
+            market_benchmark_data = (
+                benchmark_data_by_market.get(identity.market)
+                if requirements.needs_benchmark
+                else None
+            )
             results[symbol] = StockData(
                 symbol=symbol,
                 price_data=price_data if price_data is not None else pd.DataFrame(),
                 benchmark_data=(
-                    benchmark_data_by_market.get(identity.market)
-                    if requirements.needs_benchmark
-                    else None
-                ) or pd.DataFrame(),
+                    market_benchmark_data
+                    if market_benchmark_data is not None
+                    else pd.DataFrame()
+                ),
                 fundamentals=fundamentals,
                 quarterly_growth=quarterly_growth,
                 earnings_history=earnings_history,

--- a/backend/app/scanners/data_preparation.py
+++ b/backend/app/scanners/data_preparation.py
@@ -260,11 +260,10 @@ class DataPreparationLayer:
             return {}
 
         logger.info(f"Preparing data for {len(symbols)} symbols using bulk cache operations")
+        requested_keys = [self._security_master.normalize_symbol(symbol) for symbol in symbols]
         identities = [self._resolve_identity(symbol) for symbol in symbols]
         canonical_symbols = [identity.canonical_symbol for identity in identities]
-        identity_by_symbol = {
-            identity.canonical_symbol: identity for identity in identities
-        }
+        unique_canonical_symbols = list(dict.fromkeys(canonical_symbols))
 
         # PHASE 3 OPTIMIZATION: Bulk cache lookups using Redis pipelines
         # Instead of N individual Redis calls, make 2 pipeline calls (1 per cache type)
@@ -272,12 +271,12 @@ class DataPreparationLayer:
         # Price data is always needed (no needs_price_data flag)
         # IMPORTANT: Pass period so get_many() can fall back to database if Redis only has 30 days
         cached_prices = self.price_cache.get_many(
-            canonical_symbols,
+            unique_canonical_symbols,
             period=requirements.price_period,
         )
         # Fundamentals cache now includes quarterly growth data (consolidated)
         cached_fundamentals = (
-            self.fundamentals_cache.get_many(canonical_symbols)
+            self.fundamentals_cache.get_many(unique_canonical_symbols)
             if requirements.needs_fundamentals
             else {}
         )
@@ -307,9 +306,9 @@ class DataPreparationLayer:
 
         # Build StockData for each symbol
         results = {}
-        for symbol in canonical_symbols:
+        for requested_key, identity in zip(requested_keys, identities):
+            symbol = identity.canonical_symbol
             fetch_errors = {}
-            identity = identity_by_symbol[symbol]
 
             # Get price data (from cache or fetch)
             # Note: get_many() already handles sufficiency checks and database fallback
@@ -380,7 +379,7 @@ class DataPreparationLayer:
                 market_benchmark_data is None or market_benchmark_data.empty
             ):
                 fetch_errors["benchmark_data"] = f"No benchmark data returned for market {identity.market}"
-            results[symbol] = StockData(
+            results[requested_key] = StockData(
                 symbol=symbol,
                 price_data=price_data if price_data is not None else pd.DataFrame(),
                 benchmark_data=(
@@ -401,7 +400,7 @@ class DataPreparationLayer:
 
             # Collect per-symbol errors into namespaced dict for bulk error reporting
             for key, msg in fetch_errors.items():
-                all_errors[f"{symbol}/{key}"] = msg
+                all_errors[f"{requested_key}/{key}"] = msg
 
         logger.info(f"Bulk data preparation completed for {len(results)} symbols")
 

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -11,22 +11,17 @@ from typing import Any, Optional, Callable
 from datetime import datetime, timedelta
 import pandas as pd
 from sqlalchemy.orm import Session
-from zoneinfo import ZoneInfo
 
 try:
     import redis  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - exercised in desktop packaging
     redis = Any  # type: ignore
-try:
-    import exchange_calendars as xcals  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - optional dependency in some envs
-    xcals = None  # type: ignore
 
 from ..database import SessionLocal
 from ..models.stock import StockPrice
 from ..config import settings
 from .redis_pool import get_redis_client, is_redis_enabled
-from ..utils.market_hours import get_eastern_now, is_trading_day, is_market_open, get_last_trading_day
+from .market_calendar_service import MarketCalendarService
 
 logger = logging.getLogger(__name__)
 
@@ -57,19 +52,6 @@ class BenchmarkCacheService:
         "JP": "^N225",
         "TW": "^TWII",
     }
-    CALENDAR_ID_BY_MARKET: dict[str, str] = {
-        "US": "XNYS",
-        "HK": "XHKG",
-        "JP": "XTKS",
-        "TW": "XTAI",
-    }
-    TIMEZONE_BY_MARKET: dict[str, str] = {
-        "US": "America/New_York",
-        "HK": "Asia/Hong_Kong",
-        "JP": "Asia/Tokyo",
-        "TW": "Asia/Taipei",
-    }
-
     def __init__(
         self,
         redis_client: Optional[redis.Redis] = None,
@@ -88,6 +70,7 @@ class BenchmarkCacheService:
                 logger.warning("Redis connection failed. Will use database fallback.")
             else:
                 logger.info("Redis disabled for this runtime. Using database fallback.")
+        self._market_calendar = MarketCalendarService()
 
     def _normalize_market(self, market: str | None) -> str:
         normalized = (market or "US").strip().upper()
@@ -166,7 +149,11 @@ class BenchmarkCacheService:
             return cached_data
 
         # Try database cache as fallback
-        cached_data = self._get_from_database(benchmark_symbol=benchmark_symbol, period=period)
+        cached_data = self._get_from_database(
+            benchmark_symbol=benchmark_symbol,
+            period=period,
+            market=normalized_market,
+        )
         if cached_data is not None and self._is_data_fresh(cached_data, market=normalized_market):
             logger.info("Cache HIT for %s benchmark %s (%s) (Database)", normalized_market, benchmark_symbol, period)
             # Store in Redis for next time
@@ -201,13 +188,21 @@ class BenchmarkCacheService:
             logger.warning(f"Error reading from Redis: {e}")
             return None
 
-    def _get_from_database(self, benchmark_symbol: str, period: str) -> Optional[pd.DataFrame]:
+    def _get_from_database(
+        self,
+        benchmark_symbol: str,
+        period: str,
+        market: str = "US",
+    ) -> Optional[pd.DataFrame]:
         """Get cached benchmark data from database."""
         db = self._session_factory()
 
         try:
             # Calculate date range
-            end_date = get_eastern_now().date()
+            try:
+                end_date = self._market_calendar.market_now(market).date()
+            except Exception:
+                end_date = datetime.utcnow().date()
 
             if period == "2y":
                 start_date = end_date - timedelta(days=730)  # ~2 years
@@ -249,12 +244,30 @@ class BenchmarkCacheService:
         finally:
             db.close()
 
+    def _fetch_from_yfinance(self, benchmark_symbol: str, period: str) -> Optional[pd.DataFrame]:
+        """Fetch benchmark data from yfinance."""
+        # Import here to avoid circular dependency
+        from .yfinance_service import YFinanceService
+
+        yfinance_service = YFinanceService()
+        return yfinance_service.get_historical_data(benchmark_symbol, period=period)
+
     def _fetch_and_cache_benchmark(self, benchmark_symbol: str, market: str, period: str) -> Optional[pd.DataFrame]:
         """
         Fetch benchmark from yfinance and cache it.
 
         Uses distributed lock to prevent multiple workers from fetching simultaneously.
         """
+        # No Redis means no distributed coordination is possible; fetch directly
+        # and persist to DB so subsequent calls can still hit local cache.
+        if not self._redis_client:
+            benchmark_data = self._fetch_from_yfinance(benchmark_symbol, period)
+            if benchmark_data is None or benchmark_data.empty:
+                logger.error("Failed to fetch benchmark %s data from yfinance", benchmark_symbol)
+                return None
+            self._store_in_database(benchmark_symbol=benchmark_symbol, data=benchmark_data)
+            return benchmark_data
+
         lock_key = self._redis_lock_key(benchmark_symbol, period)
         # Try to acquire lock
         lock_acquired = False
@@ -278,11 +291,7 @@ class BenchmarkCacheService:
             # We have the lock - fetch from yfinance
             logger.info("Fetching benchmark %s for market %s (%s) from yfinance", benchmark_symbol, market, period)
 
-            # Import here to avoid circular dependency
-            from .yfinance_service import YFinanceService
-
-            yfinance_service = YFinanceService()
-            benchmark_data = yfinance_service.get_historical_data(benchmark_symbol, period=period)
+            benchmark_data = self._fetch_from_yfinance(benchmark_symbol, period)
 
             if benchmark_data is None or benchmark_data.empty:
                 logger.error("Failed to fetch benchmark %s data from yfinance", benchmark_symbol)
@@ -333,9 +342,12 @@ class BenchmarkCacheService:
 
         # Timeout - fetch directly as fallback
         logger.warning("Timeout waiting for benchmark %s %s cache - fetching directly", benchmark_symbol, period)
-        from .yfinance_service import YFinanceService
-        yfinance_service = YFinanceService()
-        return yfinance_service.get_historical_data(benchmark_symbol, period=period)
+        benchmark_data = self._fetch_from_yfinance(benchmark_symbol, period)
+        if benchmark_data is not None and not benchmark_data.empty:
+            # Persist fallback fetch so future calls can use DB cache even when
+            # lock-holder failed to populate Redis.
+            self._store_in_database(benchmark_symbol=benchmark_symbol, data=benchmark_data)
+        return benchmark_data
 
     def _store_in_redis(self, benchmark_symbol: str, period: str, data: pd.DataFrame) -> None:
         """Store benchmark data in Redis."""
@@ -440,7 +452,11 @@ class BenchmarkCacheService:
                 last_date = pd.Timestamp(last_date)
 
             normalized_market = self._normalize_market(market)
-            expected = self._expected_trading_date(normalized_market)
+            expected = None
+            try:
+                expected = self._market_calendar.last_completed_trading_day(normalized_market)
+            except Exception:
+                expected = None
             if expected is None:
                 # Fallback freshness check when expected trading date cannot be computed.
                 latest_allowed = pd.Timestamp.utcnow() - pd.Timedelta(hours=max_age_hours)
@@ -464,41 +480,6 @@ class BenchmarkCacheService:
         except Exception as e:
             logger.warning(f"Error checking data freshness: {e}")
             return False
-
-    def _expected_trading_date(self, market: str):
-        if market == "US":
-            now_et = get_eastern_now()
-            today = now_et.date()
-            if is_trading_day(today) and not is_market_open(now_et) and now_et.hour >= 17:
-                return today
-            return get_last_trading_day(today - timedelta(days=1))
-
-        if xcals is None:
-            return None
-
-        calendar_id = self.CALENDAR_ID_BY_MARKET.get(market)
-        timezone_name = self.TIMEZONE_BY_MARKET.get(market)
-        if not calendar_id or not timezone_name:
-            return None
-
-        calendar = xcals.get_calendar(calendar_id)
-        now_local = datetime.now(ZoneInfo(timezone_name))
-        current_session = pd.Timestamp(now_local.date())
-        if not calendar.is_session(current_session):
-            return calendar.previous_session(current_session).date()
-
-        # Daily bars are reliably available after local close + 1 hour buffer.
-        schedule = calendar.schedule.loc[current_session:current_session]
-        if schedule.empty:
-            return None
-
-        market_close = schedule.iloc[0]["market_close"]
-        if market_close.tzinfo is None:
-            market_close = market_close.tz_localize("UTC")
-        close_with_buffer = market_close.tz_convert(ZoneInfo(timezone_name)).to_pydatetime() + timedelta(hours=1)
-        if now_local >= close_with_buffer:
-            return current_session.date()
-        return calendar.previous_session(current_session).date()
 
     def invalidate_cache(self, period: str = None) -> None:
         """

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -1,7 +1,7 @@
 """
-Benchmark Cache Service for SPY data caching.
+Benchmark Cache Service for market-aware benchmark data caching.
 
-Provides singleton caching of SPY benchmark data to eliminate redundant API calls
+Provides singleton-style caching of benchmark data to eliminate redundant API calls
 during bulk scans. Uses Redis for hot cache with database persistence.
 """
 import logging
@@ -11,11 +11,16 @@ from typing import Any, Optional, Callable
 from datetime import datetime, timedelta
 import pandas as pd
 from sqlalchemy.orm import Session
+from zoneinfo import ZoneInfo
 
 try:
     import redis  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - exercised in desktop packaging
     redis = Any  # type: ignore
+try:
+    import exchange_calendars as xcals  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency in some envs
+    xcals = None  # type: ignore
 
 from ..database import SessionLocal
 from ..models.stock import StockPrice
@@ -39,14 +44,31 @@ class BenchmarkCacheService:
 
     # Redis keys
     REDIS_KEY_PREFIX = "benchmark:"
-    REDIS_KEY_SPY_2Y = "benchmark:SPY:2y"
-    REDIS_KEY_SPY_1Y = "benchmark:SPY:1y"
-    REDIS_LOCK_KEY = "benchmark:SPY:lock"
+    REDIS_LOCK_KEY_SUFFIX = ":lock"
 
     # TTL: expires at market close + 1 hour buffer
     CACHE_TTL_SECONDS = 86400  # 24 hours
     LOCK_TIMEOUT_SECONDS = 10  # Max time to wait for lock
     LOCK_EXPIRY_SECONDS = 30  # Lock auto-expires after 30 seconds
+
+    BENCHMARK_BY_MARKET: dict[str, str] = {
+        "US": "SPY",
+        "HK": "^HSI",
+        "JP": "^N225",
+        "TW": "^TWII",
+    }
+    CALENDAR_ID_BY_MARKET: dict[str, str] = {
+        "US": "XNYS",
+        "HK": "XHKG",
+        "JP": "XTKS",
+        "TW": "XTAI",
+    }
+    TIMEZONE_BY_MARKET: dict[str, str] = {
+        "US": "America/New_York",
+        "HK": "Asia/Hong_Kong",
+        "JP": "Asia/Tokyo",
+        "TW": "Asia/Taipei",
+    }
 
     def __init__(
         self,
@@ -67,62 +89,110 @@ class BenchmarkCacheService:
             else:
                 logger.info("Redis disabled for this runtime. Using database fallback.")
 
+    def _normalize_market(self, market: str | None) -> str:
+        normalized = (market or "US").strip().upper()
+        if normalized not in self.BENCHMARK_BY_MARKET:
+            raise ValueError(f"Unsupported market for benchmark cache: {market}")
+        return normalized
+
+    def get_benchmark_symbol(self, market: str = "US") -> str:
+        normalized_market = self._normalize_market(market)
+        return self.BENCHMARK_BY_MARKET[normalized_market]
+
+    def _redis_data_key(self, benchmark_symbol: str, period: str) -> str:
+        return f"{self.REDIS_KEY_PREFIX}{benchmark_symbol}:{period}"
+
+    def _redis_lock_key(self, benchmark_symbol: str, period: str) -> str:
+        return f"{self._redis_data_key(benchmark_symbol, period)}{self.REDIS_LOCK_KEY_SUFFIX}"
+
     def get_spy_data(
         self,
         period: str = "2y",
         force_refresh: bool = False
     ) -> Optional[pd.DataFrame]:
         """
-        Get SPY benchmark data with caching.
+        Compatibility wrapper for legacy SPY callers.
+        """
+        return self.get_benchmark_data(
+            market="US",
+            period=period,
+            force_refresh=force_refresh,
+        )
+
+    def get_benchmark_data(
+        self,
+        market: str = "US",
+        period: str = "2y",
+        force_refresh: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        """
+        Get benchmark data with market-aware caching.
 
         Args:
+            market: Market code (US, HK, JP, TW)
             period: Time period ('1y' or '2y')
             force_refresh: Force fetch from yfinance, bypass cache
 
         Returns:
-            DataFrame with OHLCV data for SPY
+            DataFrame with OHLCV data for market benchmark
 
         Logic:
-        1. Check Redis for cached SPY
+        1. Check Redis for cached benchmark
         2. If miss, acquire distributed lock
         3. Fetch from yfinance (once!)
         4. Cache in Redis + persist to database
         5. Return to all waiting callers
         """
+        normalized_market = self._normalize_market(market)
+        benchmark_symbol = self.get_benchmark_symbol(normalized_market)
+
         if force_refresh:
-            logger.info(f"Force refresh requested for SPY {period}")
-            return self._fetch_and_cache_spy(period)
+            logger.info(
+                "Force refresh requested for %s benchmark %s (%s)",
+                normalized_market,
+                benchmark_symbol,
+                period,
+            )
+            return self._fetch_and_cache_benchmark(
+                benchmark_symbol=benchmark_symbol,
+                market=normalized_market,
+                period=period,
+            )
 
         # Try Redis cache first
-        cached_data = self._get_from_redis(period)
+        cached_data = self._get_from_redis(benchmark_symbol=benchmark_symbol, period=period)
         if cached_data is not None:
-            logger.info(f"Cache HIT for SPY {period} (Redis)")
+            logger.info("Cache HIT for %s benchmark %s (%s) (Redis)", normalized_market, benchmark_symbol, period)
             return cached_data
 
         # Try database cache as fallback
-        cached_data = self._get_from_database(period)
-        if cached_data is not None and self._is_data_fresh(cached_data):
-            logger.info(f"Cache HIT for SPY {period} (Database)")
+        cached_data = self._get_from_database(benchmark_symbol=benchmark_symbol, period=period)
+        if cached_data is not None and self._is_data_fresh(cached_data, market=normalized_market):
+            logger.info("Cache HIT for %s benchmark %s (%s) (Database)", normalized_market, benchmark_symbol, period)
             # Store in Redis for next time
-            self._store_in_redis(period, cached_data)
+            self._store_in_redis(benchmark_symbol=benchmark_symbol, period=period, data=cached_data)
             return cached_data
 
         # Cache MISS - need to fetch from yfinance
-        logger.info(f"Cache MISS for SPY {period} - fetching from yfinance")
-        return self._fetch_and_cache_spy(period)
+        logger.info("Cache MISS for %s benchmark %s (%s) - fetching from yfinance", normalized_market, benchmark_symbol, period)
+        return self._fetch_and_cache_benchmark(
+            benchmark_symbol=benchmark_symbol,
+            market=normalized_market,
+            period=period,
+        )
 
-    def _get_from_redis(self, period: str) -> Optional[pd.DataFrame]:
-        """Get cached SPY data from Redis."""
+    def _get_from_redis(self, benchmark_symbol: str, period: str) -> Optional[pd.DataFrame]:
+        """Get cached benchmark data from Redis."""
         if not self._redis_client:
             return None
 
         try:
-            redis_key = self.REDIS_KEY_SPY_2Y if period == "2y" else self.REDIS_KEY_SPY_1Y
+            redis_key = self._redis_data_key(benchmark_symbol, period)
             cached_bytes = self._redis_client.get(redis_key)
 
             if cached_bytes:
                 df = pickle.loads(cached_bytes)
-                logger.debug(f"Retrieved SPY {period} from Redis ({len(df)} rows)")
+                logger.debug("Retrieved benchmark %s %s from Redis (%s rows)", benchmark_symbol, period, len(df))
                 return df
 
             return None
@@ -131,8 +201,8 @@ class BenchmarkCacheService:
             logger.warning(f"Error reading from Redis: {e}")
             return None
 
-    def _get_from_database(self, period: str) -> Optional[pd.DataFrame]:
-        """Get cached SPY data from database."""
+    def _get_from_database(self, benchmark_symbol: str, period: str) -> Optional[pd.DataFrame]:
+        """Get cached benchmark data from database."""
         db = self._session_factory()
 
         try:
@@ -146,13 +216,13 @@ class BenchmarkCacheService:
 
             # Query StockPrice table
             prices = db.query(StockPrice).filter(
-                StockPrice.symbol == "SPY",
+                StockPrice.symbol == benchmark_symbol,
                 StockPrice.date >= start_date,
                 StockPrice.date <= end_date
             ).order_by(StockPrice.date.asc()).all()
 
             if not prices or len(prices) < 100:  # Need substantial data
-                logger.debug(f"Insufficient data in database for SPY {period}")
+                logger.debug("Insufficient data in database for benchmark %s %s", benchmark_symbol, period)
                 return None
 
             # Convert to DataFrame
@@ -169,7 +239,7 @@ class BenchmarkCacheService:
             df['Date'] = pd.to_datetime(df['Date'])
             df.set_index('Date', inplace=True)
 
-            logger.debug(f"Retrieved SPY {period} from database ({len(df)} rows)")
+            logger.debug("Retrieved benchmark %s %s from database (%s rows)", benchmark_symbol, period, len(df))
             return df
 
         except Exception as e:
@@ -179,18 +249,19 @@ class BenchmarkCacheService:
         finally:
             db.close()
 
-    def _fetch_and_cache_spy(self, period: str) -> Optional[pd.DataFrame]:
+    def _fetch_and_cache_benchmark(self, benchmark_symbol: str, market: str, period: str) -> Optional[pd.DataFrame]:
         """
-        Fetch SPY from yfinance and cache it.
+        Fetch benchmark from yfinance and cache it.
 
         Uses distributed lock to prevent multiple workers from fetching simultaneously.
         """
+        lock_key = self._redis_lock_key(benchmark_symbol, period)
         # Try to acquire lock
         lock_acquired = False
         if self._redis_client:
             try:
                 lock_acquired = self._redis_client.set(
-                    self.REDIS_LOCK_KEY,
+                    lock_key,
                     "locked",
                     nx=True,  # Only set if not exists
                     ex=self.LOCK_EXPIRY_SECONDS
@@ -200,44 +271,49 @@ class BenchmarkCacheService:
 
         if not lock_acquired:
             # Another worker is fetching - wait for it to complete
-            logger.info("Another worker is fetching SPY - waiting...")
-            return self._wait_for_cache(period)
+            logger.info("Another worker is fetching benchmark %s (%s) - waiting...", benchmark_symbol, period)
+            return self._wait_for_cache(benchmark_symbol=benchmark_symbol, period=period)
 
         try:
             # We have the lock - fetch from yfinance
-            logger.info(f"Fetching SPY {period} from yfinance")
+            logger.info("Fetching benchmark %s for market %s (%s) from yfinance", benchmark_symbol, market, period)
 
             # Import here to avoid circular dependency
             from .yfinance_service import YFinanceService
 
             yfinance_service = YFinanceService()
-            spy_data = yfinance_service.get_historical_data("SPY", period=period)
+            benchmark_data = yfinance_service.get_historical_data(benchmark_symbol, period=period)
 
-            if spy_data is None or spy_data.empty:
-                logger.error("Failed to fetch SPY data from yfinance")
+            if benchmark_data is None or benchmark_data.empty:
+                logger.error("Failed to fetch benchmark %s data from yfinance", benchmark_symbol)
                 return None
 
-            logger.info(f"Fetched SPY {period}: {len(spy_data)} rows")
+            logger.info("Fetched benchmark %s %s: %s rows", benchmark_symbol, period, len(benchmark_data))
 
             # Cache in Redis
-            self._store_in_redis(period, spy_data)
+            self._store_in_redis(benchmark_symbol=benchmark_symbol, period=period, data=benchmark_data)
 
             # Persist to database
-            self._store_in_database(spy_data)
+            self._store_in_database(benchmark_symbol=benchmark_symbol, data=benchmark_data)
 
-            return spy_data
+            return benchmark_data
 
         finally:
             # Release lock
             if self._redis_client and lock_acquired:
                 try:
-                    self._redis_client.delete(self.REDIS_LOCK_KEY)
+                    self._redis_client.delete(lock_key)
                 except Exception as e:
                     logger.warning(f"Error releasing lock: {e}")
 
-    def _wait_for_cache(self, period: str, max_wait_seconds: int = None) -> Optional[pd.DataFrame]:
+    def _wait_for_cache(
+        self,
+        benchmark_symbol: str,
+        period: str,
+        max_wait_seconds: int = None,
+    ) -> Optional[pd.DataFrame]:
         """
-        Wait for another worker to cache SPY data.
+        Wait for another worker to cache benchmark data.
 
         Polls Redis every 0.5 seconds for cached data.
         """
@@ -248,26 +324,26 @@ class BenchmarkCacheService:
 
         while (time.time() - start_time) < max_wait_seconds:
             # Check if data is now in cache
-            cached_data = self._get_from_redis(period)
+            cached_data = self._get_from_redis(benchmark_symbol=benchmark_symbol, period=period)
             if cached_data is not None:
-                logger.info(f"SPY {period} is now cached by another worker")
+                logger.info("Benchmark %s %s is now cached by another worker", benchmark_symbol, period)
                 return cached_data
 
             time.sleep(0.5)
 
         # Timeout - fetch directly as fallback
-        logger.warning(f"Timeout waiting for SPY {period} cache - fetching directly")
+        logger.warning("Timeout waiting for benchmark %s %s cache - fetching directly", benchmark_symbol, period)
         from .yfinance_service import YFinanceService
         yfinance_service = YFinanceService()
-        return yfinance_service.get_historical_data("SPY", period=period)
+        return yfinance_service.get_historical_data(benchmark_symbol, period=period)
 
-    def _store_in_redis(self, period: str, data: pd.DataFrame) -> None:
-        """Store SPY data in Redis."""
+    def _store_in_redis(self, benchmark_symbol: str, period: str, data: pd.DataFrame) -> None:
+        """Store benchmark data in Redis."""
         if not self._redis_client:
             return
 
         try:
-            redis_key = self.REDIS_KEY_SPY_2Y if period == "2y" else self.REDIS_KEY_SPY_1Y
+            redis_key = self._redis_data_key(benchmark_symbol, period)
             pickled_data = pickle.dumps(data)
 
             self._redis_client.setex(
@@ -276,14 +352,14 @@ class BenchmarkCacheService:
                 pickled_data
             )
 
-            logger.info(f"Cached SPY {period} in Redis (TTL: {self.CACHE_TTL_SECONDS}s)")
+            logger.info("Cached benchmark %s %s in Redis (TTL: %ss)", benchmark_symbol, period, self.CACHE_TTL_SECONDS)
 
         except Exception as e:
             logger.error(f"Error storing in Redis: {e}", exc_info=True)
 
-    def _store_in_database(self, data: pd.DataFrame) -> None:
+    def _store_in_database(self, benchmark_symbol: str, data: pd.DataFrame) -> None:
         """
-        Store SPY data in database (StockPrice table).
+        Store benchmark data in database (StockPrice table).
 
         Uses bulk insert for efficiency (same pattern as PriceCacheService).
         """
@@ -293,9 +369,9 @@ class BenchmarkCacheService:
             # Reset index to get Date as a column
             df = data.reset_index()
 
-            # Fetch all existing dates for SPY upfront (avoid N+1 queries)
+            # Fetch all existing dates for benchmark upfront (avoid N+1 queries)
             existing_dates_query = db.query(StockPrice.date).filter(
-                StockPrice.symbol == "SPY"
+                StockPrice.symbol == benchmark_symbol
             )
             existing_dates = set([row[0] for row in existing_dates_query.all()])
 
@@ -318,7 +394,7 @@ class BenchmarkCacheService:
                 # Prepare row for bulk insert
                 try:
                     price_dict = {
-                        'symbol': "SPY",
+                        'symbol': benchmark_symbol,
                         'date': row_date,
                         'open': float(row.get('Open', 0)),
                         'high': float(row.get('High', 0)),
@@ -330,30 +406,30 @@ class BenchmarkCacheService:
                     rows_to_insert.append(price_dict)
 
                 except Exception as e:
-                    logger.warning(f"Error preparing SPY row for {row.get('Date')}: {e}")
+                    logger.warning("Error preparing benchmark %s row for %s: %s", benchmark_symbol, row.get("Date"), e)
                     continue
 
             # Bulk insert all new rows in one operation
             if rows_to_insert:
                 db.bulk_insert_mappings(StockPrice, rows_to_insert)
                 db.commit()
-                logger.info(f"Bulk inserted {len(rows_to_insert)} new SPY rows to database")
+                logger.info("Bulk inserted %s new benchmark %s rows to database", len(rows_to_insert), benchmark_symbol)
             else:
-                logger.debug("No new SPY rows to persist")
+                logger.debug("No new benchmark %s rows to persist", benchmark_symbol)
 
         except Exception as e:
-            logger.error(f"Error storing SPY in database: {e}", exc_info=True)
+            logger.error("Error storing benchmark %s in database: %s", benchmark_symbol, e, exc_info=True)
             db.rollback()
 
         finally:
             db.close()
 
-    def _is_data_fresh(self, data: pd.DataFrame, max_age_hours: int = 24) -> bool:
+    def _is_data_fresh(self, data: pd.DataFrame, market: str = "US", max_age_hours: int = 24) -> bool:
         """
-        Check if cached SPY data is still fresh using trading-day awareness.
+        Check if cached benchmark data is still fresh using market-aware trading-day logic.
 
-        Uses market calendar to determine expected data date instead of
-        naive timedelta checks that break on holidays and weekends.
+        US continues using legacy NYSE helper for parity. Non-US uses
+        exchange_calendars where available and falls back to max-age checks.
         """
         if data is None or data.empty:
             return False
@@ -363,30 +439,70 @@ class BenchmarkCacheService:
             if not isinstance(last_date, pd.Timestamp):
                 last_date = pd.Timestamp(last_date)
 
-            now_et = get_eastern_now()
-            today = now_et.date()
-
-            # Determine what date we should have data for
-            if is_trading_day(today) and not is_market_open(now_et) and now_et.hour >= 17:
-                # After 5 PM on trading day: expect today's close
-                expected = today
-            else:
-                # During market hours, before open, grace period, weekend, holiday:
-                # last completed trading day's data is sufficient
-                expected = get_last_trading_day(today - timedelta(days=1))
+            normalized_market = self._normalize_market(market)
+            expected = self._expected_trading_date(normalized_market)
+            if expected is None:
+                # Fallback freshness check when expected trading date cannot be computed.
+                latest_allowed = pd.Timestamp.utcnow() - pd.Timedelta(hours=max_age_hours)
+                last_ts = pd.Timestamp(last_date)
+                if last_ts.tzinfo is None:
+                    last_ts = last_ts.tz_localize("UTC")
+                else:
+                    last_ts = last_ts.tz_convert("UTC")
+                return last_ts >= latest_allowed
 
             is_fresh = last_date.date() >= expected
             if not is_fresh:
-                logger.debug(f"SPY data stale (last: {last_date.date()}, expected: {expected})")
+                logger.debug(
+                    "Benchmark data stale for market %s (last: %s, expected: %s)",
+                    normalized_market,
+                    last_date.date(),
+                    expected,
+                )
             return is_fresh
 
         except Exception as e:
             logger.warning(f"Error checking data freshness: {e}")
             return False
 
+    def _expected_trading_date(self, market: str):
+        if market == "US":
+            now_et = get_eastern_now()
+            today = now_et.date()
+            if is_trading_day(today) and not is_market_open(now_et) and now_et.hour >= 17:
+                return today
+            return get_last_trading_day(today - timedelta(days=1))
+
+        if xcals is None:
+            return None
+
+        calendar_id = self.CALENDAR_ID_BY_MARKET.get(market)
+        timezone_name = self.TIMEZONE_BY_MARKET.get(market)
+        if not calendar_id or not timezone_name:
+            return None
+
+        calendar = xcals.get_calendar(calendar_id)
+        now_local = datetime.now(ZoneInfo(timezone_name))
+        current_session = pd.Timestamp(now_local.date())
+        if not calendar.is_session(current_session):
+            return calendar.previous_session(current_session).date()
+
+        # Daily bars are reliably available after local close + 1 hour buffer.
+        schedule = calendar.schedule.loc[current_session:current_session]
+        if schedule.empty:
+            return None
+
+        market_close = schedule.iloc[0]["market_close"]
+        if market_close.tzinfo is None:
+            market_close = market_close.tz_localize("UTC")
+        close_with_buffer = market_close.tz_convert(ZoneInfo(timezone_name)).to_pydatetime() + timedelta(hours=1)
+        if now_local >= close_with_buffer:
+            return current_session.date()
+        return calendar.previous_session(current_session).date()
+
     def invalidate_cache(self, period: str = None) -> None:
         """
-        Invalidate cached SPY data.
+        Invalidate cached benchmark data.
 
         Args:
             period: Specific period to invalidate, or None for all
@@ -396,15 +512,24 @@ class BenchmarkCacheService:
             return
 
         try:
+            keys: list[str]
             if period:
-                redis_key = self.REDIS_KEY_SPY_2Y if period == "2y" else self.REDIS_KEY_SPY_1Y
-                self._redis_client.delete(redis_key)
-                logger.info(f"Invalidated SPY {period} cache")
+                keys = [
+                    self._redis_data_key(symbol, period)
+                    for symbol in self.BENCHMARK_BY_MARKET.values()
+                ]
             else:
-                # Invalidate all
-                self._redis_client.delete(self.REDIS_KEY_SPY_2Y)
-                self._redis_client.delete(self.REDIS_KEY_SPY_1Y)
-                logger.info("Invalidated all SPY cache")
+                keys = []
+                for symbol in self.BENCHMARK_BY_MARKET.values():
+                    keys.append(self._redis_data_key(symbol, "1y"))
+                    keys.append(self._redis_data_key(symbol, "2y"))
+
+            if keys:
+                self._redis_client.delete(*keys)
+            if period:
+                logger.info("Invalidated all benchmark %s cache keys", period)
+            else:
+                logger.info("Invalidated all benchmark cache keys")
 
         except Exception as e:
             logger.error(f"Error invalidating cache: {e}", exc_info=True)

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -23,6 +23,7 @@ from ..config import settings
 from .redis_pool import get_redis_client, is_redis_enabled
 from .market_calendar_service import MarketCalendarService
 from .benchmark_registry_service import benchmark_registry
+from ..utils.market_hours import get_eastern_now, get_last_trading_day, is_market_open
 
 logger = logging.getLogger(__name__)
 
@@ -492,6 +493,8 @@ class BenchmarkCacheService:
             except Exception:
                 expected = None
             if expected is None:
+                if normalized_market == "US":
+                    return self._is_us_data_fresh_without_exchange_calendars(last_date)
                 # Calendar fallback: avoid weekend/holiday false-stale by allowing data
                 # through the next business day when exchange calendar lookup is unavailable.
                 return self._is_data_fresh_without_calendar(last_date, max_age_hours=max_age_hours)
@@ -534,6 +537,17 @@ class BenchmarkCacheService:
             end=now_utc.date(),
         )
         return len(business_days_after_last) <= 1
+
+    @staticmethod
+    def _is_us_data_fresh_without_exchange_calendars(last_date: pd.Timestamp) -> bool:
+        """US-specific fallback that preserves NYSE holiday semantics via market_hours."""
+        eastern_now = get_eastern_now()
+        today = eastern_now.date()
+        if is_market_open(eastern_now):
+            expected = get_last_trading_day(today - timedelta(days=1))
+        else:
+            expected = get_last_trading_day(today)
+        return last_date.date() >= expected
 
     def invalidate_cache(self, period: str = None) -> None:
         """

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -22,6 +22,7 @@ from ..models.stock import StockPrice
 from ..config import settings
 from .redis_pool import get_redis_client, is_redis_enabled
 from .market_calendar_service import MarketCalendarService
+from .benchmark_registry_service import benchmark_registry
 
 logger = logging.getLogger(__name__)
 
@@ -46,12 +47,6 @@ class BenchmarkCacheService:
     LOCK_TIMEOUT_SECONDS = 10  # Max time to wait for lock
     LOCK_EXPIRY_SECONDS = 30  # Lock auto-expires after 30 seconds
 
-    BENCHMARK_BY_MARKET: dict[str, str] = {
-        "US": "SPY",
-        "HK": "^HSI",
-        "JP": "^N225",
-        "TW": "^TWII",
-    }
     def __init__(
         self,
         redis_client: Optional[redis.Redis] = None,
@@ -71,16 +66,16 @@ class BenchmarkCacheService:
             else:
                 logger.info("Redis disabled for this runtime. Using database fallback.")
         self._market_calendar = MarketCalendarService()
+        self._benchmark_registry = benchmark_registry
 
     def _normalize_market(self, market: str | None) -> str:
-        normalized = (market or "US").strip().upper()
-        if normalized not in self.BENCHMARK_BY_MARKET:
-            raise ValueError(f"Unsupported market for benchmark cache: {market}")
-        return normalized
+        return self._benchmark_registry.normalize_market(market)
 
     def get_benchmark_symbol(self, market: str = "US") -> str:
-        normalized_market = self._normalize_market(market)
-        return self.BENCHMARK_BY_MARKET[normalized_market]
+        return self._benchmark_registry.get_primary_symbol(market)
+
+    def get_benchmark_candidates(self, market: str = "US") -> list[str]:
+        return self._benchmark_registry.get_candidate_symbols(market)
 
     def _redis_data_key(self, benchmark_symbol: str, period: str) -> str:
         return f"{self.REDIS_KEY_PREFIX}{benchmark_symbol}:{period}"
@@ -127,46 +122,75 @@ class BenchmarkCacheService:
         5. Return to all waiting callers
         """
         normalized_market = self._normalize_market(market)
-        benchmark_symbol = self.get_benchmark_symbol(normalized_market)
+        candidates = self.get_benchmark_candidates(normalized_market)
 
-        if force_refresh:
+        for idx, benchmark_symbol in enumerate(candidates):
+            role = "primary" if idx == 0 else "fallback"
+            if force_refresh:
+                logger.info(
+                    "Force refresh requested for %s benchmark %s (%s, %s)",
+                    normalized_market,
+                    benchmark_symbol,
+                    period,
+                    role,
+                )
+                fetched = self._fetch_and_cache_benchmark(
+                    benchmark_symbol=benchmark_symbol,
+                    market=normalized_market,
+                    period=period,
+                )
+                if fetched is not None and not fetched.empty:
+                    return fetched
+                continue
+
+            # Try Redis cache first
+            cached_data = self._get_from_redis(benchmark_symbol=benchmark_symbol, period=period)
+            if cached_data is not None:
+                logger.info(
+                    "Cache HIT for %s benchmark %s (%s, %s) (Redis)",
+                    normalized_market,
+                    benchmark_symbol,
+                    period,
+                    role,
+                )
+                return cached_data
+
+            # Try database cache as fallback
+            cached_data = self._get_from_database(
+                benchmark_symbol=benchmark_symbol,
+                period=period,
+                market=normalized_market,
+            )
+            if cached_data is not None and self._is_data_fresh(cached_data, market=normalized_market):
+                logger.info(
+                    "Cache HIT for %s benchmark %s (%s, %s) (Database)",
+                    normalized_market,
+                    benchmark_symbol,
+                    period,
+                    role,
+                )
+                # Store in Redis for next time
+                self._store_in_redis(benchmark_symbol=benchmark_symbol, period=period, data=cached_data)
+                return cached_data
+
+            # Cache MISS - attempt fetch for this candidate
             logger.info(
-                "Force refresh requested for %s benchmark %s (%s)",
+                "Cache MISS for %s benchmark %s (%s, %s) - fetching from yfinance",
                 normalized_market,
                 benchmark_symbol,
                 period,
+                role,
             )
-            return self._fetch_and_cache_benchmark(
+            fetched = self._fetch_and_cache_benchmark(
                 benchmark_symbol=benchmark_symbol,
                 market=normalized_market,
                 period=period,
             )
+            if fetched is not None and not fetched.empty:
+                return fetched
 
-        # Try Redis cache first
-        cached_data = self._get_from_redis(benchmark_symbol=benchmark_symbol, period=period)
-        if cached_data is not None:
-            logger.info("Cache HIT for %s benchmark %s (%s) (Redis)", normalized_market, benchmark_symbol, period)
-            return cached_data
-
-        # Try database cache as fallback
-        cached_data = self._get_from_database(
-            benchmark_symbol=benchmark_symbol,
-            period=period,
-            market=normalized_market,
-        )
-        if cached_data is not None and self._is_data_fresh(cached_data, market=normalized_market):
-            logger.info("Cache HIT for %s benchmark %s (%s) (Database)", normalized_market, benchmark_symbol, period)
-            # Store in Redis for next time
-            self._store_in_redis(benchmark_symbol=benchmark_symbol, period=period, data=cached_data)
-            return cached_data
-
-        # Cache MISS - need to fetch from yfinance
-        logger.info("Cache MISS for %s benchmark %s (%s) - fetching from yfinance", normalized_market, benchmark_symbol, period)
-        return self._fetch_and_cache_benchmark(
-            benchmark_symbol=benchmark_symbol,
-            market=normalized_market,
-            period=period,
-        )
+        logger.warning("No benchmark candidate produced data for market=%s period=%s", normalized_market, period)
+        return None
 
     def _get_from_redis(self, benchmark_symbol: str, period: str) -> Optional[pd.DataFrame]:
         """Get cached benchmark data from Redis."""
@@ -494,14 +518,17 @@ class BenchmarkCacheService:
 
         try:
             keys: list[str]
+            symbols = set()
+            for market in self._benchmark_registry.supported_markets():
+                symbols.update(self._benchmark_registry.get_candidate_symbols(market))
             if period:
                 keys = [
                     self._redis_data_key(symbol, period)
-                    for symbol in self.BENCHMARK_BY_MARKET.values()
+                    for symbol in symbols
                 ]
             else:
                 keys = []
-                for symbol in self.BENCHMARK_BY_MARKET.values():
+                for symbol in symbols:
                     keys.append(self._redis_data_key(symbol, "1y"))
                     keys.append(self._redis_data_key(symbol, "2y"))
 

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -129,7 +129,7 @@ class BenchmarkCacheService:
             for idx, benchmark_symbol in enumerate(candidates):
                 role = "primary" if idx == 0 else "fallback"
                 cached_data = self._get_from_redis(benchmark_symbol=benchmark_symbol, period=period)
-                if cached_data is not None:
+                if cached_data is not None and self._is_data_fresh(cached_data, market=normalized_market):
                     logger.info(
                         "Cache HIT for %s benchmark %s (%s, %s) (Redis)",
                         normalized_market,
@@ -138,6 +138,14 @@ class BenchmarkCacheService:
                         role,
                     )
                     return cached_data
+                if cached_data is not None:
+                    logger.info(
+                        "Cache STALE for %s benchmark %s (%s, %s) (Redis)",
+                        normalized_market,
+                        benchmark_symbol,
+                        period,
+                        role,
+                    )
 
                 cached_data = self._get_from_database(
                     benchmark_symbol=benchmark_symbol,

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -23,7 +23,7 @@ from ..config import settings
 from .redis_pool import get_redis_client, is_redis_enabled
 from .market_calendar_service import MarketCalendarService
 from .benchmark_registry_service import benchmark_registry
-from ..utils.market_hours import get_eastern_now, get_last_trading_day, is_market_open
+from ..utils.market_hours import get_eastern_now, get_last_trading_day, is_market_open, is_trading_day
 
 logger = logging.getLogger(__name__)
 
@@ -543,10 +543,12 @@ class BenchmarkCacheService:
         """US-specific fallback that preserves NYSE holiday semantics via market_hours."""
         eastern_now = get_eastern_now()
         today = eastern_now.date()
-        if is_market_open(eastern_now):
-            expected = get_last_trading_day(today - timedelta(days=1))
+        if is_trading_day(today) and not is_market_open(eastern_now) and eastern_now.hour >= 17:
+            # After 5 PM ET on a trading day, today's close should be available.
+            expected = today
         else:
-            expected = get_last_trading_day(today)
+            # Pre-market, intraday, weekend, and holidays: previous completed trading day.
+            expected = get_last_trading_day(today - timedelta(days=1))
         return last_date.date() >= expected
 
     def invalidate_cache(self, period: str = None) -> None:

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -124,6 +124,38 @@ class BenchmarkCacheService:
         normalized_market = self._normalize_market(market)
         candidates = self.get_benchmark_candidates(normalized_market)
 
+        # Pass 1: Prefer any cached candidate before triggering network fetches.
+        if not force_refresh:
+            for idx, benchmark_symbol in enumerate(candidates):
+                role = "primary" if idx == 0 else "fallback"
+                cached_data = self._get_from_redis(benchmark_symbol=benchmark_symbol, period=period)
+                if cached_data is not None:
+                    logger.info(
+                        "Cache HIT for %s benchmark %s (%s, %s) (Redis)",
+                        normalized_market,
+                        benchmark_symbol,
+                        period,
+                        role,
+                    )
+                    return cached_data
+
+                cached_data = self._get_from_database(
+                    benchmark_symbol=benchmark_symbol,
+                    period=period,
+                    market=normalized_market,
+                )
+                if cached_data is not None and self._is_data_fresh(cached_data, market=normalized_market):
+                    logger.info(
+                        "Cache HIT for %s benchmark %s (%s, %s) (Database)",
+                        normalized_market,
+                        benchmark_symbol,
+                        period,
+                        role,
+                    )
+                    self._store_in_redis(benchmark_symbol=benchmark_symbol, period=period, data=cached_data)
+                    return cached_data
+
+        # Pass 2: Fetch candidates in deterministic order.
         for idx, benchmark_symbol in enumerate(candidates):
             role = "primary" if idx == 0 else "fallback"
             if force_refresh:
@@ -142,36 +174,6 @@ class BenchmarkCacheService:
                 if fetched is not None and not fetched.empty:
                     return fetched
                 continue
-
-            # Try Redis cache first
-            cached_data = self._get_from_redis(benchmark_symbol=benchmark_symbol, period=period)
-            if cached_data is not None:
-                logger.info(
-                    "Cache HIT for %s benchmark %s (%s, %s) (Redis)",
-                    normalized_market,
-                    benchmark_symbol,
-                    period,
-                    role,
-                )
-                return cached_data
-
-            # Try database cache as fallback
-            cached_data = self._get_from_database(
-                benchmark_symbol=benchmark_symbol,
-                period=period,
-                market=normalized_market,
-            )
-            if cached_data is not None and self._is_data_fresh(cached_data, market=normalized_market):
-                logger.info(
-                    "Cache HIT for %s benchmark %s (%s, %s) (Database)",
-                    normalized_market,
-                    benchmark_symbol,
-                    period,
-                    role,
-                )
-                # Store in Redis for next time
-                self._store_in_redis(benchmark_symbol=benchmark_symbol, period=period, data=cached_data)
-                return cached_data
 
             # Cache MISS - attempt fetch for this candidate
             logger.info(

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -482,14 +482,9 @@ class BenchmarkCacheService:
             except Exception:
                 expected = None
             if expected is None:
-                # Fallback freshness check when expected trading date cannot be computed.
-                latest_allowed = pd.Timestamp.utcnow() - pd.Timedelta(hours=max_age_hours)
-                last_ts = pd.Timestamp(last_date)
-                if last_ts.tzinfo is None:
-                    last_ts = last_ts.tz_localize("UTC")
-                else:
-                    last_ts = last_ts.tz_convert("UTC")
-                return last_ts >= latest_allowed
+                # Calendar fallback: avoid weekend/holiday false-stale by allowing data
+                # through the next business day when exchange calendar lookup is unavailable.
+                return self._is_data_fresh_without_calendar(last_date, max_age_hours=max_age_hours)
 
             is_fresh = last_date.date() >= expected
             if not is_fresh:
@@ -504,6 +499,31 @@ class BenchmarkCacheService:
         except Exception as e:
             logger.warning(f"Error checking data freshness: {e}")
             return False
+
+    @staticmethod
+    def _is_data_fresh_without_calendar(last_date: pd.Timestamp, max_age_hours: int = 24) -> bool:
+        """Fallback freshness policy when exchange calendar is unavailable."""
+        last_ts = pd.Timestamp(last_date)
+        if last_ts.tzinfo is None:
+            last_ts = last_ts.tz_localize("UTC")
+        else:
+            last_ts = last_ts.tz_convert("UTC")
+
+        now_utc = pd.Timestamp.utcnow()
+        if now_utc.tzinfo is None:
+            now_utc = now_utc.tz_localize("UTC")
+
+        latest_allowed = now_utc - pd.Timedelta(hours=max_age_hours)
+        if last_ts >= latest_allowed:
+            return True
+
+        # Allow Friday (or latest business-day) data to remain fresh until the end of
+        # the next business day when calendars are unavailable (e.g., lookup failure).
+        business_days_after_last = pd.bdate_range(
+            start=last_ts.date() + timedelta(days=1),
+            end=now_utc.date(),
+        )
+        return len(business_days_after_last) <= 1
 
     def invalidate_cache(self, period: str = None) -> None:
         """

--- a/backend/app/services/benchmark_registry_service.py
+++ b/backend/app/services/benchmark_registry_service.py
@@ -1,0 +1,96 @@
+"""Canonical benchmark mapping registry with deterministic fallback policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class BenchmarkRegistryEntry:
+    market: str
+    primary_symbol: str
+    primary_kind: str
+    fallback_symbol: str | None
+    fallback_kind: str | None
+    notes: str
+
+
+class BenchmarkRegistryService:
+    """Operator-visible benchmark mapping table for US/HK/JP/TW."""
+
+    TABLE_VERSION = "2026-04-11.v1"
+
+    _TABLE: Dict[str, BenchmarkRegistryEntry] = {
+        "US": BenchmarkRegistryEntry(
+            market="US",
+            primary_symbol="SPY",
+            primary_kind="etf",
+            fallback_symbol="IVV",
+            fallback_kind="etf",
+            notes="US baseline benchmark; ETF primary keeps behavior parity.",
+        ),
+        "HK": BenchmarkRegistryEntry(
+            market="HK",
+            primary_symbol="^HSI",
+            primary_kind="index",
+            fallback_symbol="2800.HK",
+            fallback_kind="etf",
+            notes="Index-primary for market semantics; ETF fallback when index feed unavailable.",
+        ),
+        "JP": BenchmarkRegistryEntry(
+            market="JP",
+            primary_symbol="^N225",
+            primary_kind="index",
+            fallback_symbol="1306.T",
+            fallback_kind="etf",
+            notes="Nikkei index-primary with TOPIX ETF fallback.",
+        ),
+        "TW": BenchmarkRegistryEntry(
+            market="TW",
+            primary_symbol="^TWII",
+            primary_kind="index",
+            fallback_symbol="0050.TW",
+            fallback_kind="etf",
+            notes="TAIEX index-primary with TW50 ETF fallback.",
+        ),
+    }
+
+    def normalize_market(self, market: str | None) -> str:
+        normalized = (market or "US").strip().upper()
+        if normalized not in self._TABLE:
+            raise ValueError(f"Unsupported market for benchmark registry: {market}")
+        return normalized
+
+    def get_entry(self, market: str) -> BenchmarkRegistryEntry:
+        return self._TABLE[self.normalize_market(market)]
+
+    def get_primary_symbol(self, market: str) -> str:
+        return self.get_entry(market).primary_symbol
+
+    def get_candidate_symbols(self, market: str) -> List[str]:
+        entry = self.get_entry(market)
+        candidates = [entry.primary_symbol]
+        if entry.fallback_symbol:
+            candidates.append(entry.fallback_symbol)
+        return candidates
+
+    def supported_markets(self) -> List[str]:
+        return sorted(self._TABLE.keys())
+
+    def mapping_table(self) -> Dict[str, Dict[str, str | None]]:
+        table: Dict[str, Dict[str, str | None]] = {}
+        for market in self.supported_markets():
+            entry = self._TABLE[market]
+            table[market] = {
+                "primary_symbol": entry.primary_symbol,
+                "primary_kind": entry.primary_kind,
+                "fallback_symbol": entry.fallback_symbol,
+                "fallback_kind": entry.fallback_kind,
+                "notes": entry.notes,
+                "version": self.TABLE_VERSION,
+            }
+        return table
+
+
+benchmark_registry = BenchmarkRegistryService()

--- a/backend/app/services/cache_manager.py
+++ b/backend/app/services/cache_manager.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from ..database import SessionLocal
 from .benchmark_cache_service import BenchmarkCacheService
+from .benchmark_registry_service import benchmark_registry
 from .price_cache_service import PriceCacheService
 from .redis_pool import get_redis_client, is_redis_enabled
 from ..config import settings
@@ -313,6 +314,10 @@ class CacheManager:
                 'total_keys': 0,
                 'symbols_cached': 0
             },
+            'benchmark_registry': {
+                'version': benchmark_registry.TABLE_VERSION,
+                'table': benchmark_registry.mapping_table(),
+            },
             'redis_memory': None
         }
 
@@ -322,17 +327,29 @@ class CacheManager:
         try:
             # Benchmark cache stats by market
             benchmark_stats: Dict[str, Dict[str, Optional[int] | bool | str]] = {}
-            for market, symbol in self.benchmark_cache.BENCHMARK_BY_MARKET.items():
-                key_2y = f"benchmark:{symbol}:2y"
-                key_1y = f"benchmark:{symbol}:1y"
+            for market in benchmark_registry.supported_markets():
+                entry = benchmark_registry.get_entry(market)
+                primary_symbol = entry.primary_symbol
+                fallback_symbol = entry.fallback_symbol
+                key_2y = f"benchmark:{primary_symbol}:2y"
+                key_1y = f"benchmark:{primary_symbol}:1y"
+                fallback_key_2y = f"benchmark:{fallback_symbol}:2y" if fallback_symbol else None
+                fallback_key_1y = f"benchmark:{fallback_symbol}:1y" if fallback_symbol else None
                 has_2y = self.redis_client.exists(key_2y) > 0
                 has_1y = self.redis_client.exists(key_1y) > 0
+                fallback_has_2y = self.redis_client.exists(fallback_key_2y) > 0 if fallback_key_2y else False
+                fallback_has_1y = self.redis_client.exists(fallback_key_1y) > 0 if fallback_key_1y else False
                 benchmark_stats[market] = {
-                    'symbol': symbol,
+                    'symbol': primary_symbol,
+                    'fallback_symbol': fallback_symbol,
                     '2y_cached': has_2y,
                     '1y_cached': has_1y,
                     '2y_ttl': self.redis_client.ttl(key_2y) if has_2y else None,
                     '1y_ttl': self.redis_client.ttl(key_1y) if has_1y else None,
+                    'fallback_2y_cached': fallback_has_2y,
+                    'fallback_1y_cached': fallback_has_1y,
+                    'fallback_2y_ttl': self.redis_client.ttl(fallback_key_2y) if fallback_has_2y and fallback_key_2y else None,
+                    'fallback_1y_ttl': self.redis_client.ttl(fallback_key_1y) if fallback_has_1y and fallback_key_1y else None,
                 }
             stats['benchmark_cache'] = benchmark_stats
             # Backward compatibility for existing consumers.

--- a/backend/app/services/cache_manager.py
+++ b/backend/app/services/cache_manager.py
@@ -58,32 +58,38 @@ class CacheManager:
 
         self.db = db
 
-    def warm_benchmark_cache(self, period: str = "2y") -> bool:
+    def warm_benchmark_cache(self, period: str = "2y", market: str = "US") -> bool:
         """
-        Warm SPY benchmark cache.
+        Warm market benchmark cache.
 
         Args:
             period: Time period to cache
+            market: Market code for benchmark resolution (US, HK, JP, TW)
 
         Returns:
             True if successful
         """
         try:
-            logger.info(f"Warming SPY benchmark cache ({period})...")
+            benchmark_symbol = self.benchmark_cache.get_benchmark_symbol(market)
+            logger.info(f"Warming {market} benchmark cache ({benchmark_symbol}, {period})...")
             start_time = time.time()
 
-            spy_data = self.benchmark_cache.get_spy_data(period=period, force_refresh=False)
+            benchmark_data = self.benchmark_cache.get_benchmark_data(
+                market=market,
+                period=period,
+                force_refresh=False,
+            )
 
-            if spy_data is not None and not spy_data.empty:
+            if benchmark_data is not None and not benchmark_data.empty:
                 elapsed = time.time() - start_time
-                logger.info(f"✓ SPY cache warmed: {len(spy_data)} rows in {elapsed:.2f}s")
+                logger.info(f"✓ {market} benchmark cache warmed: {len(benchmark_data)} rows in {elapsed:.2f}s")
                 return True
             else:
-                logger.warning("Failed to warm SPY cache")
+                logger.warning(f"Failed to warm {market} benchmark cache")
                 return False
 
         except Exception as e:
-            logger.error(f"Error warming SPY cache: {e}", exc_info=True)
+            logger.error(f"Error warming {market} benchmark cache: {e}", exc_info=True)
             return False
 
     def warm_price_cache(

--- a/backend/app/services/cache_manager.py
+++ b/backend/app/services/cache_manager.py
@@ -24,7 +24,7 @@ class CacheManager:
     Centralized cache management and orchestration.
 
     Coordinates:
-    - SPY benchmark caching (BenchmarkCacheService)
+    - Market benchmark caching (BenchmarkCacheService)
     - Stock price caching (PriceCacheService)
     - Cache warming operations
     - Cache statistics and monitoring
@@ -234,13 +234,21 @@ class CacheManager:
 
         return stats
 
-    def warm_all_caches(self, symbols: List[str], force_refresh: bool = True) -> Dict:
+    def warm_all_caches(
+        self,
+        symbols: List[str],
+        force_refresh: bool = True,
+        benchmark_markets: Optional[List[str]] = None,
+        warm_benchmarks: bool = True,
+    ) -> Dict:
         """
-        Warm all caches (SPY + stock prices).
+        Warm all caches (benchmarks + stock prices).
 
         Args:
             symbols: List of stock symbols
             force_refresh: Force fetch even if cached (default True)
+            benchmark_markets: Optional explicit markets to warm benchmark for
+            warm_benchmarks: Whether benchmark warmup should run in this call
 
         Returns:
             Combined statistics with warmed, failed, already_cached counts
@@ -251,8 +259,12 @@ class CacheManager:
 
         start_time = time.time()
 
-        # 1. Warm SPY benchmark cache
-        spy_success = self.warm_benchmark_cache()
+        # 1. Warm benchmark cache for requested markets
+        benchmark_results: Dict[str, bool] = {}
+        if warm_benchmarks:
+            markets_to_warm = benchmark_markets or ["US"]
+            for market in markets_to_warm:
+                benchmark_results[market] = self.warm_benchmark_cache(market=market)
 
         # 2. Warm price cache for all symbols
         price_stats = self.warm_price_cache(
@@ -274,7 +286,10 @@ class CacheManager:
             'warmed': price_stats['successful'],
             'failed': price_stats['failed'],
             'already_cached': price_stats['skipped'],
-            'spy_warmed': spy_success,
+            'benchmarks_warmed': benchmark_results,
+            'benchmark_warmed': all(benchmark_results.values()) if benchmark_results else False,
+            # Backward compatibility for older consumers expecting this field.
+            'spy_warmed': benchmark_results.get("US", False),
             'total_time': total_time,
             'details': price_stats
         }
@@ -284,12 +299,12 @@ class CacheManager:
         Get comprehensive cache statistics.
 
         Returns:
-            Dict with cache statistics for SPY, prices, and fundamentals
+            Dict with cache statistics for benchmarks, prices, and fundamentals
         """
         stats = {
             'redis_connected': self.redis_client is not None,
             'market_status': format_market_status(),
-            'spy_cache': {},
+            'benchmark_cache': {},
             'price_cache': {
                 'total_keys': 0,
                 'symbols_cached': 0
@@ -305,16 +320,23 @@ class CacheManager:
             return stats
 
         try:
-            # SPY cache stats
-            spy_key_2y = "benchmark:SPY:2y"
-            spy_key_1y = "benchmark:SPY:1y"
-
-            stats['spy_cache'] = {
-                '2y_cached': self.redis_client.exists(spy_key_2y) > 0,
-                '1y_cached': self.redis_client.exists(spy_key_1y) > 0,
-                '2y_ttl': self.redis_client.ttl(spy_key_2y) if self.redis_client.exists(spy_key_2y) else None,
-                '1y_ttl': self.redis_client.ttl(spy_key_1y) if self.redis_client.exists(spy_key_1y) else None,
-            }
+            # Benchmark cache stats by market
+            benchmark_stats: Dict[str, Dict[str, Optional[int] | bool | str]] = {}
+            for market, symbol in self.benchmark_cache.BENCHMARK_BY_MARKET.items():
+                key_2y = f"benchmark:{symbol}:2y"
+                key_1y = f"benchmark:{symbol}:1y"
+                has_2y = self.redis_client.exists(key_2y) > 0
+                has_1y = self.redis_client.exists(key_1y) > 0
+                benchmark_stats[market] = {
+                    'symbol': symbol,
+                    '2y_cached': has_2y,
+                    '1y_cached': has_1y,
+                    '2y_ttl': self.redis_client.ttl(key_2y) if has_2y else None,
+                    '1y_ttl': self.redis_client.ttl(key_1y) if has_1y else None,
+                }
+            stats['benchmark_cache'] = benchmark_stats
+            # Backward compatibility for existing consumers.
+            stats['spy_cache'] = benchmark_stats.get("US", {})
 
             # Price cache stats
             price_keys = self.redis_client.keys("price:*")

--- a/backend/app/services/cache_manager.py
+++ b/backend/app/services/cache_manager.py
@@ -306,6 +306,8 @@ class CacheManager:
             'redis_connected': self.redis_client is not None,
             'market_status': format_market_status(),
             'benchmark_cache': {},
+            # Backward compatibility key expected by existing response schema/clients.
+            'spy_cache': {},
             'price_cache': {
                 'total_keys': 0,
                 'symbols_cached': 0

--- a/backend/app/services/market_calendar_service.py
+++ b/backend/app/services/market_calendar_service.py
@@ -95,7 +95,7 @@ class MarketCalendarService:
         if schedule.empty:
             return calendar.previous_session(current_session).date()
 
-        market_close = schedule.iloc[0]["market_close"]
+        market_close = schedule.iloc[0]["close"] if "close" in schedule.columns else schedule.iloc[0]["market_close"]
         if market_close.tzinfo is None:
             market_close = market_close.tz_localize("UTC")
         close_with_buffer = (

--- a/backend/app/services/market_calendar_service.py
+++ b/backend/app/services/market_calendar_service.py
@@ -1,0 +1,107 @@
+"""Market calendar abstraction for US/HK/JP/TW session-aware decisions."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+try:
+    import exchange_calendars as xcals  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - runtime guard
+    xcals = None  # type: ignore
+
+
+class MarketCalendarService:
+    """Unified market calendar contract backed by exchange_calendars."""
+
+    CALENDAR_ID_BY_MARKET: dict[str, str] = {
+        "US": "XNYS",
+        "HK": "XHKG",
+        "JP": "XTKS",
+        "TW": "XTAI",
+    }
+    TIMEZONE_BY_MARKET: dict[str, str] = {
+        "US": "America/New_York",
+        "HK": "Asia/Hong_Kong",
+        "JP": "Asia/Tokyo",
+        "TW": "Asia/Taipei",
+    }
+
+    def __init__(self, calendar_provider=None):
+        if calendar_provider is not None:
+            self._calendar_provider = calendar_provider
+        else:
+            self._calendar_provider = xcals.get_calendar if xcals is not None else None
+        self._calendar_cache: dict[str, object] = {}
+
+    def normalize_market(self, market: str | None) -> str:
+        normalized = (market or "US").strip().upper()
+        if normalized not in self.CALENDAR_ID_BY_MARKET:
+            raise ValueError(f"Unsupported market for calendar service: {market}")
+        return normalized
+
+    def market_timezone(self, market: str) -> ZoneInfo:
+        normalized = self.normalize_market(market)
+        return ZoneInfo(self.TIMEZONE_BY_MARKET[normalized])
+
+    def market_now(self, market: str, now: datetime | None = None) -> datetime:
+        tz = self.market_timezone(market)
+        if now is None:
+            return datetime.now(tz)
+        if now.tzinfo is None:
+            return now.replace(tzinfo=tz)
+        return now.astimezone(tz)
+
+    def calendar_id(self, market: str) -> str:
+        normalized = self.normalize_market(market)
+        return self.CALENDAR_ID_BY_MARKET[normalized]
+
+    def _get_calendar(self, market: str):
+        normalized = self.normalize_market(market)
+        calendar_id = self.CALENDAR_ID_BY_MARKET[normalized]
+        if self._calendar_provider is None:
+            raise RuntimeError("exchange_calendars is required for MarketCalendarService")
+        if calendar_id not in self._calendar_cache:
+            self._calendar_cache[calendar_id] = self._calendar_provider(calendar_id)
+        return self._calendar_cache[calendar_id]
+
+    def is_trading_day(self, market: str, day: date | None = None) -> bool:
+        calendar = self._get_calendar(market)
+        candidate_day = day or self.market_now(market).date()
+        return calendar.is_session(pd.Timestamp(candidate_day))
+
+    def is_market_open(self, market: str, now: datetime | None = None) -> bool:
+        calendar = self._get_calendar(market)
+        market_now = self.market_now(market, now=now)
+        current_session = pd.Timestamp(market_now.date())
+        if not calendar.is_session(current_session):
+            return False
+        minute_utc = pd.Timestamp(market_now).tz_convert("UTC").floor("min")
+        return bool(calendar.is_open_on_minute(minute_utc, ignore_breaks=False))
+
+    def last_completed_trading_day(self, market: str, now: datetime | None = None) -> date:
+        """Return the latest trading day that should already have end-of-day bars."""
+        normalized = self.normalize_market(market)
+        calendar = self._get_calendar(normalized)
+        market_now = self.market_now(normalized, now=now)
+        current_session = pd.Timestamp(market_now.date())
+
+        if not calendar.is_session(current_session):
+            return calendar.previous_session(current_session).date()
+
+        schedule = calendar.schedule.loc[current_session:current_session]
+        if schedule.empty:
+            return calendar.previous_session(current_session).date()
+
+        market_close = schedule.iloc[0]["market_close"]
+        if market_close.tzinfo is None:
+            market_close = market_close.tz_localize("UTC")
+        close_with_buffer = (
+            market_close.tz_convert(self.market_timezone(normalized)).to_pydatetime()
+            + timedelta(hours=1)
+        )
+        if market_now >= close_with_buffer:
+            return current_session.date()
+        return calendar.previous_session(current_session).date()

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -24,6 +24,7 @@ from ..models.stock_universe import UNIVERSE_STATUS_ACTIVE, StockUniverse
 from ..utils.symbol_support import is_unsupported_yahoo_price_symbol
 from .bulk_data_fetcher import BulkDataFetcher
 from .finviz_parser import FinvizParser
+from .security_master_service import security_master_resolver
 from .technical_calculator_service import TechnicalCalculatorService
 
 if TYPE_CHECKING:
@@ -851,48 +852,23 @@ class ProviderSnapshotService:
 
     @staticmethod
     def _deserialize_universe_row(row: Dict[str, Any]) -> Dict[str, Any]:
-        raw_market = str(row.get("market") or "").strip().upper()
-        if raw_market:
-            market = raw_market
-        else:
-            exchange = str(row.get("exchange") or "").strip().upper()
-            symbol = str(row.get("symbol") or "").strip().upper()
-            if exchange in {"HKEX", "SEHK"} or symbol.endswith(".HK"):
-                market = "HK"
-            elif exchange in {"TSE", "JPX", "XTKS"} or symbol.endswith(".T"):
-                market = "JP"
-            elif exchange in {"TWSE", "TPEX", "XTAI"} or symbol.endswith(".TW") or symbol.endswith(".TWO"):
-                market = "TW"
-            else:
-                market = "US"
-        market_defaults = {
-            "HK": ("HKD", "Asia/Hong_Kong"),
-            "JP": ("JPY", "Asia/Tokyo"),
-            "TW": ("TWD", "Asia/Taipei"),
-        }
-        default_currency, default_timezone = market_defaults.get(
-            market, ("USD", "America/New_York")
+        identity = security_master_resolver.resolve_identity(
+            symbol=str(row.get("symbol") or ""),
+            market=row.get("market"),
+            exchange=row.get("exchange"),
+            currency=row.get("currency"),
+            timezone=row.get("timezone"),
+            local_code=row.get("local_code"),
         )
-        raw_local_code = row.get("local_code")
-        if raw_local_code:
-            local_code = str(raw_local_code).strip()
-        else:
-            local_code = None
-        if not local_code:
-            symbol = str(row.get("symbol") or "").strip()
-            if market != "US" and "." in symbol:
-                local_code = symbol.split(".", 1)[0]
-            elif symbol:
-                local_code = symbol
 
         return {
-            "symbol": row["symbol"],
+            "symbol": identity.normalized_symbol,
             "name": row.get("name"),
-            "market": market,
-            "exchange": row.get("exchange"),
-            "currency": row.get("currency") or default_currency,
-            "timezone": row.get("timezone") or default_timezone,
-            "local_code": local_code,
+            "market": identity.market,
+            "exchange": identity.exchange,
+            "currency": identity.currency,
+            "timezone": identity.timezone,
+            "local_code": identity.local_code,
             "sector": row.get("sector"),
             "industry": row.get("industry"),
             "market_cap": row.get("market_cap"),

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -862,7 +862,7 @@ class ProviderSnapshotService:
         )
 
         return {
-            "symbol": identity.normalized_symbol,
+            "symbol": identity.canonical_symbol,
             "name": row.get("name"),
             "market": identity.market,
             "exchange": identity.exchange,

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -775,17 +775,26 @@ class ProviderSnapshotService:
         db.add(run)
         db.flush()
 
-        rows = [
-            ProviderSnapshotRow(
-                run_id=run.id,
-                symbol=row["symbol"],
+        rows = []
+        for row in snapshot_rows:
+            identity = security_master_resolver.resolve_identity(
+                symbol=str(row.get("symbol") or ""),
+                market=row.get("market"),
                 exchange=row.get("exchange"),
-                row_hash=row["row_hash"],
-                normalized_payload_json=json.dumps(row["normalized_payload"], sort_keys=True, default=str),
-                raw_payload_json=None,
+                currency=row.get("currency"),
+                timezone=row.get("timezone"),
+                local_code=row.get("local_code"),
             )
-            for row in snapshot_rows
-        ]
+            rows.append(
+                ProviderSnapshotRow(
+                    run_id=run.id,
+                    symbol=identity.canonical_symbol,
+                    exchange=identity.exchange,
+                    row_hash=row["row_hash"],
+                    normalized_payload_json=json.dumps(row["normalized_payload"], sort_keys=True, default=str),
+                    raw_payload_json=None,
+                )
+            )
         if rows:
             db.bulk_save_objects(rows)
 

--- a/backend/app/services/security_master_service.py
+++ b/backend/app/services/security_master_service.py
@@ -109,6 +109,13 @@ class SecurityMasterResolver:
             return _SUFFIX_BY_EXCHANGE[normalized_exchange]
         return _SUFFIX_BY_MARKET.get(market)
 
+    def _recognized_symbol_suffix(self, symbol: str) -> str | None:
+        normalized_symbol = self.normalize_symbol(symbol)
+        for suffix, _ in _MARKET_BY_SUFFIX:
+            if normalized_symbol.endswith(suffix):
+                return suffix
+        return None
+
     def resolve_identity(
         self,
         *,
@@ -143,11 +150,15 @@ class SecurityMasterResolver:
 
         canonical_symbol = normalized_symbol
         if normalized_market != "US" and resolved_local_code:
-            suffix = self._resolve_suffix(normalized_market, normalized_exchange)
-            if suffix:
-                expected_canonical = f"{resolved_local_code}{suffix}"
-                if canonical_symbol != expected_canonical:
-                    canonical_symbol = expected_canonical
+            # Preserve explicit non-US suffix when no exchange override is provided.
+            if normalized_exchange is None and self._recognized_symbol_suffix(normalized_symbol):
+                canonical_symbol = normalized_symbol
+            else:
+                suffix = self._resolve_suffix(normalized_market, normalized_exchange)
+                if suffix:
+                    expected_canonical = f"{resolved_local_code}{suffix}"
+                    if canonical_symbol != expected_canonical:
+                        canonical_symbol = expected_canonical
 
         return SecurityIdentity(
             normalized_symbol=normalized_symbol,

--- a/backend/app/services/security_master_service.py
+++ b/backend/app/services/security_master_service.py
@@ -1,0 +1,149 @@
+"""SecurityMaster resolver and deterministic symbol/market normalization utilities.
+
+This service is the single source of truth for deriving canonical identity fields
+(symbol/market/exchange/currency/timezone/local_code) from mixed legacy inputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+_SUPPORTED_MARKETS = {"US", "HK", "JP", "TW"}
+
+_MARKET_DEFAULTS: dict[str, tuple[str, str]] = {
+    "US": ("USD", "America/New_York"),
+    "HK": ("HKD", "Asia/Hong_Kong"),
+    "JP": ("JPY", "Asia/Tokyo"),
+    "TW": ("TWD", "Asia/Taipei"),
+}
+
+_MARKET_BY_EXCHANGE: dict[str, str] = {
+    "NYSE": "US",
+    "NASDAQ": "US",
+    "AMEX": "US",
+    "XNYS": "US",
+    "XNAS": "US",
+    "XASE": "US",
+    "HKEX": "HK",
+    "SEHK": "HK",
+    "XHKG": "HK",
+    "TSE": "JP",
+    "JPX": "JP",
+    "XTKS": "JP",
+    "TWSE": "TW",
+    "TPEX": "TW",
+    "XTAI": "TW",
+}
+
+_MARKET_BY_SUFFIX: tuple[tuple[str, str], ...] = (
+    (".HK", "HK"),
+    (".TWO", "TW"),
+    (".TW", "TW"),
+    (".T", "JP"),
+)
+
+_SUFFIX_BY_MARKET: dict[str, str] = {
+    "HK": ".HK",
+    "JP": ".T",
+    "TW": ".TW",
+}
+
+
+@dataclass(frozen=True)
+class SecurityIdentity:
+    """Canonical security identity fields derived by SecurityMaster."""
+
+    normalized_symbol: str
+    canonical_symbol: str
+    market: str
+    exchange: Optional[str]
+    currency: str
+    timezone: str
+    local_code: str
+
+
+class SecurityMasterResolver:
+    """Deterministic resolver for symbol -> market/exchange/currency identity."""
+
+    @staticmethod
+    def normalize_symbol(symbol: str | None) -> str:
+        """Normalize a symbol without applying market-specific transforms."""
+        normalized = (symbol or "").strip().upper()
+        if normalized.startswith("$"):
+            normalized = normalized[1:]
+        return normalized
+
+    @staticmethod
+    def normalize_exchange(exchange: str | None) -> str | None:
+        normalized = (exchange or "").strip().upper()
+        return normalized or None
+
+    @staticmethod
+    def normalize_market(market: str | None) -> str | None:
+        normalized = (market or "").strip().upper()
+        if normalized in _SUPPORTED_MARKETS:
+            return normalized
+        return None
+
+    def infer_market(self, symbol: str, exchange: str | None = None) -> str:
+        normalized_exchange = self.normalize_exchange(exchange)
+        if normalized_exchange and normalized_exchange in _MARKET_BY_EXCHANGE:
+            return _MARKET_BY_EXCHANGE[normalized_exchange]
+
+        normalized_symbol = self.normalize_symbol(symbol)
+        for suffix, market in _MARKET_BY_SUFFIX:
+            if normalized_symbol.endswith(suffix):
+                return market
+        return "US"
+
+    def resolve_identity(
+        self,
+        *,
+        symbol: str,
+        market: str | None = None,
+        exchange: str | None = None,
+        currency: str | None = None,
+        timezone: str | None = None,
+        local_code: str | None = None,
+    ) -> SecurityIdentity:
+        """Resolve deterministic identity fields for a security."""
+        normalized_symbol = self.normalize_symbol(symbol)
+        normalized_exchange = self.normalize_exchange(exchange)
+        normalized_market = self.normalize_market(market)
+        if normalized_market is None:
+            normalized_market = self.infer_market(normalized_symbol, normalized_exchange)
+
+        default_currency, default_timezone = _MARKET_DEFAULTS.get(
+            normalized_market,
+            _MARKET_DEFAULTS["US"],
+        )
+
+        resolved_currency = (currency or "").strip().upper() or default_currency
+        resolved_timezone = (timezone or "").strip() or default_timezone
+
+        resolved_local_code = (local_code or "").strip()
+        if not resolved_local_code:
+            if "." in normalized_symbol:
+                resolved_local_code = normalized_symbol.split(".", 1)[0]
+            else:
+                resolved_local_code = normalized_symbol
+
+        canonical_symbol = normalized_symbol
+        if normalized_market != "US" and "." not in canonical_symbol and resolved_local_code:
+            suffix = _SUFFIX_BY_MARKET.get(normalized_market)
+            if suffix:
+                canonical_symbol = f"{resolved_local_code}{suffix}"
+
+        return SecurityIdentity(
+            normalized_symbol=normalized_symbol,
+            canonical_symbol=canonical_symbol,
+            market=normalized_market,
+            exchange=normalized_exchange,
+            currency=resolved_currency,
+            timezone=resolved_timezone,
+            local_code=resolved_local_code,
+        )
+
+
+security_master_resolver = SecurityMasterResolver()

--- a/backend/app/services/security_master_service.py
+++ b/backend/app/services/security_master_service.py
@@ -49,6 +49,12 @@ _SUFFIX_BY_MARKET: dict[str, str] = {
     "TW": ".TW",
 }
 
+_SUFFIX_BY_EXCHANGE: dict[str, str] = {
+    "TWSE": ".TW",
+    "XTAI": ".TW",
+    "TPEX": ".TWO",
+}
+
 
 @dataclass(frozen=True)
 class SecurityIdentity:
@@ -97,6 +103,12 @@ class SecurityMasterResolver:
                 return market
         return "US"
 
+    def _resolve_suffix(self, market: str, exchange: str | None) -> str | None:
+        normalized_exchange = self.normalize_exchange(exchange)
+        if normalized_exchange and normalized_exchange in _SUFFIX_BY_EXCHANGE:
+            return _SUFFIX_BY_EXCHANGE[normalized_exchange]
+        return _SUFFIX_BY_MARKET.get(market)
+
     def resolve_identity(
         self,
         *,
@@ -131,7 +143,7 @@ class SecurityMasterResolver:
 
         canonical_symbol = normalized_symbol
         if normalized_market != "US" and "." not in canonical_symbol and resolved_local_code:
-            suffix = _SUFFIX_BY_MARKET.get(normalized_market)
+            suffix = self._resolve_suffix(normalized_market, normalized_exchange)
             if suffix:
                 canonical_symbol = f"{resolved_local_code}{suffix}"
 

--- a/backend/app/services/security_master_service.py
+++ b/backend/app/services/security_master_service.py
@@ -142,10 +142,12 @@ class SecurityMasterResolver:
                 resolved_local_code = normalized_symbol
 
         canonical_symbol = normalized_symbol
-        if normalized_market != "US" and "." not in canonical_symbol and resolved_local_code:
+        if normalized_market != "US" and resolved_local_code:
             suffix = self._resolve_suffix(normalized_market, normalized_exchange)
             if suffix:
-                canonical_symbol = f"{resolved_local_code}{suffix}"
+                expected_canonical = f"{resolved_local_code}{suffix}"
+                if canonical_symbol != expected_canonical:
+                    canonical_symbol = expected_canonical
 
         return SecurityIdentity(
             normalized_symbol=normalized_symbol,

--- a/backend/app/services/stock_universe_service.py
+++ b/backend/app/services/stock_universe_service.py
@@ -321,17 +321,29 @@ class StockUniverseService:
             added_count = 0
             updated_count = 0
             now = datetime.utcnow()
+            resolved_rows: list[tuple[dict[str, Any], Any, str, str]] = []
+            lookup_symbols: set[str] = set()
+            for stock_data in stocks:
+                identity = self._resolved_identity(stock_data)
+                source_symbol = stock_data["symbol"]
+                canonical_symbol = identity.canonical_symbol
+                resolved_rows.append((stock_data, identity, source_symbol, canonical_symbol))
+                lookup_symbols.add(source_symbol)
+                lookup_symbols.add(canonical_symbol)
+
             stock_map = {
                 stock.symbol: stock
                 for stock in db.query(StockUniverse).filter(
-                    StockUniverse.symbol.in_([row["symbol"] for row in stocks])
+                    StockUniverse.symbol.in_(list(lookup_symbols))
                 ).all()
             }
 
-            for stock_data in stocks:
-                symbol = stock_data["symbol"]
-                identity = self._resolved_identity(stock_data)
-                existing = stock_map.get(symbol)
+            for stock_data, identity, source_symbol, canonical_symbol in resolved_rows:
+                existing = stock_map.get(canonical_symbol) or stock_map.get(source_symbol)
+                if existing and existing.symbol != canonical_symbol and canonical_symbol not in stock_map:
+                    stock_map.pop(existing.symbol, None)
+                    existing.symbol = canonical_symbol
+                    stock_map[canonical_symbol] = existing
 
                 if existing:
                     existing.name = stock_data["name"] or existing.name
@@ -357,7 +369,7 @@ class StockUniverseService:
                     updated_count += 1
                 else:
                     new_stock = StockUniverse(
-                        symbol=symbol,
+                        symbol=canonical_symbol,
                         name=stock_data["name"],
                         market=identity.market,
                         exchange=identity.exchange,
@@ -378,7 +390,7 @@ class StockUniverseService:
                     db.add(new_stock)
                     self._add_status_event(
                         db,
-                        symbol=symbol,
+                        symbol=canonical_symbol,
                         old_status=None,
                         new_status=UNIVERSE_STATUS_ACTIVE,
                         trigger_source="csv_import",
@@ -477,15 +489,24 @@ class StockUniverseService:
                 stock.symbol: stock
                 for stock in db.query(StockUniverse).all()
             }
-            fetched_symbols = {stock_data["symbol"] for stock_data in stocks}
-
+            resolved_rows: list[tuple[dict[str, Any], Any, str, str]] = []
+            fetched_symbols: set[str] = set()
             for stock_data in stocks:
-                symbol = stock_data["symbol"]
                 identity = self._resolved_identity(stock_data)
-                existing = existing_stocks.get(symbol)
+                source_symbol = stock_data["symbol"]
+                canonical_symbol = identity.canonical_symbol
+                resolved_rows.append((stock_data, identity, source_symbol, canonical_symbol))
+                fetched_symbols.add(canonical_symbol)
+
+            for stock_data, identity, source_symbol, canonical_symbol in resolved_rows:
+                existing = existing_stocks.get(canonical_symbol) or existing_stocks.get(source_symbol)
+                if existing and existing.symbol != canonical_symbol and canonical_symbol not in existing_stocks:
+                    existing_stocks.pop(existing.symbol, None)
+                    existing.symbol = canonical_symbol
+                    existing_stocks[canonical_symbol] = existing
                 if existing is None:
                     new_stock = StockUniverse(
-                        symbol=symbol,
+                        symbol=canonical_symbol,
                         name=stock_data["name"],
                         market=identity.market,
                         exchange=identity.exchange,
@@ -507,7 +528,7 @@ class StockUniverseService:
                     db.add(new_stock)
                     self._add_status_event(
                         db,
-                        symbol=symbol,
+                        symbol=canonical_symbol,
                         old_status=None,
                         new_status=UNIVERSE_STATUS_ACTIVE,
                         trigger_source="finviz_sync",

--- a/backend/app/services/stock_universe_service.py
+++ b/backend/app/services/stock_universe_service.py
@@ -22,6 +22,7 @@ from ..models.stock_universe import (
     UNIVERSE_STATUS_INACTIVE_MISSING_SOURCE,
     UNIVERSE_STATUS_INACTIVE_NO_DATA,
 )
+from .security_master_service import security_master_resolver
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,14 @@ class StockUniverseService:
 
     def __init__(self):
         """Initialize stock universe service."""
-        pass
+        self._security_master = security_master_resolver
+
+    def _resolved_identity(self, stock_data: Dict[str, Any]):
+        return self._security_master.resolve_identity(
+            symbol=stock_data.get("symbol", ""),
+            market=stock_data.get("market"),
+            exchange=stock_data.get("exchange"),
+        )
 
     @staticmethod
     def _normalize_status(record: StockUniverse) -> str:
@@ -322,11 +330,16 @@ class StockUniverseService:
 
             for stock_data in stocks:
                 symbol = stock_data["symbol"]
+                identity = self._resolved_identity(stock_data)
                 existing = stock_map.get(symbol)
 
                 if existing:
                     existing.name = stock_data["name"] or existing.name
-                    existing.exchange = stock_data["exchange"] or existing.exchange
+                    existing.exchange = identity.exchange or existing.exchange
+                    existing.market = identity.market
+                    existing.currency = identity.currency
+                    existing.timezone = identity.timezone
+                    existing.local_code = identity.local_code or existing.local_code
                     existing.sector = stock_data["sector"] or existing.sector
                     existing.industry = stock_data["industry"] or existing.industry
                     existing.market_cap = stock_data["market_cap"] or existing.market_cap
@@ -346,7 +359,11 @@ class StockUniverseService:
                     new_stock = StockUniverse(
                         symbol=symbol,
                         name=stock_data["name"],
-                        exchange=stock_data["exchange"],
+                        market=identity.market,
+                        exchange=identity.exchange,
+                        currency=identity.currency,
+                        timezone=identity.timezone,
+                        local_code=identity.local_code,
                         sector=stock_data["sector"],
                         industry=stock_data["industry"],
                         market_cap=stock_data["market_cap"],
@@ -464,12 +481,17 @@ class StockUniverseService:
 
             for stock_data in stocks:
                 symbol = stock_data["symbol"]
+                identity = self._resolved_identity(stock_data)
                 existing = existing_stocks.get(symbol)
                 if existing is None:
                     new_stock = StockUniverse(
                         symbol=symbol,
                         name=stock_data["name"],
-                        exchange=stock_data["exchange"],
+                        market=identity.market,
+                        exchange=identity.exchange,
+                        currency=identity.currency,
+                        timezone=identity.timezone,
+                        local_code=identity.local_code,
                         sector=stock_data["sector"],
                         industry=stock_data["industry"],
                         market_cap=stock_data["market_cap"],
@@ -496,7 +518,11 @@ class StockUniverseService:
                     continue
 
                 existing.name = stock_data["name"] or existing.name
-                existing.exchange = stock_data["exchange"] or existing.exchange
+                existing.exchange = identity.exchange or existing.exchange
+                existing.market = identity.market
+                existing.currency = identity.currency
+                existing.timezone = identity.timezone
+                existing.local_code = identity.local_code or existing.local_code
                 existing.sector = stock_data["sector"] or existing.sector
                 existing.industry = stock_data["industry"] or existing.industry
                 existing.market_cap = stock_data["market_cap"]

--- a/backend/app/services/task_registry_service.py
+++ b/backend/app/services/task_registry_service.py
@@ -63,7 +63,7 @@ SCHEDULED_TASKS = {
     'daily-smart-refresh': {
         'task_function': 'app.tasks.cache_tasks.smart_refresh_cache',
         'display_name': 'Daily Smart Refresh',
-        'description': 'Runs the SPY-first full-universe batched price refresh',
+        'description': 'Runs benchmark-first full-universe batched price refresh',
         'schedule_description': f'{settings.cache_warm_hour}:{settings.cache_warm_minute:02d} ET, Mon-Fri',
         'history_task_names': ['daily-smart-refresh', 'daily-cache-warmup'],
         'manual_dispatch_kwargs': {'mode': 'full'},

--- a/backend/app/services/theme_extraction_service.py
+++ b/backend/app/services/theme_extraction_service.py
@@ -33,6 +33,7 @@ from ..models.app_settings import AppSetting
 from .errors import ProviderQuotaServiceError, ProviderRateLimitServiceError
 from .llm import LLMService, LLMError, LLMQuotaExceededError, LLMRateLimitError
 from .llm.config import is_model_supported_for_use_case
+from .security_master_service import SecurityMasterResolver, security_master_resolver
 from .theme_embedding_service import ThemeEmbeddingEngine, ThemeEmbeddingRepository
 from .theme_identity_normalization import UNKNOWN_THEME_KEY, canonical_theme_key, display_theme_name
 from .theme_lifecycle_service import set_initial_lifecycle_defaults
@@ -241,10 +242,11 @@ class ThemeExtractionService:
         self.theme_policy_overrides = self._load_theme_policy_overrides()
 
         # Known ticker patterns for validation
-        self.ticker_pattern = re.compile(r'^[A-Z]{1,5}$')
+        self.ticker_pattern = re.compile(r"^[A-Z0-9][A-Z0-9\.\-]{0,11}$")
 
         # Cache of valid tickers (loaded from universe)
         self._valid_tickers: Optional[set] = None
+        self._security_master = security_master_resolver
 
         # Rate limiting
         self._last_request_time = 0
@@ -340,7 +342,12 @@ class ThemeExtractionService:
             tickers = self.db.query(StockUniverse.symbol).filter(
                 StockUniverse.active_filter()
             ).all()
-            self._valid_tickers = {t[0] for t in tickers}
+            resolver = getattr(self, "_security_master", None) or SecurityMasterResolver()
+            self._valid_tickers = {
+                resolver.normalize_symbol(t[0])
+                for t in tickers
+                if t[0]
+            }
         return self._valid_tickers
 
     def _get_company_name_ticker_map(self) -> list[tuple[str, str]]:
@@ -421,22 +428,25 @@ class ThemeExtractionService:
 
     def _validate_ticker(self, ticker: str) -> bool:
         """Check if ticker is valid"""
-        if not self.ticker_pattern.match(ticker):
+        resolver = getattr(self, "_security_master", None) or SecurityMasterResolver()
+        normalized_ticker = resolver.normalize_symbol(ticker)
+        if not self.ticker_pattern.match(normalized_ticker):
             return False
 
         valid_tickers = self._get_valid_tickers()
         if not valid_tickers:
             return False
-        if ticker not in valid_tickers:
+        if normalized_ticker not in valid_tickers:
             return False
 
         return True
 
     def _clean_tickers(self, tickers: list) -> list:
         """Filter and clean ticker list"""
+        resolver = getattr(self, "_security_master", None) or SecurityMasterResolver()
         cleaned = []
         for t in tickers:
-            t = t.upper().strip()
+            t = resolver.normalize_symbol(str(t))
             # Remove common false positives
             if t in self.TICKER_FALSE_POSITIVES:
                 continue

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -24,6 +24,7 @@ from ..services.benchmark_registry_service import benchmark_registry
 from ..config import settings
 from ..utils.market_hours import is_market_open, is_trading_day, get_eastern_now, format_market_status
 from ..wiring.bootstrap import get_rate_limiter, get_stock_universe_service
+from ..services.security_master_service import security_master_resolver
 from .data_fetch_lock import serialized_data_fetch
 
 logger = logging.getLogger(__name__)
@@ -36,18 +37,24 @@ _SMART_REFRESH_TIME_WINDOW_BYPASS: ContextVar[bool] = ContextVar(
 
 def _active_benchmark_markets(db) -> List[str]:
     """Return distinct active markets that have configured benchmarks."""
-    from sqlalchemy import distinct
     from ..models.stock_universe import StockUniverse
 
     supported = set(benchmark_registry.supported_markets())
     rows = (
-        db.query(distinct(StockUniverse.market))
+        db.query(
+            StockUniverse.market,
+            StockUniverse.exchange,
+            StockUniverse.symbol,
+        )
         .filter(StockUniverse.is_active == True)
         .all()
     )
     markets = []
-    for (market,) in rows:
-        normalized = (market or "US").strip().upper()
+    for market, exchange, symbol in rows:
+        normalized = security_master_resolver.normalize_market(market) or security_master_resolver.infer_market(
+            symbol=symbol or "",
+            exchange=exchange,
+        )
         if normalized in supported:
             markets.append(normalized)
     if not markets:
@@ -61,13 +68,16 @@ def _benchmark_markets_for_symbols(db, symbols: List[str]) -> List[str]:
 
     supported = set(benchmark_registry.supported_markets())
     rows = (
-        db.query(StockUniverse.market)
+        db.query(StockUniverse.market, StockUniverse.exchange, StockUniverse.symbol)
         .filter(StockUniverse.symbol.in_(symbols))
         .all()
     )
     markets = []
-    for (market,) in rows:
-        normalized = (market or "US").strip().upper()
+    for market, exchange, symbol in rows:
+        normalized = security_master_resolver.normalize_market(market) or security_master_resolver.infer_market(
+            symbol=symbol or "",
+            exchange=exchange,
+        )
         if normalized in supported:
             markets.append(normalized)
     if not markets:

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -20,6 +20,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from ..celery_app import celery_app
 from ..database import SessionLocal, is_corruption_error, safe_rollback
 from ..services.cache_manager import CacheManager
+from ..services.benchmark_cache_service import BenchmarkCacheService
 from ..config import settings
 from ..utils.market_hours import is_market_open, is_trading_day, get_eastern_now, format_market_status
 from ..wiring.bootstrap import get_rate_limiter, get_stock_universe_service
@@ -31,6 +32,47 @@ _SMART_REFRESH_TIME_WINDOW_BYPASS: ContextVar[bool] = ContextVar(
     "smart_refresh_time_window_bypass",
     default=False,
 )
+
+
+def _active_benchmark_markets(db) -> List[str]:
+    """Return distinct active markets that have configured benchmarks."""
+    from sqlalchemy import distinct
+    from ..models.stock_universe import StockUniverse
+
+    supported = set(BenchmarkCacheService.BENCHMARK_BY_MARKET.keys())
+    rows = (
+        db.query(distinct(StockUniverse.market))
+        .filter(StockUniverse.is_active == True)
+        .all()
+    )
+    markets = []
+    for (market,) in rows:
+        normalized = (market or "US").strip().upper()
+        if normalized in supported:
+            markets.append(normalized)
+    if "US" not in markets:
+        markets.insert(0, "US")
+    return sorted(set(markets))
+
+
+def _benchmark_markets_for_symbols(db, symbols: List[str]) -> List[str]:
+    """Resolve benchmark markets for a specific symbol set from active universe metadata."""
+    from ..models.stock_universe import StockUniverse
+
+    supported = set(BenchmarkCacheService.BENCHMARK_BY_MARKET.keys())
+    rows = (
+        db.query(StockUniverse.market)
+        .filter(StockUniverse.symbol.in_(symbols))
+        .all()
+    )
+    markets = []
+    for (market,) in rows:
+        normalized = (market or "US").strip().upper()
+        if normalized in supported:
+            markets.append(normalized)
+    if "US" not in markets:
+        markets.append("US")
+    return sorted(set(markets))
 
 
 @contextmanager
@@ -46,31 +88,43 @@ def allow_smart_refresh_time_window_bypass():
 @celery_app.task(name='app.tasks.cache_tasks.warm_spy_cache')
 def warm_spy_cache():
     """
-    Warm SPY benchmark cache.
+    Warm benchmark cache for active markets.
 
     This task is typically run after market close to ensure
-    the next day's scans have fresh SPY data cached.
+    the next day's scans have fresh benchmark data cached.
 
     Returns:
         Dict with task results
     """
     logger.info("=" * 60)
-    logger.info("TASK: Warming SPY Benchmark Cache")
+    logger.info("TASK: Warming Market Benchmark Cache")
     logger.info(f"Market status: {format_market_status()}")
     logger.info("=" * 60)
 
+    db = SessionLocal()
     try:
         cache_manager = CacheManager()
+        markets = _active_benchmark_markets(db)
+        logger.info(f"Warming benchmark cache for markets: {markets}")
 
-        # Warm both 1y and 2y periods
+        # Warm both 1y and 2y periods for each active market
+        by_market = {}
+        for market in markets:
+            by_market[market] = {
+                '2y': cache_manager.warm_benchmark_cache(period="2y", market=market),
+                '1y': cache_manager.warm_benchmark_cache(period="1y", market=market),
+            }
+
         results = {
-            '2y': cache_manager.warm_benchmark_cache(period="2y"),
-            '1y': cache_manager.warm_benchmark_cache(period="1y"),
+            'by_market': by_market,
+            # Backward compatibility aliases for legacy SPY consumers.
+            '2y': by_market.get("US", {}).get("2y", False),
+            '1y': by_market.get("US", {}).get("1y", False),
             'market_status': format_market_status(),
             'timestamp': datetime.now().isoformat()
         }
 
-        logger.info("✓ SPY cache warming task completed")
+        logger.info("✓ Market benchmark cache warming task completed")
         return results
 
     except Exception as e:
@@ -79,6 +133,8 @@ def warm_spy_cache():
             'error': str(e),
             'timestamp': datetime.now().isoformat()
         }
+    finally:
+        db.close()
 
 
 @celery_app.task(name='app.tasks.cache_tasks.warm_top_symbols')
@@ -141,8 +197,13 @@ def warm_top_symbols(symbols: Optional[List[str]] = None, count: Optional[int] =
 
         cache_manager = CacheManager(db)
 
+        benchmark_markets = _benchmark_markets_for_symbols(db, symbols)
+
         # Warm all caches
-        results = cache_manager.warm_all_caches(symbols)
+        results = cache_manager.warm_all_caches(
+            symbols,
+            benchmark_markets=benchmark_markets,
+        )
 
         logger.info("✓ Symbol cache warming task completed")
         return results
@@ -166,7 +227,7 @@ def daily_cache_warmup(self):
 
     The scheduler and manual refresh entrypoints now use the batched smart refresh
     path directly. This task remains as a stable compatibility name for legacy
-    callers, but delegates to the same SPY-first, full-universe batch refresh
+    callers, but delegates to the same benchmark-first, full-universe batch refresh
     implementation used by ``smart_refresh_cache(mode="full")``.
 
     Returns:
@@ -187,7 +248,7 @@ def weekly_full_refresh(self):
     Weekly full cache refresh.
 
     Cleans up orphaned cache keys (delisted/deactivated symbols),
-    warms SPY, then performs a full universe refresh inline.
+    warms required benchmarks, then performs a full universe refresh inline.
     Typically runs Sunday morning before markets open.
 
     NOTE: Previously this task called smart_refresh_cache.delay(mode="full"),
@@ -226,9 +287,9 @@ def weekly_full_refresh(self):
         orphan_count = cache_manager.cleanup_orphaned_cache_keys(active_symbols)
         logger.info(f"✓ Cleaned up {orphan_count} orphaned cache entries")
 
-        # 2. Warm SPY cache
-        logger.info("\n[2/4] Re-warming SPY benchmark cache...")
-        spy_results = warm_spy_cache()
+        # 2. Warm benchmark cache for active markets
+        logger.info("\n[2/4] Re-warming market benchmark cache...")
+        benchmark_results = warm_spy_cache()
 
         # 3. Get all active symbols ordered by market cap
         logger.info(f"\n[3/4] Preparing full universe refresh ({len(active_symbols)} symbols)...")
@@ -244,7 +305,8 @@ def weekly_full_refresh(self):
             price_cache.save_warmup_metadata("completed", 0, 0)
             return {
                 'orphans_cleaned': orphan_count,
-                'spy': spy_results,
+                'benchmark': benchmark_results,
+                'spy': benchmark_results.get("by_market", {}).get("US", {}),
                 'refreshed': 0,
                 'universe_size': 0,
                 'completed_at': datetime.now().isoformat()
@@ -348,7 +410,8 @@ def weekly_full_refresh(self):
 
         return {
             'orphans_cleaned': orphan_count,
-            'spy': spy_results,
+            'benchmark': benchmark_results,
+            'spy': benchmark_results.get("by_market", {}).get("US", {}),
             'status': status,
             'refreshed': refreshed,
             'failed': failed,
@@ -479,11 +542,16 @@ def _prewarm_scan_cache_impl(task, symbol_list: List[str], priority: str = 'norm
         chunk_size = 50
         chunks = [symbol_list[i:i + chunk_size] for i in range(0, total, chunk_size)]
 
+        benchmark_markets = _benchmark_markets_for_symbols(db, symbol_list)
         for chunk_num, chunk in enumerate(chunks, 1):
             chunk_start = datetime.now()
 
             # Warm this chunk
-            result = cache_manager.warm_all_caches(chunk)
+            result = cache_manager.warm_all_caches(
+                chunk,
+                benchmark_markets=benchmark_markets,
+                warm_benchmarks=(chunk_num == 1),
+            )
 
             # Update counters
             warmed += result.get('warmed', 0)
@@ -1079,7 +1147,7 @@ def smart_refresh_cache(self, mode: str = "auto"):
     between daily_cache_warmup and force_refresh_stale_intraday.
 
     Key features:
-    1. Always warms SPY first (required for RS calculations)
+    1. Always warms benchmarks first (required for RS calculations)
     2. Fetches symbols in market cap order (high cap first)
     3. Updates heartbeat for stuck detection
     4. Saves warmup metadata for partial completion tracking
@@ -1151,11 +1219,11 @@ def smart_refresh_cache(self, mode: str = "auto"):
     failed_symbols = []
 
     try:
-        # Step 1: Always warm SPY first (required for RS calculations)
-        logger.info("[1/3] Warming SPY benchmark...")
-        spy_result = warm_spy_cache()
-        if spy_result.get('error'):
-            logger.error(f"SPY warmup failed: {spy_result.get('error')}")
+        # Step 1: Always warm market benchmarks first (required for RS calculations)
+        logger.info("[1/3] Warming market benchmarks...")
+        benchmark_result = warm_spy_cache()
+        if benchmark_result.get('error'):
+            logger.error(f"Benchmark warmup failed: {benchmark_result.get('error')}")
 
         # Step 2: Get symbols to refresh, ordered by market cap
         logger.info(f"[2/3] Determining symbols to refresh (mode={mode})...")

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -50,8 +50,8 @@ def _active_benchmark_markets(db) -> List[str]:
         normalized = (market or "US").strip().upper()
         if normalized in supported:
             markets.append(normalized)
-    if "US" not in markets:
-        markets.insert(0, "US")
+    if not markets:
+        markets.append("US")
     return sorted(set(markets))
 
 
@@ -70,7 +70,7 @@ def _benchmark_markets_for_symbols(db, symbols: List[str]) -> List[str]:
         normalized = (market or "US").strip().upper()
         if normalized in supported:
             markets.append(normalized)
-    if "US" not in markets:
+    if not markets:
         markets.append("US")
     return sorted(set(markets))
 

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -148,9 +148,7 @@ def warm_spy_cache():
         }
 
         if failed_periods:
-            raise RuntimeError(
-                "Benchmark warm failed for " + ", ".join(failed_periods)
-            )
+            results["error"] = "Benchmark warm failed for " + ", ".join(failed_periods)
 
         logger.info("✓ Market benchmark cache warming task completed")
         return results

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -57,8 +57,8 @@ def _active_benchmark_markets(db) -> List[str]:
         )
         if normalized in supported:
             markets.append(normalized)
-    if not markets:
-        markets.append("US")
+    # Preserve US benchmark warmups for legacy SPY consumers until migration is complete.
+    markets.append("US")
     return sorted(set(markets))
 
 
@@ -73,13 +73,22 @@ def _benchmark_markets_for_symbols(db, symbols: List[str]) -> List[str]:
         .all()
     )
     markets = []
+    matched_symbols = set()
     for market, exchange, symbol in rows:
+        matched_symbols.add((symbol or "").upper())
         normalized = security_master_resolver.normalize_market(market) or security_master_resolver.infer_market(
             symbol=symbol or "",
             exchange=exchange,
         )
         if normalized in supported:
             markets.append(normalized)
+    for symbol in symbols:
+        normalized_symbol = (symbol or "").upper()
+        if normalized_symbol in matched_symbols:
+            continue
+        inferred = security_master_resolver.infer_market(symbol=symbol or "")
+        if inferred in supported:
+            markets.append(inferred)
     if not markets:
         markets.append("US")
     return sorted(set(markets))
@@ -119,11 +128,15 @@ def warm_spy_cache():
 
         # Warm both 1y and 2y periods for each active market
         by_market = {}
+        failed_periods: list[str] = []
         for market in markets:
             by_market[market] = {
                 '2y': cache_manager.warm_benchmark_cache(period="2y", market=market),
                 '1y': cache_manager.warm_benchmark_cache(period="1y", market=market),
             }
+            for period, ok in by_market[market].items():
+                if not ok:
+                    failed_periods.append(f"{market}:{period}")
 
         results = {
             'by_market': by_market,
@@ -133,6 +146,11 @@ def warm_spy_cache():
             'market_status': format_market_status(),
             'timestamp': datetime.now().isoformat()
         }
+
+        if failed_periods:
+            raise RuntimeError(
+                "Benchmark warm failed for " + ", ".join(failed_periods)
+            )
 
         logger.info("✓ Market benchmark cache warming task completed")
         return results

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -20,7 +20,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from ..celery_app import celery_app
 from ..database import SessionLocal, is_corruption_error, safe_rollback
 from ..services.cache_manager import CacheManager
-from ..services.benchmark_cache_service import BenchmarkCacheService
+from ..services.benchmark_registry_service import benchmark_registry
 from ..config import settings
 from ..utils.market_hours import is_market_open, is_trading_day, get_eastern_now, format_market_status
 from ..wiring.bootstrap import get_rate_limiter, get_stock_universe_service
@@ -39,7 +39,7 @@ def _active_benchmark_markets(db) -> List[str]:
     from sqlalchemy import distinct
     from ..models.stock_universe import StockUniverse
 
-    supported = set(BenchmarkCacheService.BENCHMARK_BY_MARKET.keys())
+    supported = set(benchmark_registry.supported_markets())
     rows = (
         db.query(distinct(StockUniverse.market))
         .filter(StockUniverse.is_active == True)
@@ -59,7 +59,7 @@ def _benchmark_markets_for_symbols(db, symbols: List[str]) -> List[str]:
     """Resolve benchmark markets for a specific symbol set from active universe metadata."""
     from ..models.stock_universe import StockUniverse
 
-    supported = set(BenchmarkCacheService.BENCHMARK_BY_MARKET.keys())
+    supported = set(benchmark_registry.supported_markets())
     rows = (
         db.query(StockUniverse.market)
         .filter(StockUniverse.symbol.in_(symbols))

--- a/backend/app/utils/market_hours.py
+++ b/backend/app/utils/market_hours.py
@@ -4,12 +4,18 @@ Market hours utilities for cache staleness detection.
 Provides functions to determine if US stock market is open,
 when it closes, and if cached data is stale based on market hours.
 
-Uses pandas_market_calendars for authoritative NYSE holiday/schedule data.
+Uses exchange_calendars as the primary calendar engine for NYSE sessions.
 """
 from datetime import UTC, datetime, date, time, timedelta
 from typing import Optional
 import pytz
-import pandas_market_calendars as mcal
+import pandas as pd
+
+try:
+    import exchange_calendars as xcals  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for legacy environments
+    xcals = None  # type: ignore
+    import pandas_market_calendars as mcal  # type: ignore
 
 
 # US Eastern timezone
@@ -20,7 +26,12 @@ MARKET_OPEN_TIME = time(9, 30)  # 9:30 AM ET
 MARKET_CLOSE_TIME = time(16, 0)  # 4:00 PM ET
 
 # NYSE calendar singleton
-_NYSE = mcal.get_calendar("NYSE")
+if xcals is not None:
+    _CALENDAR_ENGINE = "exchange_calendars"
+    _NYSE = xcals.get_calendar("XNYS")
+else:
+    _CALENDAR_ENGINE = "pandas_market_calendars"
+    _NYSE = mcal.get_calendar("NYSE")
 
 # Cache: pre-compute 3-year window of valid trading days for O(1) lookups
 _trading_days_cache: Optional[set] = None
@@ -34,10 +45,19 @@ def _get_trading_days_set() -> set:
     if _trading_days_cache is None or _cache_year != current_year:
         start = f"{current_year - 1}-01-01"
         end = f"{current_year + 1}-12-31"
-        schedule = _NYSE.schedule(start_date=start, end_date=end)
-        _trading_days_cache = set(schedule.index.date)
+        if _CALENDAR_ENGINE == "exchange_calendars":
+            sessions = _NYSE.sessions_in_range(pd.Timestamp(start), pd.Timestamp(end))
+            _trading_days_cache = set(session.date() for session in sessions)
+        else:
+            schedule = _NYSE.schedule(start_date=start, end_date=end)
+            _trading_days_cache = set(schedule.index.date)
         _cache_year = current_year
     return _trading_days_cache
+
+
+def calendar_engine() -> str:
+    """Return the active calendar backend name."""
+    return _CALENDAR_ENGINE
 
 
 def get_eastern_now() -> datetime:
@@ -85,11 +105,13 @@ def is_market_open(dt: Optional[datetime] = None) -> bool:
         # Convert to Eastern timezone
         dt = dt.astimezone(EASTERN)
 
-    # Check if this is a trading day (handles weekends + holidays)
+    if _CALENDAR_ENGINE == "exchange_calendars":
+        minute_utc = pd.Timestamp(dt.astimezone(UTC)).floor("min")
+        return bool(_NYSE.is_open_on_minute(minute_utc, ignore_breaks=False))
+
+    # Legacy fallback path
     if not is_trading_day(dt.date()):
         return False
-
-    # Check if within market hours
     current_time = dt.time()
     return MARKET_OPEN_TIME <= current_time < MARKET_CLOSE_TIME
 

--- a/backend/app/wiring/bootstrap.py
+++ b/backend/app/wiring/bootstrap.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from app.services.price_cache_service import PriceCacheService
     from app.services.provider_snapshot_service import ProviderSnapshotService
     from app.services.rate_limiter import RedisRateLimiter
+    from app.services.security_master_service import SecurityMasterResolver
     from app.services.stock_universe_service import StockUniverseService
     from app.services.task_registry_service import TaskRegistryService
     from app.services.ticker_validation_service import TickerValidationService
@@ -100,6 +101,7 @@ class RuntimeServices:
         self._groq_key_manager: GroqKeyManager | None = None
         self._zai_key_manager: ZAIKeyManager | None = None
         self._rate_limiter: RedisRateLimiter | None = None
+        self._security_master_resolver: SecurityMasterResolver | None = None
         self._eps_rating_service: EPSRatingService | None = None
         self._yfinance_service: YFinanceService | None = None
         self._finviz_service: FinvizService | None = None
@@ -228,6 +230,15 @@ class RuntimeServices:
 
                     self._rate_limiter = RedisRateLimiter()
         return self._rate_limiter
+
+    def security_master_resolver(self) -> SecurityMasterResolver:
+        if self._security_master_resolver is None:
+            with self._init_lock:
+                if self._security_master_resolver is None:
+                    from app.services.security_master_service import security_master_resolver
+
+                    self._security_master_resolver = security_master_resolver
+        return self._security_master_resolver
 
     def eps_rating_service(self) -> EPSRatingService:
         if self._eps_rating_service is None:
@@ -367,6 +378,7 @@ class RuntimeServices:
             self._groq_key_manager = None
             self._zai_key_manager = None
             self._rate_limiter = None
+            self._security_master_resolver = None
             self._eps_rating_service = None
             self._yfinance_service = None
             self._finviz_service = None
@@ -551,6 +563,11 @@ def get_zai_key_manager() -> ZAIKeyManager:
 def get_rate_limiter() -> RedisRateLimiter:
     """Return process-scoped distributed rate limiter."""
     return _resolve_runtime_services().rate_limiter()
+
+
+def get_security_master_resolver() -> SecurityMasterResolver:
+    """Return process-scoped SecurityMaster resolver."""
+    return _resolve_runtime_services().security_master_resolver()
 
 
 def get_eps_rating_service() -> EPSRatingService:

--- a/backend/tests/unit/infra/test_stock_data_provider.py
+++ b/backend/tests/unit/infra/test_stock_data_provider.py
@@ -72,7 +72,7 @@ def mock_yfinance():
 @pytest.fixture
 def mock_benchmark_cache():
     bc = MagicMock()
-    bc.get_spy_data.return_value = _make_price_df(days=252, price=450.0)
+    bc.get_benchmark_data.return_value = _make_price_df(days=252, price=450.0)
     return bc
 
 
@@ -126,7 +126,7 @@ class TestPartialFailureAllowPartialTrue:
     def test_benchmark_failure_does_not_crash(
         self, data_layer, mock_benchmark_cache,
     ):
-        mock_benchmark_cache.get_spy_data.side_effect = TimeoutError("SPY timeout")
+        mock_benchmark_cache.get_benchmark_data.side_effect = TimeoutError("SPY timeout")
 
         result = data_layer.prepare_data("AAPL", REQUIREMENTS)
 
@@ -150,7 +150,7 @@ class TestPartialFailureAllowPartialTrue:
     ):
         mock_price_cache.get_historical_data.return_value = None
         mock_yfinance.get_historical_data.side_effect = ConnectionError("no net")
-        mock_benchmark_cache.get_spy_data.side_effect = TimeoutError("spy down")
+        mock_benchmark_cache.get_benchmark_data.side_effect = TimeoutError("spy down")
         mock_fundamentals_cache.get_fundamentals.side_effect = RuntimeError("db")
 
         result = data_layer.prepare_data("AAPL", REQUIREMENTS)
@@ -277,7 +277,7 @@ class TestRetryWithBackoff:
     def test_retry_on_benchmark_and_fundamentals(
         self, data_layer, mock_benchmark_cache, mock_fundamentals_cache, mock_sleep,
     ):
-        mock_benchmark_cache.get_spy_data.side_effect = [
+        mock_benchmark_cache.get_benchmark_data.side_effect = [
             TimeoutError("timeout"),
             _make_price_df(days=252, price=450.0),
         ]
@@ -290,8 +290,17 @@ class TestRetryWithBackoff:
 
         assert "benchmark_data" not in result.fetch_errors
         assert result.fundamentals == FUNDAMENTALS
-        assert mock_benchmark_cache.get_spy_data.call_count == 2
+        assert mock_benchmark_cache.get_benchmark_data.call_count == 2
         assert mock_fundamentals_cache.get_fundamentals.call_count == 2
+
+    def test_non_us_symbol_routes_benchmark_by_market(self, data_layer, mock_benchmark_cache):
+        result = data_layer.prepare_data("700.HK", REQUIREMENTS)
+
+        assert "benchmark_data" not in result.fetch_errors
+        mock_benchmark_cache.get_benchmark_data.assert_called_once_with(
+            market="HK",
+            period="2y",
+        )
 
 
 # ===================================================================
@@ -425,9 +434,31 @@ class TestBulkDataPreparation:
         results = data_layer.prepare_data_bulk(["AAPL", "MSFT"], REQUIREMENTS)
 
         # Benchmark fetched once, shared across both symbols
-        mock_benchmark_cache.get_spy_data.assert_called_once()
+        mock_benchmark_cache.get_benchmark_data.assert_called_once_with(
+            market="US",
+            period="2y",
+        )
         # Both symbols should have the same benchmark_data reference
         assert results["AAPL"].benchmark_data is results["MSFT"].benchmark_data
+
+    def test_bulk_fetches_benchmark_once_per_market_for_mixed_symbols(
+        self, data_layer, mock_price_cache, mock_benchmark_cache
+    ):
+        hk_df = _make_price_df(price=280.0)
+        us_df = _make_price_df(price=450.0)
+        mock_benchmark_cache.get_benchmark_data.side_effect = lambda *, market, period: (
+            hk_df if market == "HK" else us_df
+        )
+        mock_price_cache.get_many.return_value = {
+            "AAPL": _make_price_df(),
+            "0700.HK": _make_price_df(),
+        }
+
+        results = data_layer.prepare_data_bulk(["AAPL", "0700.HK"], REQUIREMENTS)
+
+        assert mock_benchmark_cache.get_benchmark_data.call_count == 2
+        assert results["AAPL"].benchmark_data is us_df
+        assert results["0700.HK"].benchmark_data is hk_df
 
     def test_bulk_batch_only_prices_never_falls_back_to_per_symbol_fetch(
         self, data_layer, mock_price_cache, mock_yfinance,

--- a/backend/tests/unit/infra/test_stock_data_provider.py
+++ b/backend/tests/unit/infra/test_stock_data_provider.py
@@ -460,6 +460,28 @@ class TestBulkDataPreparation:
         assert results["AAPL"].benchmark_data is us_df
         assert results["0700.HK"].benchmark_data is hk_df
 
+    def test_bulk_records_benchmark_error_when_market_benchmark_missing(
+        self, data_layer, mock_price_cache, mock_benchmark_cache
+    ):
+        mock_benchmark_cache.get_benchmark_data.return_value = None
+        mock_price_cache.get_many.return_value = {"AAPL": _make_price_df()}
+
+        results = data_layer.prepare_data_bulk(["AAPL"], REQUIREMENTS)
+
+        assert results["AAPL"].benchmark_data.empty
+        assert "benchmark_data" in results["AAPL"].fetch_errors
+
+    def test_bulk_strict_mode_raises_when_market_benchmark_missing(
+        self, data_layer, mock_price_cache, mock_benchmark_cache
+    ):
+        mock_benchmark_cache.get_benchmark_data.return_value = None
+        mock_price_cache.get_many.return_value = {"AAPL": _make_price_df()}
+
+        with pytest.raises(DataFetchError) as exc_info:
+            data_layer.prepare_data_bulk(["AAPL"], REQUIREMENTS, allow_partial=False)
+
+        assert "AAPL/benchmark_data" in exc_info.value.errors
+
     def test_bulk_batch_only_prices_never_falls_back_to_per_symbol_fetch(
         self, data_layer, mock_price_cache, mock_yfinance,
         mock_fundamentals_cache,

--- a/backend/tests/unit/infra/test_stock_data_provider.py
+++ b/backend/tests/unit/infra/test_stock_data_provider.py
@@ -144,6 +144,26 @@ class TestPartialFailureAllowPartialTrue:
         assert result.fundamentals is None
         assert "fundamentals" in result.fetch_errors
 
+    def test_prepare_data_uses_canonical_symbol_for_price_and_fundamentals(
+        self, data_layer, mock_price_cache, mock_fundamentals_cache
+    ):
+        data_layer._resolve_identity = MagicMock(return_value=MagicMock(
+            normalized_symbol="700",
+            canonical_symbol="0700.HK",
+            market="HK",
+            exchange="XHKG",
+            currency="HKD",
+            timezone="Asia/Hong_Kong",
+            local_code="0700",
+        ))
+        mock_price_cache.get_historical_data.return_value = _make_price_df()
+
+        result = data_layer.prepare_data("700", REQUIREMENTS)
+
+        assert result.symbol == "0700.HK"
+        mock_price_cache.get_historical_data.assert_called_once_with("0700.HK", period="2y")
+        mock_fundamentals_cache.get_fundamentals.assert_called_once_with("0700.HK", force_refresh=False)
+
     def test_all_components_fail_returns_stock_data_with_all_errors(
         self, data_layer, mock_price_cache, mock_yfinance,
         mock_benchmark_cache, mock_fundamentals_cache,

--- a/backend/tests/unit/infra/test_stock_data_provider.py
+++ b/backend/tests/unit/infra/test_stock_data_provider.py
@@ -480,6 +480,59 @@ class TestBulkDataPreparation:
         assert results["AAPL"].benchmark_data is us_df
         assert results["0700.HK"].benchmark_data is hk_df
 
+    def test_bulk_results_preserve_requested_input_key_for_unsuffixed_symbol(
+        self, data_layer, mock_price_cache
+    ):
+        data_layer._resolve_identity = MagicMock(side_effect=[
+            MagicMock(
+                normalized_symbol="700",
+                canonical_symbol="0700.HK",
+                market="HK",
+                exchange="XHKG",
+                currency="HKD",
+                timezone="Asia/Hong_Kong",
+                local_code="0700",
+            )
+        ])
+        mock_price_cache.get_many.return_value = {"0700.HK": _make_price_df(price=380.0)}
+
+        results = data_layer.prepare_data_bulk(["700"], REQUIREMENTS)
+
+        assert "700" in results
+        assert "0700.HK" not in results
+        assert results["700"].symbol == "0700.HK"
+
+    def test_bulk_keeps_entries_for_aliases_that_share_same_canonical_symbol(
+        self, data_layer, mock_price_cache
+    ):
+        data_layer._resolve_identity = MagicMock(side_effect=[
+            MagicMock(
+                normalized_symbol="700",
+                canonical_symbol="0700.HK",
+                market="HK",
+                exchange="XHKG",
+                currency="HKD",
+                timezone="Asia/Hong_Kong",
+                local_code="0700",
+            ),
+            MagicMock(
+                normalized_symbol="0700.HK",
+                canonical_symbol="0700.HK",
+                market="HK",
+                exchange="XHKG",
+                currency="HKD",
+                timezone="Asia/Hong_Kong",
+                local_code="0700",
+            ),
+        ])
+        mock_price_cache.get_many.return_value = {"0700.HK": _make_price_df(price=380.0)}
+
+        results = data_layer.prepare_data_bulk(["700", "0700.HK"], REQUIREMENTS)
+
+        assert set(results.keys()) == {"700", "0700.HK"}
+        assert results["700"].symbol == "0700.HK"
+        assert results["0700.HK"].symbol == "0700.HK"
+
     def test_bulk_records_benchmark_error_when_market_benchmark_missing(
         self, data_layer, mock_price_cache, mock_benchmark_cache
     ):

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -2,6 +2,7 @@ import pandas as pd
 from datetime import datetime
 
 from app.services.benchmark_cache_service import BenchmarkCacheService
+import app.services.benchmark_cache_service as benchmark_cache_module
 
 
 def test_get_benchmark_symbol_supports_all_markets():
@@ -167,3 +168,23 @@ def test_is_data_fresh_fallback_allows_weekend_without_calendar(monkeypatch):
     )
 
     assert service._is_data_fresh(data, market="HK") is True
+
+
+def test_is_data_fresh_uses_us_market_hours_fallback_when_calendar_unavailable(monkeypatch):
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    data = pd.DataFrame({"Close": [100.0]}, index=pd.to_datetime(["2026-04-10"]))  # Friday
+    service._market_calendar.last_completed_trading_day = lambda market: (_ for _ in ()).throw(RuntimeError("no calendar"))  # type: ignore[method-assign]
+
+    monkeypatch.setattr(
+        benchmark_cache_module,
+        "get_eastern_now",
+        lambda: datetime.fromisoformat("2026-04-13T10:00:00-04:00"),  # Monday, market open
+    )
+    monkeypatch.setattr(benchmark_cache_module, "is_market_open", lambda _dt=None: True)
+    monkeypatch.setattr(
+        benchmark_cache_module,
+        "get_last_trading_day",
+        lambda d=None: pd.Timestamp("2026-04-10").date(),
+    )
+
+    assert service._is_data_fresh(data, market="US") is True

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -100,6 +100,32 @@ def test_get_benchmark_data_uses_fallback_when_primary_fails():
     assert result is fallback_df
 
 
+def test_get_benchmark_data_prefers_cached_fallback_before_primary_network_fetch():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    service._redis_client = None
+
+    fallback_df = pd.DataFrame({"Close": [1.0]}, index=pd.to_datetime(["2026-04-10"]))
+    calls = []
+
+    def fake_get_from_db(*, benchmark_symbol, period, market):
+        if benchmark_symbol == "2800.HK":
+            return fallback_df
+        return None
+
+    def fake_fetch(*, benchmark_symbol, market, period):
+        calls.append(benchmark_symbol)
+        return pd.DataFrame()
+
+    service._get_from_database = fake_get_from_db  # type: ignore[assignment]
+    service._is_data_fresh = lambda data, market="US", max_age_hours=24: True  # type: ignore[assignment]
+    service._fetch_and_cache_benchmark = fake_fetch  # type: ignore[assignment]
+
+    result = service.get_benchmark_data(market="HK", period="2y", force_refresh=False)
+
+    assert result is fallback_df
+    assert calls == []
+
+
 def test_is_data_fresh_fallback_allows_weekend_without_calendar(monkeypatch):
     service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
     data = pd.DataFrame({"Close": [100.0]}, index=pd.to_datetime(["2026-04-10"]))  # Friday

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -186,5 +186,48 @@ def test_is_data_fresh_uses_us_market_hours_fallback_when_calendar_unavailable(m
         "get_last_trading_day",
         lambda d=None: pd.Timestamp("2026-04-10").date(),
     )
+    monkeypatch.setattr(benchmark_cache_module, "is_trading_day", lambda d=None: True)
 
     assert service._is_data_fresh(data, market="US") is True
+
+
+def test_is_data_fresh_us_fallback_premarket_uses_previous_trading_day(monkeypatch):
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    data = pd.DataFrame({"Close": [100.0]}, index=pd.to_datetime(["2026-04-10"]))  # Friday close
+    service._market_calendar.last_completed_trading_day = lambda market: (_ for _ in ()).throw(RuntimeError("no calendar"))  # type: ignore[method-assign]
+
+    monkeypatch.setattr(
+        benchmark_cache_module,
+        "get_eastern_now",
+        lambda: datetime.fromisoformat("2026-04-13T08:00:00-04:00"),  # Monday pre-market
+    )
+    monkeypatch.setattr(benchmark_cache_module, "is_market_open", lambda _dt=None: False)
+    monkeypatch.setattr(benchmark_cache_module, "is_trading_day", lambda d=None: True)
+    monkeypatch.setattr(
+        benchmark_cache_module,
+        "get_last_trading_day",
+        lambda d=None: pd.Timestamp("2026-04-10").date(),
+    )
+
+    assert service._is_data_fresh(data, market="US") is True
+
+
+def test_is_data_fresh_us_fallback_after_close_requires_same_day(monkeypatch):
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    stale_data = pd.DataFrame({"Close": [100.0]}, index=pd.to_datetime(["2026-04-10"]))  # Friday close
+    service._market_calendar.last_completed_trading_day = lambda market: (_ for _ in ()).throw(RuntimeError("no calendar"))  # type: ignore[method-assign]
+
+    monkeypatch.setattr(
+        benchmark_cache_module,
+        "get_eastern_now",
+        lambda: datetime.fromisoformat("2026-04-13T17:30:00-04:00"),  # Monday after close buffer
+    )
+    monkeypatch.setattr(benchmark_cache_module, "is_market_open", lambda _dt=None: False)
+    monkeypatch.setattr(benchmark_cache_module, "is_trading_day", lambda d=None: True)
+    monkeypatch.setattr(
+        benchmark_cache_module,
+        "get_last_trading_day",
+        lambda d=None: pd.Timestamp("2026-04-10").date(),
+    )
+
+    assert service._is_data_fresh(stale_data, market="US") is False

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -12,6 +12,14 @@ def test_get_benchmark_symbol_supports_all_markets():
     assert service.get_benchmark_symbol("TW") == "^TWII"
 
 
+def test_non_us_candidates_do_not_include_spy():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+
+    assert "SPY" not in service.get_benchmark_candidates("HK")
+    assert "SPY" not in service.get_benchmark_candidates("JP")
+    assert "SPY" not in service.get_benchmark_candidates("TW")
+
+
 def test_get_spy_data_delegates_to_market_api():
     service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
 
@@ -65,3 +73,27 @@ def test_fetch_and_cache_benchmark_without_redis_fetches_directly_and_persists()
     assert result is data
     assert calls["wait"] == 0
     assert calls["store_db"] == 1
+
+
+def test_get_benchmark_data_uses_fallback_when_primary_fails():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    service._redis_client = None
+
+    calls = []
+    fallback_df = pd.DataFrame({"Close": [1.0]}, index=pd.to_datetime(["2026-04-10"]))
+
+    def fake_fetch(symbol, period):
+        calls.append(symbol)
+        if symbol == "^HSI":
+            return pd.DataFrame()
+        if symbol == "2800.HK":
+            return fallback_df
+        return pd.DataFrame()
+
+    service._fetch_from_yfinance = fake_fetch  # type: ignore[assignment]
+    service._store_in_database = lambda **kwargs: None  # type: ignore[assignment]
+
+    result = service.get_benchmark_data(market="HK", period="2y", force_refresh=True)
+
+    assert calls[:2] == ["^HSI", "2800.HK"]
+    assert result is fallback_df

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from app.services.benchmark_cache_service import BenchmarkCacheService
 
 
@@ -36,3 +38,30 @@ def test_market_scoped_redis_keys_are_deterministic():
 
     assert data_key == "benchmark:^N225:2y"
     assert lock_key == "benchmark:^N225:2y:lock"
+
+
+def test_fetch_and_cache_benchmark_without_redis_fetches_directly_and_persists():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    service._redis_client = None
+
+    calls = {"wait": 0, "store_db": 0}
+    data = pd.DataFrame({"Close": [100.0]}, index=pd.to_datetime(["2026-04-10"]))
+
+    def fail_if_wait(*args, **kwargs):
+        calls["wait"] += 1
+        raise AssertionError("wait path must not run when redis is unavailable")
+
+    def fake_store_db(*, benchmark_symbol, data):
+        calls["store_db"] += 1
+        assert benchmark_symbol == "^HSI"
+        assert not data.empty
+
+    service._wait_for_cache = fail_if_wait  # type: ignore[assignment]
+    service._store_in_database = fake_store_db  # type: ignore[assignment]
+    service._fetch_from_yfinance = lambda benchmark_symbol, period: data  # type: ignore[assignment]
+
+    result = service._fetch_and_cache_benchmark("^HSI", "HK", "2y")
+
+    assert result is data
+    assert calls["wait"] == 0
+    assert calls["store_db"] == 1

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from datetime import datetime
 
 from app.services.benchmark_cache_service import BenchmarkCacheService
 
@@ -97,3 +98,17 @@ def test_get_benchmark_data_uses_fallback_when_primary_fails():
 
     assert calls[:2] == ["^HSI", "2800.HK"]
     assert result is fallback_df
+
+
+def test_is_data_fresh_fallback_allows_weekend_without_calendar(monkeypatch):
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    data = pd.DataFrame({"Close": [100.0]}, index=pd.to_datetime(["2026-04-10"]))  # Friday
+    service._market_calendar.last_completed_trading_day = lambda market: None  # type: ignore[method-assign]
+
+    monkeypatch.setattr(
+        pd.Timestamp,
+        "utcnow",
+        lambda: pd.Timestamp(datetime(2026, 4, 12, 12, 0), tz="UTC"),
+    )
+
+    assert service._is_data_fresh(data, market="HK") is True

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -126,6 +126,35 @@ def test_get_benchmark_data_prefers_cached_fallback_before_primary_network_fetch
     assert calls == []
 
 
+def test_get_benchmark_data_skips_stale_redis_hit():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    service._redis_client = None
+
+    stale_df = pd.DataFrame({"Close": [1.0]}, index=pd.to_datetime(["2026-04-01"]))
+    fresh_df = pd.DataFrame({"Close": [2.0]}, index=pd.to_datetime(["2026-04-10"]))
+
+    def fake_get_from_redis(*, benchmark_symbol, period):
+        if benchmark_symbol == "^HSI":
+            return stale_df
+        return None
+
+    def fake_get_from_db(*, benchmark_symbol, period, market):
+        if benchmark_symbol == "2800.HK":
+            return fresh_df
+        return None
+
+    def fake_is_fresh(data, market="US", max_age_hours=24):
+        return data is fresh_df
+
+    service._get_from_redis = fake_get_from_redis  # type: ignore[assignment]
+    service._get_from_database = fake_get_from_db  # type: ignore[assignment]
+    service._is_data_fresh = fake_is_fresh  # type: ignore[assignment]
+
+    result = service.get_benchmark_data(market="HK", period="2y", force_refresh=False)
+
+    assert result is fresh_df
+
+
 def test_is_data_fresh_fallback_allows_weekend_without_calendar(monkeypatch):
     service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
     data = pd.DataFrame({"Close": [100.0]}, index=pd.to_datetime(["2026-04-10"]))  # Friday

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -1,0 +1,38 @@
+from app.services.benchmark_cache_service import BenchmarkCacheService
+
+
+def test_get_benchmark_symbol_supports_all_markets():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+
+    assert service.get_benchmark_symbol("US") == "SPY"
+    assert service.get_benchmark_symbol("HK") == "^HSI"
+    assert service.get_benchmark_symbol("JP") == "^N225"
+    assert service.get_benchmark_symbol("TW") == "^TWII"
+
+
+def test_get_spy_data_delegates_to_market_api():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+
+    captured = {}
+
+    def fake_get_benchmark_data(*, market, period, force_refresh):
+        captured["market"] = market
+        captured["period"] = period
+        captured["force_refresh"] = force_refresh
+        return "ok"
+
+    service.get_benchmark_data = fake_get_benchmark_data  # type: ignore[assignment]
+    result = service.get_spy_data(period="1y", force_refresh=True)
+
+    assert result == "ok"
+    assert captured == {"market": "US", "period": "1y", "force_refresh": True}
+
+
+def test_market_scoped_redis_keys_are_deterministic():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+
+    data_key = service._redis_data_key("^N225", "2y")
+    lock_key = service._redis_lock_key("^N225", "2y")
+
+    assert data_key == "benchmark:^N225:2y"
+    assert lock_key == "benchmark:^N225:2y:lock"

--- a/backend/tests/unit/test_benchmark_registry_service.py
+++ b/backend/tests/unit/test_benchmark_registry_service.py
@@ -1,0 +1,15 @@
+from app.services.benchmark_registry_service import benchmark_registry
+
+
+def test_registry_versioned_mapping_exists_for_all_markets():
+    table = benchmark_registry.mapping_table()
+
+    assert benchmark_registry.TABLE_VERSION == "2026-04-11.v1"
+    assert set(table.keys()) == {"US", "HK", "JP", "TW"}
+
+
+def test_non_us_candidates_have_no_spy_leakage():
+    for market in ("HK", "JP", "TW"):
+        candidates = benchmark_registry.get_candidate_symbols(market)
+        assert "SPY" not in candidates
+        assert len(candidates) >= 1

--- a/backend/tests/unit/test_cache_tasks_market_resolution.py
+++ b/backend/tests/unit/test_cache_tasks_market_resolution.py
@@ -1,4 +1,5 @@
 from app.tasks.cache_tasks import _active_benchmark_markets, _benchmark_markets_for_symbols
+import app.tasks.cache_tasks as cache_tasks
 
 
 class _FakeQuery:
@@ -46,3 +47,40 @@ def test_benchmark_markets_for_symbols_infers_market_from_symbol_suffix():
 
     assert markets == ["TW"]
 
+
+def test_benchmark_markets_for_symbols_infers_market_when_db_has_no_rows():
+    db = _FakeDB([])
+
+    markets = _benchmark_markets_for_symbols(db, symbols=["0700.HK"])
+
+    assert markets == ["HK"]
+
+
+def test_active_benchmark_markets_always_includes_us():
+    db = _FakeDB([("HK", "XHKG", "0700.HK")])
+
+    markets = _active_benchmark_markets(db)
+
+    assert markets == ["HK", "US"]
+
+
+def test_warm_spy_cache_returns_error_when_any_market_warm_fails(monkeypatch):
+    class _FakeCacheManager:
+        @staticmethod
+        def warm_benchmark_cache(*, period, market):
+            return not (market == "HK" and period == "1y")
+
+    class _FakeSession:
+        @staticmethod
+        def close():
+            return None
+
+    monkeypatch.setattr(cache_tasks, "SessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(cache_tasks, "CacheManager", lambda: _FakeCacheManager())
+    monkeypatch.setattr(cache_tasks, "_active_benchmark_markets", lambda _db: ["HK", "US"])
+    monkeypatch.setattr(cache_tasks, "format_market_status", lambda: "closed")
+
+    result = cache_tasks.warm_spy_cache()
+
+    assert "error" in result
+    assert "HK:1y" in result["error"]

--- a/backend/tests/unit/test_cache_tasks_market_resolution.py
+++ b/backend/tests/unit/test_cache_tasks_market_resolution.py
@@ -1,0 +1,48 @@
+from app.tasks.cache_tasks import _active_benchmark_markets, _benchmark_markets_for_symbols
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+class _FakeDB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self, *_args, **_kwargs):
+        return _FakeQuery(self._rows)
+
+
+def test_active_benchmark_markets_infers_non_us_when_market_blank():
+    db = _FakeDB(
+        [
+            ("", "XHKG", "0700"),
+            (None, "XTKS", "9984"),
+            ("US", "NASDAQ", "AAPL"),
+        ]
+    )
+
+    markets = _active_benchmark_markets(db)
+
+    assert markets == ["HK", "JP", "US"]
+
+
+def test_benchmark_markets_for_symbols_infers_market_from_symbol_suffix():
+    db = _FakeDB(
+        [
+            ("", None, "3008.TWO"),
+            ("", None, "2330.TW"),
+        ]
+    )
+
+    markets = _benchmark_markets_for_symbols(db, symbols=["3008.TWO", "2330.TW"])
+
+    assert markets == ["TW"]
+

--- a/backend/tests/unit/test_cache_tasks_market_resolution.py
+++ b/backend/tests/unit/test_cache_tasks_market_resolution.py
@@ -84,3 +84,5 @@ def test_warm_spy_cache_returns_error_when_any_market_warm_fails(monkeypatch):
 
     assert "error" in result
     assert "HK:1y" in result["error"]
+    assert "by_market" in result
+    assert result["by_market"]["US"]["2y"] is True

--- a/backend/tests/unit/test_market_calendar_service.py
+++ b/backend/tests/unit/test_market_calendar_service.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+
+import pandas as pd
+
+from app.services.market_calendar_service import MarketCalendarService
+
+
+class _FakeCalendar:
+    def __init__(self):
+        self.sessions = [
+            pd.Timestamp("2026-04-09"),
+            pd.Timestamp("2026-04-10"),
+        ]
+        self.schedule = pd.DataFrame(
+            {
+                "market_close": [
+                    pd.Timestamp("2026-04-09 08:00:00+00:00"),
+                    pd.Timestamp("2026-04-10 08:00:00+00:00"),
+                ],
+            },
+            index=self.sessions,
+        )
+
+    def is_session(self, session: pd.Timestamp) -> bool:
+        return any(s.date() == session.date() for s in self.sessions)
+
+    def previous_session(self, session: pd.Timestamp) -> pd.Timestamp:
+        previous = [s for s in self.sessions if s.date() < session.date()]
+        return previous[-1]
+
+    def is_open_on_minute(self, ts: pd.Timestamp, ignore_breaks: bool = False) -> bool:
+        # Keep this deterministic: only one minute is considered open.
+        return ts == pd.Timestamp("2026-04-10 01:30:00+00:00")
+
+
+def test_market_calendar_service_uses_canonical_calendar_ids():
+    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+
+    assert service.calendar_id("US") == "XNYS"
+    assert service.calendar_id("HK") == "XHKG"
+    assert service.calendar_id("JP") == "XTKS"
+    assert service.calendar_id("TW") == "XTAI"
+
+
+def test_last_completed_trading_day_before_close_returns_previous_session():
+    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    now_hkt = datetime.fromisoformat("2026-04-10T15:30:00+08:00")
+
+    expected = service.last_completed_trading_day("HK", now=now_hkt)
+
+    assert expected == pd.Timestamp("2026-04-09").date()
+
+
+def test_last_completed_trading_day_after_close_returns_current_session():
+    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    now_hkt = datetime.fromisoformat("2026-04-10T17:30:00+08:00")
+
+    expected = service.last_completed_trading_day("HK", now=now_hkt)
+
+    assert expected == pd.Timestamp("2026-04-10").date()
+
+
+def test_is_market_open_uses_calendar_open_minute():
+    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    open_minute_hkt = datetime.fromisoformat("2026-04-10T09:30:00+08:00")
+    closed_minute_hkt = datetime.fromisoformat("2026-04-10T09:31:00+08:00")
+
+    assert service.is_market_open("HK", now=open_minute_hkt) is True
+    assert service.is_market_open("HK", now=closed_minute_hkt) is False

--- a/backend/tests/unit/test_market_calendar_service.py
+++ b/backend/tests/unit/test_market_calendar_service.py
@@ -13,7 +13,7 @@ class _FakeCalendar:
         ]
         self.schedule = pd.DataFrame(
             {
-                "market_close": [
+                "close": [
                     pd.Timestamp("2026-04-09 08:00:00+00:00"),
                     pd.Timestamp("2026-04-10 08:00:00+00:00"),
                 ],

--- a/backend/tests/unit/test_market_calendar_service_engine.py
+++ b/backend/tests/unit/test_market_calendar_service_engine.py
@@ -1,0 +1,37 @@
+from datetime import date, datetime
+
+import pytest
+
+from app.services import market_calendar_service as module
+from app.services.market_calendar_service import MarketCalendarService
+
+
+pytestmark = pytest.mark.skipif(
+    module.xcals is None,
+    reason="exchange_calendars is required for engine-level calendar tests",
+)
+
+
+def test_calendar_ids_are_canonical_for_supported_markets():
+    service = MarketCalendarService()
+
+    assert service.calendar_id("US") == "XNYS"
+    assert service.calendar_id("HK") == "XHKG"
+    assert service.calendar_id("JP") == "XTKS"
+    assert service.calendar_id("TW") == "XTAI"
+
+
+def test_weekend_is_non_trading_day_for_all_supported_markets():
+    service = MarketCalendarService()
+    saturday = date(2026, 4, 11)
+
+    for market in ("US", "HK", "JP", "TW"):
+        assert service.is_trading_day(market, saturday) is False
+
+
+def test_last_completed_session_on_sunday_returns_previous_friday():
+    service = MarketCalendarService()
+    sunday_utc = datetime.fromisoformat("2026-04-12T12:00:00+00:00")
+
+    for market in ("US", "HK", "JP", "TW"):
+        assert service.last_completed_trading_day(market, now=sunday_utc) == date(2026, 4, 10)

--- a/backend/tests/unit/test_market_hours.py
+++ b/backend/tests/unit/test_market_hours.py
@@ -1,7 +1,7 @@
 """
 Unit tests for market_hours utility module.
 
-Tests the NYSE calendar integration via pandas_market_calendars,
+Tests the NYSE calendar integration via exchange_calendars,
 ensuring trading day detection, holiday handling, and timezone
 correctness.
 """
@@ -16,6 +16,7 @@ from app.utils.market_hours import (
     get_last_market_close,
     get_next_market_close,
     _get_trading_days_set,
+    calendar_engine,
     EASTERN,
 )
 
@@ -194,3 +195,7 @@ class TestTradingDaysCache:
         # Should recompute
         _get_trading_days_set()
         assert mh._cache_year == initial_year  # Restored to current year
+
+
+def test_calendar_engine_prefers_exchange_calendars():
+    assert calendar_engine() in {"exchange_calendars", "pandas_market_calendars"}

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -754,3 +754,21 @@ def test_get_fundamentals_fetches_on_demand_when_fresh_cache_is_missing_required
 
     assert result == enriched
     assert fetch_calls == ["AAPL"]
+
+
+def test_deserialize_universe_row_infers_hk_from_xhkg_exchange():
+    row = ProviderSnapshotService._deserialize_universe_row(
+        {
+            "symbol": "0700",
+            "exchange": "XHKG",
+            "market": "",
+            "currency": None,
+            "timezone": None,
+            "local_code": None,
+        }
+    )
+
+    assert row["market"] == "HK"
+    assert row["currency"] == "HKD"
+    assert row["timezone"] == "Asia/Hong_Kong"
+    assert row["local_code"] == "0700"

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -719,6 +719,53 @@ def test_imported_weekly_reference_bundle_hydrates_ipo_date_back_to_database(tmp
     db.close()
 
 
+def test_import_weekly_reference_bundle_canonicalizes_snapshot_row_symbol(tmp_path):
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    service = _make_provider_snapshot_service()
+
+    bundle_path = tmp_path / "weekly_reference_bundle.json.gz"
+    payload = {
+        "schema_version": service.WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION,
+        "generated_at": "2026-04-11T12:00:00Z",
+        "as_of_date": "2026-04-11",
+        "snapshot": {
+            "snapshot_key": service.SNAPSHOT_KEY_FUNDAMENTALS,
+            "run_mode": "publish",
+            "status": "published",
+            "source_revision": "fundamentals_v1:20260411120000",
+            "created_at": "2026-04-11T12:00:00Z",
+            "published_at": "2026-04-11T12:00:00Z",
+            "rows": [
+                {
+                    "symbol": "3008.TW",
+                    "exchange": "TPEX",
+                    "row_hash": "row-hash-1",
+                    "normalized_payload": {"symbol": "3008.TW", "exchange": "TPEX"},
+                }
+            ],
+        },
+        "universe": [
+            {
+                "symbol": "3008.TW",
+                "exchange": "TPEX",
+                "is_active": True,
+                "status": UNIVERSE_STATUS_ACTIVE,
+            }
+        ],
+    }
+    with gzip.open(bundle_path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh, sort_keys=True)
+
+    service.import_weekly_reference_bundle(db, input_path=bundle_path)
+
+    run = service.get_published_run(db)
+    row = db.query(ProviderSnapshotRow).filter(ProviderSnapshotRow.run_id == run.id).one()
+    assert row.symbol == "3008.TWO"
+    assert row.exchange == "TPEX"
+    db.close()
+
+
 def test_get_fundamentals_fetches_on_demand_when_fresh_cache_is_missing_required_fields(monkeypatch):
     monkeypatch.setattr(fundamentals_cache_module, "get_redis_client", lambda: None)
     service = FundamentalsCacheService(

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -768,7 +768,25 @@ def test_deserialize_universe_row_infers_hk_from_xhkg_exchange():
         }
     )
 
+    assert row["symbol"] == "0700.HK"
     assert row["market"] == "HK"
     assert row["currency"] == "HKD"
     assert row["timezone"] == "Asia/Hong_Kong"
     assert row["local_code"] == "0700"
+
+
+def test_deserialize_universe_row_normalizes_tpex_symbol_to_two_suffix():
+    row = ProviderSnapshotService._deserialize_universe_row(
+        {
+            "symbol": "3008.TW",
+            "exchange": "TPEX",
+            "market": "TW",
+            "currency": "TWD",
+            "timezone": "Asia/Taipei",
+            "local_code": "3008",
+        }
+    )
+
+    assert row["symbol"] == "3008.TWO"
+    assert row["exchange"] == "TPEX"
+    assert row["market"] == "TW"

--- a/backend/tests/unit/test_security_master_service.py
+++ b/backend/tests/unit/test_security_master_service.py
@@ -61,6 +61,16 @@ def test_resolve_identity_rewrites_mismatched_tw_suffix_for_tpex_symbol():
     assert identity.canonical_symbol == "3008.TWO"
 
 
+def test_resolve_identity_preserves_explicit_two_suffix_without_exchange_override():
+    resolver = SecurityMasterResolver()
+
+    identity = resolver.resolve_identity(symbol="3008.TWO")
+
+    assert identity.market == "TW"
+    assert identity.exchange is None
+    assert identity.canonical_symbol == "3008.TWO"
+
+
 def test_normalize_symbol_strips_dollar_prefix():
     resolver = SecurityMasterResolver()
 

--- a/backend/tests/unit/test_security_master_service.py
+++ b/backend/tests/unit/test_security_master_service.py
@@ -1,0 +1,46 @@
+from app.services.security_master_service import SecurityMasterResolver
+
+
+def test_resolve_identity_prefers_explicit_market_and_exchange():
+    resolver = SecurityMasterResolver()
+
+    identity = resolver.resolve_identity(
+        symbol=" 0700.hk ",
+        market="hk",
+        exchange=" sehk ",
+    )
+
+    assert identity.normalized_symbol == "0700.HK"
+    assert identity.market == "HK"
+    assert identity.exchange == "SEHK"
+    assert identity.currency == "HKD"
+    assert identity.timezone == "Asia/Hong_Kong"
+    assert identity.local_code == "0700"
+
+
+def test_resolve_identity_infers_market_from_exchange_alias():
+    resolver = SecurityMasterResolver()
+
+    identity = resolver.resolve_identity(symbol="9984", exchange="XTKS")
+
+    assert identity.market == "JP"
+    assert identity.currency == "JPY"
+    assert identity.timezone == "Asia/Tokyo"
+    assert identity.canonical_symbol == "9984.T"
+
+
+def test_resolve_identity_infers_market_from_suffix_when_exchange_missing():
+    resolver = SecurityMasterResolver()
+
+    identity = resolver.resolve_identity(symbol="2330.tw")
+
+    assert identity.market == "TW"
+    assert identity.currency == "TWD"
+    assert identity.timezone == "Asia/Taipei"
+    assert identity.local_code == "2330"
+
+
+def test_normalize_symbol_strips_dollar_prefix():
+    resolver = SecurityMasterResolver()
+
+    assert resolver.normalize_symbol("$nvda") == "NVDA"

--- a/backend/tests/unit/test_security_master_service.py
+++ b/backend/tests/unit/test_security_master_service.py
@@ -40,6 +40,16 @@ def test_resolve_identity_infers_market_from_suffix_when_exchange_missing():
     assert identity.local_code == "2330"
 
 
+def test_resolve_identity_uses_tpex_suffix_for_unsuffixed_tw_symbol():
+    resolver = SecurityMasterResolver()
+
+    identity = resolver.resolve_identity(symbol="3008", exchange="TPEX")
+
+    assert identity.market == "TW"
+    assert identity.exchange == "TPEX"
+    assert identity.canonical_symbol == "3008.TWO"
+
+
 def test_normalize_symbol_strips_dollar_prefix():
     resolver = SecurityMasterResolver()
 

--- a/backend/tests/unit/test_security_master_service.py
+++ b/backend/tests/unit/test_security_master_service.py
@@ -50,6 +50,17 @@ def test_resolve_identity_uses_tpex_suffix_for_unsuffixed_tw_symbol():
     assert identity.canonical_symbol == "3008.TWO"
 
 
+def test_resolve_identity_rewrites_mismatched_tw_suffix_for_tpex_symbol():
+    resolver = SecurityMasterResolver()
+
+    identity = resolver.resolve_identity(symbol="3008.TW", exchange="TPEX")
+
+    assert identity.market == "TW"
+    assert identity.exchange == "TPEX"
+    assert identity.local_code == "3008"
+    assert identity.canonical_symbol == "3008.TWO"
+
+
 def test_normalize_symbol_strips_dollar_prefix():
     resolver = SecurityMasterResolver()
 

--- a/backend/tests/unit/test_stock_universe_service.py
+++ b/backend/tests/unit/test_stock_universe_service.py
@@ -101,3 +101,24 @@ def test_get_active_symbols_market_filter_falls_back_to_exchange_when_market_bla
 
     assert symbols == ["AAPL", "IBM"]
     db.close()
+
+
+def test_populate_from_csv_sets_market_identity_fields_from_resolver():
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+
+    csv_content = "\n".join(
+        [
+            "symbol,name,exchange,sector,industry,market_cap",
+            "0700.HK,Tencent,SEHK,Technology,Internet,500B",
+        ]
+    )
+    stats = stock_universe_service.populate_from_csv(db, csv_content)
+
+    row = db.query(StockUniverse).filter(StockUniverse.symbol == "0700.HK").one()
+    assert stats["added"] == 1
+    assert row.market == "HK"
+    assert row.currency == "HKD"
+    assert row.timezone == "Asia/Hong_Kong"
+    assert row.local_code == "0700"
+    db.close()

--- a/backend/tests/unit/test_stock_universe_service.py
+++ b/backend/tests/unit/test_stock_universe_service.py
@@ -122,3 +122,42 @@ def test_populate_from_csv_sets_market_identity_fields_from_resolver():
     assert row.timezone == "Asia/Hong_Kong"
     assert row.local_code == "0700"
     db.close()
+
+
+def test_populate_from_csv_persists_canonical_symbol_from_security_master():
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+
+    csv_content = "\n".join(
+        [
+            "symbol,name,exchange,sector,industry,market_cap",
+            "700,Tencent,SEHK,Technology,Internet,500B",
+        ]
+    )
+    stats = stock_universe_service.populate_from_csv(db, csv_content)
+
+    row = db.query(StockUniverse).filter(StockUniverse.symbol == "700.HK").one()
+    assert stats["added"] == 1
+    assert row.exchange == "SEHK"
+    assert row.market == "HK"
+    assert row.local_code == "700"
+    db.close()
+
+
+def test_populate_from_csv_uses_tpex_two_suffix_for_unsuffixed_symbols():
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+
+    csv_content = "\n".join(
+        [
+            "symbol,name,exchange,sector,industry,market_cap",
+            "3008,Largan,TPEX,Technology,Electronics,120B",
+        ]
+    )
+    stock_universe_service.populate_from_csv(db, csv_content)
+
+    row = db.query(StockUniverse).filter(StockUniverse.symbol == "3008.TWO").one()
+    assert row.exchange == "TPEX"
+    assert row.market == "TW"
+    assert row.timezone == "Asia/Taipei"
+    db.close()

--- a/docs/asia/benchmark_registry_table_v1.md
+++ b/docs/asia/benchmark_registry_table_v1.md
@@ -1,7 +1,7 @@
 # ASIA Benchmark Registry Table v1
 
 - Version: `2026-04-11.v1`
-- Owner Bead: `StockScreenClaude-asia.3.6`
+- Owner: `StockScreenClaude-asia.3.6`
 - Policy: index-primary with configured ETF fallback; non-US paths must not fall back to SPY.
 
 | Market | Primary Symbol | Primary Kind | Fallback Symbol | Fallback Kind | Notes |

--- a/docs/asia/benchmark_registry_table_v1.md
+++ b/docs/asia/benchmark_registry_table_v1.md
@@ -1,0 +1,19 @@
+# ASIA Benchmark Registry Table v1
+
+- Version: `2026-04-11.v1`
+- Owner Bead: `StockScreenClaude-asia.3.6`
+- Policy: index-primary with configured ETF fallback; non-US paths must not fall back to SPY.
+
+| Market | Primary Symbol | Primary Kind | Fallback Symbol | Fallback Kind | Notes |
+|---|---|---|---|---|---|
+| US | `SPY` | etf | `IVV` | etf | US baseline parity |
+| HK | `^HSI` | index | `2800.HK` | etf | index semantics first |
+| JP | `^N225` | index | `1306.T` | etf | Nikkei primary |
+| TW | `^TWII` | index | `0050.TW` | etf | TAIEX primary |
+
+## Runtime Contract
+
+1. Resolution order is deterministic: `primary -> fallback`.
+2. Cache keys/locks are symbol-scoped (`benchmark:<symbol>:<period>`).
+3. Health surfaces include both primary and fallback cache presence.
+4. Non-US mappings are market-local only; no implicit SPY fallback.


### PR DESCRIPTION
## Summary
This PR merges the ASIA E3 architecture/implementation track from `codex/asia-1-1-adr-pack`.

### Included
- SecurityMaster + universe identity hardening
  - exchange-aware canonicalization (`TPEX -> .TWO`)
  - canonical-symbol persistence in universe ingestion/update paths
- Benchmark cache generalization
  - market-aware benchmark fetch/cache for `US/HK/JP/TW`
  - compatibility wrapper retained for legacy `get_spy_data()` callers
  - market-scoped Redis cache/lock keys
- Market calendar architecture
  - added `MarketCalendarService` with canonical IDs (`XNYS/XHKG/XTKS/XTAI`)
  - migrated market-hours engine to `exchange_calendars`
  - benchmark freshness/date logic routed through market-aware calendar contract
- Scheduler/cache-path de-hardcoding
  - cache warm flows moved from SPY-first to benchmark-by-market behavior
  - cache stats/health surfaces updated with compatibility aliases
- BenchmarkRegistry policy implementation
  - versioned benchmark mapping table with deterministic primary/fallback routing
  - non-US paths prevent implicit SPY leakage
  - operator mapping artifact: `docs/asia/benchmark_registry_table_v1.md`
- Review follow-up fixes
  - cache-stats schema compatibility under Redis-unavailable paths
  - non-US benchmark warm paths no longer force US benchmark warming

## Beads covered
- `StockScreenClaude-asia.3.2`
- `StockScreenClaude-asia.3.3`
- `StockScreenClaude-asia.3.4`
- `StockScreenClaude-asia.3.5`
- `StockScreenClaude-asia.3.6`

## Validation
- Static compile checks passed for changed Python modules.
- Full pytest execution is environment-blocked in this branch context due missing `sqlalchemy` dependency in the runner environment.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-market benchmark support (US, HK, JP, TW); canonical identity resolution storing canonical symbol + market/exchange/currency/timezone/local-code; region-aware market calendar and market-now/last-completed-session logic.

* **Bug Fixes / Improvements**
  * Dashboard/health/reporting use benchmark-based freshness and per-market cache stats (US alias preserved); benchmark-aware cache warming, bulk data prep, and ticker normalization improvements.

* **Documentation**
  * Added benchmark registry docs.

* **Tests**
  * Extensive unit tests for benchmark routing, registry, calendar, resolver, cache tasks, and data preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->