### PR TITLE
fix(backend): clamp trading-days range to exchange_calendars bounds

### DIFF
--- a/backend/app/utils/market_hours.py
+++ b/backend/app/utils/market_hours.py
@@ -46,7 +46,19 @@ def _get_trading_days_set() -> set:
         start = f"{current_year - 1}-01-01"
         end = f"{current_year + 1}-12-31"
         if _CALENDAR_ENGINE == "exchange_calendars":
-            sessions = _NYSE.sessions_in_range(pd.Timestamp(start), pd.Timestamp(end))
+            start_ts = pd.Timestamp(start)
+            end_ts = pd.Timestamp(end)
+            # Clamp to the calendar's bounds — the installed exchange_calendars
+            # package only includes sessions through a finite horizon (typically
+            # ~1 year past install date). Without clamping, requesting an `end`
+            # beyond `last_session` raises DateOutOfBounds.
+            first_session = _NYSE.first_session
+            last_session = _NYSE.last_session
+            if start_ts < first_session:
+                start_ts = first_session
+            if end_ts > last_session:
+                end_ts = last_session
+            sessions = _NYSE.sessions_in_range(start_ts, end_ts)
             _trading_days_cache = set(session.date() for session in sessions)
         else:
             schedule = _NYSE.schedule(start_date=start, end_date=end)

--- a/backend/app/utils/market_hours.py
+++ b/backend/app/utils/market_hours.py
@@ -58,7 +58,10 @@ def _get_trading_days_set() -> set:
                 start_ts = first_session
             if end_ts > last_session:
                 end_ts = last_session
-            sessions = _NYSE.sessions_in_range(start_ts, end_ts)
+            if start_ts > end_ts:
+                sessions = pd.DatetimeIndex([])
+            else:
+                sessions = _NYSE.sessions_in_range(start_ts, end_ts)
             _trading_days_cache = set(session.date() for session in sessions)
         else:
             schedule = _NYSE.schedule(start_date=start, end_date=end)


### PR DESCRIPTION
## Summary

Fixes the **Static Site** GitHub Actions workflow failure (run [24298375330](https://github.com/xang1234/stock-screener/actions/runs/24298375330)):

\`\`\`
exchange_calendars.errors.DateOutOfBounds: Parameter \`end\` received as
'2027-12-31 00:00:00' although cannot be later than the last session of
calendar 'XNYS' ('2027-04-12 00:00:00').
\`\`\`

## Root cause

\`exchange_calendars\` bundles XNYS session data with a finite horizon (~1 year past the package install date). The installed version has \`last_session = 2027-04-12\`, but \`_get_trading_days_set()\` in \`backend/app/utils/market_hours.py\` computed a 3-year window ending at \`{current_year + 1}-12-31\` = \`2027-12-31\`, exceeding the calendar's bounds and raising \`DateOutOfBounds\`.

## Fix

Clamp the requested start/end to \`_NYSE.first_session\` / \`_NYSE.last_session\` before calling \`sessions_in_range()\`. The resulting cached range is the intersection of "desired 3-year window" and "calendar's available session data" — exactly what's needed for \`is_trading_day()\` lookups in the near future.

## Test plan

- [x] Verified locally: \`_get_trading_days_set()\` now returns 569 trading days (2025-01-02 to 2027-04-12) instead of raising \`DateOutOfBounds\`
- [x] Verified \`get_last_market_close()\` returns a valid date (\`2026-04-10 16:00:00-04:00\`)
- [ ] CI: Static Site workflow completes the \"Export static data bundle\" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed market trading-day lookups that could return incorrect results for date ranges outside the available calendar. Queries are now clamped to the calendar bounds; out-of-range or inverted ranges produce an empty result rather than incorrect data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->