### PR TITLE
claude/add-stock-charts-scans-080kC

### DIFF
--- a/backend/app/services/preset_screens.py
+++ b/backend/app/services/preset_screens.py
@@ -344,12 +344,13 @@ def _matches_preset_filters(row: dict, filters: dict) -> bool:
 def get_preset_chart_symbols(
     serialized_rows: list[dict],
     presets: list[dict] | None = None,
-    top_n: int = 50,
+    top_n: int = 200,
 ) -> set[str]:
     """Return the union of top-N symbols per preset screen.
 
     Used by the chart export to expand chart coverage beyond the default
-    top-200 composite-score ranking.
+    composite-score ranking so each preset scan's top N matches also
+    receive chart + stock-info payloads.
     """
     if presets is None:
         presets = PRESET_SCREENS

--- a/backend/app/services/preset_screens.py
+++ b/backend/app/services/preset_screens.py
@@ -8,6 +8,8 @@ logic is involved at runtime.
 
 from __future__ import annotations
 
+import heapq
+
 RANGE_FILTER_TO_FIELD: dict[str, str] = {
     "compositeScore": "composite_score",
     "minerviniScore": "minervini_score",
@@ -346,11 +348,8 @@ def get_preset_chart_symbols(
     presets: list[dict] | None = None,
     top_n: int = 200,
 ) -> set[str]:
-    """Return the union of top-N symbols per preset screen.
-
-    Used by the chart export to expand chart coverage beyond the default
-    composite-score ranking so each preset scan's top N matches also
-    receive chart + stock-info payloads.
+    """Return the union of top-N symbols per preset screen, used to expand
+    static-site chart coverage beyond the composite-score ranking.
     """
     if presets is None:
         presets = PRESET_SCREENS
@@ -362,16 +361,19 @@ def get_preset_chart_symbols(
             if _matches_preset_filters(row, preset["filters"])
         ]
         sort_field = preset.get("sort_by", "composite_score")
-        reverse = preset.get("sort_order", "desc") == "desc"
-        # Always sort None values last regardless of direction: a None row
-        # should never "win" a slot over a real row.
-        matching.sort(
-            key=lambda r, f=sort_field, d=reverse: (
-                r.get(f) is None,
-                -(r.get(f) or 0) if d else (r.get(f) or 0),
-            ),
-        )
-        for row in matching[:top_n]:
+        descending = preset.get("sort_order", "desc") == "desc"
+
+        # Rank None values last regardless of direction: a None row should
+        # never win a slot over a real row. heapq.nlargest keeps this
+        # O(m log top_n) instead of sorting the full match list.
+        def sort_key(row, f=sort_field, d=descending):
+            value = row.get(f)
+            if value is None:
+                return (0, 0)
+            return (1, value if d else -value)
+
+        top_rows = heapq.nlargest(top_n, matching, key=sort_key)
+        for row in top_rows:
             sym = row.get("symbol")
             if sym:
                 symbols.add(sym)

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -39,7 +39,7 @@ STATIC_CHART_PERIOD = "6mo"
 STATIC_CHART_PERIOD_DAYS = 180
 STATIC_CHART_LOOKUP_BATCH_SIZE = 250
 STATIC_DEFAULT_SCAN_FILTERS = {"minVolume": 100_000_000}
-STATIC_CHART_PRESET_TOP_N = 50
+STATIC_CHART_PRESET_TOP_N = 200
 STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
 
 _DEFAULT_KEY_MARKETS = (
@@ -399,7 +399,7 @@ class StaticSiteExportService:
                     }
                 )
 
-        # --- Pass 2: expand charts for preset screen top-50s ---
+        # --- Pass 2: expand charts for preset screen top-N (per STATIC_CHART_PRESET_TOP_N) ---
         if serialized_rows is not None:
             preset_symbols = get_preset_chart_symbols(
                 serialized_rows, PRESET_SCREENS, STATIC_CHART_PRESET_TOP_N,

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -399,7 +399,7 @@ class StaticSiteExportService:
                     }
                 )
 
-        # --- Pass 2: expand charts for preset screen top-N (per STATIC_CHART_PRESET_TOP_N) ---
+        # --- Pass 2: expand preset screen top-N charts ---
         if serialized_rows is not None:
             preset_symbols = get_preset_chart_symbols(
                 serialized_rows, PRESET_SCREENS, STATIC_CHART_PRESET_TOP_N,

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -601,6 +601,224 @@ def test_export_chart_bundle_backfills_past_skipped_symbols_to_fill_limit(
     assert index_payload["skipped_symbols"] == ["NVDA"]
 
 
+def test_export_chart_bundle_expands_coverage_for_preset_screens(
+    service_and_session_factory,
+    monkeypatch,
+    tmp_path,
+):
+    """Pass 2 should export charts for preset top-N matches that fall
+    outside the composite-score top-N covered by Pass 1, so selective or
+    orthogonally-ranked presets (e.g. 97 Club) get full chart coverage.
+    """
+    service, session_factory = service_and_session_factory
+    _insert_runs(
+        session_factory,
+        FeatureRun(
+            id=19,
+            as_of_date=date(2026, 4, 2),
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 4, 2, 21, 30, 0),
+        ),
+        pointer_run_id=19,
+    )
+
+    # Pass 1 keeps only 1 chart (the top composite-score row).
+    # Pass 2 per-preset budget of 5 gives us headroom for extras.
+    monkeypatch.setattr(export_module, "STATIC_CHART_LIMIT", 1)
+    monkeypatch.setattr(export_module, "STATIC_CHART_LOOKUP_BATCH_SIZE", 5)
+    monkeypatch.setattr(export_module, "STATIC_CHART_PRESET_TOP_N", 5)
+
+    def make_price_frame(close: float) -> pd.DataFrame:
+        dates = pd.date_range("2026-03-28", periods=2, freq="D")
+        return pd.DataFrame(
+            {
+                "Open": [close - 1, close],
+                "High": [close, close + 1],
+                "Low": [close - 2, close - 1],
+                "Close": [close - 0.5, close],
+                "Volume": [1_000_000, 1_100_000],
+            },
+            index=dates,
+        )
+
+    # Every symbol has cached price data so nothing is force-skipped.
+    service._price_cache = SimpleNamespace(
+        get_many_cached_only=lambda symbols, period="2y": {
+            symbol: make_price_frame(100.0 + i)
+            for i, symbol in enumerate(symbols)
+        }
+    )
+    service._fundamentals_cache = SimpleNamespace(
+        get_many_cached_only=lambda symbols: {s: {"symbol": s} for s in symbols}
+    )
+
+    # NVDA tops the composite ranking and gets Pass 1.
+    # The remaining rows have lower composite scores but massive perfDay
+    # values, so they match the "4% Daily Gainers" preset — Pass 2 should
+    # pick them up.
+    rows = [
+        SimpleNamespace(
+            symbol="NVDA",
+            composite_score=99.0,
+            rating="Strong Buy",
+            current_price=100.0,
+            screeners_run=[],
+            extended_fields={"price_change_1d": 2.0},
+        ),
+        SimpleNamespace(
+            symbol="GAIN1",
+            composite_score=50.0,
+            rating="Buy",
+            current_price=101.0,
+            screeners_run=[],
+            extended_fields={"price_change_1d": 12.0},
+        ),
+        SimpleNamespace(
+            symbol="GAIN2",
+            composite_score=49.0,
+            rating="Buy",
+            current_price=102.0,
+            screeners_run=[],
+            extended_fields={"price_change_1d": 9.0},
+        ),
+        SimpleNamespace(
+            symbol="GAIN3",
+            composite_score=48.0,
+            rating="Hold",
+            current_price=103.0,
+            screeners_run=[],
+            extended_fields={"price_change_1d": 7.0},
+        ),
+    ]
+
+    serialized_rows = [
+        {"symbol": "NVDA", "composite_score": 99.0, "price_change_1d": 2.0},
+        {"symbol": "GAIN1", "composite_score": 50.0, "price_change_1d": 12.0},
+        {"symbol": "GAIN2", "composite_score": 49.0, "price_change_1d": 9.0},
+        {"symbol": "GAIN3", "composite_score": 48.0, "price_change_1d": 7.0},
+    ]
+
+    with session_factory() as db:
+        run = db.get(FeatureRun, 19)
+        manifest = service._export_chart_bundle(  # noqa: SLF001 - intentional unit coverage
+            output_dir=tmp_path,
+            generated_at="2026-04-02T22:00:00Z",
+            run=run,
+            rows=rows,
+            serialized_rows=serialized_rows,
+        )
+
+    index_payload = json.loads((tmp_path / "charts" / "index.json").read_text(encoding="utf-8"))
+    symbols_in_order = [entry["symbol"] for entry in index_payload["symbols"]]
+
+    # Pass 1 exported NVDA (composite top-1).
+    assert symbols_in_order[0] == "NVDA"
+    assert index_payload["symbols"][0]["rank"] == 1
+
+    # Pass 2 added the 4% Daily Gainers preset matches with rank=None.
+    assert set(symbols_in_order[1:]) == {"GAIN1", "GAIN2", "GAIN3"}
+    for entry in index_payload["symbols"][1:]:
+        assert entry["rank"] is None
+
+    assert manifest["symbols_total"] == 4
+    assert manifest["available"] is True
+    # Each Pass 2 chart has its own payload with rank=None.
+    gain1_payload = json.loads((tmp_path / "charts" / "GAIN1.json").read_text(encoding="utf-8"))
+    assert gain1_payload["rank"] is None
+    assert gain1_payload["symbol"] == "GAIN1"
+
+
+def test_export_chart_bundle_skips_preset_symbols_without_cached_prices(
+    service_and_session_factory,
+    monkeypatch,
+    tmp_path,
+):
+    """Symbols skipped in Pass 1 for lack of cached prices should not be
+    re-attempted in Pass 2 (they're already tracked in skipped_symbols).
+    """
+    service, session_factory = service_and_session_factory
+    _insert_runs(
+        session_factory,
+        FeatureRun(
+            id=20,
+            as_of_date=date(2026, 4, 2),
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 4, 2, 21, 30, 0),
+        ),
+        pointer_run_id=20,
+    )
+
+    monkeypatch.setattr(export_module, "STATIC_CHART_LIMIT", 5)
+    monkeypatch.setattr(export_module, "STATIC_CHART_LOOKUP_BATCH_SIZE", 5)
+    monkeypatch.setattr(export_module, "STATIC_CHART_PRESET_TOP_N", 5)
+
+    def make_price_frame() -> pd.DataFrame:
+        dates = pd.date_range("2026-03-28", periods=2, freq="D")
+        return pd.DataFrame(
+            {
+                "Open": [100.0, 101.0],
+                "High": [101.0, 102.0],
+                "Low": [99.0, 100.0],
+                "Close": [100.5, 101.5],
+                "Volume": [1_000_000, 1_100_000],
+            },
+            index=dates,
+        )
+
+    # NOCACHE has no price data; it's also a preset match.
+    service._price_cache = SimpleNamespace(
+        get_many_cached_only=lambda symbols, period="2y": {
+            "NVDA": make_price_frame(),
+            "NOCACHE": None,
+        }
+    )
+    service._fundamentals_cache = SimpleNamespace(
+        get_many_cached_only=lambda symbols: {s: {"symbol": s} for s in symbols}
+    )
+
+    rows = [
+        SimpleNamespace(
+            symbol="NVDA",
+            composite_score=99.0,
+            rating="Strong Buy",
+            current_price=100.0,
+            screeners_run=[],
+            extended_fields={"price_change_1d": 1.0},
+        ),
+        SimpleNamespace(
+            symbol="NOCACHE",
+            composite_score=10.0,
+            rating="Hold",
+            current_price=50.0,
+            screeners_run=[],
+            extended_fields={"price_change_1d": 15.0},
+        ),
+    ]
+    serialized_rows = [
+        {"symbol": "NVDA", "composite_score": 99.0, "price_change_1d": 1.0},
+        {"symbol": "NOCACHE", "composite_score": 10.0, "price_change_1d": 15.0},
+    ]
+
+    with session_factory() as db:
+        run = db.get(FeatureRun, 20)
+        manifest = service._export_chart_bundle(  # noqa: SLF001 - intentional unit coverage
+            output_dir=tmp_path,
+            generated_at="2026-04-02T22:00:00Z",
+            run=run,
+            rows=rows,
+            serialized_rows=serialized_rows,
+        )
+
+    index_payload = json.loads((tmp_path / "charts" / "index.json").read_text(encoding="utf-8"))
+    exported = [e["symbol"] for e in index_payload["symbols"]]
+
+    assert exported == ["NVDA"]
+    assert index_payload["skipped_symbols"] == ["NOCACHE"]
+    assert manifest["symbols_total"] == 1
+
+
 def test_build_key_markets_skips_change_when_latest_close_is_null(service_and_session_factory):
     service, session_factory = service_and_session_factory
 

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -601,6 +601,20 @@ def test_export_chart_bundle_backfills_past_skipped_symbols_to_fill_limit(
     assert index_payload["skipped_symbols"] == ["NVDA"]
 
 
+def _make_chart_price_frame(close: float = 100.0) -> pd.DataFrame:
+    dates = pd.date_range("2026-03-28", periods=2, freq="D")
+    return pd.DataFrame(
+        {
+            "Open": [close - 1, close],
+            "High": [close, close + 1],
+            "Low": [close - 2, close - 1],
+            "Close": [close - 0.5, close],
+            "Volume": [1_000_000, 1_100_000],
+        },
+        index=dates,
+    )
+
+
 def test_export_chart_bundle_expands_coverage_for_preset_screens(
     service_and_session_factory,
     monkeypatch,
@@ -623,29 +637,14 @@ def test_export_chart_bundle_expands_coverage_for_preset_screens(
         pointer_run_id=19,
     )
 
-    # Pass 1 keeps only 1 chart (the top composite-score row).
-    # Pass 2 per-preset budget of 5 gives us headroom for extras.
+    # Tight Pass 1 limit forces the GAIN* rows to rely on Pass 2 expansion.
     monkeypatch.setattr(export_module, "STATIC_CHART_LIMIT", 1)
     monkeypatch.setattr(export_module, "STATIC_CHART_LOOKUP_BATCH_SIZE", 5)
     monkeypatch.setattr(export_module, "STATIC_CHART_PRESET_TOP_N", 5)
 
-    def make_price_frame(close: float) -> pd.DataFrame:
-        dates = pd.date_range("2026-03-28", periods=2, freq="D")
-        return pd.DataFrame(
-            {
-                "Open": [close - 1, close],
-                "High": [close, close + 1],
-                "Low": [close - 2, close - 1],
-                "Close": [close - 0.5, close],
-                "Volume": [1_000_000, 1_100_000],
-            },
-            index=dates,
-        )
-
-    # Every symbol has cached price data so nothing is force-skipped.
     service._price_cache = SimpleNamespace(
         get_many_cached_only=lambda symbols, period="2y": {
-            symbol: make_price_frame(100.0 + i)
+            symbol: _make_chart_price_frame(100.0 + i)
             for i, symbol in enumerate(symbols)
         }
     )
@@ -653,10 +652,8 @@ def test_export_chart_bundle_expands_coverage_for_preset_screens(
         get_many_cached_only=lambda symbols: {s: {"symbol": s} for s in symbols}
     )
 
-    # NVDA tops the composite ranking and gets Pass 1.
-    # The remaining rows have lower composite scores but massive perfDay
-    # values, so they match the "4% Daily Gainers" preset — Pass 2 should
-    # pick them up.
+    # NVDA has the highest composite score but a small perfDay (won't match
+    # the 4% Gainers preset). GAIN* rows invert that — they rely on Pass 2.
     rows = [
         SimpleNamespace(
             symbol="NVDA",
@@ -712,18 +709,14 @@ def test_export_chart_bundle_expands_coverage_for_preset_screens(
     index_payload = json.loads((tmp_path / "charts" / "index.json").read_text(encoding="utf-8"))
     symbols_in_order = [entry["symbol"] for entry in index_payload["symbols"]]
 
-    # Pass 1 exported NVDA (composite top-1).
     assert symbols_in_order[0] == "NVDA"
     assert index_payload["symbols"][0]["rank"] == 1
-
-    # Pass 2 added the 4% Daily Gainers preset matches with rank=None.
     assert set(symbols_in_order[1:]) == {"GAIN1", "GAIN2", "GAIN3"}
     for entry in index_payload["symbols"][1:]:
         assert entry["rank"] is None
 
     assert manifest["symbols_total"] == 4
     assert manifest["available"] is True
-    # Each Pass 2 chart has its own payload with rank=None.
     gain1_payload = json.loads((tmp_path / "charts" / "GAIN1.json").read_text(encoding="utf-8"))
     assert gain1_payload["rank"] is None
     assert gain1_payload["symbol"] == "GAIN1"
@@ -754,23 +747,11 @@ def test_export_chart_bundle_skips_preset_symbols_without_cached_prices(
     monkeypatch.setattr(export_module, "STATIC_CHART_LOOKUP_BATCH_SIZE", 5)
     monkeypatch.setattr(export_module, "STATIC_CHART_PRESET_TOP_N", 5)
 
-    def make_price_frame() -> pd.DataFrame:
-        dates = pd.date_range("2026-03-28", periods=2, freq="D")
-        return pd.DataFrame(
-            {
-                "Open": [100.0, 101.0],
-                "High": [101.0, 102.0],
-                "Low": [99.0, 100.0],
-                "Close": [100.5, 101.5],
-                "Volume": [1_000_000, 1_100_000],
-            },
-            index=dates,
-        )
-
-    # NOCACHE has no price data; it's also a preset match.
+    # NOCACHE has no cached prices but matches the 4% Gainers preset —
+    # Pass 2 must honor the skipped_symbols exclusion and not re-attempt.
     service._price_cache = SimpleNamespace(
         get_many_cached_only=lambda symbols, period="2y": {
-            "NVDA": make_price_frame(),
+            "NVDA": _make_chart_price_frame(),
             "NOCACHE": None,
         }
     )


### PR DESCRIPTION
Previously the static site exported charts for the global composite
top 200 (Pass 1) plus only the top 50 matches per preset screen
(Pass 2). Selective or orthogonally-ranked presets like 97 Club —
which sorts by price_change_1d and filters on pctDay/pctWeek/pctMonth
>= 97 — rarely overlap with the composite top 200, so rows beyond the
50-per-preset budget rendered with no chart icon in StaticScanPage.

Bump STATIC_CHART_PRESET_TOP_N from 50 to 200 (and the
get_preset_chart_symbols default to match) so each preset scan's top
200 matches receive chart + stock-info payloads, matching the global
composite top 200. Pass 2 already dedupes against Pass 1 and skipped
symbols, so the only cost is extra JSON payloads for presets whose
matches weren't already covered.

Adds two unit tests covering Pass 2: one verifying preset matches
outside the composite top-N get exported with rank=None, and one
ensuring symbols skipped in Pass 1 (no cached price data) aren't
re-attempted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased preset chart selection limit from 50 to 200, expanding the number of preset symbols and chart files included in preset-screen exports for broader coverage.

* **Tests**
  * Added unit tests for chart bundle export behavior, including validation of preset symbol expansion and cache handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->