### PR TITLE
Reduce static-site and weekly reference build runtime

### DIFF
--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -22,8 +22,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release view weekly-reference-data >/dev/null 2>&1 || \
+          gh release view weekly-reference-data \
+            --repo "${{ github.repository }}" >/dev/null 2>&1 || \
           gh release create weekly-reference-data \
+            --repo "${{ github.repository }}" \
             --title "Weekly Reference Data" \
             --notes "Automated weekly market-scoped reference bundles for static-site builds."
 


### PR DESCRIPTION
## Summary
- remove the daily published-snapshot hydration pass and switch static exports to a price-delta flow
- import weekly reference bundles directly into local fundamentals storage and tighten import failure handling
- avoid redundant weekly release/bootstrap and seeded bundle regressions, including explicit gh repo context in CI

## Testing
- backend/venv/bin/pytest -q backend/tests/unit/test_weekly_reference_scripts.py backend/tests/unit/test_export_static_site_script.py backend/tests/unit/test_feature_store_tasks.py backend/tests/unit/test_provider_snapshot_service.py backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
- backend/venv/bin/pytest -q backend/tests/unit/test_feature_store_tasks.py backend/tests/unit/test_provider_snapshot_service.py backend/tests/unit/test_weekly_reference_scripts.py
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow configuration for better reliability and explicit repository targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->