### PR TITLE
Add market-scoped weekly reference bundles for US, HK, JP, and TW

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -64,40 +64,52 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p /tmp/weekly-reference
-          gh release download weekly-reference-data \
-            --pattern weekly-reference-latest.json \
-            --dir /tmp/weekly-reference
+          for market in us hk jp tw; do
+            gh release download weekly-reference-data \
+              --pattern "weekly-reference-latest-${market}.json" \
+              --dir /tmp/weekly-reference
+          done
 
       - name: Download weekly reference bundle
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          BUNDLE_ASSET_NAME="$(python - <<'PY'
+          for market in us hk jp tw; do
+            export MARKET="$market"
+            BUNDLE_ASSET_NAME="$(python - <<'PY'
           import json
+          import os
           from pathlib import Path
 
-          manifest = json.loads(Path("/tmp/weekly-reference/weekly-reference-latest.json").read_text(encoding="utf-8"))
+          manifest = json.loads(
+              Path(f"/tmp/weekly-reference/weekly-reference-latest-{os.environ['MARKET']}.json").read_text(
+                  encoding="utf-8"
+              )
+          )
           print(manifest["bundle_asset_name"])
           PY
-          )"
-          BUNDLE_SHA256="$(python - <<'PY'
+            )"
+            BUNDLE_SHA256="$(python - <<'PY'
           import json
+          import os
           from pathlib import Path
 
-          manifest = json.loads(Path("/tmp/weekly-reference/weekly-reference-latest.json").read_text(encoding="utf-8"))
+          manifest = json.loads(
+              Path(f"/tmp/weekly-reference/weekly-reference-latest-{os.environ['MARKET']}.json").read_text(
+                  encoding="utf-8"
+              )
+          )
           print(manifest["sha256"])
           PY
-          )"
-          export BUNDLE_ASSET_NAME
-          export BUNDLE_SHA256
-          echo "BUNDLE_ASSET_NAME=$BUNDLE_ASSET_NAME" >> "$GITHUB_ENV"
-          echo "BUNDLE_SHA256=$BUNDLE_SHA256" >> "$GITHUB_ENV"
+            )"
 
-          gh release download weekly-reference-data \
-            --pattern "$BUNDLE_ASSET_NAME" \
-            --dir /tmp/weekly-reference
+            gh release download weekly-reference-data \
+              --pattern "$BUNDLE_ASSET_NAME" \
+              --dir /tmp/weekly-reference
 
-          python - <<'PY'
+            export BUNDLE_ASSET_NAME
+            export BUNDLE_SHA256
+            python - <<'PY'
           import hashlib
           import os
           from pathlib import Path
@@ -111,12 +123,30 @@ jobs:
                   f"{digest} != {expected}"
               )
           PY
+          done
 
       - name: Import weekly reference bundle
         run: |
           cd backend
-          python -m app.scripts.import_weekly_reference_bundle \
-            --input "/tmp/weekly-reference/${BUNDLE_ASSET_NAME}"
+          for market in us hk jp tw; do
+            export MARKET="$market"
+            BUNDLE_ASSET_NAME="$(python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          market = os.environ["MARKET"]
+          manifest = json.loads(
+              Path(f"/tmp/weekly-reference/weekly-reference-latest-{market}.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          print(manifest["bundle_asset_name"])
+          PY
+            )"
+            python -m app.scripts.import_weekly_reference_bundle \
+              --input "/tmp/weekly-reference/${BUNDLE_ASSET_NAME}"
+          done
 
       - name: Load tracked IBD industry seed
         run: |

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -64,19 +64,76 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p /tmp/weekly-reference
-          for market in us hk jp tw; do
+          if gh release download weekly-reference-data \
+            --pattern "weekly-reference-latest-us.json" \
+            --dir /tmp/weekly-reference >/dev/null 2>&1; then
+            echo "WEEKLY_REFERENCE_MODE=market_scoped" >> "$GITHUB_ENV"
+            for market in hk jp tw; do
+              gh release download weekly-reference-data \
+                --pattern "weekly-reference-latest-${market}.json" \
+                --dir /tmp/weekly-reference
+            done
+          else
             gh release download weekly-reference-data \
-              --pattern "weekly-reference-latest-${market}.json" \
+              --pattern "weekly-reference-latest.json" \
               --dir /tmp/weekly-reference
-          done
+            echo "WEEKLY_REFERENCE_MODE=legacy" >> "$GITHUB_ENV"
+          fi
 
       - name: Download weekly reference bundle
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          for market in us hk jp tw; do
-            export MARKET="$market"
+          if [ "${WEEKLY_REFERENCE_MODE}" = "legacy" ]; then
             BUNDLE_ASSET_NAME="$(python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(
+              Path("/tmp/weekly-reference/weekly-reference-latest.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          print(manifest["bundle_asset_name"])
+          PY
+            )"
+            BUNDLE_SHA256="$(python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(
+              Path("/tmp/weekly-reference/weekly-reference-latest.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          print(manifest["sha256"])
+          PY
+            )"
+
+            gh release download weekly-reference-data \
+              --pattern "$BUNDLE_ASSET_NAME" \
+              --dir /tmp/weekly-reference
+
+            export BUNDLE_ASSET_NAME
+            export BUNDLE_SHA256
+            python - <<'PY'
+          import hashlib
+          import os
+          from pathlib import Path
+
+          bundle_path = Path("/tmp/weekly-reference") / os.environ["BUNDLE_ASSET_NAME"]
+          digest = hashlib.sha256(bundle_path.read_bytes()).hexdigest()
+          expected = os.environ["BUNDLE_SHA256"]
+          if digest != expected:
+              raise SystemExit(
+                  f"Weekly reference bundle checksum mismatch for {bundle_path.name}: "
+                  f"{digest} != {expected}"
+              )
+          PY
+          else
+            for market in us hk jp tw; do
+              export MARKET="$market"
+              BUNDLE_ASSET_NAME="$(python - <<'PY'
           import json
           import os
           from pathlib import Path
@@ -123,14 +180,30 @@ jobs:
                   f"{digest} != {expected}"
               )
           PY
-          done
+            done
+          fi
 
       - name: Import weekly reference bundle
         run: |
           cd backend
-          for market in us hk jp tw; do
-            export MARKET="$market"
-            BUNDLE_ASSET_NAME="$(python - <<'PY'
+          if [ "${WEEKLY_REFERENCE_MODE}" = "legacy" ]; then
+            python -m app.scripts.import_weekly_reference_bundle \
+              --input "/tmp/weekly-reference/$(python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(
+              Path("/tmp/weekly-reference/weekly-reference-latest.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          print(manifest["bundle_asset_name"])
+          PY
+            )"
+          else
+            for market in us hk jp tw; do
+              export MARKET="$market"
+              BUNDLE_ASSET_NAME="$(python - <<'PY'
           import json
           import os
           from pathlib import Path
@@ -146,7 +219,8 @@ jobs:
             )"
             python -m app.scripts.import_weekly_reference_bundle \
               --input "/tmp/weekly-reference/${BUNDLE_ASSET_NAME}"
-          done
+            done
+          fi
 
       - name: Load tracked IBD industry seed
         run: |

--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -14,8 +14,22 @@ permissions:
   contents: write
 
 jobs:
+  ensure_release:
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure weekly release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view weekly-reference-data >/dev/null 2>&1 || \
+          gh release create weekly-reference-data \
+            --title "Weekly Reference Data" \
+            --notes "Automated weekly market-scoped reference bundles for static-site builds."
+
   publish:
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    needs: ensure_release
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -57,15 +71,6 @@ jobs:
           python -m app.scripts.build_weekly_reference_bundle \
             --market "${{ matrix.market }}" \
             --output-dir /tmp/weekly-reference
-
-      - name: Ensure weekly release exists
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release view weekly-reference-data >/dev/null 2>&1 || \
-          gh release create weekly-reference-data \
-            --title "Weekly Reference Data" \
-            --notes "Automated weekly market-scoped reference bundles for static-site builds."
 
       - name: Upload weekly reference assets
         env:

--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -17,6 +17,10 @@ jobs:
   publish:
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        market: [US, HK, JP, TW]
     services:
       postgres:
         image: postgres:16-alpine
@@ -51,6 +55,7 @@ jobs:
         run: |
           cd backend
           python -m app.scripts.build_weekly_reference_bundle \
+            --market "${{ matrix.market }}" \
             --output-dir /tmp/weekly-reference
 
       - name: Ensure weekly release exists
@@ -60,14 +65,15 @@ jobs:
           gh release view weekly-reference-data >/dev/null 2>&1 || \
           gh release create weekly-reference-data \
             --title "Weekly Reference Data" \
-            --notes "Automated weekly fundamentals reference bundle for static-site builds."
+            --notes "Automated weekly market-scoped reference bundles for static-site builds."
 
       - name: Upload weekly reference assets
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          BUNDLE_PATH="$(find /tmp/weekly-reference -maxdepth 1 -name 'weekly-reference-*.json.gz' | head -n 1)"
-          MANIFEST_PATH="/tmp/weekly-reference/weekly-reference-latest.json"
+          MARKET_LOWER="$(echo "${{ matrix.market }}" | tr '[:upper:]' '[:lower:]')"
+          BUNDLE_PATH="$(find /tmp/weekly-reference -maxdepth 1 -name "weekly-reference-${MARKET_LOWER}-*.json.gz" | head -n 1)"
+          MANIFEST_PATH="/tmp/weekly-reference/weekly-reference-latest-${MARKET_LOWER}.json"
 
           if [ -z "$BUNDLE_PATH" ] || [ ! -f "$MANIFEST_PATH" ]; then
             echo "Missing weekly reference bundle outputs" >&2

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -1,24 +1,39 @@
-"""Build the weekly fundamentals reference bundle for static-site workflows."""
+"""Build market-scoped weekly fundamentals reference bundles for static-site workflows."""
 
 from __future__ import annotations
 
 import argparse
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from app.database import SessionLocal
+from app.models.stock_universe import StockUniverse
 from app.scripts._runtime import prepare_runtime, repo_root
+from app.services.official_market_universe_source_service import (
+    OfficialMarketUniverseSourceService,
+)
 from app.services.provider_snapshot_service import ProviderSnapshotService
-from app.wiring.bootstrap import get_provider_snapshot_service, get_stock_universe_service
+from app.wiring.bootstrap import (
+    get_fundamentals_cache,
+    get_hybrid_fundamentals_service,
+    get_provider_snapshot_service,
+    get_stock_universe_service,
+)
 
 
 def _default_output_dir() -> Path:
     return repo_root() / ".tmp" / "weekly-reference"
 
 
