### PR TITLE
feat(frontend): add preset stock screens to static site

### DIFF
--- a/backend/app/services/preset_screens.py
+++ b/backend/app/services/preset_screens.py
@@ -1,0 +1,309 @@
+"""Preset stock screen definitions for the static site.
+
+Each preset is a named filter configuration using the frontend's camelCase
+filter key names (matching scanClient.js and defaultFilters.js). Presets are
+embedded in the scan manifest and consumed client-side — no backend scanner
+logic is involved at runtime.
+"""
+
+from __future__ import annotations
+
+RANGE_FILTER_TO_FIELD: dict[str, str] = {
+    "compositeScore": "composite_score",
+    "minerviniScore": "minervini_score",
+    "canslimScore": "canslim_score",
+    "ipoScore": "ipo_score",
+    "customScore": "custom_score",
+    "volBreakthroughScore": "volume_breakthrough_score",
+    "seSetupScore": "se_setup_score",
+    "seDistanceToPivot": "se_distance_to_pivot_pct",
+    "seBbSqueeze": "se_bb_width_pctile_252",
+    "seVolumeVs50d": "se_volume_vs_50d",
+    "rsRating": "rs_rating",
+    "rs1m": "rs_rating_1m",
+    "rs3m": "rs_rating_3m",
+    "rs12m": "rs_rating_12m",
+    "epsRating": "eps_rating",
+    "price": "current_price",
+    "adrPercent": "adr_percent",
+    "epsGrowth": "eps_growth_qq",
+    "salesGrowth": "sales_growth_qq",
+    "vcpScore": "vcp_score",
+    "vcpPivot": "vcp_pivot",
+    "perfDay": "price_change_1d",
+    "perfWeek": "perf_week",
+    "perfMonth": "perf_month",
+    "perf3m": "perf_3m",
+    "perf6m": "perf_6m",
+    "gapPercent": "gap_percent",
+    "volumeSurge": "volume_surge",
+    "ema10Distance": "ema_10_distance",
+    "ema20Distance": "ema_20_distance",
+    "ema50Distance": "ema_50_distance",
+    "week52HighDistance": "week_52_high_distance",
+    "week52LowDistance": "week_52_low_distance",
+    "beta": "beta",
+    "betaAdjRs": "beta_adj_rs",
+}
+
+BOOLEAN_FILTER_TO_FIELD: dict[str, str] = {
+    "seSetupReady": "se_setup_ready",
+    "seRsLineNewHigh": "se_rs_line_new_high",
+    "vcpDetected": "vcp_detected",
+    "vcpReady": "vcp_ready_for_breakout",
+    "maAlignment": "ma_alignment",
+    "passesTemplate": "passes_template",
+}
+
+# ---------------------------------------------------------------------------
+# Preset screen definitions
+# ---------------------------------------------------------------------------
+
+PRESET_SCREENS: list[dict] = [
+    # -- Tier 1: Score-based (existing scanners) --
+    {
+        "id": "minervini",
+        "name": "Minervini Trend Template",
+        "short_name": "Minervini",
+        "description": "Stage 2 uptrend stocks passing the 8-point trend template",
+        "tier": 1,
+        "filters": {
+            "minerviniScore": {"min": 70, "max": None},
+            "stage": 2,
+            "maAlignment": True,
+            "rsRating": {"min": 70, "max": None},
+        },
+        "sort_by": "minervini_score",
+        "sort_order": "desc",
+    },
+    {
+        "id": "canslim",
+        "name": "CANSLIM",
+        "short_name": "CANSLIM",
+        "description": "William O'Neil growth screen: strong earnings, RS, and institutional demand",
+        "tier": 1,
+        "filters": {
+            "canslimScore": {"min": 70, "max": None},
+            "epsGrowth": {"min": 25, "max": None},
+            "rsRating": {"min": 80, "max": None},
+        },
+        "sort_by": "canslim_score",
+        "sort_order": "desc",
+    },
+    {
+        "id": "vcp",
+        "name": "VCP Setups",
+        "short_name": "VCP",
+        "description": "Volatility contraction patterns with Minervini trend confirmation",
+        "tier": 1,
+        "filters": {
+            "vcpDetected": True,
+            "minerviniScore": {"min": 50, "max": None},
+        },
+        "sort_by": "vcp_score",
+        "sort_order": "desc",
+    },
+    {
+        "id": "vol_break",
+        "name": "Volume Breakthrough",
+        "short_name": "Vol Breakout",
+        "description": "Record-volume breakouts across 1-year and 5-year lookbacks",
+        "tier": 1,
+        "filters": {
+            "volBreakthroughScore": {"min": 33, "max": None},
+        },
+        "sort_by": "volume_breakthrough_score",
+        "sort_order": "desc",
+    },
+    # -- Tier 2: Filter-based (composable from existing fields) --
+    {
+        "id": "episodic_pivot",
+        "name": "Episodic Pivot",
+        "short_name": "Episodic Pivot",
+        "description": "Qullamaggie-style gap-ups on massive volume",
+        "tier": 2,
+        "filters": {
+            "gapPercent": {"min": 10, "max": None},
+            "volumeSurge": {"min": 2.0, "max": None},
+            "rsRating": {"min": 70, "max": None},
+        },
+        "sort_by": "gap_percent",
+        "sort_order": "desc",
+    },
+    {
+        "id": "momentum",
+        "name": "Momentum Leaders",
+        "short_name": "Momentum",
+        "description": "Top performers over 3-6 months in confirmed Stage 2 uptrends",
+        "tier": 2,
+        "filters": {
+            "perf3m": {"min": 30, "max": None},
+            "perf6m": {"min": 80, "max": None},
+            "rsRating": {"min": 85, "max": None},
+            "stage": 2,
+        },
+        "sort_by": "perf_6m",
+        "sort_order": "desc",
+    },
+    {
+        "id": "kell_growth",
+        "name": "Oliver Kell Growth",
+        "short_name": "Kell Growth",
+        "description": "Growth stocks near highs with strong earnings and sales acceleration",
+        "tier": 2,
+        "filters": {
+            "price": {"min": 20, "max": None},
+            "epsGrowth": {"min": 25, "max": None},
+            "salesGrowth": {"min": 15, "max": None},
+            "rsRating": {"min": 80, "max": None},
+            "week52HighDistance": {"min": -15, "max": None},
+        },
+        "sort_by": "composite_score",
+        "sort_order": "desc",
+    },
+    {
+        "id": "rs_power",
+        "name": "RS Power Play",
+        "short_name": "RS Power",
+        "description": "Elite relative strength leaders in Stage 2 uptrends",
+        "tier": 2,
+        "filters": {
+            "rsRating": {"min": 90, "max": None},
+            "rs3m": {"min": 85, "max": None},
+            "stage": 2,
+        },
+        "sort_by": "rs_rating",
+        "sort_order": "desc",
+    },
+    {
+        "id": "new_highs",
+        "name": "New Highs + Volume",
+        "short_name": "New Highs",
+        "description": "Stocks at or near 52-week highs with above-average volume",
+        "tier": 2,
+        "filters": {
+            "week52HighDistance": {"min": -5, "max": None},
+            "volumeSurge": {"min": 1.3, "max": None},
+            "rsRating": {"min": 70, "max": None},
+        },
+        "sort_by": "week_52_high_distance",
+        "sort_order": "desc",
+    },
+    {
+        "id": "growth",
+        "name": "Growth Rockets",
+        "short_name": "Growth",
+        "description": "Triple-digit EPS and sales growth with strong relative strength",
+        "tier": 2,
+        "filters": {
+            "epsGrowth": {"min": 40, "max": None},
+            "salesGrowth": {"min": 30, "max": None},
+            "rsRating": {"min": 70, "max": None},
+        },
+        "sort_by": "eps_growth_qq",
+        "sort_order": "desc",
+    },
+    {
+        "id": "tight",
+        "name": "Tight Setups",
+        "short_name": "Tight",
+        "description": "Low-volatility bases with VCP characteristics in strong uptrends",
+        "tier": 2,
+        "filters": {
+            "adrPercent": {"min": None, "max": 4},
+            "rsRating": {"min": 80, "max": None},
+            "vcpScore": {"min": 30, "max": None},
+            "stage": 2,
+        },
+        "sort_by": "vcp_score",
+        "sort_order": "desc",
+    },
+    {
+        "id": "ipo",
+        "name": "Recent IPOs",
+        "short_name": "IPOs",
+        "description": "High-scoring recent IPOs with strong early price action",
+        "tier": 2,
+        "filters": {
+            "ipoScore": {"min": 50, "max": None},
+        },
+        "sort_by": "ipo_score",
+        "sort_order": "desc",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _matches_preset_filters(row: dict, filters: dict) -> bool:
+    """Check if a serialized scan row matches a preset's filter criteria.
+
+    Mirrors the logic in frontend/src/static/scanClient.js filterStaticScanRows.
+    """
+    for key, value in filters.items():
+        # Stage filter (integer equality)
+        if key == "stage":
+            if row.get("stage") != value:
+                return False
+            continue
+
+        # Boolean filter
+        if key in BOOLEAN_FILTER_TO_FIELD:
+            field = BOOLEAN_FILTER_TO_FIELD[key]
+            if bool(row.get(field)) != value:
+                return False
+            continue
+
+        # Range filter
+        if key in RANGE_FILTER_TO_FIELD:
+            field = RANGE_FILTER_TO_FIELD[key]
+            row_val = row.get(field)
+            if isinstance(value, dict):
+                if row_val is None:
+                    return False
+                if value.get("min") is not None and row_val < value["min"]:
+                    return False
+                if value.get("max") is not None and row_val > value["max"]:
+                    return False
+            continue
+
+    return True
+
+
+def get_preset_chart_symbols(
+    serialized_rows: list[dict],
+    presets: list[dict] | None = None,
+    top_n: int = 50,
+) -> set[str]:
+    """Return the union of top-N symbols per preset screen.
+
+    Used by the chart export to expand chart coverage beyond the default
+    top-200 composite-score ranking.
+    """
+    if presets is None:
+        presets = PRESET_SCREENS
+
+    symbols: set[str] = set()
+    for preset in presets:
+        matching = [
+            row for row in serialized_rows
+            if _matches_preset_filters(row, preset["filters"])
+        ]
+        sort_field = preset.get("sort_by", "composite_score")
+        reverse = preset.get("sort_order", "desc") == "desc"
+        # Always sort None values last regardless of direction: a None row
+        # should never "win" a slot over a real row.
+        matching.sort(
+            key=lambda r, f=sort_field, d=reverse: (
+                r.get(f) is None,
+                -(r.get(f) or 0) if d else (r.get(f) or 0),
+            ),
+        )
+        for row in matching[:top_n]:
+            sym = row.get("symbol")
+            if sym:
+                symbols.add(sym)
+
+    return symbols

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -20,6 +20,7 @@ from app.models.stock import StockPrice
 from app.schemas.groups import GroupRankResponse, GroupRankingsResponse, MoversResponse
 from app.schemas.scanning import FilterOptionsResponse, ScanResultItem
 from app.services.ui_snapshot_service import UISnapshotService
+from app.services.preset_screens import PRESET_SCREENS, get_preset_chart_symbols
 from app.wiring.bootstrap import (
     get_fundamentals_cache,
     get_group_rank_service,
@@ -38,6 +39,7 @@ STATIC_CHART_PERIOD = "6mo"
 STATIC_CHART_PERIOD_DAYS = 180
 STATIC_CHART_LOOKUP_BATCH_SIZE = 250
 STATIC_DEFAULT_SCAN_FILTERS = {"minVolume": 100_000_000}
+STATIC_CHART_PRESET_TOP_N = 50
 STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
 
 _DEFAULT_KEY_MARKETS = (
@@ -93,7 +95,7 @@ class StaticSiteExportService:
                 raise RuntimeError("No published feature run is available for static-site export")
 
             scan_rows, filter_options = self._load_scan_export_source(db, latest_run)
-            scan_manifest = self._export_scan_bundle(
+            scan_manifest, serialized_rows = self._export_scan_bundle(
                 db=db,
                 output_dir=output_dir,
                 generated_at=generated_at,
@@ -106,6 +108,7 @@ class StaticSiteExportService:
                 generated_at=generated_at,
                 run=latest_run,
                 rows=scan_rows,
+                serialized_rows=serialized_rows,
             )
             breadth_payload = self._build_optional_section_payload(
                 section="breadth",
@@ -272,7 +275,7 @@ class StaticSiteExportService:
         run: FeatureRun,
         rows: list[Any] | None = None,
         filter_options: Any | None = None,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         if rows is None or filter_options is None:
             repo = SqlFeatureStoreRepository(db)
             rows = repo.query_all_as_scan_results(
@@ -326,12 +329,13 @@ class StaticSiteExportService:
                 gics_sectors=list(filter_options.gics_sectors),
                 ratings=list(filter_options.ratings),
             ).model_dump(mode="json"),
+            "preset_screens": PRESET_SCREENS,
             "chunks": chunk_refs,
             "initial_rows": default_filtered_rows[:50],
             "preview_rows": default_filtered_rows[:10],
         }
         self._write_json(scan_dir / "manifest.json", manifest)
-        return manifest
+        return manifest, serialized_rows
 
     def _export_chart_bundle(
         self,
@@ -340,12 +344,16 @@ class StaticSiteExportService:
         generated_at: str,
         run: FeatureRun,
         rows: list[Any],
+        serialized_rows: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         chart_dir = output_dir / "charts"
         chart_dir.mkdir(parents=True, exist_ok=True)
 
         entries: list[dict[str, Any]] = []
         skipped_symbols: list[str] = []
+        row_by_symbol: dict[str, Any] = {}
+
+        # --- Pass 1: export charts for top-N by composite score (default) ---
         for start in range(0, len(rows), STATIC_CHART_LOOKUP_BATCH_SIZE):
             if len(entries) >= STATIC_CHART_LIMIT:
                 break
@@ -363,6 +371,7 @@ class StaticSiteExportService:
                 if not symbol:
                     continue
 
+                row_by_symbol[symbol] = row
                 bars = self._serialize_chart_bars(price_data.get(symbol))
                 if not bars:
                     skipped_symbols.append(symbol)
@@ -387,6 +396,64 @@ class StaticSiteExportService:
                         "rank": rank,
                         "path": rel_path.as_posix(),
                     }
+                )
+
+        # --- Pass 2: expand charts for preset screen top-50s ---
+        if serialized_rows is not None:
+            preset_symbols = get_preset_chart_symbols(
+                serialized_rows, PRESET_SCREENS, STATIC_CHART_PRESET_TOP_N,
+            )
+            exported_symbols = {e["symbol"] for e in entries}
+            extra_symbols = sorted(preset_symbols - exported_symbols - set(skipped_symbols))
+            entries_before_pass_2 = len(entries)
+
+            if extra_symbols:
+                # Build a lookup from serialized rows for extra symbols
+                ser_by_symbol = {r["symbol"]: r for r in serialized_rows if r.get("symbol")}
+                # Also need domain rows for _serialize_scan_row
+                for row in rows:
+                    sym = getattr(row, "symbol", None)
+                    if sym and sym not in row_by_symbol:
+                        row_by_symbol[sym] = row
+
+                for batch_start in range(0, len(extra_symbols), STATIC_CHART_LOOKUP_BATCH_SIZE):
+                    batch = extra_symbols[batch_start:batch_start + STATIC_CHART_LOOKUP_BATCH_SIZE]
+                    price_data = self._price_cache.get_many_cached_only(batch, period="2y")
+                    fundamentals = self._fundamentals_cache.get_many_cached_only(batch)
+
+                    for symbol in batch:
+                        bars = self._serialize_chart_bars(price_data.get(symbol))
+                        if not bars:
+                            skipped_symbols.append(symbol)
+                            continue
+
+                        rel_path = self._chart_payload_path(symbol)
+                        domain_row = row_by_symbol.get(symbol)
+                        stock_data = self._serialize_scan_row(domain_row) if domain_row else ser_by_symbol.get(symbol)
+                        payload = {
+                            "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
+                            "generated_at": generated_at,
+                            "as_of_date": run.as_of_date.isoformat(),
+                            "symbol": symbol,
+                            "rank": None,
+                            "period": STATIC_CHART_PERIOD,
+                            "bars": bars,
+                            "stock_data": stock_data,
+                            "fundamentals": fundamentals.get(symbol),
+                        }
+                        self._write_json(output_dir / rel_path, payload)
+                        entries.append(
+                            {
+                                "symbol": symbol,
+                                "rank": None,
+                                "path": rel_path.as_posix(),
+                            }
+                        )
+
+                logger.info(
+                    "Preset screen expansion added %d charts (%d extra symbols attempted)",
+                    len(entries) - entries_before_pass_2,
+                    len(extra_symbols),
                 )
 
         index_rel_path = Path("charts/index.json")

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -177,7 +177,7 @@ def test_export_writes_serializable_manifest_and_page_bundles(
     }
 
     monkeypatch.setattr(service, "_load_scan_export_source", lambda *_args, **_kwargs: ([], SimpleNamespace()))
-    monkeypatch.setattr(service, "_export_scan_bundle", lambda **_kwargs: scan_manifest)
+    monkeypatch.setattr(service, "_export_scan_bundle", lambda **_kwargs: (scan_manifest, []))
     monkeypatch.setattr(service, "_export_chart_bundle", lambda **_kwargs: chart_manifest)
     monkeypatch.setattr(service, "_build_breadth_payload", lambda **_kwargs: breadth_payload)
     monkeypatch.setattr(service, "_build_groups_payload", lambda **_kwargs: groups_payload)
@@ -261,7 +261,7 @@ def test_export_scan_bundle_chunks_large_result_sets(service_and_session_factory
 
     with session_factory() as db:
         run = db.get(FeatureRun, 11)
-        manifest = service._export_scan_bundle(  # noqa: SLF001 - intentional unit test coverage
+        manifest, _serialized = service._export_scan_bundle(  # noqa: SLF001 - intentional unit test coverage
             db=db,
             output_dir=tmp_path,
             generated_at="2026-03-31T22:00:00Z",
@@ -319,7 +319,7 @@ def test_export_marks_optional_sections_unavailable_without_aborting(
     }
 
     monkeypatch.setattr(service, "_load_scan_export_source", lambda *_args, **_kwargs: ([], SimpleNamespace()))
-    monkeypatch.setattr(service, "_export_scan_bundle", lambda **_kwargs: scan_manifest)
+    monkeypatch.setattr(service, "_export_scan_bundle", lambda **_kwargs: (scan_manifest, []))
     monkeypatch.setattr(service, "_export_chart_bundle", lambda **_kwargs: chart_manifest)
     monkeypatch.setattr(
         service,

--- a/frontend/src/App.static.test.jsx
+++ b/frontend/src/App.static.test.jsx
@@ -93,6 +93,18 @@ const staticPayloads = {
       { symbol: 'NVDA', company_name: 'NVIDIA Corporation', composite_score: 97.5, rating: 'Strong Buy' },
       { symbol: 'MSFT', company_name: 'Microsoft Corporation', composite_score: 89.2, rating: 'Buy' },
     ],
+    preset_screens: [
+      {
+        id: 'minervini',
+        name: 'Minervini Trend Template',
+        short_name: 'Minervini',
+        description: 'Stage 2 uptrend stocks',
+        tier: 1,
+        filters: { minerviniScore: { min: 70, max: null }, stage: 2 },
+        sort_by: 'minervini_score',
+        sort_order: 'desc',
+      },
+    ],
     chunks: [{ path: 'scan/chunks/chunk-0001.json', count: 2 }],
     charts: {
       path: 'charts/index.json',

--- a/frontend/src/static/components/ScreenSelector.jsx
+++ b/frontend/src/static/components/ScreenSelector.jsx
@@ -1,0 +1,65 @@
+import { Box, Chip, Divider, Tooltip } from '@mui/material';
+
+const chipSx = (isActive) => ({
+  fontSize: '11px',
+  fontWeight: isActive ? 600 : 400,
+  cursor: 'pointer',
+  '& .MuiChip-label': { px: 1 },
+});
+
+function ScreenSelector({ screens, activeScreenId, onSelectScreen, matchCounts }) {
+  if (!screens?.length) return null;
+
+  const tier1 = screens.filter((s) => s.tier === 1);
+  const tier2 = screens.filter((s) => s.tier !== 1);
+
+  const renderChip = (screen) => {
+    const isActive = activeScreenId === screen.id;
+    const count = matchCounts?.[screen.id];
+    const label = count != null ? `${screen.short_name} (${count})` : screen.short_name;
+
+    return (
+      <Tooltip key={screen.id} title={`${screen.name} — ${screen.description}`} arrow>
+        <Chip
+          label={label}
+          size="small"
+          variant={isActive ? 'filled' : 'outlined'}
+          color={isActive ? 'primary' : 'default'}
+          onClick={() => onSelectScreen(isActive ? null : screen.id)}
+          sx={chipSx(isActive)}
+        />
+      </Tooltip>
+    );
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        overflowX: 'auto',
+        pb: 0.5,
+        mb: 1.5,
+        '&::-webkit-scrollbar': { height: 4 },
+        '&::-webkit-scrollbar-thumb': { borderRadius: 2, bgcolor: 'divider' },
+      }}
+    >
+      <Chip
+        label="All Stocks"
+        size="small"
+        variant={activeScreenId == null ? 'filled' : 'outlined'}
+        color={activeScreenId == null ? 'primary' : 'default'}
+        onClick={() => onSelectScreen(null)}
+        sx={chipSx(activeScreenId == null)}
+      />
+      {tier1.map(renderChip)}
+      {tier2.length > 0 && (
+        <Divider orientation="vertical" flexItem sx={{ mx: 0.25 }} />
+      )}
+      {tier2.map(renderChip)}
+    </Box>
+  );
+}
+
+export default ScreenSelector;

--- a/frontend/src/static/hooks/usePresetScreens.js
+++ b/frontend/src/static/hooks/usePresetScreens.js
@@ -1,0 +1,23 @@
+import { useMemo, useState } from 'react';
+import { applyScanFilterDefaults } from '../../features/scan/defaultFilters';
+import { filterStaticScanRows } from '../scanClient';
+
+export function buildFiltersFromPreset(screen) {
+  return applyScanFilterDefaults(screen.filters);
+}
+
+export function usePresetScreens({ screens, allRows, hydrationComplete }) {
+  const [activeScreenId, setActiveScreenId] = useState(null);
+
+  const matchCounts = useMemo(() => {
+    if (!hydrationComplete || !screens?.length) return {};
+    return Object.fromEntries(
+      screens.map((s) => [
+        s.id,
+        filterStaticScanRows(allRows, buildFiltersFromPreset(s)).length,
+      ]),
+    );
+  }, [allRows, hydrationComplete, screens]);
+
+  return { activeScreenId, setActiveScreenId, matchCounts };
+}

--- a/frontend/src/static/pages/StaticScanPage.jsx
+++ b/frontend/src/static/pages/StaticScanPage.jsx
@@ -64,6 +64,8 @@ function StaticScanPage() {
     () => applyScanFilterDefaults(scanManifestQuery.data?.default_filters),
     [scanManifestQuery.data?.default_filters]
   );
+  const manifestDefaultSortBy = scanManifestQuery.data?.sort?.field ?? 'composite_score';
+  const manifestDefaultSortOrder = scanManifestQuery.data?.sort?.order ?? 'desc';
   const presetScreens = scanManifestQuery.data?.preset_screens;
 
   useEffect(() => {
@@ -176,8 +178,8 @@ function StaticScanPage() {
     setActiveScreenId(screenId);
     if (!screenId) {
       setFilters(manifestDefaultFilters);
-      setSortBy('composite_score');
-      setSortOrder('desc');
+      setSortBy(manifestDefaultSortBy);
+      setSortOrder(manifestDefaultSortOrder);
     } else {
       const screen = presetScreens?.find((s) => s.id === screenId);
       if (screen) {
@@ -186,7 +188,7 @@ function StaticScanPage() {
         setSortOrder(screen.sort_order);
       }
     }
-  }, [presetScreens, manifestDefaultFilters, setActiveScreenId]);
+  }, [presetScreens, manifestDefaultFilters, manifestDefaultSortBy, manifestDefaultSortOrder, setActiveScreenId]);
 
   const filterKey = useMemo(() => getStableFilterKey(filters), [filters]);
   useEffect(() => {
@@ -299,7 +301,7 @@ function StaticScanPage() {
         <FilterPanel
           filters={filters}
           onFilterChange={setFilters}
-          onReset={() => { setFilters(manifestDefaultFilters); setActiveScreenId(null); }}
+          onReset={() => { setFilters(manifestDefaultFilters); setSortBy(manifestDefaultSortBy); setSortOrder(manifestDefaultSortOrder); setActiveScreenId(null); }}
           filterOptions={normalizeScanFilterOptions(scanManifestQuery.data.filter_options)}
           expanded={showFilters}
           onToggle={() => setShowFilters((previous) => !previous)}

--- a/frontend/src/static/pages/StaticScanPage.jsx
+++ b/frontend/src/static/pages/StaticScanPage.jsx
@@ -23,6 +23,8 @@ import {
   sortStaticScanRows,
 } from '../scanClient';
 import StaticChartViewerModal from '../StaticChartViewerModal';
+import ScreenSelector from '../components/ScreenSelector';
+import { usePresetScreens, buildFiltersFromPreset } from '../hooks/usePresetScreens';
 
 const HYDRATION_BATCH_SIZE = 2;
 
@@ -62,6 +64,7 @@ function StaticScanPage() {
     () => applyScanFilterDefaults(scanManifestQuery.data?.default_filters),
     [scanManifestQuery.data?.default_filters]
   );
+  const presetScreens = scanManifestQuery.data?.preset_screens;
 
   useEffect(() => {
     if (scanManifestQuery.data?.default_page_size) {
@@ -162,12 +165,33 @@ function StaticScanPage() {
   }, [scanManifestQuery.data]);
 
   const hydrationComplete = hydrationState.status === 'complete';
+  const hydratedRows = hydrationState.rows;
+  const { activeScreenId, setActiveScreenId, matchCounts } = usePresetScreens({
+    screens: presetScreens,
+    allRows: hydratedRows,
+    hydrationComplete,
+  });
+
+  const handleSelectScreen = useCallback((screenId) => {
+    setActiveScreenId(screenId);
+    if (!screenId) {
+      setFilters(manifestDefaultFilters);
+      setSortBy('composite_score');
+      setSortOrder('desc');
+    } else {
+      const screen = presetScreens?.find((s) => s.id === screenId);
+      if (screen) {
+        setFilters(buildFiltersFromPreset(screen));
+        setSortBy(screen.sort_by);
+        setSortOrder(screen.sort_order);
+      }
+    }
+  }, [presetScreens, manifestDefaultFilters, setActiveScreenId]);
+
   const filterKey = useMemo(() => getStableFilterKey(filters), [filters]);
   useEffect(() => {
     setPage(1);
   }, [filterKey]);
-
-  const hydratedRows = hydrationState.rows;
   const chartEntries = useMemo(
     () => chartIndexQuery.data?.symbols || [],
     [chartIndexQuery.data]
@@ -222,35 +246,35 @@ function StaticScanPage() {
 
   return (
     <Box>
-      <Typography variant="h4" gutterBottom>
+      <Typography variant="h5" sx={{ fontWeight: 700, letterSpacing: '-0.5px', mb: 0.5 }}>
         Daily Scan
       </Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
-        Fixed daily ranking from published run {scanManifestQuery.data.run_id} as of {scanManifestQuery.data.as_of_date}.
-        The first page renders from the exported default-filtered top rows, then the remaining chunks hydrate in the background.
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2, fontSize: '12px' }}>
+        Run {scanManifestQuery.data.run_id} as of {scanManifestQuery.data.as_of_date}.
       </Typography>
 
-      <Paper sx={{ p: 2, mb: 2 }}>
-        <Typography variant="subtitle2" color="text.secondary">
-          Results
-        </Typography>
-        <Typography variant="h6">
-          {(hydrationComplete ? filteredRows.length : hydrationState.loadedRows).toLocaleString()} rows ready
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {scanManifestQuery.data.rows_total.toLocaleString()} total rows exported
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Default view applies dollar volume &gt; $100M to {scanManifestQuery.data.default_filtered_rows_total?.toLocaleString?.() ?? 0} rows.
-        </Typography>
-        {scanManifestQuery.data.charts?.available ? (
-          <Typography variant="body2" color="text.secondary">
-            Static charts exported for{' '}
-            {(scanManifestQuery.data.charts.symbols_total ?? scanManifestQuery.data.charts.limit).toLocaleString()}{' '}
-            ranked symbols.
+      <Paper elevation={0} sx={{ p: 1.5, mb: 1.5, border: '1px solid', borderColor: 'divider' }}>
+        <Box display="flex" alignItems="baseline" gap={1.5}>
+          <Typography variant="body1" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+            {(hydrationComplete ? filteredRows.length : hydrationState.loadedRows).toLocaleString()}
           </Typography>
-        ) : null}
+          <Typography variant="caption" color="text.disabled" sx={{ fontSize: '10px' }}>
+            of {scanManifestQuery.data.rows_total.toLocaleString()} rows
+            {scanManifestQuery.data.charts?.available
+              ? ` · ${(scanManifestQuery.data.charts.symbols_total ?? scanManifestQuery.data.charts.limit).toLocaleString()} charts`
+              : ''}
+          </Typography>
+        </Box>
       </Paper>
+
+      {hydrationComplete && presetScreens?.length > 0 && (
+        <ScreenSelector
+          screens={presetScreens}
+          activeScreenId={activeScreenId}
+          onSelectScreen={handleSelectScreen}
+          matchCounts={matchCounts}
+        />
+      )}
 
       {!hydrationComplete && (
         <Alert severity="info" sx={{ mb: 2 }}>
@@ -275,7 +299,7 @@ function StaticScanPage() {
         <FilterPanel
           filters={filters}
           onFilterChange={setFilters}
-          onReset={() => setFilters(manifestDefaultFilters)}
+          onReset={() => { setFilters(manifestDefaultFilters); setActiveScreenId(null); }}
           filterOptions={normalizeScanFilterOptions(scanManifestQuery.data.filter_options)}
           expanded={showFilters}
           onToggle={() => setShowFilters((previous) => !previous)}

--- a/frontend/src/static/pages/StaticScanPage.test.jsx
+++ b/frontend/src/static/pages/StaticScanPage.test.jsx
@@ -653,6 +653,6 @@ describe('StaticScanPage', () => {
 
     expect(await screen.findByText(/Background hydration failed/i)).toBeInTheDocument();
     expect(screen.getByTestId('results-table-rows')).toHaveTextContent('NVDA,MSFT,AAPL');
-    expect(screen.getByText(/Static charts exported for 143 ranked symbols/i)).toBeInTheDocument();
+    expect(screen.getByText(/143 charts/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- **12 preset screens** defined in the new \`preset_screens.py\` module, covering popular methodologies: Minervini Trend Template, CANSLIM, VCP, Volume Breakthrough, Qullamaggie (Episodic Pivot, Momentum Leaders), Oliver Kell Growth, RS Power Play, New Highs + Volume, Growth Rockets, Tight Setups, Recent IPOs
- **Screen selector UI** — horizontal chip bar with tier separator, tooltips, and live match counts — appears above the filter panel on the static scan page
- **Expanded chart export** — instead of a fixed top 200 by composite score, the chart export now also includes the top 50 per preset screen (union set), ensuring every screened stock has detailed chart data
- **Zero backend scanner changes** — presets are client-side filter configurations applied to the existing scan data; \`scanClient.js\` already supports every filter type used

## Architecture

1. Backend \`preset_screens.py\` defines 12 presets using the frontend's camelCase filter keys (\`minerviniScore\`, \`rsRating\`, etc.) matching \`scanClient.js\` and \`defaultFilters.js\` exactly
2. Scan manifest embeds the full preset list as \`preset_screens\`
3. Chart export runs a second pass over the union of preset top-50s that weren't already in the default top-200
4. Frontend \`usePresetScreens\` hook computes match counts and manages selection state
5. Selecting a preset applies its filters via the existing \`filterStaticScanRows\` machinery

## Test plan

- [x] 22 static-site frontend tests pass
- [x] Python smoke test validates filter matching + sort (both directions) with null handling
- [x] Static site build succeeds with \`VITE_STATIC_SITE=true\`
- [ ] Manual: run export locally, verify \`scan/manifest.json\` includes \`preset_screens\` array and chart count > 200
- [ ] Visual: serve built site, verify screen selector renders, each preset filters correctly, chart modal works for preset-only stocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preset stock screens added—select curated filters and sort options to view focused stock lists.
  * Screen selector UI with tiered grouping and match counts; tap to apply or clear a preset.

* **UX Improvements**
  * Quick switching between presets applies filters and sorting; reset clears active preset.
  * Results header condensed to a compact "charts" summary.

* **Tests**
  * Static export and UI tests updated to reflect new preset and export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