-def _default_bundle_name(published_run) -> str:
+def _default_bundle_name(market: str, published_run) -> str:
     as_of = (published_run.published_at or published_run.created_at).date().isoformat().replace("-", "")
     revision = (published_run.source_revision or "snapshot").replace(":", "-").replace("/", "-")
-    return f"weekly-reference-{as_of}-{revision}.json.gz"
+    return f"weekly-reference-{market.lower()}-{as_of}-{revision}.json.gz"
+
+
+def _default_latest_manifest_name(market: str) -> str:
+    return ProviderSnapshotService.weekly_reference_latest_manifest_name_for_market(market)
 
 
 def _print_progress(event: dict[str, object]) -> None:
@@ -59,8 +74,235 @@ def _print_progress(event: dict[str, object]) -> None:
         )
 
 
+def _ingest_official_market_snapshot(db, stock_universe_service, snapshot) -> dict[str, Any]:
+    if snapshot.market == "HK":
+        return stock_universe_service.ingest_hk_snapshot_rows(
+            db,
+            rows=snapshot.rows,
+            source_name=snapshot.source_name,
+            snapshot_id=snapshot.snapshot_id,
+            snapshot_as_of=snapshot.snapshot_as_of,
+            source_metadata=snapshot.source_metadata,
+        )
+    if snapshot.market == "JP":
+        return stock_universe_service.ingest_jp_snapshot_rows(
+            db,
+            rows=snapshot.rows,
+            source_name=snapshot.source_name,
+            snapshot_id=snapshot.snapshot_id,
+            snapshot_as_of=snapshot.snapshot_as_of,
+            source_metadata=snapshot.source_metadata,
+        )
+    if snapshot.market == "TW":
+        return stock_universe_service.ingest_tw_snapshot_rows(
+            db,
+            rows=snapshot.rows,
+            source_name=snapshot.source_name,
+            snapshot_id=snapshot.snapshot_id,
+            snapshot_as_of=snapshot.snapshot_as_of,
+            source_metadata=snapshot.source_metadata,
+        )
+    raise ValueError(f"Unsupported official weekly reference market {snapshot.market!r}")
+
+
+def _build_us_bundle(
+    db,
+    *,
+    provider_snapshot_service,
+    stock_universe_service,
+    market: str,
+    output_dir: Path,
+    bundle_name: str | None,
+    latest_manifest_name: str,
+) -> dict[str, Any]:
+    snapshot_key = ProviderSnapshotService.snapshot_key_for_market(market)
+
+    print("Starting stock universe refresh from Finviz...", flush=True)
+    universe_stats = stock_universe_service.populate_universe(db)
+    print(f"Universe refresh complete: {universe_stats}", flush=True)
+
+    print("Starting published fundamentals snapshot build from Finviz...", flush=True)
+    snapshot_stats = provider_snapshot_service.create_snapshot_run(
+        db,
+        run_mode="publish",
+        snapshot_key=snapshot_key,
+        publish=True,
+        progress_callback=_print_progress,
+        show_finviz_progress=True,
+    )
+    if not snapshot_stats.get("published"):
+        raise RuntimeError(
+            "Weekly fundamentals snapshot did not publish: "
+            f"{snapshot_stats.get('warnings') or 'coverage gate blocked publish'}"
+        )
+
+    print("Starting snapshot hydration (batched price enrichment + Yahoo-only fallback)...", flush=True)
+    hydrate_stats = provider_snapshot_service.hydrate_published_snapshot(
+        db,
+        snapshot_key=snapshot_key,
+        allow_yahoo_hydration=True,
+        progress_callback=_print_progress,
+    )
+    published_run = provider_snapshot_service.get_published_run(db, snapshot_key=snapshot_key)
+    if published_run is None:
+        raise RuntimeError("Published weekly fundamentals snapshot was not found after hydration")
+
+    resolved_bundle_name = bundle_name or _default_bundle_name(market, published_run)
+    bundle_path = output_dir / resolved_bundle_name
+    latest_manifest_path = output_dir / latest_manifest_name
+    export_stats = provider_snapshot_service.export_weekly_reference_bundle(
+        db,
+        output_path=bundle_path,
+        bundle_asset_name=resolved_bundle_name,
+        latest_manifest_path=latest_manifest_path,
+        snapshot_key=snapshot_key,
+        market=market,
+    )
+
+    return {
+        "output_dir": output_dir,
+        "bundle": bundle_path,
+        "latest_manifest": latest_manifest_path,
+        "universe_refresh": universe_stats,
+        "snapshot_publish": snapshot_stats,
+        "snapshot_hydrate": hydrate_stats,
+        "export": export_stats,
+    }
+
+
+def _build_asia_bundle(
+    db,
+    *,
+    provider_snapshot_service,
+    stock_universe_service,
+    market: str,
+    output_dir: Path,
+    bundle_name: str | None,
+    latest_manifest_name: str,
+) -> dict[str, Any]:
+    snapshot_key = ProviderSnapshotService.snapshot_key_for_market(market)
+    official_source_service = OfficialMarketUniverseSourceService()
+    fundamentals_cache = get_fundamentals_cache()
+    hybrid_service = get_hybrid_fundamentals_service()
+
+    print(f"Starting official universe refresh for {market}...", flush=True)
+    official_snapshot = official_source_service.fetch_market_snapshot(market)
+    universe_stats = _ingest_official_market_snapshot(db, stock_universe_service, official_snapshot)
+    print(f"Universe refresh complete: {universe_stats}", flush=True)
+
+    active_rows = (
+        db.query(StockUniverse)
+        .filter(
+            StockUniverse.active_filter(),
+            StockUniverse.market == market,
+        )
+        .order_by(StockUniverse.symbol.asc())
+        .all()
+    )
+    if not active_rows:
+        raise RuntimeError(f"No active {market} universe rows found after official-source ingest")
+
+    symbols = [row.symbol for row in active_rows]
+    market_by_symbol = {row.symbol: market for row in active_rows}
+
+    print(f"Starting hybrid fundamentals refresh for {market}...", flush=True)
+    all_data = hybrid_service.fetch_fundamentals_batch(
+        symbols,
+        include_technicals=True,
+        include_finviz=False,
+        market_by_symbol=market_by_symbol,
+    )
+    fundamentals_stats = hybrid_service.store_all_caches(
+        all_data,
+        fundamentals_cache,
+        session_factory=SessionLocal,
+        include_quarterly=True,
+        market_by_symbol=market_by_symbol,
+    )
+
+    cached_fundamentals = fundamentals_cache.get_many(symbols)
+    snapshot_rows = []
+    for row in active_rows:
+        payload = dict(cached_fundamentals.get(row.symbol) or {})
+        if not payload:
+            continue
+        payload.setdefault("company_name", row.name)
+        payload.setdefault("sector", row.sector)
+        payload.setdefault("industry", row.industry)
+        payload.setdefault("market_cap", row.market_cap)
+        snapshot_rows.append(
+            provider_snapshot_service.build_market_snapshot_row(
+                market=market,
+                symbol=row.symbol,
+                exchange=row.exchange,
+                normalized_payload=payload,
+                raw_payload=None,
+            )
+        )
+
+    coverage_stats = {
+        "active_symbols": len(symbols),
+        "snapshot_symbols": len(snapshot_rows),
+        "covered_active_symbols": len(snapshot_rows),
+        "missing_active_symbols": max(len(symbols) - len(snapshot_rows), 0),
+    }
+    warnings: list[str] = []
+    if fundamentals_stats.get("failed"):
+        warnings.append(
+            f"{fundamentals_stats['failed']} symbols failed during {market} hybrid fundamentals refresh"
+        )
+
+    source_revision = f"{snapshot_key}:{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+    snapshot_stats = provider_snapshot_service.publish_market_snapshot_run(
+        db,
+        snapshot_key=snapshot_key,
+        market=market,
+        source_revision=source_revision,
+        rows=snapshot_rows,
+        coverage_stats=coverage_stats,
+        warnings=warnings,
+    )
+    if not snapshot_stats.get("published"):
+        raise RuntimeError(
+            "Weekly fundamentals snapshot did not publish: "
+            f"{snapshot_stats.get('warnings') or 'coverage gate blocked publish'}"
+        )
+
+    published_run = provider_snapshot_service.get_published_run(db, snapshot_key=snapshot_key)
+    if published_run is None:
+        raise RuntimeError(f"Published weekly fundamentals snapshot for {market} was not found")
+
+    resolved_bundle_name = bundle_name or _default_bundle_name(market, published_run)
+    bundle_path = output_dir / resolved_bundle_name
+    latest_manifest_path = output_dir / latest_manifest_name
+    export_stats = provider_snapshot_service.export_weekly_reference_bundle(
+        db,
+        output_path=bundle_path,
+        bundle_asset_name=resolved_bundle_name,
+        latest_manifest_path=latest_manifest_path,
+        snapshot_key=snapshot_key,
+        market=market,
+    )
+
+    return {
+        "output_dir": output_dir,
+        "bundle": bundle_path,
+        "latest_manifest": latest_manifest_path,
+        "universe_refresh": universe_stats,
+        "fundamentals_refresh": fundamentals_stats,
+        "snapshot_publish": snapshot_stats,
+        "export": export_stats,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--market",
+        required=True,
+        choices=list(ProviderSnapshotService.SNAPSHOT_KEY_FUNDAMENTALS_BY_MARKET),
+        help="Market code to build the weekly reference bundle for.",
+    )
     parser.add_argument(
         "--output-dir",
         default=str(_default_output_dir()),
@@ -69,12 +311,12 @@ def main() -> int:
     parser.add_argument(
         "--bundle-name",
         default=None,
-        help="Bundle asset filename. Defaults to weekly-reference-<YYYYMMDD>.json.gz",
+        help="Bundle asset filename. Defaults to weekly-reference-<market>-<YYYYMMDD>-<revision>.json.gz",
     )
     parser.add_argument(
         "--latest-manifest-name",
-        default=ProviderSnapshotService.WEEKLY_REFERENCE_LATEST_MANIFEST_NAME,
-        help="Filename for the latest-pointer manifest JSON.",
+        default=None,
+        help="Filename for the latest-pointer manifest JSON. Defaults to the market-scoped name.",
     )
     args = parser.parse_args()
 
@@ -82,56 +324,36 @@ def main() -> int:
     provider_snapshot_service = get_provider_snapshot_service()
     stock_universe_service = get_stock_universe_service()
 
+    market = args.market.upper()
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    latest_manifest_name = args.latest_manifest_name or _default_latest_manifest_name(market)
 
     with SessionLocal() as db:
-        print("Starting stock universe refresh from Finviz...", flush=True)
-        universe_stats = stock_universe_service.populate_universe(db)
-        print(f"Universe refresh complete: {universe_stats}", flush=True)
-
-        print("Starting published fundamentals snapshot build from Finviz...", flush=True)
-        snapshot_stats = provider_snapshot_service.create_snapshot_run(
-            db,
-            run_mode="publish",
-            publish=True,
-            progress_callback=_print_progress,
-            show_finviz_progress=True,
-        )
-        if not snapshot_stats.get("published"):
-            raise RuntimeError(
-                "Weekly fundamentals snapshot did not publish: "
-                f"{snapshot_stats.get('warnings') or 'coverage gate blocked publish'}"
+        if market == "US":
+            summary = _build_us_bundle(
+                db,
+                provider_snapshot_service=provider_snapshot_service,
+                stock_universe_service=stock_universe_service,
+                market=market,
+                output_dir=output_dir,
+                bundle_name=args.bundle_name,
+                latest_manifest_name=latest_manifest_name,
+            )
+        else:
+            summary = _build_asia_bundle(
+                db,
+                provider_snapshot_service=provider_snapshot_service,
+                stock_universe_service=stock_universe_service,
+                market=market,
+                output_dir=output_dir,
+                bundle_name=args.bundle_name,
+                latest_manifest_name=latest_manifest_name,
             )
 
-        print("Starting snapshot hydration (batched price enrichment + Yahoo-only fallback)...", flush=True)
-        hydrate_stats = provider_snapshot_service.hydrate_published_snapshot(
-            db,
-            allow_yahoo_hydration=True,
-            progress_callback=_print_progress,
-        )
-        published_run = provider_snapshot_service.get_published_run(db)
-        if published_run is None:
-            raise RuntimeError("Published weekly fundamentals snapshot was not found after hydration")
-
-        bundle_name = args.bundle_name or _default_bundle_name(published_run)
-        bundle_path = output_dir / bundle_name
-        latest_manifest_path = output_dir / args.latest_manifest_name
-        export_stats = provider_snapshot_service.export_weekly_reference_bundle(
-            db,
-            output_path=bundle_path,
-            bundle_asset_name=bundle_name,
-            latest_manifest_path=latest_manifest_path,
-        )
-
-    print("Weekly reference bundle complete:")
-    print(f"  - output_dir: {output_dir}")
-    print(f"  - bundle: {bundle_path}")
-    print(f"  - latest_manifest: {latest_manifest_path}")
-    print(f"  - universe_refresh: {universe_stats}")
-    print(f"  - snapshot_publish: {snapshot_stats}")
-    print(f"  - snapshot_hydrate: {hydrate_stats}")
-    print(f"  - export: {export_stats}")
+    print(f"Weekly reference bundle complete for {market}:")
+    for key, value in summary.items():
+        print(f"  - {key}: {value}")
     return 0
 
 

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -126,6 +126,7 @@ def _build_us_bundle(
         db,
         run_mode="publish",
         snapshot_key=snapshot_key,
+        market=market,
         publish=True,
         progress_callback=_print_progress,
         show_finviz_progress=True,

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -324,7 +324,7 @@ def _run_daily_refresh(
         if hydrate_published_snapshot:
             provider_snapshot_service = get_provider_snapshot_service()
             with SessionLocal() as db:
-                results["fundamentals_hydrate"] = provider_snapshot_service.hydrate_published_snapshot(
+                results["fundamentals_hydrate"] = provider_snapshot_service.hydrate_all_published_snapshots(
                     db,
                     allow_yahoo_hydration=False,
                 )

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -851,6 +851,8 @@ class ProviderSnapshotService:
     def get_snapshot_stats(self, db: Session, snapshot_key: str = SNAPSHOT_KEY_FUNDAMENTALS) -> Dict[str, Any]:
         """Return published snapshot stats for API/status reporting."""
         run = self.get_published_run(db, snapshot_key=snapshot_key)
+        if run is None and snapshot_key == self.SNAPSHOT_KEY_FUNDAMENTALS:
+            run = self.get_published_run(db, snapshot_key="fundamentals_v1")
         if run is None:
             return {
                 "published_snapshot_revision": None,

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -398,6 +398,21 @@ class ProviderSnapshotService:
             db.bulk_save_objects(imported_universe)
         return len(imported_universe)
 
+    @staticmethod
+    def _replace_all_universe_rows(
+        db: Session,
+        *,
+        rows: Iterable[Dict[str, Any]],
+    ) -> int:
+        db.query(StockUniverse).delete(synchronize_session=False)
+        imported_universe = [
+            StockUniverse(**ProviderSnapshotService._deserialize_universe_row(row))
+            for row in rows
+        ]
+        if imported_universe:
+            db.bulk_save_objects(imported_universe)
+        return len(imported_universe)
+
     def publish_market_snapshot_run(
         self,
         db: Session,
@@ -985,16 +1000,23 @@ class ProviderSnapshotService:
         bundle_market = str(
             payload.get("market") or inferred_market or self.market_for_snapshot_key(snapshot_key)
         ).strip().upper()
+        legacy_global_bundle = snapshot_key == "fundamentals_v1" and not payload.get("market")
         coverage = snapshot.get("coverage_stats")
         parity = snapshot.get("parity_stats")
         warnings = snapshot.get("warnings")
 
         self._replace_snapshot_key_runs(db, snapshot_key=snapshot_key)
-        imported_universe_count = self._replace_market_universe_rows(
-            db,
-            market=bundle_market,
-            rows=universe_rows,
-        )
+        if legacy_global_bundle:
+            imported_universe_count = self._replace_all_universe_rows(
+                db,
+                rows=universe_rows,
+            )
+        else:
+            imported_universe_count = self._replace_market_universe_rows(
+                db,
+                market=bundle_market,
+                rows=universe_rows,
+            )
         db.commit()
         db.expunge_all()
 
@@ -1056,7 +1078,7 @@ class ProviderSnapshotService:
             "rows": len(rows),
             "universe_rows": imported_universe_count,
             "as_of_date": payload.get("as_of_date"),
-            "market": bundle_market,
+            "market": "MULTI" if legacy_global_bundle else bundle_market,
         }
 
     @staticmethod

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -39,6 +39,16 @@ WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION = "weekly-reference-bundle-v1"
 WEEKLY_REFERENCE_MANIFEST_SCHEMA_VERSION = "weekly-reference-manifest-v1"
 WEEKLY_REFERENCE_RELEASE_TAG = "weekly-reference-data"
 WEEKLY_REFERENCE_LATEST_MANIFEST_NAME = "weekly-reference-latest.json"
+WEEKLY_REFERENCE_MARKETS: tuple[str, ...] = ("US", "HK", "JP", "TW")
+WEEKLY_REFERENCE_SNAPSHOT_KEYS: dict[str, str] = {
+    "US": "fundamentals_v1_us",
+    "HK": "fundamentals_v1_hk",
+    "JP": "fundamentals_v1_jp",
+    "TW": "fundamentals_v1_tw",
+}
+WEEKLY_REFERENCE_MARKET_BY_SNAPSHOT_KEY: dict[str, str] = {
+    snapshot_key: market for market, snapshot_key in WEEKLY_REFERENCE_SNAPSHOT_KEYS.items()
+}
 
 
 def _serialize_datetime(value: datetime | None) -> str | None:
@@ -54,7 +64,8 @@ def _deserialize_datetime(value: str | None) -> datetime | None:
 class ProviderSnapshotService:
     """Build, publish, and hydrate provider-backed fundamentals snapshots."""
 
-    SNAPSHOT_KEY_FUNDAMENTALS = "fundamentals_v1"
+    SNAPSHOT_KEY_FUNDAMENTALS = WEEKLY_REFERENCE_SNAPSHOT_KEYS["US"]
+    SNAPSHOT_KEY_FUNDAMENTALS_BY_MARKET = WEEKLY_REFERENCE_SNAPSHOT_KEYS
     CATEGORY_LOADERS = {
         "overview": ("finvizfinance.screener.overview", "Overview"),
         "valuation": ("finvizfinance.screener.valuation", "Valuation"),
@@ -84,6 +95,55 @@ class ProviderSnapshotService:
     WEEKLY_REFERENCE_MANIFEST_SCHEMA_VERSION = WEEKLY_REFERENCE_MANIFEST_SCHEMA_VERSION
     WEEKLY_REFERENCE_RELEASE_TAG = WEEKLY_REFERENCE_RELEASE_TAG
     WEEKLY_REFERENCE_LATEST_MANIFEST_NAME = WEEKLY_REFERENCE_LATEST_MANIFEST_NAME
+
+    @classmethod
+    def snapshot_key_for_market(cls, market: str) -> str:
+        normalized_market = str(market or "").strip().upper()
+        if normalized_market not in cls.SNAPSHOT_KEY_FUNDAMENTALS_BY_MARKET:
+            raise ValueError(
+                f"Unsupported weekly reference market {market!r}. "
+                f"Expected one of {sorted(cls.SNAPSHOT_KEY_FUNDAMENTALS_BY_MARKET)}."
+            )
+        return cls.SNAPSHOT_KEY_FUNDAMENTALS_BY_MARKET[normalized_market]
+
+    @classmethod
+    def market_for_snapshot_key(cls, snapshot_key: str) -> str:
+        normalized_key = str(snapshot_key or "").strip()
+        if normalized_key == "fundamentals_v1":
+            return "US"
+        market = WEEKLY_REFERENCE_MARKET_BY_SNAPSHOT_KEY.get(normalized_key)
+        if market is None:
+            raise ValueError(f"Unsupported weekly reference snapshot key {snapshot_key!r}")
+        return market
+
+    @classmethod
+    def weekly_reference_snapshot_keys(cls) -> tuple[str, ...]:
+        return tuple(
+            cls.SNAPSHOT_KEY_FUNDAMENTALS_BY_MARKET[market]
+            for market in WEEKLY_REFERENCE_MARKETS
+        )
+
+    @classmethod
+    def weekly_reference_latest_manifest_name_for_market(cls, market: str) -> str:
+        return f"weekly-reference-latest-{str(market or '').strip().lower()}.json"
+
+    @staticmethod
+    def _infer_market_from_bundle_rows(
+        universe_rows: Iterable[Dict[str, Any]],
+        snapshot_rows: Iterable[Dict[str, Any]],
+    ) -> str | None:
+        for row in [*list(universe_rows), *list(snapshot_rows)]:
+            identity = security_master_resolver.resolve_identity(
+                symbol=str(row.get("symbol") or ""),
+                market=row.get("market"),
+                exchange=row.get("exchange"),
+                currency=row.get("currency"),
+                timezone=row.get("timezone"),
+                local_code=row.get("local_code"),
+            )
+            if identity.market:
+                return identity.market
+        return None
 
     def __init__(
         self,
@@ -240,6 +300,40 @@ class ProviderSnapshotService:
     def _needs_yahoo_hydration(self, payload: Dict[str, Any]) -> bool:
         return any(not self._has_value(payload.get(key)) for key in self.YAHOO_ONLY_REQUIRED_KEYS)
 
+    def build_market_snapshot_row(
+        self,
+        *,
+        market: str,
+        symbol: str,
+        exchange: str | None,
+        normalized_payload: Dict[str, Any],
+        raw_payload: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        """Return a ProviderSnapshotRow-ready payload for a market-scoped bundle."""
+        identity = security_master_resolver.resolve_identity(
+            symbol=str(symbol or ""),
+            market=market,
+            exchange=exchange,
+            currency=normalized_payload.get("currency"),
+            timezone=normalized_payload.get("timezone"),
+            local_code=normalized_payload.get("local_code"),
+        )
+        payload = dict(normalized_payload)
+        payload.setdefault("symbol", identity.canonical_symbol)
+        payload.setdefault("market", identity.market)
+        payload.setdefault("exchange", identity.exchange)
+        payload.setdefault("currency", identity.currency)
+        payload.setdefault("timezone", identity.timezone)
+        payload.setdefault("local_code", identity.local_code)
+        payload_json = json.dumps(payload, sort_keys=True, default=str)
+        return {
+            "symbol": identity.canonical_symbol,
+            "exchange": identity.exchange,
+            "row_hash": hashlib.sha256(payload_json.encode("utf-8")).hexdigest(),
+            "normalized_payload": payload,
+            "raw_payload": raw_payload,
+        }
+
     def _coverage_gate(
         self,
         coverage_stats: Dict[str, Any],
@@ -266,6 +360,138 @@ class ProviderSnapshotService:
                 f"{settings.provider_snapshot_max_missing_active_symbols}"
             )
         return (not warnings), warnings
+
+    @staticmethod
+    def _replace_snapshot_key_runs(db: Session, *, snapshot_key: str) -> None:
+        existing_run_ids = [
+            row[0]
+            for row in db.query(ProviderSnapshotRun.id)
+            .filter(ProviderSnapshotRun.snapshot_key == snapshot_key)
+            .all()
+        ]
+        db.query(ProviderSnapshotPointer).filter(
+            ProviderSnapshotPointer.snapshot_key == snapshot_key
+        ).delete()
+        if existing_run_ids:
+            db.query(ProviderSnapshotRow).filter(
+                ProviderSnapshotRow.run_id.in_(existing_run_ids)
+            ).delete(synchronize_session=False)
+            db.query(ProviderSnapshotRun).filter(
+                ProviderSnapshotRun.id.in_(existing_run_ids)
+            ).delete(synchronize_session=False)
+
+    @staticmethod
+    def _replace_market_universe_rows(
+        db: Session,
+        *,
+        market: str,
+        rows: Iterable[Dict[str, Any]],
+    ) -> int:
+        db.query(StockUniverse).filter(StockUniverse.market == market).delete(
+            synchronize_session=False
+        )
+        imported_universe = [
+            StockUniverse(**ProviderSnapshotService._deserialize_universe_row(row))
+            for row in rows
+        ]
+        if imported_universe:
+            db.bulk_save_objects(imported_universe)
+        return len(imported_universe)
+
+    def publish_market_snapshot_run(
+        self,
+        db: Session,
+        *,
+        snapshot_key: str,
+        market: str,
+        source_revision: str,
+        rows: Iterable[Dict[str, Any]],
+        coverage_stats: Dict[str, Any],
+        warnings: Optional[list[str]] = None,
+        run_mode: str = "publish",
+        publish: bool = True,
+    ) -> Dict[str, Any]:
+        """Publish a pre-built market snapshot using the standard run/pointer tables."""
+        normalized_market = str(market or "").strip().upper()
+        parity_stats = {
+            "market": normalized_market,
+            "missing_active_symbols": [],
+        }
+        coverage_ok, coverage_warnings = self._coverage_gate(coverage_stats)
+        all_warnings = list(warnings or [])
+        all_warnings.extend(coverage_warnings)
+
+        run = ProviderSnapshotRun(
+            snapshot_key=snapshot_key,
+            run_mode=run_mode,
+            status="building",
+            source_revision=source_revision,
+        )
+        db.add(run)
+        db.flush()
+
+        materialized_rows = list(rows)
+        if materialized_rows:
+            db.bulk_save_objects(
+                [
+                    ProviderSnapshotRow(
+                        run_id=run.id,
+                        symbol=row["symbol"],
+                        exchange=row.get("exchange"),
+                        row_hash=row["row_hash"],
+                        normalized_payload_json=json.dumps(
+                            row["normalized_payload"], sort_keys=True, default=str
+                        ),
+                        raw_payload_json=(
+                            json.dumps(row["raw_payload"], sort_keys=True, default=str)
+                            if row.get("raw_payload") is not None
+                            else None
+                        ),
+                    )
+                    for row in materialized_rows
+                ]
+            )
+
+        run.symbols_total = int(coverage_stats.get("snapshot_symbols", len(materialized_rows)) or 0)
+        run.symbols_published = int(
+            coverage_stats.get("covered_active_symbols", len(materialized_rows)) or 0
+        )
+        run.coverage_stats_json = json.dumps(coverage_stats, sort_keys=True)
+        run.parity_stats_json = json.dumps(parity_stats, sort_keys=True)
+        run.warnings_json = json.dumps(all_warnings, sort_keys=True) if all_warnings else None
+        run.status = "preview_ready" if not publish else "published"
+        published = False
+        if publish and coverage_ok:
+            published_at = datetime.utcnow()
+            run.published_at = published_at
+            pointer = db.query(ProviderSnapshotPointer).filter(
+                ProviderSnapshotPointer.snapshot_key == snapshot_key
+            ).first()
+            if pointer is None:
+                db.add(
+                    ProviderSnapshotPointer(
+                        snapshot_key=snapshot_key,
+                        run_id=run.id,
+                        updated_at=published_at,
+                    )
+                )
+            else:
+                pointer.run_id = run.id
+                pointer.updated_at = published_at
+            published = True
+        elif publish and not coverage_ok:
+            run.status = "publish_blocked"
+
+        db.commit()
+        return {
+            "run_id": run.id,
+            "source_revision": run.source_revision,
+            "coverage": coverage_stats,
+            "parity": parity_stats,
+            "published": published,
+            "warnings": all_warnings,
+            "market": normalized_market,
+        }
 
     def _fetch_yahoo_only_fields(self, symbol: str) -> Dict[str, Any]:
         import yfinance as yf
@@ -577,6 +803,25 @@ class ProviderSnapshotService:
             "skipped_yahoo_field_symbols": skipped_yahoo_field_symbols,
         }
 
+    def hydrate_all_published_snapshots(
+        self,
+        db: Session,
+        *,
+        allow_yahoo_hydration: bool = True,
+    ) -> Dict[str, Dict[str, Any]]:
+        """Hydrate every market-scoped weekly reference snapshot that is currently published."""
+        results: Dict[str, Dict[str, Any]] = {}
+        for snapshot_key in self.weekly_reference_snapshot_keys():
+            if self.get_published_run(db, snapshot_key=snapshot_key) is None:
+                continue
+            market = self.market_for_snapshot_key(snapshot_key)
+            results[market] = self.hydrate_published_snapshot(
+                db,
+                snapshot_key=snapshot_key,
+                allow_yahoo_hydration=allow_yahoo_hydration,
+            )
+        return results
+
     def get_snapshot_stats(self, db: Session, snapshot_key: str = SNAPSHOT_KEY_FUNDAMENTALS) -> Dict[str, Any]:
         """Return published snapshot stats for API/status reporting."""
         run = self.get_published_run(db, snapshot_key=snapshot_key)
@@ -609,11 +854,13 @@ class ProviderSnapshotService:
         bundle_asset_name: str,
         latest_manifest_path: Path | None = None,
         snapshot_key: str = SNAPSHOT_KEY_FUNDAMENTALS,
+        market: str | None = None,
     ) -> Dict[str, Any]:
         """Export the current published fundamentals snapshot + active universe bundle."""
         run = self.get_published_run(db, snapshot_key=snapshot_key)
         if run is None:
             raise ValueError(f"No published snapshot for {snapshot_key}")
+        bundle_market = str(market or self.market_for_snapshot_key(snapshot_key)).strip().upper()
 
         coverage = json.loads(run.coverage_stats_json) if run.coverage_stats_json else None
         parity = json.loads(run.parity_stats_json) if run.parity_stats_json else None
@@ -621,7 +868,10 @@ class ProviderSnapshotService:
 
         active_universe_rows = (
             db.query(StockUniverse)
-            .filter(StockUniverse.active_filter())
+            .filter(
+                StockUniverse.active_filter(),
+                StockUniverse.market == bundle_market,
+            )
             .order_by(StockUniverse.symbol.asc())
             .all()
         )
@@ -655,6 +905,7 @@ class ProviderSnapshotService:
 
         bundle_payload = {
             "schema_version": self.WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION,
+            "market": bundle_market,
             "generated_at": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
             "as_of_date": (
                 (run.published_at or run.created_at).date().isoformat()
@@ -685,6 +936,7 @@ class ProviderSnapshotService:
         sha256 = hashlib.sha256(output_path.read_bytes()).hexdigest()
         manifest = {
             "schema_version": self.WEEKLY_REFERENCE_MANIFEST_SCHEMA_VERSION,
+            "market": bundle_market,
             "generated_at": bundle_payload["generated_at"],
             "as_of_date": bundle_payload["as_of_date"],
             "source_revision": run.source_revision,
@@ -708,6 +960,7 @@ class ProviderSnapshotService:
             "rows": len(bundle_rows),
             "universe_rows": len(active_universe_rows),
             "as_of_date": bundle_payload["as_of_date"],
+            "market": bundle_market,
         }
 
     def import_weekly_reference_bundle(
@@ -728,36 +981,22 @@ class ProviderSnapshotService:
         snapshot_key = snapshot["snapshot_key"]
         universe_rows = payload.get("universe", [])
         snapshot_rows = snapshot.get("rows", [])
+        inferred_market = self._infer_market_from_bundle_rows(universe_rows, snapshot_rows)
+        bundle_market = str(
+            payload.get("market") or inferred_market or self.market_for_snapshot_key(snapshot_key)
+        ).strip().upper()
         coverage = snapshot.get("coverage_stats")
         parity = snapshot.get("parity_stats")
         warnings = snapshot.get("warnings")
 
-        existing_run_ids = [
-            row[0]
-            for row in db.query(ProviderSnapshotRun.id)
-            .filter(ProviderSnapshotRun.snapshot_key == snapshot_key)
-            .all()
-        ]
-        db.query(ProviderSnapshotPointer).filter(
-            ProviderSnapshotPointer.snapshot_key == snapshot_key
-        ).delete()
-        if existing_run_ids:
-            db.query(ProviderSnapshotRow).filter(
-                ProviderSnapshotRow.run_id.in_(existing_run_ids)
-            ).delete(synchronize_session=False)
-            db.query(ProviderSnapshotRun).filter(
-                ProviderSnapshotRun.id.in_(existing_run_ids)
-            ).delete(synchronize_session=False)
-        db.query(StockUniverse).delete()
+        self._replace_snapshot_key_runs(db, snapshot_key=snapshot_key)
+        imported_universe_count = self._replace_market_universe_rows(
+            db,
+            market=bundle_market,
+            rows=universe_rows,
+        )
         db.commit()
         db.expunge_all()
-
-        imported_universe = [
-            StockUniverse(**self._deserialize_universe_row(row))
-            for row in universe_rows
-        ]
-        if imported_universe:
-            db.bulk_save_objects(imported_universe)
 
         run = ProviderSnapshotRun(
             snapshot_key=snapshot["snapshot_key"],
@@ -779,7 +1018,11 @@ class ProviderSnapshotService:
         for row in snapshot_rows:
             identity = security_master_resolver.resolve_identity(
                 symbol=str(row.get("symbol") or ""),
-                market=row.get("market"),
+                market=(
+                    row.get("market")
+                    or row.get("normalized_payload", {}).get("market")
+                    or bundle_market
+                ),
                 exchange=row.get("exchange"),
                 currency=row.get("currency"),
                 timezone=row.get("timezone"),
@@ -811,8 +1054,9 @@ class ProviderSnapshotService:
             "run_id": run.id,
             "source_revision": run.source_revision,
             "rows": len(rows),
-            "universe_rows": len(universe_rows),
+            "universe_rows": imported_universe_count,
             "as_of_date": payload.get("as_of_date"),
+            "market": bundle_market,
         }
 
     @staticmethod

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -563,6 +563,7 @@ class ProviderSnapshotService:
         *,
         run_mode: str,
         snapshot_key: str = SNAPSHOT_KEY_FUNDAMENTALS,
+        market: Optional[str] = None,
         exchange_filter: Optional[str] = None,
         publish: bool = False,
         progress_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
@@ -584,12 +585,12 @@ class ProviderSnapshotService:
             progress_callback=progress_callback,
             show_finviz_progress=show_finviz_progress,
         )
-        active_symbols = {
-            row[0]
-            for row in db.query(StockUniverse.symbol).filter(
-                StockUniverse.active_filter()
-            ).all()
-        }
+        active_symbols_query = db.query(StockUniverse.symbol).filter(StockUniverse.active_filter())
+        if market is not None:
+            active_symbols_query = active_symbols_query.filter(
+                StockUniverse.market == str(market).strip().upper()
+            )
+        active_symbols = {row[0] for row in active_symbols_query.all()}
         missing_active = sorted(symbol for symbol in active_symbols if symbol not in merged_rows)
         coverage_stats = {
             "active_symbols": len(active_symbols),
@@ -835,6 +836,16 @@ class ProviderSnapshotService:
                 snapshot_key=snapshot_key,
                 allow_yahoo_hydration=allow_yahoo_hydration,
             )
+        legacy_snapshot_key = "fundamentals_v1"
+        if (
+            self.get_published_run(db, snapshot_key=legacy_snapshot_key) is not None
+            and "US" not in results
+        ):
+            results["US"] = self.hydrate_published_snapshot(
+                db,
+                snapshot_key=legacy_snapshot_key,
+                allow_yahoo_hydration=allow_yahoo_hydration,
+            )
         return results
 
     def get_snapshot_stats(self, db: Session, snapshot_key: str = SNAPSHOT_KEY_FUNDAMENTALS) -> Dict[str, Any]:
@@ -1005,72 +1016,88 @@ class ProviderSnapshotService:
         parity = snapshot.get("parity_stats")
         warnings = snapshot.get("warnings")
 
-        self._replace_snapshot_key_runs(db, snapshot_key=snapshot_key)
-        if legacy_global_bundle:
-            imported_universe_count = self._replace_all_universe_rows(
-                db,
-                rows=universe_rows,
-            )
-        else:
-            imported_universe_count = self._replace_market_universe_rows(
-                db,
-                market=bundle_market,
-                rows=universe_rows,
-            )
-        db.commit()
-        db.expunge_all()
+        try:
+            self._replace_snapshot_key_runs(db, snapshot_key=snapshot_key)
+            if legacy_global_bundle:
+                imported_universe_count = self._replace_all_universe_rows(
+                    db,
+                    rows=universe_rows,
+                )
+            else:
+                imported_universe_count = self._replace_market_universe_rows(
+                    db,
+                    market=bundle_market,
+                    rows=universe_rows,
+                )
 
-        run = ProviderSnapshotRun(
-            snapshot_key=snapshot["snapshot_key"],
-            run_mode=snapshot["run_mode"],
-            status=snapshot["status"],
-            source_revision=snapshot["source_revision"],
-            coverage_stats_json=json.dumps(coverage, sort_keys=True) if coverage is not None else None,
-            parity_stats_json=json.dumps(parity, sort_keys=True) if parity is not None else None,
-            warnings_json=json.dumps(warnings, sort_keys=True) if warnings else None,
-            symbols_total=snapshot.get("symbols_total", len(snapshot_rows)),
-            symbols_published=snapshot.get("symbols_published", len(snapshot_rows)),
-            created_at=_deserialize_datetime(snapshot.get("created_at")),
-            published_at=_deserialize_datetime(snapshot.get("published_at")),
-        )
-        db.add(run)
-        db.flush()
-
-        rows = []
-        for row in snapshot_rows:
-            identity = security_master_resolver.resolve_identity(
-                symbol=str(row.get("symbol") or ""),
-                market=(
-                    row.get("market")
-                    or row.get("normalized_payload", {}).get("market")
-                    or bundle_market
-                ),
-                exchange=row.get("exchange"),
-                currency=row.get("currency"),
-                timezone=row.get("timezone"),
-                local_code=row.get("local_code"),
+            run = ProviderSnapshotRun(
+                snapshot_key=snapshot["snapshot_key"],
+                run_mode=snapshot["run_mode"],
+                status=snapshot["status"],
+                source_revision=snapshot["source_revision"],
+                coverage_stats_json=json.dumps(coverage, sort_keys=True) if coverage is not None else None,
+                parity_stats_json=json.dumps(parity, sort_keys=True) if parity is not None else None,
+                warnings_json=json.dumps(warnings, sort_keys=True) if warnings else None,
+                symbols_total=snapshot.get("symbols_total", len(snapshot_rows)),
+                symbols_published=snapshot.get("symbols_published", len(snapshot_rows)),
+                created_at=_deserialize_datetime(snapshot.get("created_at")),
+                published_at=_deserialize_datetime(snapshot.get("published_at")),
             )
-            rows.append(
-                ProviderSnapshotRow(
+            db.add(run)
+            db.flush()
+
+            rows = []
+            for row in snapshot_rows:
+                identity = security_master_resolver.resolve_identity(
+                    symbol=str(row.get("symbol") or ""),
+                    market=(
+                        row.get("market")
+                        or row.get("normalized_payload", {}).get("market")
+                        or bundle_market
+                    ),
+                    exchange=row.get("exchange"),
+                    currency=row.get("currency"),
+                    timezone=row.get("timezone"),
+                    local_code=row.get("local_code"),
+                )
+                normalized_payload = dict(row["normalized_payload"])
+                normalized_payload.update(
+                    {
+                        "symbol": identity.canonical_symbol,
+                        "market": identity.market,
+                        "exchange": identity.exchange,
+                        "currency": identity.currency,
+                        "timezone": identity.timezone,
+                        "local_code": identity.local_code,
+                    }
+                )
+                rows.append(
+                    ProviderSnapshotRow(
+                        run_id=run.id,
+                        symbol=identity.canonical_symbol,
+                        exchange=identity.exchange,
+                        row_hash=row["row_hash"],
+                        normalized_payload_json=json.dumps(
+                            normalized_payload, sort_keys=True, default=str
+                        ),
+                        raw_payload_json=None,
+                    )
+                )
+            if rows:
+                db.bulk_save_objects(rows)
+
+            db.add(
+                ProviderSnapshotPointer(
+                    snapshot_key=run.snapshot_key,
                     run_id=run.id,
-                    symbol=identity.canonical_symbol,
-                    exchange=identity.exchange,
-                    row_hash=row["row_hash"],
-                    normalized_payload_json=json.dumps(row["normalized_payload"], sort_keys=True, default=str),
-                    raw_payload_json=None,
+                    updated_at=_deserialize_datetime(snapshot.get("published_at"))
+                    or datetime.utcnow(),
                 )
             )
-        if rows:
-            db.bulk_save_objects(rows)
-
-        db.add(
-            ProviderSnapshotPointer(
-                snapshot_key=run.snapshot_key,
-                run_id=run.id,
-                updated_at=_deserialize_datetime(snapshot.get("published_at")) or datetime.utcnow(),
-            )
-        )
-        db.commit()
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
 
         return {
             "run_id": run.id,

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -152,7 +152,7 @@ def test_run_daily_refresh_can_hydrate_imported_snapshot_without_live_fundamenta
         export_script,
         "get_provider_snapshot_service",
         lambda: SimpleNamespace(
-            hydrate_published_snapshot=lambda db, allow_yahoo_hydration=False: hydrate_calls.append((db, allow_yahoo_hydration))
+            hydrate_all_published_snapshots=lambda db, allow_yahoo_hydration=False: hydrate_calls.append((db, allow_yahoo_hydration))
             or {"task": "fundamentals_hydrate"},
         ),
     )

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -709,6 +709,95 @@ def test_import_weekly_reference_bundle_preserves_other_market_universe_rows(
     db.close()
 
 
+def test_import_legacy_weekly_reference_bundle_replaces_global_universe(tmp_path):
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    db.add_all(
+        [
+            StockUniverse(
+                symbol="AAPL",
+                market="US",
+                exchange="NASDAQ",
+                is_active=True,
+                status=UNIVERSE_STATUS_ACTIVE,
+                status_reason="active",
+            ),
+            StockUniverse(
+                symbol="2330.TW",
+                market="TW",
+                exchange="TWSE",
+                is_active=True,
+                status=UNIVERSE_STATUS_ACTIVE,
+                status_reason="active",
+            ),
+        ]
+    )
+    db.commit()
+
+    service = _make_provider_snapshot_service()
+    bundle_path = tmp_path / "weekly-reference-legacy.json.gz"
+    payload = {
+        "schema_version": service.WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION,
+        "generated_at": "2026-04-11T12:00:00Z",
+        "as_of_date": "2026-04-11",
+        "snapshot": {
+            "snapshot_key": "fundamentals_v1",
+            "run_mode": "publish",
+            "status": "published",
+            "source_revision": "fundamentals_v1:20260411120000",
+            "created_at": "2026-04-11T12:00:00Z",
+            "published_at": "2026-04-11T12:00:00Z",
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "exchange": "NASDAQ",
+                    "row_hash": "row-hash-aapl",
+                    "normalized_payload": {"symbol": "AAPL", "exchange": "NASDAQ"},
+                },
+                {
+                    "symbol": "0700.HK",
+                    "exchange": "XHKG",
+                    "row_hash": "row-hash-hk",
+                    "normalized_payload": {"symbol": "0700.HK", "exchange": "XHKG"},
+                },
+            ],
+        },
+        "universe": [
+            {
+                "symbol": "AAPL",
+                "exchange": "NASDAQ",
+                "market": "US",
+                "is_active": True,
+                "status": UNIVERSE_STATUS_ACTIVE,
+            },
+            {
+                "symbol": "0700.HK",
+                "exchange": "XHKG",
+                "market": "HK",
+                "is_active": True,
+                "status": UNIVERSE_STATUS_ACTIVE,
+            },
+        ],
+    }
+    with gzip.open(bundle_path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh, sort_keys=True)
+
+    import_stats = service.import_weekly_reference_bundle(db, input_path=bundle_path)
+
+    imported_symbols = [
+        row.symbol
+        for row in db.query(StockUniverse).order_by(StockUniverse.symbol.asc()).all()
+    ]
+    imported_run = service.get_published_run(db, snapshot_key="fundamentals_v1")
+
+    assert import_stats["market"] == "MULTI"
+    assert import_stats["universe_rows"] == 2
+    assert imported_symbols == ["0700.HK", "AAPL"]
+    assert imported_run is not None
+    assert imported_run.source_revision == "fundamentals_v1:20260411120000"
+    db.close()
+
+
 def test_imported_weekly_reference_bundle_hydrates_ipo_date_back_to_database(tmp_path, monkeypatch):
     TestingSessionLocal = _make_session()
     db = TestingSessionLocal()

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -132,6 +132,61 @@ def test_create_snapshot_run_blocks_publish_when_coverage_below_threshold(monkey
     db.close()
 
 
+def test_create_snapshot_run_market_scope_ignores_other_markets(monkeypatch):
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    db.add_all(
+        [
+            StockUniverse(
+                symbol="AAPL",
+                market="US",
+                exchange="NASDAQ",
+                is_active=True,
+                status=UNIVERSE_STATUS_ACTIVE,
+                status_reason="active",
+            ),
+            StockUniverse(
+                symbol="0700.HK",
+                market="HK",
+                exchange="XHKG",
+                is_active=True,
+                status=UNIVERSE_STATUS_ACTIVE,
+                status_reason="active",
+            ),
+        ]
+    )
+    db.commit()
+
+    service = _make_provider_snapshot_service()
+    monkeypatch.setattr(
+        service,
+        "_build_snapshot_rows",
+        lambda exchange_filter=None, **kwargs: {
+            "AAPL": {
+                "exchange": "NASDAQ",
+                "row_hash": "hash-aapl",
+                "normalized_payload": {"symbol": "AAPL", "exchange": "NASDAQ"},
+                "raw_payload": {"overview": {"Ticker": "AAPL"}},
+            }
+        },
+    )
+    monkeypatch.setattr(settings, "provider_snapshot_min_active_coverage", 0.98)
+    monkeypatch.setattr(settings, "provider_snapshot_max_missing_active_symbols", 50)
+
+    result = service.create_snapshot_run(
+        db,
+        run_mode="publish",
+        market="US",
+        publish=True,
+    )
+
+    assert result["published"] is True
+    assert result["coverage"]["active_symbols"] == 1
+    assert result["coverage"]["covered_active_symbols"] == 1
+    assert result["coverage"]["missing_active_symbols"] == 0
+    db.close()
+
+
 def test_hydrate_published_snapshot_fetches_yahoo_only_fields_for_missing_scan_data():
     TestingSessionLocal = _make_session()
     db = TestingSessionLocal()
@@ -401,6 +456,43 @@ def test_hydrate_published_snapshot_emits_progress_events():
     assert progress_events[1]["stage"] == "hydrate_chunk_complete"
     assert progress_events[1]["processed_symbols"] == 1
     assert progress_events[1]["percent_complete"] == 100.0
+    db.close()
+
+
+def test_hydrate_all_published_snapshots_falls_back_to_legacy_snapshot_key():
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    run = ProviderSnapshotRun(
+        snapshot_key="fundamentals_v1",
+        run_mode="publish",
+        status="published",
+        source_revision="fundamentals_v1:20260416110000",
+        created_at=datetime.utcnow(),
+        published_at=datetime.utcnow(),
+    )
+    db.add(run)
+    db.flush()
+    db.add(
+        ProviderSnapshotPointer(
+            snapshot_key="fundamentals_v1",
+            run_id=run.id,
+        )
+    )
+    db.commit()
+
+    service = _make_provider_snapshot_service()
+    hydrate_calls: list[str] = []
+
+    def fake_hydrate(db, *, snapshot_key=ProviderSnapshotService.SNAPSHOT_KEY_FUNDAMENTALS, **kwargs):
+        hydrate_calls.append(snapshot_key)
+        return {"snapshot_key": snapshot_key}
+
+    service.hydrate_published_snapshot = fake_hydrate
+
+    result = service.hydrate_all_published_snapshots(db, allow_yahoo_hydration=False)
+
+    assert hydrate_calls == ["fundamentals_v1"]
+    assert result == {"US": {"snapshot_key": "fundamentals_v1"}}
     db.close()
 
 
@@ -798,6 +890,84 @@ def test_import_legacy_weekly_reference_bundle_replaces_global_universe(tmp_path
     db.close()
 
 
+def test_import_weekly_reference_bundle_rolls_back_on_error(tmp_path):
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    db.add(
+        StockUniverse(
+            symbol="AAPL",
+            market="US",
+            exchange="NASDAQ",
+            is_active=True,
+            status=UNIVERSE_STATUS_ACTIVE,
+            status_reason="active",
+        )
+    )
+    existing_run = ProviderSnapshotRun(
+        snapshot_key=ProviderSnapshotService.SNAPSHOT_KEY_FUNDAMENTALS,
+        run_mode="publish",
+        status="published",
+        source_revision="fundamentals_v1_us:20260401000000",
+        created_at=datetime.utcnow(),
+        published_at=datetime.utcnow(),
+    )
+    db.add(existing_run)
+    db.flush()
+    db.add(
+        ProviderSnapshotPointer(
+            snapshot_key=ProviderSnapshotService.SNAPSHOT_KEY_FUNDAMENTALS,
+            run_id=existing_run.id,
+        )
+    )
+    db.commit()
+
+    service = _make_provider_snapshot_service()
+    bundle_path = tmp_path / "weekly-reference-invalid.json.gz"
+    payload = {
+        "schema_version": service.WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION,
+        "market": "US",
+        "generated_at": "2026-04-11T12:00:00Z",
+        "as_of_date": "2026-04-11",
+        "snapshot": {
+            "snapshot_key": ProviderSnapshotService.SNAPSHOT_KEY_FUNDAMENTALS,
+            "run_mode": "publish",
+            "status": "published",
+            "source_revision": "fundamentals_v1_us:20260411120000",
+            "created_at": "2026-04-11T12:00:00Z",
+            "published_at": "2026-04-11T12:00:00Z",
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "exchange": "NASDAQ",
+                    "normalized_payload": {"symbol": "AAPL", "exchange": "NASDAQ", "market": "US"},
+                }
+            ],
+        },
+        "universe": [
+            {
+                "symbol": "AAPL",
+                "exchange": "NASDAQ",
+                "market": "US",
+                "is_active": True,
+                "status": UNIVERSE_STATUS_ACTIVE,
+            }
+        ],
+    }
+    with gzip.open(bundle_path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh, sort_keys=True)
+
+    with pytest.raises(KeyError):
+        service.import_weekly_reference_bundle(db, input_path=bundle_path)
+
+    original_run = service.get_published_run(db)
+    symbols = [row.symbol for row in db.query(StockUniverse).order_by(StockUniverse.symbol.asc()).all()]
+
+    assert original_run is not None
+    assert original_run.source_revision == "fundamentals_v1_us:20260401000000"
+    assert symbols == ["AAPL"]
+    db.close()
+
+
 def test_imported_weekly_reference_bundle_hydrates_ipo_date_back_to_database(tmp_path, monkeypatch):
     TestingSessionLocal = _make_session()
     db = TestingSessionLocal()
@@ -929,8 +1099,15 @@ def test_import_weekly_reference_bundle_canonicalizes_snapshot_row_symbol(tmp_pa
 
     run = service.get_published_run(db)
     row = db.query(ProviderSnapshotRow).filter(ProviderSnapshotRow.run_id == run.id).one()
+    payload = json.loads(row.normalized_payload_json)
     assert row.symbol == "3008.TWO"
     assert row.exchange == "TPEX"
+    assert payload["symbol"] == "3008.TWO"
+    assert payload["market"] == "TW"
+    assert payload["exchange"] == "TPEX"
+    assert payload["currency"] == "TWD"
+    assert payload["timezone"] == "Asia/Taipei"
+    assert payload["local_code"] == "3008"
     db.close()
 
 

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -5,6 +5,7 @@ import json
 from datetime import date, datetime
 from unittest.mock import MagicMock
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -493,7 +494,7 @@ def test_weekly_reference_bundle_round_trips_active_universe_and_enriched_snapsh
         snapshot_key=ProviderSnapshotService.SNAPSHOT_KEY_FUNDAMENTALS,
         run_mode="publish",
         status="published",
-        source_revision="fundamentals_v1:20260402081000",
+        source_revision="fundamentals_v1_us:20260402081000",
         coverage_stats_json=json.dumps({"active_symbols": 1, "covered_active_symbols": 1, "missing_active_symbols": 0}),
         parity_stats_json=json.dumps({"missing_active_symbols": []}),
         warnings_json=json.dumps([]),
@@ -550,30 +551,22 @@ def test_weekly_reference_bundle_round_trips_active_universe_and_enriched_snapsh
         payload = json.load(fh)
 
     assert export_stats["rows"] == 1
-    assert export_stats["universe_rows"] == 2
+    assert export_stats["universe_rows"] == 1
+    assert export_stats["market"] == "US"
     assert payload["schema_version"] == ProviderSnapshotService.WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION
+    assert payload["market"] == "US"
     assert len(payload["snapshot"]["rows"]) == 1
     assert payload["snapshot"]["rows"][0]["normalized_payload"]["ipo_date"] == "2020-01-02"
     assert payload["snapshot"]["rows"][0]["normalized_payload"]["description_yfinance"] == "Long summary"
-    assert len(payload["universe"]) == 2
-    hk_row = next(row for row in payload["universe"] if row["symbol"] == "0700.HK")
-    assert hk_row["market"] == "HK"
-    assert hk_row["currency"] == "HKD"
-    assert hk_row["timezone"] == "Asia/Hong_Kong"
-    assert hk_row["local_code"] == "0700"
-
-    # Simulate legacy bundle row with market absent and currency/timezone missing.
-    hk_row.pop("market", None)
-    hk_row["exchange"] = " sehk "
-    hk_row.pop("currency", None)
-    hk_row.pop("timezone", None)
-    hk_row.pop("local_code", None)
-    with gzip.open(bundle_path, "wt", encoding="utf-8") as fh:
-        json.dump(payload, fh, sort_keys=True, default=str)
+    assert len(payload["universe"]) == 1
+    us_row = payload["universe"][0]
+    assert us_row["symbol"] == "AAPL"
+    assert us_row["market"] == "US"
 
     manifest = json.loads(latest_manifest_path.read_text(encoding="utf-8"))
     assert manifest["bundle_asset_name"] == bundle_path.name
     assert manifest["sha256"]
+    assert manifest["market"] == "US"
 
     unrelated_run = ProviderSnapshotRun(
         snapshot_key="other_snapshot",
@@ -611,15 +604,12 @@ def test_weekly_reference_bundle_round_trips_active_universe_and_enriched_snapsh
     imported_hk_row = next(row for row in imported_universe_rows if row.symbol == "0700.HK")
 
     assert import_stats["rows"] == 1
-    assert import_stats["universe_rows"] == 2
-    assert imported_run.source_revision == "fundamentals_v1:20260402081000"
+    assert import_stats["universe_rows"] == 1
+    assert import_stats["market"] == "US"
+    assert imported_run.source_revision == "fundamentals_v1_us:20260402081000"
     assert imported_payload["ipo_date"] == "2020-01-02"
     assert imported_symbols == ["0700.HK", "AAPL"]
     assert imported_hk_row.market == "HK"
-    # Missing bundle values should hydrate from market-aware defaults.
-    assert imported_hk_row.currency == "HKD"
-    assert imported_hk_row.timezone == "Asia/Hong_Kong"
-    assert imported_hk_row.local_code == "0700"
     assert db.query(ProviderSnapshotRun).filter(
         ProviderSnapshotRun.snapshot_key == ProviderSnapshotService.SNAPSHOT_KEY_FUNDAMENTALS
     ).count() == 1
@@ -627,6 +617,95 @@ def test_weekly_reference_bundle_round_trips_active_universe_and_enriched_snapsh
         ProviderSnapshotRun.snapshot_key == "other_snapshot"
     ).count() == 1
     assert db.query(ProviderSnapshotPointer).count() == 2
+    db.close()
+
+
+@pytest.mark.parametrize(
+    ("market", "symbol", "exchange", "expected_symbols"),
+    [
+        ("HK", "0700.HK", "XHKG", ["0700.HK", "AAPL", "2330.TW"]),
+        ("JP", "7203.T", "XTKS", ["2330.TW", "7203.T", "AAPL"]),
+    ],
+)
+def test_import_weekly_reference_bundle_preserves_other_market_universe_rows(
+    tmp_path,
+    market,
+    symbol,
+    exchange,
+    expected_symbols,
+):
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    db.add_all(
+        [
+            StockUniverse(
+                symbol="AAPL",
+                market="US",
+                exchange="NASDAQ",
+                is_active=True,
+                status=UNIVERSE_STATUS_ACTIVE,
+                status_reason="active",
+            ),
+            StockUniverse(
+                symbol="2330.TW",
+                market="TW",
+                exchange="TWSE",
+                is_active=True,
+                status=UNIVERSE_STATUS_ACTIVE,
+                status_reason="active",
+            ),
+        ]
+    )
+    db.commit()
+
+    service = _make_provider_snapshot_service()
+    snapshot_key = ProviderSnapshotService.snapshot_key_for_market(market)
+    bundle_path = tmp_path / f"weekly-reference-{market.lower()}.json.gz"
+    payload = {
+        "schema_version": service.WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION,
+        "market": market,
+        "generated_at": "2026-04-11T12:00:00Z",
+        "as_of_date": "2026-04-11",
+        "snapshot": {
+            "snapshot_key": snapshot_key,
+            "run_mode": "publish",
+            "status": "published",
+            "source_revision": f"{snapshot_key}:20260411120000",
+            "created_at": "2026-04-11T12:00:00Z",
+            "published_at": "2026-04-11T12:00:00Z",
+            "rows": [
+                {
+                    "symbol": symbol,
+                    "exchange": exchange,
+                    "row_hash": "row-hash-1",
+                    "normalized_payload": {
+                        "symbol": symbol,
+                        "exchange": exchange,
+                        "market": market,
+                    },
+                }
+            ],
+        },
+        "universe": [
+            {
+                "symbol": symbol,
+                "exchange": exchange,
+                "market": market,
+                "is_active": True,
+                "status": UNIVERSE_STATUS_ACTIVE,
+            }
+        ],
+    }
+    with gzip.open(bundle_path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh, sort_keys=True)
+
+    service.import_weekly_reference_bundle(db, input_path=bundle_path)
+
+    imported_symbols = [
+        row.symbol
+        for row in db.query(StockUniverse).order_by(StockUniverse.symbol.asc()).all()
+    ]
+    assert imported_symbols == sorted(expected_symbols)
     db.close()
 
 

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -496,6 +496,38 @@ def test_hydrate_all_published_snapshots_falls_back_to_legacy_snapshot_key():
     db.close()
 
 
+def test_get_snapshot_stats_falls_back_to_legacy_snapshot_key():
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    run = ProviderSnapshotRun(
+        snapshot_key="fundamentals_v1",
+        run_mode="publish",
+        status="published",
+        source_revision="fundamentals_v1:20260416110000",
+        coverage_stats_json=json.dumps({"active_symbols": 1, "covered_active_symbols": 1}),
+        parity_stats_json=json.dumps({"missing_active_symbols": []}),
+        created_at=datetime.utcnow(),
+        published_at=datetime.utcnow(),
+    )
+    db.add(run)
+    db.flush()
+    db.add(
+        ProviderSnapshotPointer(
+            snapshot_key="fundamentals_v1",
+            run_id=run.id,
+        )
+    )
+    db.commit()
+
+    service = _make_provider_snapshot_service()
+    stats = service.get_snapshot_stats(db)
+
+    assert stats["published_snapshot_revision"] == "fundamentals_v1:20260416110000"
+    assert stats["snapshot_coverage"] == {"active_symbols": 1, "covered_active_symbols": 1}
+    assert stats["parity_summary"] == {"missing_active_symbols": []}
+    db.close()
+
+
 def test_snapshot_active_coverage_ignores_status_active_rows_marked_inactive(monkeypatch):
     TestingSessionLocal = _make_session()
     db = TestingSessionLocal()

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -38,7 +38,7 @@ def test_build_weekly_reference_bundle_runs_us_publish_hydrate_and_export(monkey
         populate_universe=lambda db: {"added": 10},
     )
     provider_snapshot_service = SimpleNamespace(
-        create_snapshot_run=lambda db, run_mode, publish, snapshot_key, **kwargs: (
+        create_snapshot_run=lambda db, run_mode, publish, snapshot_key, market, **kwargs: (
             kwargs["progress_callback"](
                 {
                     "stage": "snapshot_fetch_complete",
@@ -54,6 +54,7 @@ def test_build_weekly_reference_bundle_runs_us_publish_hydrate_and_export(monkey
                 "published": True,
                 "source_revision": "fundamentals_v1_us:20260404121000",
                 "snapshot_key": snapshot_key,
+                "market": market,
             }
         ),
         hydrate_published_snapshot=lambda db, snapshot_key, allow_yahoo_hydration=True, **kwargs: (

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -5,6 +5,9 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
 
 import app.scripts.build_weekly_reference_bundle as build_script
 import app.scripts.import_weekly_reference_bundle as import_script
@@ -12,11 +15,22 @@ import app.scripts.load_ibd_industry_groups as load_ibd_script
 
 
 @contextmanager
-def _fake_session():
-    yield "db-session"
+def _fake_session(db="db-session"):
+    yield db
 
 
-def test_build_weekly_reference_bundle_runs_publish_hydrate_and_export(monkeypatch, tmp_path, capsys):
+def test_build_weekly_reference_bundle_requires_market(monkeypatch, tmp_path):
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["build_weekly_reference_bundle", "--output-dir", str(tmp_path)],
+    )
+
+    with pytest.raises(SystemExit):
+        build_script.main()
+
+
+def test_build_weekly_reference_bundle_runs_us_publish_hydrate_and_export(monkeypatch, tmp_path, capsys):
     published_at = datetime(2026, 4, 4, 12, 10, 0)
     monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
     monkeypatch.setattr(build_script, "SessionLocal", _fake_session)
@@ -24,7 +38,7 @@ def test_build_weekly_reference_bundle_runs_publish_hydrate_and_export(monkeypat
         populate_universe=lambda db: {"added": 10},
     )
     provider_snapshot_service = SimpleNamespace(
-        create_snapshot_run=lambda db, run_mode, publish, **kwargs: (
+        create_snapshot_run=lambda db, run_mode, publish, snapshot_key, **kwargs: (
             kwargs["progress_callback"](
                 {
                     "stage": "snapshot_fetch_complete",
@@ -36,9 +50,13 @@ def test_build_weekly_reference_bundle_runs_publish_hydrate_and_export(monkeypat
                     "rows": 20,
                 }
             )
-            or {"published": True, "source_revision": "fundamentals_v1:20260404121000"}
+            or {
+                "published": True,
+                "source_revision": "fundamentals_v1_us:20260404121000",
+                "snapshot_key": snapshot_key,
+            }
         ),
-        hydrate_published_snapshot=lambda db, allow_yahoo_hydration=True, **kwargs: (
+        hydrate_published_snapshot=lambda db, snapshot_key, allow_yahoo_hydration=True, **kwargs: (
             kwargs["progress_callback"](
                 {
                     "stage": "hydrate_start",
@@ -64,46 +82,183 @@ def test_build_weekly_reference_bundle_runs_publish_hydrate_and_export(monkeypat
                     "skipped_yahoo_field_symbols": 1,
                 }
             )
-            or {"hydrated": 10}
+            or {"hydrated": 10, "snapshot_key": snapshot_key}
         ),
-        get_published_run=lambda db: type(
+        get_published_run=lambda db, snapshot_key: type(
             "Run",
             (),
             {
                 "published_at": published_at,
                 "created_at": published_at,
-                "source_revision": "fundamentals_v1:20260404121000",
+                "source_revision": "fundamentals_v1_us:20260404121000",
             },
         )(),
     )
     monkeypatch.setattr(build_script, "get_stock_universe_service", lambda: stock_universe_service)
     monkeypatch.setattr(build_script, "get_provider_snapshot_service", lambda: provider_snapshot_service)
 
-    export_calls: list[tuple[Path, str, Path]] = []
+    export_calls: list[dict[str, object]] = []
 
-    def fake_export(db, *, output_path, bundle_asset_name, latest_manifest_path):
-        export_calls.append((output_path, bundle_asset_name, latest_manifest_path))
-        latest_manifest_path.write_text(json.dumps({"bundle_asset_name": bundle_asset_name}), encoding="utf-8")
-        output_path.write_bytes(b"bundle")
-        return {"bundle_path": str(output_path)}
+    def fake_export(db, **kwargs):
+        export_calls.append(kwargs)
+        kwargs["latest_manifest_path"].write_text(
+            json.dumps({"bundle_asset_name": kwargs["bundle_asset_name"]}),
+            encoding="utf-8",
+        )
+        kwargs["output_path"].write_bytes(b"bundle")
+        return {"bundle_path": str(kwargs["output_path"])}
 
     provider_snapshot_service.export_weekly_reference_bundle = fake_export
 
     monkeypatch.setattr(
         "sys.argv",
-        ["build_weekly_reference_bundle", "--output-dir", str(tmp_path)],
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "US",
+            "--output-dir",
+            str(tmp_path),
+        ],
     )
 
     assert build_script.main() == 0
-    assert export_calls[0][0] == tmp_path / "weekly-reference-20260404-fundamentals_v1-20260404121000.json.gz"
-    assert export_calls[0][1] == "weekly-reference-20260404-fundamentals_v1-20260404121000.json.gz"
-    assert export_calls[0][2] == tmp_path / build_script.ProviderSnapshotService.WEEKLY_REFERENCE_LATEST_MANIFEST_NAME
+    assert export_calls[0]["output_path"] == (
+        tmp_path / "weekly-reference-us-20260404-fundamentals_v1_us-20260404121000.json.gz"
+    )
+    assert export_calls[0]["bundle_asset_name"] == (
+        "weekly-reference-us-20260404-fundamentals_v1_us-20260404121000.json.gz"
+    )
+    assert export_calls[0]["latest_manifest_path"] == tmp_path / "weekly-reference-latest-us.json"
+    assert export_calls[0]["snapshot_key"] == build_script.ProviderSnapshotService.snapshot_key_for_market("US")
+    assert export_calls[0]["market"] == "US"
     stdout = capsys.readouterr().out
     assert "Starting stock universe refresh from Finviz..." in stdout
     assert "[snapshot] 1/12 (8.3%) NYSE overview rows=20" in stdout
     assert "[hydrate] starting 10 symbols in 1 chunks (chunk_size=200)" in stdout
     assert "[hydrate] chunk 1/1 processed 10/10 (100.0%)" in stdout
-    assert "Weekly reference bundle complete:" in stdout
+    assert "Weekly reference bundle complete for US:" in stdout
+
+
+def test_build_weekly_reference_bundle_runs_hk_official_path(monkeypatch, tmp_path, capsys):
+    published_at = datetime(2026, 4, 4, 12, 10, 0)
+    active_rows = [
+        SimpleNamespace(
+            symbol="0700.HK",
+            market="HK",
+            exchange="XHKG",
+            name="Tencent",
+            sector="Technology",
+            industry="Internet Content & Information",
+            market_cap=456.0,
+        )
+    ]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.order_by.return_value.all.return_value = active_rows
+    fake_db = MagicMock()
+    fake_db.query.return_value = fake_query
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+
+    fetch_calls: list[str] = []
+    official_service = SimpleNamespace(
+        fetch_market_snapshot=lambda market: fetch_calls.append(market)
+        or SimpleNamespace(
+            market=market,
+            source_name="hkex_official",
+            snapshot_id="hkex-listofsecurities-2026-04-04",
+            snapshot_as_of="2026-04-04",
+            source_metadata={"source_urls": ["https://example.com"]},
+            rows=(
+                {
+                    "symbol": "0700.HK",
+                    "name": "Tencent",
+                    "exchange": "XHKG",
+                    "sector": "",
+                    "industry": "",
+                    "market_cap": None,
+                },
+            ),
+        )
+    )
+    monkeypatch.setattr(build_script, "OfficialMarketUniverseSourceService", lambda: official_service)
+
+    stock_universe_service = SimpleNamespace(
+        ingest_hk_snapshot_rows=lambda db, **kwargs: {"added": 1, "updated": 0, "deactivated": 0},
+    )
+    monkeypatch.setattr(build_script, "get_stock_universe_service", lambda: stock_universe_service)
+
+    hybrid_calls: list[dict[str, object]] = []
+    hybrid_service = SimpleNamespace(
+        fetch_fundamentals_batch=lambda symbols, **kwargs: hybrid_calls.append(
+            {"symbols": symbols, **kwargs}
+        )
+        or {"0700.HK": {"market_cap": 456.0, "sector": "Technology"}},
+        store_all_caches=lambda *args, **kwargs: {"fundamentals_stored": 1, "failed": 0},
+    )
+    monkeypatch.setattr(build_script, "get_hybrid_fundamentals_service", lambda: hybrid_service)
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_many=lambda symbols: {"0700.HK": {"market_cap": 456.0, "sector": "Technology"}}),
+    )
+
+    published_rows: list[dict[str, object]] = []
+    export_calls: list[dict[str, object]] = []
+    provider_snapshot_service = SimpleNamespace(
+        build_market_snapshot_row=lambda **kwargs: {
+            "symbol": kwargs["symbol"],
+            "exchange": kwargs["exchange"],
+            "row_hash": "row-hash",
+            "normalized_payload": kwargs["normalized_payload"],
+            "raw_payload": kwargs["raw_payload"],
+        },
+        publish_market_snapshot_run=lambda db, **kwargs: published_rows.append(kwargs)
+        or {
+            "published": True,
+            "source_revision": "fundamentals_v1_hk:20260404121000",
+            "snapshot_key": kwargs["snapshot_key"],
+        },
+        get_published_run=lambda db, snapshot_key: type(
+            "Run",
+            (),
+            {
+                "published_at": published_at,
+                "created_at": published_at,
+                "source_revision": "fundamentals_v1_hk:20260404121000",
+            },
+        )(),
+        export_weekly_reference_bundle=lambda db, **kwargs: export_calls.append(kwargs)
+        or {"bundle_path": str(kwargs["output_path"])},
+    )
+    monkeypatch.setattr(build_script, "get_provider_snapshot_service", lambda: provider_snapshot_service)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "HK",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert build_script.main() == 0
+    assert fetch_calls == ["HK"]
+    assert hybrid_calls[0]["include_finviz"] is False
+    assert hybrid_calls[0]["market_by_symbol"] == {"0700.HK": "HK"}
+    assert published_rows[0]["snapshot_key"] == build_script.ProviderSnapshotService.snapshot_key_for_market("HK")
+    assert published_rows[0]["market"] == "HK"
+    assert export_calls[0]["output_path"] == (
+        tmp_path / "weekly-reference-hk-20260404-fundamentals_v1_hk-20260404121000.json.gz"
+    )
+    assert export_calls[0]["latest_manifest_path"] == tmp_path / "weekly-reference-latest-hk.json"
+    assert export_calls[0]["market"] == "HK"
+    stdout = capsys.readouterr().out
+    assert "Starting official universe refresh for HK..." in stdout
+    assert "Starting hybrid fundamentals refresh for HK..." in stdout
+    assert "Weekly reference bundle complete for HK:" in stdout
 
 
 def test_import_weekly_reference_bundle_script_calls_service(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- split the weekly reference-data pipeline into separate market-scoped bundles for `US`, `HK`, `JP`, and `TW`
- keep `US` on the Finviz snapshot path while building Asia bundles from the official universe adapters plus hybrid fundamentals
- make weekly reference import/export market-scoped so static-site builds can import all four bundles without deleting other markets
- add a transition-safe static-site fallback for legacy single-bundle releases and preserve legacy `fundamentals_v1` bundle imports

## Verification
- `cd backend && TMPDIR=/Users/admin/StockScreenClaude/.tmp ./venv/bin/python -m pytest -q tests/unit/test_weekly_reference_scripts.py tests/unit/test_provider_snapshot_service.py tests/unit/test_export_static_site_script.py`
- `cd backend && TMPDIR=/Users/admin/StockScreenClaude/.tmp ./venv/bin/python -m pytest -q tests/unit/test_provider_snapshot_service.py tests/unit/test_weekly_reference_scripts.py tests/unit/test_export_static_site_script.py tests/unit/test_celery_config.py`
- `git diff --check -- .github/workflows/static-site.yml backend/app/services/provider_snapshot_service.py backend/tests/unit/test_provider_snapshot_service.py`

## Notes
- includes backward-compatible handling for legacy `weekly-reference-latest.json` / `fundamentals_v1` bundles during rollout
- branch tip: `c7b9d59c`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market-scoped weekly reference bundles for US, HK, JP, and TW with market-specific manifests and bundle names.
  * Per-market publish/import flows so bundles are built, verified, and imported per market.

* **Chores**
  * CI now ensures a release exists and publishes market-specific bundle artifacts.

* **Tests**
  * Expanded and updated tests covering market-scoped build, import/export, and legacy fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->