### PR TITLE
Add market-scoped static site bundles

### DIFF
--- a/backend/app/domain/feature_store/ports.py
+++ b/backend/app/domain/feature_store/ports.py
@@ -93,7 +93,11 @@ class FeatureRunRepository(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def publish_atomically(self, run_id: int) -> FeatureRunDomain:
+    def publish_atomically(
+        self,
+        run_id: int,
+        pointer_key: str = "latest_published",
+    ) -> FeatureRunDomain:
         """Transition COMPLETED|QUARANTINED → PUBLISHED and update the pointer.
 
         Both the status change and the pointer swap happen in the same
@@ -107,8 +111,11 @@ class FeatureRunRepository(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_latest_published(self) -> FeatureRunDomain | None:
-        """Return the run pointed to by 'latest_published', or None."""
+    def get_latest_published(
+        self,
+        pointer_key: str = "latest_published",
+    ) -> FeatureRunDomain | None:
+        """Return the run pointed to by *pointer_key*, or None."""
         ...
 
     @abc.abstractmethod

--- a/backend/app/infra/db/repositories/feature_run_repo.py
+++ b/backend/app/infra/db/repositories/feature_run_repo.py
@@ -119,7 +119,11 @@ class SqlFeatureRunRepository(FeatureRunRepository):
         self._session.flush()
         return self._to_domain(row)
 
-    def publish_atomically(self, run_id) -> FeatureRunDomain:
+    def publish_atomically(
+        self,
+        run_id,
+        pointer_key: str = "latest_published",
+    ) -> FeatureRunDomain:
         row = self._get_or_raise(run_id)
         validate_transition(RunStatus(row.status), RunStatus.PUBLISHED)
 
@@ -130,11 +134,11 @@ class SqlFeatureRunRepository(FeatureRunRepository):
         # Upsert the pointer in the same flush
         pointer = (
             self._session.query(FeatureRunPointer)
-            .filter(FeatureRunPointer.key == "latest_published")
+            .filter(FeatureRunPointer.key == pointer_key)
             .first()
         )
         if pointer is None:
-            pointer = FeatureRunPointer(key="latest_published", run_id=run_id)
+            pointer = FeatureRunPointer(key=pointer_key, run_id=run_id)
             self._session.add(pointer)
         else:
             pointer.run_id = run_id
@@ -142,10 +146,13 @@ class SqlFeatureRunRepository(FeatureRunRepository):
         self._session.flush()
         return self._to_domain(row)
 
-    def get_latest_published(self) -> FeatureRunDomain | None:
+    def get_latest_published(
+        self,
+        pointer_key: str = "latest_published",
+    ) -> FeatureRunDomain | None:
         pointer = (
             self._session.query(FeatureRunPointer)
-            .filter(FeatureRunPointer.key == "latest_published")
+            .filter(FeatureRunPointer.key == pointer_key)
             .first()
         )
         if pointer is None:

--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -26,19 +26,34 @@ logger = logging.getLogger(__name__)
 
 def _upsert_feature_run_pointer(*, session_factory, pointer_key: str, run_id: int) -> None:
     """Ensure a published-run pointer references *run_id*."""
+    from sqlalchemy.exc import IntegrityError
+
     from app.infra.db.models.feature_store import FeatureRunPointer
 
     with session_factory() as db:
-        pointer = (
-            db.query(FeatureRunPointer)
-            .filter(FeatureRunPointer.key == pointer_key)
-            .first()
-        )
-        if pointer is None:
-            db.add(FeatureRunPointer(key=pointer_key, run_id=run_id))
-        else:
-            pointer.run_id = run_id
-        db.commit()
+        try:
+            pointer = (
+                db.query(FeatureRunPointer)
+                .filter(FeatureRunPointer.key == pointer_key)
+                .first()
+            )
+            if pointer is None:
+                db.add(FeatureRunPointer(key=pointer_key, run_id=run_id))
+            else:
+                pointer.run_id = run_id
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            pointer = (
+                db.query(FeatureRunPointer)
+                .filter(FeatureRunPointer.key == pointer_key)
+                .first()
+            )
+            if pointer is None:
+                db.add(FeatureRunPointer(key=pointer_key, run_id=run_id))
+            else:
+                pointer.run_id = run_id
+            db.commit()
 
 
 def _fail_stale_feature_runs(*, session_factory, stale_after_minutes: int) -> int:

--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -24,6 +24,23 @@ from app.tasks.data_fetch_lock import serialized_data_fetch
 logger = logging.getLogger(__name__)
 
 
+def _upsert_feature_run_pointer(*, session_factory, pointer_key: str, run_id: int) -> None:
+    """Ensure a published-run pointer references *run_id*."""
+    from app.infra.db.models.feature_store import FeatureRunPointer
+
+    with session_factory() as db:
+        pointer = (
+            db.query(FeatureRunPointer)
+            .filter(FeatureRunPointer.key == pointer_key)
+            .first()
+        )
+        if pointer is None:
+            db.add(FeatureRunPointer(key=pointer_key, run_id=run_id))
+        else:
+            pointer.run_id = run_id
+        db.commit()
+
+
 def _fail_stale_feature_runs(*, session_factory, stale_after_minutes: int) -> int:
     """Fail abandoned RUNNING feature runs and emit a warning log."""
     from sqlalchemy import func
@@ -411,6 +428,11 @@ def build_daily_snapshot(
                 as_of_date=as_of,
             )
             if matching_run is not None:
+                _upsert_feature_run_pointer(
+                    session_factory=SessionLocal,
+                    pointer_key=publish_pointer_key,
+                    run_id=matching_run.id,
+                )
                 auto_scan_id = _create_auto_scan_for_published_run(
                     feature_run_id=matching_run.id,
                     universe_name=universe_name,

--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -310,6 +310,7 @@ def build_daily_snapshot(
     skip_if_published: bool = True,
     static_daily_mode: bool = False,
     market: str | None = None,
+    publish_pointer_key: str = "latest_published",
 ) -> dict:
     """Build a full feature snapshot for a trading day.
 
@@ -451,6 +452,7 @@ def build_daily_snapshot(
         static_parallel_workers=(
             settings.static_snapshot_parallel_workers if static_daily_mode else 1
         ),
+        publish_pointer_key=publish_pointer_key,
     )
 
     try:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -366,11 +366,16 @@ def _run_daily_refresh(
 
         results["feature_snapshots"] = feature_snapshots
         default_snapshot = feature_snapshots.get(STATIC_DEFAULT_MARKET, {})
+        default_snapshot_status = default_snapshot.get("status")
+        default_snapshot_ready = default_snapshot_status == "published" or (
+            default_snapshot_status == "skipped"
+            and default_snapshot.get("reason") == "already_published"
+        )
         default_run_id = (
             default_snapshot.get("run_id")
             or default_snapshot.get("existing_run_id")
         )
-        if default_run_id is not None:
+        if default_snapshot_ready and default_run_id is not None:
             _upsert_feature_run_pointer(
                 pointer_key="latest_published",
                 run_id=default_run_id,
@@ -380,6 +385,11 @@ def _run_daily_refresh(
                 "pointer_key": "latest_published",
                 "run_id": default_run_id,
             }
+        elif default_run_id is not None:
+            warnings.append(
+                f"{STATIC_DEFAULT_MARKET} feature snapshot returned status "
+                f"{default_snapshot_status!r}; 'latest_published' was not updated."
+            )
         else:
             warnings.append(
                 f"No {STATIC_DEFAULT_MARKET} feature snapshot produced a run id; "

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from sqlalchemy import func
 
 from app.database import SessionLocal
+from app.infra.db.models.feature_store import FeatureRunPointer
 from app.models.industry import IBDGroupRank
 from app.models.market_breadth import MarketBreadth
 from app.models.stock import StockPrice
@@ -36,6 +37,8 @@ STATIC_BREADTH_HISTORY_MIN_TRADING_DAYS = 20
 STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
 STATIC_BUILD_MODE_PRICE_DELTA = "price_delta"
 STATIC_BUILD_MODE_FULL = "full"
+STATIC_EXPORT_MARKETS = ("US", "HK", "JP", "TW")
+STATIC_DEFAULT_MARKET = "US"
 
 
 def _default_output_dir() -> Path:
@@ -53,6 +56,26 @@ def _resolve_latest_completed_us_trading_date() -> date:
 
 def _iter_chunks(items: list[str], chunk_size: int) -> list[list[str]]:
     return [items[index:index + chunk_size] for index in range(0, len(items), chunk_size)]
+
+
+def _market_pointer_key(market: str) -> str:
+    return f"latest_published_market:{market.upper()}"
+
+
+def _upsert_feature_run_pointer(*, pointer_key: str, run_id: int) -> None:
+    with SessionLocal() as db:
+        if not hasattr(db, "query"):
+            return
+        pointer = (
+            db.query(FeatureRunPointer)
+            .filter(FeatureRunPointer.key == pointer_key)
+            .first()
+        )
+        if pointer is None:
+            db.add(FeatureRunPointer(key=pointer_key, run_id=run_id))
+        else:
+            pointer.run_id = run_id
+        db.commit()
 
 
 def _refresh_static_daily_prices(*, as_of_date: date) -> dict[str, Any]:
@@ -301,17 +324,8 @@ def _run_daily_refresh(
 ) -> tuple[dict[str, Any], list[str]]:
     from app.interfaces.tasks.feature_store_tasks import (
         build_daily_snapshot,
-        _enrich_feature_run_with_ibd_metadata,
-    )
-    from app.tasks.breadth_tasks import (
-        allow_same_day_breadth_warmup_bypass,
-        calculate_daily_breadth,
     )
     from app.tasks.fundamentals_tasks import refresh_all_fundamentals
-    from app.tasks.group_rank_tasks import (
-        allow_same_day_group_rank_warmup_bypass,
-        calculate_daily_group_rankings,
-    )
     from app.tasks.universe_tasks import refresh_stock_universe
 
     warnings: list[str] = []
@@ -339,31 +353,32 @@ def _run_daily_refresh(
             }
 
         results["price_refresh"] = _refresh_static_daily_prices(as_of_date=as_of_date)
-        results["feature_snapshot"] = build_daily_snapshot.run(
-            as_of_date_str=as_of_date.isoformat(),
-            static_daily_mode=True,
+        feature_snapshots: dict[str, Any] = {}
+        for market in STATIC_EXPORT_MARKETS:
+            market_result = build_daily_snapshot.run(
+                as_of_date_str=as_of_date.isoformat(),
+                static_daily_mode=True,
+                universe_name=f"market:{market.lower()}",
+                market=market,
+                publish_pointer_key=_market_pointer_key(market),
+            )
+            feature_snapshots[market] = market_result
+
+        results["feature_snapshots"] = feature_snapshots
+        default_run_id = (
+            feature_snapshots.get(STATIC_DEFAULT_MARKET, {}).get("run_id")
+            or feature_snapshots.get(STATIC_DEFAULT_MARKET, {}).get("existing_run_id")
         )
-        with allow_same_day_breadth_warmup_bypass():
-            results["breadth_refresh"] = calculate_daily_breadth.run(
-                calculation_date=as_of_date.isoformat(),
-                force_cache_only=True,
+        if default_run_id is not None:
+            _upsert_feature_run_pointer(
+                pointer_key="latest_published",
+                run_id=default_run_id,
             )
-        results["breadth_history_refresh"] = _ensure_breadth_history(as_of_date=as_of_date)
-        results["groups_history_refresh"] = _ensure_group_rank_history(as_of_date=as_of_date)
-        with allow_same_day_group_rank_warmup_bypass():
-            results["groups_refresh"] = calculate_daily_group_rankings.run(
-                calculation_date=as_of_date.isoformat(),
-                force_cache_only=True,
-            )
-        feature_run_id = (
-            results.get("feature_snapshot", {}).get("run_id")
-            or results.get("feature_snapshot", {}).get("existing_run_id")
-        )
-        if feature_run_id is not None:
-            results["feature_metadata_refresh"] = _enrich_feature_run_with_ibd_metadata(
-                feature_run_id=feature_run_id,
-                ranking_date=as_of_date,
-            )
+            results["default_market_pointer"] = {
+                "market": STATIC_DEFAULT_MARKET,
+                "pointer_key": "latest_published",
+                "run_id": default_run_id,
+            }
 
     return results, warnings
 

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -365,9 +365,10 @@ def _run_daily_refresh(
             feature_snapshots[market] = market_result
 
         results["feature_snapshots"] = feature_snapshots
+        default_snapshot = feature_snapshots.get(STATIC_DEFAULT_MARKET, {})
         default_run_id = (
-            feature_snapshots.get(STATIC_DEFAULT_MARKET, {}).get("run_id")
-            or feature_snapshots.get(STATIC_DEFAULT_MARKET, {}).get("existing_run_id")
+            default_snapshot.get("run_id")
+            or default_snapshot.get("existing_run_id")
         )
         if default_run_id is not None:
             _upsert_feature_run_pointer(
@@ -379,6 +380,11 @@ def _run_daily_refresh(
                 "pointer_key": "latest_published",
                 "run_id": default_run_id,
             }
+        else:
+            warnings.append(
+                f"No {STATIC_DEFAULT_MARKET} feature snapshot produced a run id; "
+                "'latest_published' was not updated."
+            )
 
     return results, warnings
 

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -701,6 +701,7 @@ class StaticSiteExportService:
                 "spy_overlay": self._serialize_history_bars(
                     benchmark,
                     period_days=31,
+                    end_date=expected_as_of_date,
                 ),
             },
         }
@@ -1339,13 +1340,20 @@ class StaticSiteExportService:
         ]
 
     @staticmethod
-    def _serialize_history_bars(data: pd.DataFrame | None, *, period_days: int) -> list[dict[str, Any]]:
+    def _serialize_history_bars(
+        data: pd.DataFrame | None,
+        *,
+        period_days: int,
+        end_date: date | None = None,
+    ) -> list[dict[str, Any]]:
         if data is None or data.empty:
             return []
-        cutoff_date = pd.Timestamp(datetime.utcnow() - timedelta(days=period_days))
+        end_timestamp = pd.Timestamp(end_date or datetime.utcnow())
+        cutoff_date = end_timestamp - timedelta(days=period_days)
         if data.index.tz is not None:
             cutoff_date = cutoff_date.tz_localize(data.index.tz)
-        filtered = data[data.index >= cutoff_date]
+            end_timestamp = end_timestamp.tz_localize(data.index.tz)
+        filtered = data[(data.index >= cutoff_date) & (data.index <= end_timestamp)]
         if filtered.empty:
             return []
         frame = filtered.reset_index()
@@ -1362,6 +1370,10 @@ class StaticSiteExportService:
                 "volume": int(row["Volume"]),
             }
             for _, row in frame.iterrows()
+            if all(
+                value is not None and not math.isnan(float(value))
+                for value in (row["Open"], row["High"], row["Low"], row["Close"], row["Volume"])
+            )
         ]
 
     def _serialize_scan_row(self, row) -> dict[str, Any]:

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -1273,12 +1273,18 @@ class StaticSiteExportService:
                 history["Close"].to_numpy(),
                 index=[ts.date() for ts in pd.to_datetime(history.index)],
             )
-            close_series = close_series[~close_series.index.duplicated(keep="last")].reindex(date_index)
-            valid = close_series.notna().to_numpy()
+            close_series = close_series[~close_series.index.duplicated(keep="last")].sort_index()
             pct_1d = ((close_series / close_series.shift(1)) - 1.0) * 100.0
             pct_21d = ((close_series / close_series.shift(21)) - 1.0) * 100.0
             pct_34d = ((close_series / close_series.shift(34)) - 1.0) * 100.0
             pct_63d = ((close_series / close_series.shift(63)) - 1.0) * 100.0
+
+            close_series = close_series.reindex(date_index)
+            pct_1d = pct_1d.reindex(date_index)
+            pct_21d = pct_21d.reindex(date_index)
+            pct_34d = pct_34d.reindex(date_index)
+            pct_63d = pct_63d.reindex(date_index)
+            valid = close_series.notna().to_numpy()
 
             for index, is_valid in enumerate(valid):
                 if is_valid:

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -346,8 +346,9 @@ class StaticSiteExportService:
         }
 
     def _get_latest_published_run(self, db: Session, market: str | None = None) -> FeatureRun | None:
+        normalized_market = market.upper() if market is not None else None
         pointer_key = (
-            f"latest_published_market:{market.upper()}"
+            f"latest_published_market:{normalized_market}"
             if market is not None
             else "latest_published"
         )
@@ -358,7 +359,11 @@ class StaticSiteExportService:
         )
         if pointer is not None:
             run = db.query(FeatureRun).filter(FeatureRun.id == pointer.run_id).first()
-            if run is not None and run.status == "published":
+            if (
+                run is not None
+                and run.status == "published"
+                and (normalized_market is None or self._run_market(run) == normalized_market)
+            ):
                 return run
 
         query = (
@@ -369,7 +374,7 @@ class StaticSiteExportService:
         if market is None:
             return query.first()
         for run in query.all():
-            if self._run_market(run) == market.upper():
+            if self._run_market(run) == normalized_market:
                 return run
         return None
 
@@ -949,10 +954,14 @@ class StaticSiteExportService:
             .all()
         )
         market_runs: list[FeatureRun] = []
+        seen_dates: set[date] = set()
         for run in published_runs:
             if self._run_market(run) != normalized_market:
                 continue
+            if run.as_of_date in seen_dates:
+                continue
             market_runs.append(run)
+            seen_dates.add(run.as_of_date)
             if len(market_runs) >= max_runs:
                 break
         return market_runs

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -2,26 +2,37 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 import json
 import logging
+import math
 from pathlib import Path
 import shutil
 from typing import Any
 from urllib.parse import quote
 
+import pandas as pd
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.domain.common.query import FilterSpec, SortOrder, SortSpec
 from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer
 from app.infra.db.repositories.feature_store_repo import SqlFeatureStoreRepository
 from app.models.stock import StockPrice
-from app.schemas.groups import GroupRankResponse, GroupRankingsResponse, MoversResponse
+from app.schemas.groups import (
+    ConstituentStock,
+    GroupDetailResponse,
+    GroupRankResponse,
+    GroupRankingsResponse,
+    HistoricalDataPoint,
+    MoversResponse,
+)
 from app.schemas.scanning import FilterOptionsResponse, ScanResultItem
-from app.services.ui_snapshot_service import UISnapshotService
 from app.services.preset_screens import PRESET_SCREENS, get_preset_chart_symbols
+from app.services.ui_snapshot_service import UISnapshotService
 from app.wiring.bootstrap import (
+    get_benchmark_cache,
     get_fundamentals_cache,
     get_group_rank_service,
     get_price_cache,
@@ -30,7 +41,7 @@ from app.wiring.bootstrap import (
 
 logger = logging.getLogger(__name__)
 
-STATIC_SITE_SCHEMA_VERSION = "static-site-v1"
+STATIC_SITE_SCHEMA_VERSION = "static-site-v2"
 SCAN_BUNDLE_SCHEMA_VERSION = "static-scan-v1"
 CHART_BUNDLE_SCHEMA_VERSION = "static-charts-v1"
 SCAN_CHUNK_SIZE = 1000
@@ -41,14 +52,52 @@ STATIC_CHART_LOOKUP_BATCH_SIZE = 250
 STATIC_DEFAULT_SCAN_FILTERS = {"minVolume": 100_000_000}
 STATIC_CHART_PRESET_TOP_N = 200
 STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
-
-_DEFAULT_KEY_MARKETS = (
-    {"symbol": "SPY", "display_name": "S&P 500 ETF"},
-    {"symbol": "QQQ", "display_name": "Nasdaq 100 ETF"},
-    {"symbol": "IWM", "display_name": "Russell 2000 ETF"},
-    {"symbol": "GLD", "display_name": "Gold ETF"},
-    {"symbol": "TLT", "display_name": "20+ Year Treasury ETF"},
-)
+STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
+STATIC_DEFAULT_MARKET = "US"
+STATIC_SUPPORTED_MARKETS = ("US", "HK", "JP", "TW")
+STATIC_MARKET_DISPLAY = {
+    "US": "United States",
+    "HK": "Hong Kong",
+    "JP": "Japan",
+    "TW": "Taiwan",
+}
+STATIC_GROUP_HISTORY_RUNS = 40
+STATIC_GROUP_CHANGE_OFFSETS = {
+    "1w": 5,
+    "1m": 21,
+    "3m": 63,
+    "6m": 126,
+}
+_DEFAULT_KEY_MARKETS = {
+    "US": (
+        {"symbol": "SPY", "display_name": "S&P 500 ETF", "currency": "USD"},
+        {"symbol": "QQQ", "display_name": "Nasdaq 100 ETF", "currency": "USD"},
+        {"symbol": "IWM", "display_name": "Russell 2000 ETF", "currency": "USD"},
+        {"symbol": "GLD", "display_name": "Gold ETF", "currency": "USD"},
+        {"symbol": "TLT", "display_name": "20+ Year Treasury ETF", "currency": "USD"},
+    ),
+    "HK": (
+        {"symbol": "^HSI", "display_name": "Hang Seng Index", "currency": "HKD"},
+        {"symbol": "2800.HK", "display_name": "Tracker Fund Hong Kong", "currency": "HKD"},
+        {"symbol": "0700.HK", "display_name": "Tencent", "currency": "HKD"},
+        {"symbol": "3690.HK", "display_name": "Meituan", "currency": "HKD"},
+        {"symbol": "0941.HK", "display_name": "China Mobile", "currency": "HKD"},
+    ),
+    "JP": (
+        {"symbol": "^N225", "display_name": "Nikkei 225", "currency": "JPY"},
+        {"symbol": "1306.T", "display_name": "TOPIX ETF", "currency": "JPY"},
+        {"symbol": "7203.T", "display_name": "Toyota", "currency": "JPY"},
+        {"symbol": "6758.T", "display_name": "Sony Group", "currency": "JPY"},
+        {"symbol": "9984.T", "display_name": "SoftBank Group", "currency": "JPY"},
+    ),
+    "TW": (
+        {"symbol": "^TWII", "display_name": "TAIEX", "currency": "TWD"},
+        {"symbol": "0050.TW", "display_name": "TW50 ETF", "currency": "TWD"},
+        {"symbol": "2330.TW", "display_name": "TSMC", "currency": "TWD"},
+        {"symbol": "2317.TW", "display_name": "Hon Hai", "currency": "TWD"},
+        {"symbol": "2454.TW", "display_name": "MediaTek", "currency": "TWD"},
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -79,6 +128,7 @@ class StaticSiteExportService:
         self._ui_snapshot_service = UISnapshotService(session_factory)
         self._price_cache = get_price_cache()
         self._fundamentals_cache = get_fundamentals_cache()
+        self._benchmark_cache = get_benchmark_cache()
 
     def export(self, output_dir: Path, *, clean: bool = True) -> StaticSiteExportResult:
         output_dir = Path(output_dir)
@@ -90,55 +140,122 @@ class StaticSiteExportService:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         with self._session_factory() as db:
-            latest_run = self._get_latest_published_run(db)
-            if latest_run is None:
-                raise RuntimeError("No published feature run is available for static-site export")
+            market_entries: dict[str, dict[str, Any]] = {}
+            available_markets = [
+                market
+                for market in STATIC_SUPPORTED_MARKETS
+                if self._get_latest_published_run(db, market=market) is not None
+            ]
+            if not available_markets:
+                latest_run = self._get_latest_published_run(db)
+                if latest_run is None:
+                    raise RuntimeError("No published feature run is available for static-site export")
+                available_markets = [STATIC_DEFAULT_MARKET]
 
-            scan_rows, filter_options = self._load_scan_export_source(db, latest_run)
-            scan_manifest, serialized_rows = self._export_scan_bundle(
-                db=db,
-                output_dir=output_dir,
-                generated_at=generated_at,
-                run=latest_run,
-                rows=scan_rows,
-                filter_options=filter_options,
-            )
-            chart_manifest = self._export_chart_bundle(
-                output_dir=output_dir,
-                generated_at=generated_at,
-                run=latest_run,
-                rows=scan_rows,
-                serialized_rows=serialized_rows,
-            )
-            breadth_payload = self._build_optional_section_payload(
-                section="breadth",
-                warnings=warnings,
-                generated_at=generated_at,
-                expected_as_of_date=latest_run.as_of_date,
-                build=lambda: self._build_breadth_payload(
-                    generated_at=generated_at,
-                    expected_as_of_date=latest_run.as_of_date,
-                ),
-            )
-            groups_payload = self._build_optional_section_payload(
-                section="groups",
-                warnings=warnings,
-                generated_at=generated_at,
-                expected_as_of_date=latest_run.as_of_date,
-                build=lambda: self._build_groups_payload(
+            for market in available_markets:
+                market_entries[market] = self._export_market_bundle(
                     db=db,
+                    output_dir=output_dir,
+                    market=market,
                     generated_at=generated_at,
-                    expected_as_of_date=latest_run.as_of_date,
-                ),
-            )
-            home_payload = self._build_home_payload(
+                    warnings=warnings,
+                )
+
+        default_market = (
+            STATIC_DEFAULT_MARKET
+            if STATIC_DEFAULT_MARKET in market_entries
+            else next(iter(market_entries))
+        )
+        default_entry = market_entries[default_market]
+        manifest = {
+            "schema_version": STATIC_SITE_SCHEMA_VERSION,
+            "generated_at": generated_at,
+            "as_of_date": default_entry["as_of_date"],
+            "default_market": default_market,
+            "supported_markets": list(market_entries.keys()),
+            "features": dict(default_entry["features"]),
+            "pages": dict(default_entry["pages"]),
+            "assets": dict(default_entry["assets"]),
+            "markets": market_entries,
+            "warnings": warnings,
+        }
+        self._write_json(output_dir / "manifest.json", manifest)
+
+        return StaticSiteExportResult(
+            output_dir=output_dir,
+            generated_at=generated_at,
+            as_of_date=default_entry["as_of_date"],
+            warnings=tuple(warnings),
+            manifest=manifest,
+        )
+
+    def _export_market_bundle(
+        self,
+        *,
+        db: Session,
+        output_dir: Path,
+        market: str,
+        generated_at: str,
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        latest_run = self._get_latest_published_run(db, market=market)
+        if latest_run is None:
+            raise RuntimeError(f"No published feature run is available for static-site export market {market}")
+
+        path_prefix = Path("markets") / market.lower()
+        scan_rows, filter_options = self._load_scan_export_source(db, latest_run)
+        scan_manifest, serialized_rows = self._export_scan_bundle(
+            db=db,
+            output_dir=output_dir,
+            generated_at=generated_at,
+            run=latest_run,
+            rows=scan_rows,
+            filter_options=filter_options,
+            path_prefix=path_prefix,
+        )
+        chart_manifest = self._export_chart_bundle(
+            output_dir=output_dir,
+            generated_at=generated_at,
+            run=latest_run,
+            rows=scan_rows,
+            serialized_rows=serialized_rows,
+            path_prefix=path_prefix,
+        )
+        breadth_payload = self._build_optional_section_payload(
+            section=f"{market} breadth",
+            warnings=warnings,
+            generated_at=generated_at,
+            expected_as_of_date=latest_run.as_of_date,
+            build=lambda: self._build_breadth_payload(
+                generated_at=generated_at,
+                expected_as_of_date=latest_run.as_of_date,
+                market=market,
+                serialized_rows=serialized_rows,
+            ),
+        )
+        groups_payload = self._build_optional_section_payload(
+            section=f"{market} groups",
+            warnings=warnings,
+            generated_at=generated_at,
+            expected_as_of_date=latest_run.as_of_date,
+            build=lambda: self._build_groups_payload(
                 db=db,
                 generated_at=generated_at,
+                expected_as_of_date=latest_run.as_of_date,
+                market=market,
                 latest_run=latest_run,
-                scan_manifest=scan_manifest,
-                breadth_payload=breadth_payload,
-                groups_payload=groups_payload,
-            )
+                current_rows=scan_rows,
+                serialized_rows=serialized_rows,
+            ),
+        )
+        home_payload = self._build_home_payload(
+            generated_at=generated_at,
+            latest_run=latest_run,
+            market=market,
+            scan_manifest=scan_manifest,
+            breadth_payload=breadth_payload,
+            groups_payload=groups_payload,
+        )
 
         scan_manifest["charts"] = {
             "path": chart_manifest["path"],
@@ -146,28 +263,26 @@ class StaticSiteExportService:
             "symbols_total": chart_manifest["symbols_total"],
             "available": chart_manifest["available"],
         }
-        self._write_json(output_dir / "scan" / "manifest.json", scan_manifest)
+        self._write_json(output_dir / path_prefix / "scan" / "manifest.json", scan_manifest)
 
         skipped_chart_symbols = chart_manifest.get("skipped_symbols") or []
         if skipped_chart_symbols:
             preview = ", ".join(skipped_chart_symbols[:5])
             warnings.append(
-                "Static charts skipped "
-                f"{len(skipped_chart_symbols)} symbols without cached {STATIC_CHART_PERIOD} price history"
-                + (f": {preview}" if preview else "")
+                f"Static charts skipped {len(skipped_chart_symbols)} {market} symbols without cached "
+                f"{STATIC_CHART_PERIOD} price history" + (f": {preview}" if preview else "")
             )
 
-        breadth_path = Path("breadth.json")
-        groups_path = Path("groups.json")
-        home_path = Path("home.json")
-
+        breadth_path = path_prefix / "breadth.json"
+        groups_path = path_prefix / "groups.json"
+        home_path = path_prefix / "home.json"
         self._write_json(output_dir / breadth_path, breadth_payload)
         self._write_json(output_dir / groups_path, groups_payload)
         self._write_json(output_dir / home_path, home_payload)
 
-        manifest = {
-            "schema_version": STATIC_SITE_SCHEMA_VERSION,
-            "generated_at": generated_at,
+        return {
+            "market": market,
+            "display_name": STATIC_MARKET_DISPLAY.get(market, market),
             "as_of_date": latest_run.as_of_date.isoformat(),
             "features": {
                 "scan": True,
@@ -177,7 +292,7 @@ class StaticSiteExportService:
             },
             "pages": {
                 "home": {"path": home_path.as_posix()},
-                "scan": {"path": Path("scan/manifest.json").as_posix()},
+                "scan": {"path": (path_prefix / "scan" / "manifest.json").as_posix()},
                 "breadth": {"path": breadth_path.as_posix()},
                 "groups": {"path": groups_path.as_posix()},
             },
@@ -188,17 +303,8 @@ class StaticSiteExportService:
                     "symbols_total": chart_manifest["symbols_total"],
                 },
             },
-            "warnings": warnings,
+            "freshness": home_payload.get("freshness", {}),
         }
-        self._write_json(output_dir / "manifest.json", manifest)
-
-        return StaticSiteExportResult(
-            output_dir=output_dir,
-            generated_at=generated_at,
-            as_of_date=latest_run.as_of_date.isoformat(),
-            warnings=tuple(warnings),
-            manifest=manifest,
-        )
 
     def _build_optional_section_payload(
         self,
@@ -237,10 +343,15 @@ class StaticSiteExportService:
             "payload": {},
         }
 
-    def _get_latest_published_run(self, db: Session) -> FeatureRun | None:
+    def _get_latest_published_run(self, db: Session, market: str | None = None) -> FeatureRun | None:
+        pointer_key = (
+            f"latest_published_market:{market.upper()}"
+            if market is not None
+            else "latest_published"
+        )
         pointer = (
             db.query(FeatureRunPointer)
-            .filter(FeatureRunPointer.key == "latest_published")
+            .filter(FeatureRunPointer.key == pointer_key)
             .first()
         )
         if pointer is not None:
@@ -248,12 +359,31 @@ class StaticSiteExportService:
             if run is not None and run.status == "published":
                 return run
 
-        return (
+        query = (
             db.query(FeatureRun)
             .filter(FeatureRun.status == "published")
             .order_by(FeatureRun.published_at.desc(), FeatureRun.id.desc())
-            .first()
         )
+        if market is None:
+            return query.first()
+        for run in query.all():
+            if self._run_market(run) == market.upper():
+                return run
+        if market.upper() == STATIC_DEFAULT_MARKET:
+            return query.first()
+        return None
+
+    @staticmethod
+    def _run_market(run: FeatureRun) -> str | None:
+        config = run.config_json or {}
+        if not isinstance(config, dict):
+            return None
+        universe = config.get("universe")
+        if isinstance(universe, dict):
+            market = universe.get("market")
+            if market:
+                return str(market).upper()
+        return None
 
     def _load_scan_export_source(self, db: Session, run: FeatureRun) -> tuple[list[Any], Any]:
         repo = SqlFeatureStoreRepository(db)
@@ -275,6 +405,7 @@ class StaticSiteExportService:
         run: FeatureRun,
         rows: list[Any] | None = None,
         filter_options: Any | None = None,
+        path_prefix: Path | None = None,
     ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         if rows is None or filter_options is None:
             repo = SqlFeatureStoreRepository(db)
@@ -286,7 +417,8 @@ class StaticSiteExportService:
             )
             filter_options = repo.get_filter_options_for_run(run.id)
 
-        scan_dir = output_dir / "scan"
+        normalized_prefix = Path() if path_prefix is None else Path(path_prefix)
+        scan_dir = output_dir / normalized_prefix / "scan"
         chunk_dir = scan_dir / "chunks"
         chunk_dir.mkdir(parents=True, exist_ok=True)
 
@@ -297,7 +429,7 @@ class StaticSiteExportService:
         for index in range(0, len(serialized_rows), SCAN_CHUNK_SIZE):
             chunk_rows = serialized_rows[index:index + SCAN_CHUNK_SIZE]
             chunk_num = (index // SCAN_CHUNK_SIZE) + 1
-            rel_path = Path(f"scan/chunks/chunk-{chunk_num:04d}.json")
+            rel_path = normalized_prefix / "scan" / "chunks" / f"chunk-{chunk_num:04d}.json"
             payload = {
                 "schema_version": SCAN_BUNDLE_SCHEMA_VERSION,
                 "generated_at": generated_at,
@@ -346,8 +478,10 @@ class StaticSiteExportService:
         run: FeatureRun,
         rows: list[Any],
         serialized_rows: list[dict[str, Any]] | None = None,
+        path_prefix: Path | None = None,
     ) -> dict[str, Any]:
-        chart_dir = output_dir / "charts"
+        normalized_prefix = Path() if path_prefix is None else Path(path_prefix)
+        chart_dir = output_dir / normalized_prefix / "charts"
         chart_dir.mkdir(parents=True, exist_ok=True)
 
         entries: list[dict[str, Any]] = []
@@ -378,7 +512,7 @@ class StaticSiteExportService:
                     skipped_symbols.append(symbol)
                     continue
 
-                rel_path = self._chart_payload_path(symbol)
+                rel_path = self._chart_payload_path(symbol, path_prefix=normalized_prefix)
                 payload = {
                     "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
                     "generated_at": generated_at,
@@ -428,7 +562,7 @@ class StaticSiteExportService:
                             skipped_symbols.append(symbol)
                             continue
 
-                        rel_path = self._chart_payload_path(symbol)
+                        rel_path = self._chart_payload_path(symbol, path_prefix=normalized_prefix)
                         domain_row = row_by_symbol.get(symbol)
                         stock_data = self._serialize_scan_row(domain_row) if domain_row else ser_by_symbol.get(symbol)
                         payload = {
@@ -457,7 +591,7 @@ class StaticSiteExportService:
                     len(extra_symbols),
                 )
 
-        index_rel_path = Path("charts/index.json")
+        index_rel_path = normalized_prefix / "charts" / "index.json"
         index_payload = {
             "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
             "generated_at": generated_at,
@@ -481,25 +615,94 @@ class StaticSiteExportService:
         *,
         generated_at: str,
         expected_as_of_date: date,
+        market: str = STATIC_DEFAULT_MARKET,
+        serialized_rows: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
-        snapshot = self._ui_snapshot_service.publish_breadth_bootstrap().to_dict()
-        payload = snapshot.get("payload", {})
-        current_date = ((payload.get("current") or {}).get("date"))
-        if current_date != expected_as_of_date.isoformat():
+        if serialized_rows is None:
+            snapshot = self._ui_snapshot_service.publish_breadth_bootstrap().to_dict()
+            payload = snapshot.get("payload", {})
+            current_date = ((payload.get("current") or {}).get("date"))
+            if current_date != expected_as_of_date.isoformat():
+                raise StaticSiteSectionUnavailableError(
+                    section="breadth",
+                    reason=(
+                        "No breadth snapshot is available for static-site export date "
+                        f"{expected_as_of_date.isoformat()} (latest snapshot date: {current_date or 'none'})."
+                    ),
+                )
+            return {
+                "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                "generated_at": generated_at,
+                "available": True,
+                "published_at": _coerce_datetime(snapshot.get("published_at")),
+                "source_revision": snapshot.get("source_revision"),
+                "payload": payload,
+            }
+
+        symbols = [row["symbol"] for row in serialized_rows if row.get("symbol")]
+        if not symbols:
+            raise StaticSiteSectionUnavailableError(
+                section="breadth",
+                reason=f"No scan rows are available for market {market} on {expected_as_of_date.isoformat()}.",
+            )
+
+        benchmark = self._get_market_benchmark_history(market, period="1y")
+        if benchmark is None or benchmark.empty:
+            raise StaticSiteSectionUnavailableError(
+                section="breadth",
+                reason=f"No cached benchmark price history is available for market {market}.",
+            )
+
+        canonical_dates = [
+            ts.date()
+            for ts in pd.to_datetime(benchmark.index)
+            if ts.date() <= expected_as_of_date
+        ]
+        if expected_as_of_date not in canonical_dates:
             raise StaticSiteSectionUnavailableError(
                 section="breadth",
                 reason=(
-                    "No breadth snapshot is available for static-site export date "
-                    f"{expected_as_of_date.isoformat()} (latest snapshot date: {current_date or 'none'})."
+                    f"No benchmark trading session is available for market {market} "
+                    f"on {expected_as_of_date.isoformat()}."
                 ),
             )
+
+        canonical_dates = canonical_dates[-max(STATIC_BREADTH_HISTORY_LOOKBACK_DAYS + 15, 120):]
+        price_data = self._get_cached_price_histories(symbols, period="1y")
+        metrics_by_date = self._compute_breadth_metrics_by_date(canonical_dates, price_data)
+        current = metrics_by_date.get(expected_as_of_date)
+        if current is None:
+            raise StaticSiteSectionUnavailableError(
+                section="breadth",
+                reason=f"No breadth snapshot could be derived for market {market} on {expected_as_of_date.isoformat()}.",
+            )
+
+        ordered_dates = sorted(metrics_by_date.keys())
+        ordered_history = [metrics_by_date[item_date] for item_date in ordered_dates]
+        chart_data = ordered_history[-31:]
         return {
             "schema_version": STATIC_SITE_SCHEMA_VERSION,
             "generated_at": generated_at,
             "available": True,
-            "published_at": _coerce_datetime(snapshot.get("published_at")),
-            "source_revision": snapshot.get("source_revision"),
-            "payload": payload,
+            "published_at": _coerce_datetime(datetime.utcnow()),
+            "source_revision": f"feature-run:{market}:{expected_as_of_date.isoformat()}",
+            "market": market,
+            "payload": {
+                "current": current,
+                "summary": {
+                    "latest_date": expected_as_of_date.isoformat(),
+                    "total_records": len(ordered_history),
+                    "date_range_start": ordered_dates[0].isoformat() if ordered_dates else None,
+                    "date_range_end": ordered_dates[-1].isoformat() if ordered_dates else None,
+                },
+                "history_90d": list(reversed(ordered_history[-STATIC_BREADTH_HISTORY_LOOKBACK_DAYS:])),
+                "chart_range": "1M",
+                "chart_data": list(reversed(chart_data)),
+                "spy_overlay": self._serialize_history_bars(
+                    benchmark,
+                    period_days=31,
+                ),
+            },
         }
 
     def _build_groups_payload(
@@ -508,12 +711,77 @@ class StaticSiteExportService:
         db: Session,
         generated_at: str,
         expected_as_of_date: date,
+        market: str | None = None,
+        latest_run: FeatureRun | None = None,
+        current_rows: list[Any] | None = None,
+        serialized_rows: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
-        service = get_group_rank_service()
-        rankings = service.get_current_rankings(
-            db,
-            limit=197,
-            calculation_date=expected_as_of_date,
+        if market is None or latest_run is None or serialized_rows is None:
+            service = get_group_rank_service()
+            rankings = service.get_current_rankings(
+                db,
+                limit=197,
+                calculation_date=expected_as_of_date,
+            )
+            if not rankings:
+                raise StaticSiteSectionUnavailableError(
+                    section="groups",
+                    reason=(
+                        "No group rankings are available for static-site export date "
+                        f"{expected_as_of_date.isoformat()}."
+                    ),
+                )
+            movers = service.get_rank_movers(
+                db,
+                period="1w",
+                limit=10,
+                calculation_date=expected_as_of_date,
+            )
+            ranking_date = rankings[0]["date"]
+            if ranking_date != expected_as_of_date.isoformat():
+                raise StaticSiteSectionUnavailableError(
+                    section="groups",
+                    reason=(
+                        "Group rankings are stale for static-site export date "
+                        f"{expected_as_of_date.isoformat()} (latest ranking date: {ranking_date})."
+                    ),
+                )
+            group_details: dict[str, Any] = {}
+            for row in rankings:
+                group_name = row["industry_group"]
+                try:
+                    group_details[group_name] = service.get_group_history(
+                        db,
+                        group_name,
+                        days=STATIC_GROUP_DETAIL_HISTORY_DAYS,
+                    )
+                except Exception:
+                    logger.warning("Failed to export detail for group %s", group_name, exc_info=True)
+                    db.rollback()
+
+            return {
+                "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                "generated_at": generated_at,
+                "available": True,
+                "payload": {
+                    "rankings": GroupRankingsResponse(
+                        date=ranking_date,
+                        total_groups=len(rankings),
+                        rankings=[GroupRankResponse(**row) for row in rankings],
+                    ).model_dump(mode="json"),
+                    "movers_period": "1w",
+                    "movers": MoversResponse(
+                        period=movers["period"],
+                        gainers=[GroupRankResponse(**row) for row in movers.get("gainers", [])],
+                        losers=[GroupRankResponse(**row) for row in movers.get("losers", [])],
+                    ).model_dump(mode="json"),
+                    "group_details": group_details,
+                },
+            }
+
+        rankings = self._compute_group_rankings_from_serialized_rows(
+            serialized_rows,
+            ranking_date=expected_as_of_date,
         )
         if not rankings:
             raise StaticSiteSectionUnavailableError(
@@ -523,39 +791,32 @@ class StaticSiteExportService:
                     f"{expected_as_of_date.isoformat()}."
                 ),
             )
-        movers = service.get_rank_movers(
-            db,
-            period="1w",
-            limit=10,
-            calculation_date=expected_as_of_date,
-        )
-        ranking_date = rankings[0]["date"]
-        if ranking_date != expected_as_of_date.isoformat():
-            raise StaticSiteSectionUnavailableError(
-                section="groups",
-                reason=(
-                    "Group rankings are stale for static-site export date "
-                    f"{expected_as_of_date.isoformat()} (latest ranking date: {ranking_date})."
-                ),
+        market_runs = self._get_market_run_series(db, market, latest_run)
+        history_runs = self._select_group_history_runs(market_runs)
+        historical_rankings = {
+            run.id: self._compute_group_rankings_from_rows(
+                self._load_scan_export_source(db, run)[0],
+                ranking_date=run.as_of_date,
             )
-        group_details: dict[str, Any] = {}
-        for row in rankings:
-            group_name = row["industry_group"]
-            try:
-                group_details[group_name] = service.get_group_history(
-                    db, group_name, days=STATIC_GROUP_DETAIL_HISTORY_DAYS,
-                )
-            except Exception:
-                logger.warning("Failed to export detail for group %s", group_name, exc_info=True)
-                db.rollback()
+            for run in history_runs
+        }
+        self._apply_group_rank_changes(rankings, market_runs, historical_rankings)
+        group_details = self._build_group_details(
+            rankings=rankings,
+            serialized_rows=serialized_rows,
+            market_runs=market_runs,
+            historical_rankings=historical_rankings,
+        )
+        movers = self._build_group_movers(rankings)
 
         return {
             "schema_version": STATIC_SITE_SCHEMA_VERSION,
             "generated_at": generated_at,
             "available": True,
+            "market": market,
             "payload": {
                 "rankings": GroupRankingsResponse(
-                    date=ranking_date,
+                    date=expected_as_of_date.isoformat(),
                     total_groups=len(rankings),
                     rankings=[GroupRankResponse(**row) for row in rankings],
                 ).model_dump(mode="json"),
@@ -572,14 +833,14 @@ class StaticSiteExportService:
     def _build_home_payload(
         self,
         *,
-        db: Session,
         generated_at: str,
         latest_run: FeatureRun,
+        market: str,
         scan_manifest: dict[str, Any],
         breadth_payload: dict[str, Any],
         groups_payload: dict[str, Any],
     ) -> dict[str, Any]:
-        key_markets = self._build_key_markets(db)
+        key_markets = self._build_key_markets(market)
         top_groups = (
             ((groups_payload.get("payload") or {}).get("rankings") or {}).get("rankings") or []
         )[:10]
@@ -590,6 +851,8 @@ class StaticSiteExportService:
             "schema_version": STATIC_SITE_SCHEMA_VERSION,
             "generated_at": generated_at,
             "as_of_date": latest_run.as_of_date.isoformat(),
+            "market": market,
+            "market_display_name": STATIC_MARKET_DISPLAY.get(market, market),
             "freshness": {
                 "scan_run_id": latest_run.id,
                 "scan_as_of_date": latest_run.as_of_date.isoformat(),
@@ -607,42 +870,499 @@ class StaticSiteExportService:
             "top_groups": top_groups,
         }
 
-    def _build_key_markets(self, db: Session) -> list[dict[str, Any]]:
-        markets: list[dict[str, Any]] = []
-        for item in _DEFAULT_KEY_MARKETS:
-            rows = (
-                db.query(StockPrice)
-                .filter(StockPrice.symbol == item["symbol"])
-                .order_by(StockPrice.date.desc())
-                .limit(30)
-                .all()
-            )
-            ordered = list(reversed(rows))
+    def _build_key_markets(self, market: str | Session = STATIC_DEFAULT_MARKET) -> list[dict[str, Any]]:
+        if isinstance(market, Session):
+            db = market
+            entries: list[dict[str, Any]] = []
+            for item in _DEFAULT_KEY_MARKETS[STATIC_DEFAULT_MARKET]:
+                rows = (
+                    db.query(StockPrice)
+                    .filter(StockPrice.symbol == item["symbol"])
+                    .order_by(StockPrice.date.desc())
+                    .limit(30)
+                    .all()
+                )
+                ordered = list(reversed(rows))
+                latest = ordered[-1] if ordered else None
+                previous = ordered[-2] if len(ordered) > 1 else None
+                change_1d = None
+                if (
+                    latest is not None
+                    and previous is not None
+                    and latest.close is not None
+                    and previous.close not in (None, 0)
+                ):
+                    change_1d = round(((latest.close - previous.close) / previous.close) * 100, 2)
+                entries.append(
+                    {
+                        "symbol": item["symbol"],
+                        "display_name": item["display_name"],
+                        "latest_close": latest.close if latest is not None else None,
+                        "latest_date": latest.date.isoformat() if latest is not None else None,
+                        "change_1d": change_1d,
+                        "history": [
+                            {"date": row.date.isoformat(), "close": row.close}
+                            for row in ordered
+                        ],
+                    }
+                )
+            return entries
+
+        entries: list[dict[str, Any]] = []
+        for item in _DEFAULT_KEY_MARKETS.get(market, ()):
+            history = self._get_symbol_price_history(item["symbol"], period="6mo")
+            ordered = self._serialize_close_history(history, days=30)
             latest = ordered[-1] if ordered else None
             previous = ordered[-2] if len(ordered) > 1 else None
             change_1d = None
-            if (
-                latest is not None
-                and previous is not None
-                and latest.close is not None
-                and previous.close not in (None, 0)
-            ):
-                change_1d = round(((latest.close - previous.close) / previous.close) * 100, 2)
-
-            markets.append(
+            if latest is not None and previous is not None and previous.get("close") not in (None, 0):
+                change_1d = round(((latest["close"] - previous["close"]) / previous["close"]) * 100, 2)
+            entries.append(
                 {
                     "symbol": item["symbol"],
                     "display_name": item["display_name"],
-                    "latest_close": latest.close if latest is not None else None,
-                    "latest_date": latest.date.isoformat() if latest is not None else None,
+                    "currency": item.get("currency"),
+                    "latest_close": latest["close"] if latest is not None else None,
+                    "latest_date": latest["date"] if latest is not None else None,
                     "change_1d": change_1d,
-                    "history": [
-                        {"date": row.date.isoformat(), "close": row.close}
-                        for row in ordered
-                    ],
+                    "history": ordered,
                 }
             )
-        return markets
+        return entries
+
+    def _get_market_run_series(
+        self,
+        db: Session,
+        market: str,
+        latest_run: FeatureRun,
+    ) -> list[FeatureRun]:
+        max_runs = max(STATIC_GROUP_HISTORY_RUNS, max(STATIC_GROUP_CHANGE_OFFSETS.values()) + 1)
+        published_runs = (
+            db.query(FeatureRun)
+            .filter(
+                FeatureRun.status == "published",
+                FeatureRun.as_of_date <= latest_run.as_of_date,
+            )
+            .order_by(FeatureRun.as_of_date.desc(), FeatureRun.published_at.desc(), FeatureRun.id.desc())
+            .all()
+        )
+        market_runs: list[FeatureRun] = []
+        for run in published_runs:
+            if self._run_market(run) != market:
+                continue
+            market_runs.append(run)
+            if len(market_runs) >= max_runs:
+                break
+        return market_runs
+
+    @staticmethod
+    def _select_group_history_runs(market_runs: list[FeatureRun]) -> list[FeatureRun]:
+        selected_indexes = set(range(min(STATIC_GROUP_HISTORY_RUNS, len(market_runs))))
+        selected_indexes.update(
+            offset
+            for offset in STATIC_GROUP_CHANGE_OFFSETS.values()
+            if offset < len(market_runs)
+        )
+        return [market_runs[index] for index in sorted(selected_indexes)]
+
+    def _compute_group_rankings_from_rows(
+        self,
+        rows: list[Any],
+        *,
+        ranking_date: date,
+    ) -> list[dict[str, Any]]:
+        normalized_rows = [self._extract_group_row_payload(row) for row in rows]
+        return self._compute_group_rankings_from_serialized_rows(
+            normalized_rows,
+            ranking_date=ranking_date,
+        )
+
+    def _compute_group_rankings_from_serialized_rows(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        ranking_date: date,
+    ) -> list[dict[str, Any]]:
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in rows:
+            group_name = row.get("ibd_industry_group")
+            rs_rating = row.get("rs_rating")
+            if not group_name or rs_rating is None:
+                continue
+            grouped[str(group_name)].append(row)
+
+        rankings: list[dict[str, Any]] = []
+        ranking_date_str = ranking_date.isoformat()
+        for group_name, group_rows in grouped.items():
+            rs_values = [float(row["rs_rating"]) for row in group_rows if row.get("rs_rating") is not None]
+            if not rs_values:
+                continue
+            avg_rs = round(sum(rs_values) / len(rs_values), 2)
+            median_rs = round(float(pd.Series(rs_values).median()), 2)
+            std_dev = round(float(pd.Series(rs_values).std(ddof=0)), 2) if len(rs_values) > 1 else 0.0
+            weight_pairs = [
+                (
+                    float(row.get("market_cap_usd") or row.get("market_cap") or 0),
+                    float(row["rs_rating"]),
+                )
+                for row in group_rows
+                if row.get("rs_rating") is not None
+            ]
+            total_weight = sum(weight for weight, _ in weight_pairs if weight > 0)
+            weighted_avg = (
+                round(sum(weight * value for weight, value in weight_pairs if weight > 0) / total_weight, 2)
+                if total_weight > 0
+                else None
+            )
+            top_row = max(
+                group_rows,
+                key=lambda row: (
+                    row.get("rs_rating") if row.get("rs_rating") is not None else float("-inf"),
+                    row.get("composite_score") if row.get("composite_score") is not None else float("-inf"),
+                ),
+            )
+            above_80 = sum(1 for value in rs_values if value >= 80)
+            rankings.append(
+                {
+                    "industry_group": group_name,
+                    "date": ranking_date_str,
+                    "rank": 0,
+                    "avg_rs_rating": avg_rs,
+                    "median_rs_rating": median_rs,
+                    "weighted_avg_rs_rating": weighted_avg,
+                    "rs_std_dev": std_dev,
+                    "num_stocks": len(rs_values),
+                    "num_stocks_rs_above_80": above_80,
+                    "pct_rs_above_80": round((above_80 / len(rs_values)) * 100, 2) if rs_values else None,
+                    "top_symbol": top_row.get("symbol"),
+                    "top_rs_rating": top_row.get("rs_rating"),
+                    "rank_change_1w": None,
+                    "rank_change_1m": None,
+                    "rank_change_3m": None,
+                    "rank_change_6m": None,
+                }
+            )
+
+        rankings.sort(
+            key=lambda row: (
+                -(row.get("avg_rs_rating") or 0),
+                -(row.get("weighted_avg_rs_rating") or 0),
+                -(row.get("num_stocks") or 0),
+                row["industry_group"],
+            )
+        )
+        for index, row in enumerate(rankings, start=1):
+            row["rank"] = index
+        return rankings
+
+    @staticmethod
+    def _extract_group_row_payload(row: Any) -> dict[str, Any]:
+        extended = getattr(row, "extended_fields", {}) or {}
+        return {
+            "symbol": getattr(row, "symbol", None),
+            "composite_score": getattr(row, "composite_score", None),
+            "current_price": getattr(row, "current_price", None),
+            "rs_rating": extended.get("rs_rating"),
+            "rs_rating_1m": extended.get("rs_rating_1m"),
+            "rs_rating_3m": extended.get("rs_rating_3m"),
+            "rs_rating_12m": extended.get("rs_rating_12m"),
+            "eps_growth_qq": extended.get("eps_growth_qq"),
+            "eps_growth_yy": extended.get("eps_growth_yy"),
+            "sales_growth_qq": extended.get("sales_growth_qq"),
+            "sales_growth_yy": extended.get("sales_growth_yy"),
+            "stage": extended.get("stage"),
+            "market_cap": extended.get("market_cap"),
+            "market_cap_usd": extended.get("market_cap_usd"),
+            "ibd_industry_group": extended.get("ibd_industry_group"),
+            "price_sparkline_data": extended.get("price_sparkline_data"),
+            "price_trend": extended.get("price_trend"),
+            "price_change_1d": extended.get("price_change_1d"),
+            "rs_sparkline_data": extended.get("rs_sparkline_data"),
+            "rs_trend": extended.get("rs_trend"),
+        }
+
+    @staticmethod
+    def _group_rank_map(rankings: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        return {row["industry_group"]: row for row in rankings}
+
+    def _apply_group_rank_changes(
+        self,
+        rankings: list[dict[str, Any]],
+        market_runs: list[FeatureRun],
+        historical_rankings: dict[int, list[dict[str, Any]]],
+    ) -> None:
+        for period, offset in STATIC_GROUP_CHANGE_OFFSETS.items():
+            key = f"rank_change_{period}"
+            if offset >= len(market_runs):
+                for ranking in rankings:
+                    ranking[key] = None
+                continue
+            reference_run = market_runs[offset]
+            reference_map = self._group_rank_map(historical_rankings.get(reference_run.id, []))
+            for ranking in rankings:
+                historical = reference_map.get(ranking["industry_group"])
+                ranking[key] = (
+                    historical["rank"] - ranking["rank"]
+                    if historical is not None
+                    else None
+                )
+
+    def _build_group_details(
+        self,
+        *,
+        rankings: list[dict[str, Any]],
+        serialized_rows: list[dict[str, Any]],
+        market_runs: list[FeatureRun],
+        historical_rankings: dict[int, list[dict[str, Any]]],
+    ) -> dict[str, Any]:
+        current_rows_by_group: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in serialized_rows:
+            group_name = row.get("ibd_industry_group")
+            if group_name:
+                current_rows_by_group[str(group_name)].append(row)
+
+        history_runs = market_runs[:STATIC_GROUP_HISTORY_RUNS]
+        ranking_maps = {
+            run.id: self._group_rank_map(historical_rankings.get(run.id, []))
+            for run in history_runs
+        }
+        details: dict[str, Any] = {}
+        for ranking in rankings:
+            group_name = ranking["industry_group"]
+            history = []
+            for run in history_runs:
+                historical = ranking_maps.get(run.id, {}).get(group_name)
+                if historical is None:
+                    continue
+                history.append(
+                    HistoricalDataPoint(
+                        date=historical["date"],
+                        rank=historical["rank"],
+                        avg_rs_rating=historical["avg_rs_rating"],
+                        num_stocks=historical["num_stocks"],
+                    ).model_dump(mode="json")
+                )
+
+            stocks = sorted(
+                current_rows_by_group.get(group_name, []),
+                key=lambda row: (
+                    row.get("rs_rating") if row.get("rs_rating") is not None else float("-inf"),
+                    row.get("composite_score") if row.get("composite_score") is not None else float("-inf"),
+                ),
+                reverse=True,
+            )
+            stock_payload = [
+                ConstituentStock(
+                    symbol=row["symbol"],
+                    price=row.get("current_price"),
+                    rs_rating=row.get("rs_rating"),
+                    rs_rating_1m=row.get("rs_rating_1m"),
+                    rs_rating_3m=row.get("rs_rating_3m"),
+                    rs_rating_12m=row.get("rs_rating_12m"),
+                    eps_growth_qq=row.get("eps_growth_qq"),
+                    eps_growth_yy=row.get("eps_growth_yy"),
+                    sales_growth_qq=row.get("sales_growth_qq"),
+                    sales_growth_yy=row.get("sales_growth_yy"),
+                    composite_score=row.get("composite_score"),
+                    stage=row.get("stage"),
+                    price_sparkline_data=row.get("price_sparkline_data"),
+                    price_trend=row.get("price_trend"),
+                    price_change_1d=row.get("price_change_1d"),
+                    rs_sparkline_data=row.get("rs_sparkline_data"),
+                    rs_trend=row.get("rs_trend"),
+                ).model_dump(mode="json")
+                for row in stocks
+            ]
+
+            details[group_name] = GroupDetailResponse(
+                industry_group=group_name,
+                current_rank=ranking["rank"],
+                current_avg_rs=ranking["avg_rs_rating"],
+                current_median_rs=ranking.get("median_rs_rating"),
+                current_weighted_avg_rs=ranking.get("weighted_avg_rs_rating"),
+                current_rs_std_dev=ranking.get("rs_std_dev"),
+                num_stocks=ranking["num_stocks"],
+                pct_rs_above_80=ranking.get("pct_rs_above_80"),
+                top_symbol=ranking.get("top_symbol"),
+                top_rs_rating=ranking.get("top_rs_rating"),
+                rank_change_1w=ranking.get("rank_change_1w"),
+                rank_change_1m=ranking.get("rank_change_1m"),
+                rank_change_3m=ranking.get("rank_change_3m"),
+                rank_change_6m=ranking.get("rank_change_6m"),
+                history=history,
+                stocks=stock_payload,
+            ).model_dump(mode="json")
+        return details
+
+    @staticmethod
+    def _build_group_movers(rankings: list[dict[str, Any]]) -> dict[str, Any]:
+        gainers = sorted(
+            [row for row in rankings if (row.get("rank_change_1w") or 0) > 0],
+            key=lambda row: (-(row.get("rank_change_1w") or 0), row["rank"]),
+        )[:10]
+        losers = sorted(
+            [row for row in rankings if (row.get("rank_change_1w") or 0) < 0],
+            key=lambda row: ((row.get("rank_change_1w") or 0), row["rank"]),
+        )[:10]
+        return {"period": "1w", "gainers": gainers, "losers": losers}
+
+    def _get_cached_price_histories(
+        self,
+        symbols: list[str],
+        *,
+        period: str,
+    ) -> dict[str, pd.DataFrame | None]:
+        results: dict[str, pd.DataFrame | None] = {}
+        for start in range(0, len(symbols), STATIC_CHART_LOOKUP_BATCH_SIZE):
+            batch = symbols[start:start + STATIC_CHART_LOOKUP_BATCH_SIZE]
+            results.update(self._price_cache.get_many_cached_only(batch, period=period))
+        return results
+
+    def _get_market_benchmark_history(self, market: str, *, period: str) -> pd.DataFrame | None:
+        for candidate in self._benchmark_cache.get_benchmark_candidates(market):
+            history = self._get_symbol_price_history(candidate, period=period)
+            if history is not None and not history.empty:
+                return history
+        return None
+
+    def _get_symbol_price_history(self, symbol: str, *, period: str) -> pd.DataFrame | None:
+        data = self._price_cache.get_cached_only(symbol.upper(), period=period)
+        if data is None or data.empty:
+            return None
+        return data
+
+    def _compute_breadth_metrics_by_date(
+        self,
+        canonical_dates: list[date],
+        price_data: dict[str, pd.DataFrame | None],
+    ) -> dict[date, dict[str, Any]]:
+        if not canonical_dates:
+            return {}
+
+        date_index = pd.Index(canonical_dates)
+        empty = lambda: [0] * len(canonical_dates)
+        aggregates = {
+            "stocks_up_4pct": empty(),
+            "stocks_down_4pct": empty(),
+            "stocks_up_25pct_quarter": empty(),
+            "stocks_down_25pct_quarter": empty(),
+            "stocks_up_25pct_month": empty(),
+            "stocks_down_25pct_month": empty(),
+            "stocks_up_50pct_month": empty(),
+            "stocks_down_50pct_month": empty(),
+            "stocks_up_13pct_34days": empty(),
+            "stocks_down_13pct_34days": empty(),
+            "total_stocks_scanned": empty(),
+        }
+
+        for history in price_data.values():
+            if history is None or history.empty or "Close" not in history.columns:
+                continue
+            close_series = pd.Series(
+                history["Close"].to_numpy(),
+                index=[ts.date() for ts in pd.to_datetime(history.index)],
+            )
+            close_series = close_series[~close_series.index.duplicated(keep="last")].reindex(date_index)
+            valid = close_series.notna().to_numpy()
+            pct_1d = ((close_series / close_series.shift(1)) - 1.0) * 100.0
+            pct_21d = ((close_series / close_series.shift(21)) - 1.0) * 100.0
+            pct_34d = ((close_series / close_series.shift(34)) - 1.0) * 100.0
+            pct_63d = ((close_series / close_series.shift(63)) - 1.0) * 100.0
+
+            for index, is_valid in enumerate(valid):
+                if is_valid:
+                    aggregates["total_stocks_scanned"][index] += 1
+
+            for key, series in (
+                ("stocks_up_4pct", pct_1d >= 4.0),
+                ("stocks_down_4pct", pct_1d <= -4.0),
+                ("stocks_up_25pct_month", pct_21d >= 25.0),
+                ("stocks_down_25pct_month", pct_21d <= -25.0),
+                ("stocks_up_50pct_month", pct_21d >= 50.0),
+                ("stocks_down_50pct_month", pct_21d <= -50.0),
+                ("stocks_up_13pct_34days", pct_34d >= 13.0),
+                ("stocks_down_13pct_34days", pct_34d <= -13.0),
+                ("stocks_up_25pct_quarter", pct_63d >= 25.0),
+                ("stocks_down_25pct_quarter", pct_63d <= -25.0),
+            ):
+                flags = series.fillna(False).to_numpy()
+                for index, flag in enumerate(flags):
+                    if flag and valid[index]:
+                        aggregates[key][index] += 1
+
+        results: dict[date, dict[str, Any]] = {}
+        for index, item_date in enumerate(canonical_dates):
+            ratio_5day = None
+            ratio_10day = None
+            if index >= 5:
+                up_5 = sum(aggregates["stocks_up_4pct"][max(index - 5, 0):index])
+                down_5 = sum(aggregates["stocks_down_4pct"][max(index - 5, 0):index])
+                ratio_5day = round(up_5 / down_5, 2) if down_5 > 0 else None
+            if index >= 10:
+                up_10 = sum(aggregates["stocks_up_4pct"][index - 10:index])
+                down_10 = sum(aggregates["stocks_down_4pct"][index - 10:index])
+                ratio_10day = round(up_10 / down_10, 2) if down_10 > 0 else None
+
+            results[item_date] = {
+                "date": item_date.isoformat(),
+                "stocks_up_4pct": int(aggregates["stocks_up_4pct"][index]),
+                "stocks_down_4pct": int(aggregates["stocks_down_4pct"][index]),
+                "ratio_5day": ratio_5day,
+                "ratio_10day": ratio_10day,
+                "stocks_up_25pct_quarter": int(aggregates["stocks_up_25pct_quarter"][index]),
+                "stocks_down_25pct_quarter": int(aggregates["stocks_down_25pct_quarter"][index]),
+                "stocks_up_25pct_month": int(aggregates["stocks_up_25pct_month"][index]),
+                "stocks_down_25pct_month": int(aggregates["stocks_down_25pct_month"][index]),
+                "stocks_up_50pct_month": int(aggregates["stocks_up_50pct_month"][index]),
+                "stocks_down_50pct_month": int(aggregates["stocks_down_50pct_month"][index]),
+                "stocks_up_13pct_34days": int(aggregates["stocks_up_13pct_34days"][index]),
+                "stocks_down_13pct_34days": int(aggregates["stocks_down_13pct_34days"][index]),
+                "total_stocks_scanned": int(aggregates["total_stocks_scanned"][index]),
+            }
+        return results
+
+    @staticmethod
+    def _serialize_close_history(data: pd.DataFrame | None, *, days: int) -> list[dict[str, Any]]:
+        if data is None or data.empty or "Close" not in data.columns:
+            return []
+        frame = data.tail(days).reset_index()
+        date_col = frame.columns[0]
+        frame = frame.rename(columns={date_col: "Date"})
+        frame["Date"] = pd.to_datetime(frame["Date"]).dt.strftime("%Y-%m-%d")
+        return [
+            {
+                "date": row["Date"],
+                "close": round(float(row["Close"]), 2),
+            }
+            for _, row in frame.iterrows()
+            if row["Close"] is not None and not math.isnan(float(row["Close"]))
+        ]
+
+    @staticmethod
+    def _serialize_history_bars(data: pd.DataFrame | None, *, period_days: int) -> list[dict[str, Any]]:
+        if data is None or data.empty:
+            return []
+        cutoff_date = pd.Timestamp(datetime.utcnow() - timedelta(days=period_days))
+        if data.index.tz is not None:
+            cutoff_date = cutoff_date.tz_localize(data.index.tz)
+        filtered = data[data.index >= cutoff_date]
+        if filtered.empty:
+            return []
+        frame = filtered.reset_index()
+        date_col = frame.columns[0]
+        frame = frame.rename(columns={date_col: "Date"})
+        frame["Date"] = pd.to_datetime(frame["Date"]).dt.strftime("%Y-%m-%d")
+        return [
+            {
+                "date": row["Date"],
+                "open": round(float(row["Open"]), 2),
+                "high": round(float(row["High"]), 2),
+                "low": round(float(row["Low"]), 2),
+                "close": round(float(row["Close"]), 2),
+                "volume": int(row["Volume"]),
+            }
+            for _, row in frame.iterrows()
+        ]
 
     def _serialize_scan_row(self, row) -> dict[str, Any]:
         item = ScanResultItem.from_domain(row, include_setup_payload=False).model_dump(mode="json")
@@ -741,8 +1461,9 @@ class StaticSiteExportService:
         return bars
 
     @staticmethod
-    def _chart_payload_path(symbol: str) -> Path:
-        return Path("charts") / f"{quote(symbol, safe='')}.json"
+    def _chart_payload_path(symbol: str, *, path_prefix: Path | None = None) -> Path:
+        normalized_prefix = Path() if path_prefix is None else Path(path_prefix)
+        return normalized_prefix / "charts" / f"{quote(symbol, safe='')}.json"
 
     @staticmethod
     def _write_json(path: Path, payload: dict[str, Any]) -> None:

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -150,7 +150,9 @@ class StaticSiteExportService:
                 latest_run = self._get_latest_published_run(db)
                 if latest_run is None:
                     raise RuntimeError("No published feature run is available for static-site export")
-                available_markets = [STATIC_DEFAULT_MARKET]
+                raise RuntimeError(
+                    "No market-scoped published feature runs are available for static-site export"
+                )
 
             for market in available_markets:
                 market_entries[market] = self._export_market_bundle(
@@ -369,8 +371,6 @@ class StaticSiteExportService:
         for run in query.all():
             if self._run_market(run) == market.upper():
                 return run
-        if market.upper() == STATIC_DEFAULT_MARKET:
-            return query.first()
         return None
 
     @staticmethod

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -937,6 +937,7 @@ class StaticSiteExportService:
         market: str,
         latest_run: FeatureRun,
     ) -> list[FeatureRun]:
+        normalized_market = market.upper()
         max_runs = max(STATIC_GROUP_HISTORY_RUNS, max(STATIC_GROUP_CHANGE_OFFSETS.values()) + 1)
         published_runs = (
             db.query(FeatureRun)
@@ -949,7 +950,7 @@ class StaticSiteExportService:
         )
         market_runs: list[FeatureRun] = []
         for run in published_runs:
-            if self._run_market(run) != market:
+            if self._run_market(run) != normalized_market:
                 continue
             market_runs.append(run)
             if len(market_runs) >= max_runs:

--- a/backend/app/use_cases/feature_store/build_daily_snapshot.py
+++ b/backend/app/use_cases/feature_store/build_daily_snapshot.py
@@ -102,6 +102,21 @@ def _map_orchestrator_to_feature_row(
     )
 
 
+def _serialize_universe_definition(universe_def: object) -> dict[str, object]:
+    """Best-effort JSON-safe snapshot of the requested universe definition."""
+    model_dump = getattr(universe_def, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
+
+    result: dict[str, object] = {}
+    for key in ("type", "market", "exchange", "index", "symbols", "allow_inactive_symbols"):
+        value = getattr(universe_def, key, None)
+        if value is None:
+            continue
+        result[key] = getattr(value, "value", value)
+    return result
+
+
 # ── Command (input) ──────────────────────────────────────────────────────
 
 
@@ -123,6 +138,7 @@ class BuildDailySnapshotCommand:
     require_bulk_prefetch: bool = False
     static_parallel_workers: int = 1
     static_chunk_size: int | None = None
+    publish_pointer_key: str = "latest_published"
 
     # DQ thresholds (overridable per-invocation)
     dq_thresholds: DQThresholds = field(default_factory=DQThresholds)
@@ -226,6 +242,12 @@ class BuildDailyFeatureSnapshotUseCase:
                 composite_method=cmd.composite_method,
                 criteria=cmd.criteria,
             )
+            run_config = {
+                **signature_payload,
+                "signature": signature_payload,
+                "universe": _serialize_universe_definition(cmd.universe_def),
+                "publish_pointer_key": cmd.publish_pointer_key,
+            }
 
             # Start run BEFORE the try-except so run_id is available
             # for best-effort error handling.
@@ -235,7 +257,7 @@ class BuildDailyFeatureSnapshotUseCase:
                 code_version=cmd.code_version,
                 universe_hash=hash_universe_symbols(symbols),
                 input_hash=hash_scan_signature(signature_payload),
-                config_json=signature_payload,
+                config_json=run_config,
                 correlation_id=cmd.correlation_id,
             )
             run_id = run.id
@@ -567,6 +589,7 @@ class BuildDailyFeatureSnapshotUseCase:
         publish_cmd = PublishRunCommand(
             run_id=run_id,
             dq_inputs=dq_inputs,
+            pointer_key=cmd.publish_pointer_key,
             dq_thresholds=cmd.dq_thresholds,
         )
         pub_result = PublishFeatureRunUseCase().execute(uow, publish_cmd)

--- a/backend/app/use_cases/feature_store/publish_run.py
+++ b/backend/app/use_cases/feature_store/publish_run.py
@@ -39,6 +39,7 @@ class PublishRunCommand:
     run_id: int
     dq_inputs: DQInputs | None = None  # None → load from DB
     force_publish: bool = False
+    pointer_key: str = "latest_published"
     dq_thresholds: DQThresholds = field(default_factory=DQThresholds)
 
 
@@ -82,7 +83,10 @@ class PublishFeatureRunUseCase:
                     f"Force-publish requires QUARANTINED status, "
                     f"got {run.status.value}"
                 )
-            uow.feature_runs.publish_atomically(cmd.run_id)
+            if cmd.pointer_key == "latest_published":
+                uow.feature_runs.publish_atomically(cmd.run_id)
+            else:
+                uow.feature_runs.publish_atomically(cmd.run_id, pointer_key=cmd.pointer_key)
             uow.commit()
             logger.info("Run %d force-published by admin", cmd.run_id)
             return PublishRunResult(
@@ -120,7 +124,10 @@ class PublishFeatureRunUseCase:
         dq_warnings = tuple(r.message for r in dq_results if not r.passed)
 
         if decision.allowed:
-            uow.feature_runs.publish_atomically(cmd.run_id)
+            if cmd.pointer_key == "latest_published":
+                uow.feature_runs.publish_atomically(cmd.run_id)
+            else:
+                uow.feature_runs.publish_atomically(cmd.run_id, pointer_key=cmd.pointer_key)
             uow.commit()
             logger.info("Run %d published", cmd.run_id)
             return PublishRunResult(

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -24,8 +24,6 @@ def test_run_daily_refresh_bootstraps_universe_before_other_tasks(monkeypatch):
 
     monkeypatch.setattr(universe_tasks, "refresh_stock_universe", make_task("universe_refresh"))
     monkeypatch.setattr(fundamentals_tasks, "refresh_all_fundamentals", make_task("fundamentals_refresh"))
-    monkeypatch.setattr(breadth_tasks, "calculate_daily_breadth", make_task("breadth_refresh"))
-    monkeypatch.setattr(group_rank_tasks, "calculate_daily_group_rankings", make_task("groups_refresh"))
     monkeypatch.setattr(
         feature_store_tasks,
         "build_daily_snapshot",
@@ -41,16 +39,6 @@ def test_run_daily_refresh_bootstraps_universe_before_other_tasks(monkeypatch):
     )
     monkeypatch.setattr(
         export_script,
-        "_ensure_breadth_history",
-        lambda *, as_of_date: calls.append("breadth_history_refresh") or {"task": "breadth_history_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_group_rank_history",
-        lambda *, as_of_date: calls.append("groups_history_refresh") or {"task": "groups_history_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
         "_resolve_latest_completed_us_trading_date",
         lambda: date(2026, 4, 2),
     )
@@ -60,41 +48,39 @@ def test_run_daily_refresh_bootstraps_universe_before_other_tasks(monkeypatch):
         lambda db, csv_path=None: 10105,
     )
     monkeypatch.setattr(
-        feature_store_tasks,
-        "_enrich_feature_run_with_ibd_metadata",
-        lambda *, feature_run_id, ranking_date: calls.append("feature_metadata_refresh")
-        or {"run_id": feature_run_id, "ranking_date": ranking_date.isoformat(), "updated_rows": 2},
+        export_script,
+        "_upsert_feature_run_pointer",
+        lambda *, pointer_key, run_id: calls.append(f"pointer:{pointer_key}:{run_id}"),
     )
 
     results, warnings = export_script._run_daily_refresh()  # noqa: SLF001 - intentional unit test coverage
+
+    expected_markets = list(export_script.STATIC_EXPORT_MARKETS)
 
     assert warnings == []
     assert calls == [
         "universe_refresh",
         "fundamentals_refresh",
         "price_refresh",
-        "feature_snapshot",
-        "breadth_refresh",
-        "breadth_history_refresh",
-        "groups_history_refresh",
-        "groups_refresh",
-        "feature_metadata_refresh",
+        *(["feature_snapshot"] * len(expected_markets)),
+        "pointer:latest_published:77",
     ]
     assert results["universe_refresh"]["task"] == "universe_refresh"
     assert results["ibd_seed_refresh"]["loaded"] == 10105
-    assert results["feature_snapshot"]["kwargs"] == {
-        "as_of_date_str": "2026-04-02",
-        "static_daily_mode": True,
+    assert set(results["feature_snapshots"]) == set(expected_markets)
+    for market in expected_markets:
+        assert results["feature_snapshots"][market]["kwargs"] == {
+            "as_of_date_str": "2026-04-02",
+            "static_daily_mode": True,
+            "universe_name": f"market:{market.lower()}",
+            "market": market,
+            "publish_pointer_key": f"latest_published_market:{market}",
+        }
+    assert results["default_market_pointer"] == {
+        "market": "US",
+        "pointer_key": "latest_published",
+        "run_id": 77,
     }
-    assert results["breadth_refresh"]["kwargs"] == {
-        "calculation_date": "2026-04-02",
-        "force_cache_only": True,
-    }
-    assert results["groups_refresh"]["kwargs"] == {
-        "calculation_date": "2026-04-02",
-        "force_cache_only": True,
-    }
-    assert results["feature_metadata_refresh"]["run_id"] == 77
 
 
 def test_run_daily_refresh_can_hydrate_imported_snapshot_without_live_fundamentals(monkeypatch):
@@ -113,8 +99,6 @@ def test_run_daily_refresh_can_hydrate_imported_snapshot_without_live_fundamenta
 
     monkeypatch.setattr(export_script, "SessionLocal", fake_session)
     monkeypatch.setattr(fundamentals_tasks, "refresh_all_fundamentals", make_task("fundamentals_refresh"))
-    monkeypatch.setattr(breadth_tasks, "calculate_daily_breadth", make_task("breadth_refresh"))
-    monkeypatch.setattr(group_rank_tasks, "calculate_daily_group_rankings", make_task("groups_refresh"))
     monkeypatch.setattr(
         feature_store_tasks,
         "build_daily_snapshot",
@@ -127,16 +111,6 @@ def test_run_daily_refresh_can_hydrate_imported_snapshot_without_live_fundamenta
         export_script,
         "_refresh_static_daily_prices",
         lambda *, as_of_date: calls.append("price_refresh") or {"task": "price_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_breadth_history",
-        lambda *, as_of_date: calls.append("breadth_history_refresh") or {"task": "breadth_history_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_group_rank_history",
-        lambda *, as_of_date: calls.append("groups_history_refresh") or {"task": "groups_history_refresh", "as_of_date": as_of_date.isoformat()},
     )
     monkeypatch.setattr(
         export_script,
@@ -157,10 +131,9 @@ def test_run_daily_refresh_can_hydrate_imported_snapshot_without_live_fundamenta
         ),
     )
     monkeypatch.setattr(
-        feature_store_tasks,
-        "_enrich_feature_run_with_ibd_metadata",
-        lambda *, feature_run_id, ranking_date: calls.append("feature_metadata_refresh")
-        or {"run_id": feature_run_id, "ranking_date": ranking_date.isoformat(), "updated_rows": 2},
+        export_script,
+        "_upsert_feature_run_pointer",
+        lambda *, pointer_key, run_id: calls.append(f"pointer:{pointer_key}:{run_id}"),
     )
 
     results, warnings = export_script._run_daily_refresh(  # noqa: SLF001 - intentional unit test coverage
@@ -173,12 +146,8 @@ def test_run_daily_refresh_can_hydrate_imported_snapshot_without_live_fundamenta
     assert warnings == []
     assert calls == [
         "price_refresh",
-        "feature_snapshot",
-        "breadth_refresh",
-        "breadth_history_refresh",
-        "groups_history_refresh",
-        "groups_refresh",
-        "feature_metadata_refresh",
+        *(["feature_snapshot"] * len(export_script.STATIC_EXPORT_MARKETS)),
+        "pointer:latest_published:77",
     ]
     assert hydrate_calls == [("db-session", False)]
     assert "universe_refresh" not in results
@@ -201,8 +170,6 @@ def test_run_daily_refresh_price_delta_mode_skips_snapshot_hydration(monkeypatch
     hydrate_calls: list[tuple[object, bool]] = []
 
     monkeypatch.setattr(export_script, "SessionLocal", fake_session)
-    monkeypatch.setattr(breadth_tasks, "calculate_daily_breadth", make_task("breadth_refresh"))
-    monkeypatch.setattr(group_rank_tasks, "calculate_daily_group_rankings", make_task("groups_refresh"))
     monkeypatch.setattr(
         feature_store_tasks,
         "build_daily_snapshot",
@@ -215,16 +182,6 @@ def test_run_daily_refresh_price_delta_mode_skips_snapshot_hydration(monkeypatch
         export_script,
         "_refresh_static_daily_prices",
         lambda *, as_of_date: calls.append("price_refresh") or {"task": "price_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_breadth_history",
-        lambda *, as_of_date: {"task": "breadth_history_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_group_rank_history",
-        lambda *, as_of_date: {"task": "groups_history_refresh", "as_of_date": as_of_date.isoformat()},
     )
     monkeypatch.setattr(
         export_script,
@@ -244,11 +201,7 @@ def test_run_daily_refresh_price_delta_mode_skips_snapshot_hydration(monkeypatch
             or {"task": "fundamentals_hydrate"},
         ),
     )
-    monkeypatch.setattr(
-        feature_store_tasks,
-        "_enrich_feature_run_with_ibd_metadata",
-        lambda *, feature_run_id, ranking_date: {"run_id": feature_run_id, "ranking_date": ranking_date.isoformat(), "updated_rows": 2},
-    )
+    monkeypatch.setattr(export_script, "_upsert_feature_run_pointer", lambda **_kwargs: None)
 
     results, warnings = export_script._run_daily_refresh(  # noqa: SLF001 - intentional unit test coverage
         skip_universe_refresh=True,
@@ -287,23 +240,11 @@ def test_run_daily_refresh_disables_serialized_lock_during_export(monkeypatch):
     monkeypatch.setattr(export_script, "disable_serialized_data_fetch_lock", fake_disable_lock)
     monkeypatch.setattr(universe_tasks, "refresh_stock_universe", make_task("universe_refresh"))
     monkeypatch.setattr(fundamentals_tasks, "refresh_all_fundamentals", make_task("fundamentals_refresh"))
-    monkeypatch.setattr(breadth_tasks, "calculate_daily_breadth", make_task("breadth_refresh"))
-    monkeypatch.setattr(group_rank_tasks, "calculate_daily_group_rankings", make_task("groups_refresh"))
     monkeypatch.setattr(feature_store_tasks, "build_daily_snapshot", make_task("feature_snapshot"))
     monkeypatch.setattr(
         export_script,
         "_refresh_static_daily_prices",
         lambda *, as_of_date: {"task": "price_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_breadth_history",
-        lambda *, as_of_date: {"task": "breadth_history_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_group_rank_history",
-        lambda *, as_of_date: {"task": "groups_history_refresh", "as_of_date": as_of_date.isoformat()},
     )
     monkeypatch.setattr(
         export_script,
@@ -315,11 +256,7 @@ def test_run_daily_refresh_disables_serialized_lock_during_export(monkeypatch):
         "load_from_csv",
         lambda db, csv_path=None: 10105,
     )
-    monkeypatch.setattr(
-        feature_store_tasks,
-        "_enrich_feature_run_with_ibd_metadata",
-        lambda **_kwargs: {"run_id": 1, "ranking_date": "2026-04-02", "updated_rows": 0},
-    )
+    monkeypatch.setattr(export_script, "_upsert_feature_run_pointer", lambda **_kwargs: None)
 
     export_script._run_daily_refresh()  # noqa: SLF001 - intentional unit test coverage
 
@@ -328,53 +265,22 @@ def test_run_daily_refresh_disables_serialized_lock_during_export(monkeypatch):
 
 
 def test_run_daily_refresh_uses_static_daily_mode_and_group_rank_bypass(monkeypatch):
-    calls: list[tuple[str, dict, bool, bool]] = []
-    state = {"group_bypass": False, "breadth_bypass": False}
-
-    @contextmanager
-    def fake_group_bypass():
-        state["group_bypass"] = True
-        try:
-            yield
-        finally:
-            state["group_bypass"] = False
-
-    @contextmanager
-    def fake_breadth_bypass():
-        state["breadth_bypass"] = True
-        try:
-            yield
-        finally:
-            state["breadth_bypass"] = False
+    calls: list[tuple[str, dict]] = []
 
     def make_task(name: str):
         def run(**kwargs):
-            calls.append((name, kwargs, state["group_bypass"], state["breadth_bypass"]))
+            calls.append((name, kwargs))
             return {"task": name, "kwargs": kwargs}
 
         return SimpleNamespace(run=run)
 
-    monkeypatch.setattr(group_rank_tasks, "allow_same_day_group_rank_warmup_bypass", fake_group_bypass)
-    monkeypatch.setattr(breadth_tasks, "allow_same_day_breadth_warmup_bypass", fake_breadth_bypass)
     monkeypatch.setattr(universe_tasks, "refresh_stock_universe", make_task("universe_refresh"))
     monkeypatch.setattr(fundamentals_tasks, "refresh_all_fundamentals", make_task("fundamentals_refresh"))
-    monkeypatch.setattr(breadth_tasks, "calculate_daily_breadth", make_task("breadth_refresh"))
-    monkeypatch.setattr(group_rank_tasks, "calculate_daily_group_rankings", make_task("groups_refresh"))
     monkeypatch.setattr(feature_store_tasks, "build_daily_snapshot", make_task("feature_snapshot"))
     monkeypatch.setattr(
         export_script,
         "_refresh_static_daily_prices",
         lambda *, as_of_date: {"task": "price_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_breadth_history",
-        lambda *, as_of_date: {"task": "breadth_history_refresh", "as_of_date": as_of_date.isoformat()},
-    )
-    monkeypatch.setattr(
-        export_script,
-        "_ensure_group_rank_history",
-        lambda *, as_of_date: {"task": "groups_history_refresh", "as_of_date": as_of_date.isoformat()},
     )
     monkeypatch.setattr(
         export_script,
@@ -386,30 +292,18 @@ def test_run_daily_refresh_uses_static_daily_mode_and_group_rank_bypass(monkeypa
         "load_from_csv",
         lambda db, csv_path=None: 10105,
     )
-    monkeypatch.setattr(
-        feature_store_tasks,
-        "_enrich_feature_run_with_ibd_metadata",
-        lambda **_kwargs: {"run_id": 1, "ranking_date": "2026-04-02", "updated_rows": 0},
-    )
+    monkeypatch.setattr(export_script, "_upsert_feature_run_pointer", lambda **_kwargs: None)
 
     export_script._run_daily_refresh()  # noqa: SLF001 - intentional unit test coverage
 
-    groups_call = next(call for call in calls if call[0] == "groups_refresh")
-    breadth_call = next(call for call in calls if call[0] == "breadth_refresh")
-    feature_call = next(call for call in calls if call[0] == "feature_snapshot")
-    assert groups_call[2] is True
-    assert breadth_call[3] is True
-    assert feature_call[1] == {
+    feature_calls = [call for call in calls if call[0] == "feature_snapshot"]
+    assert len(feature_calls) == len(export_script.STATIC_EXPORT_MARKETS)
+    assert feature_calls[0][1] == {
         "as_of_date_str": "2026-04-02",
         "static_daily_mode": True,
-    }
-    assert groups_call[1] == {
-        "calculation_date": "2026-04-02",
-        "force_cache_only": True,
-    }
-    assert breadth_call[1] == {
-        "calculation_date": "2026-04-02",
-        "force_cache_only": True,
+        "universe_name": "market:us",
+        "market": "US",
+        "publish_pointer_key": "latest_published_market:US",
     }
 
 

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -263,6 +263,53 @@ def test_run_daily_refresh_warns_when_default_market_run_id_is_missing(monkeypat
     assert warnings == ["No US feature snapshot produced a run id; 'latest_published' was not updated."]
 
 
+def test_run_daily_refresh_does_not_repoint_default_pointer_for_unpublished_us_run(monkeypatch):
+    pointer_calls: list[dict] = []
+
+    def build_snapshot(**kwargs):
+        if kwargs["market"] == export_script.STATIC_DEFAULT_MARKET:
+            return {"status": "failed", "run_id": 91}
+        return {"status": "published", "run_id": 77, "kwargs": kwargs}
+
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(run=build_snapshot),
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date: {"task": "price_refresh", "as_of_date": as_of_date.isoformat()},
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_resolve_latest_completed_us_trading_date",
+        lambda: date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        export_script.IBDIndustryService,
+        "load_from_csv",
+        lambda db, csv_path=None: 10105,
+    )
+    monkeypatch.setattr(universe_tasks, "refresh_stock_universe", SimpleNamespace(run=lambda: {"task": "universe_refresh"}))
+    monkeypatch.setattr(
+        fundamentals_tasks,
+        "refresh_all_fundamentals",
+        SimpleNamespace(run=lambda: {"task": "fundamentals_refresh"}),
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_upsert_feature_run_pointer",
+        lambda **kwargs: pointer_calls.append(kwargs),
+    )
+
+    results, warnings = export_script._run_daily_refresh()  # noqa: SLF001 - intentional unit test coverage
+
+    assert pointer_calls == []
+    assert "default_market_pointer" not in results
+    assert warnings == ["US feature snapshot returned status 'failed'; 'latest_published' was not updated."]
+
+
 def test_run_daily_refresh_disables_serialized_lock_during_export(monkeypatch):
     calls: list[tuple[str, bool]] = []
     state = {"lock_disabled": False}

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -215,6 +215,54 @@ def test_run_daily_refresh_price_delta_mode_skips_snapshot_hydration(monkeypatch
     assert "fundamentals_hydrate" not in results
 
 
+def test_run_daily_refresh_warns_when_default_market_run_id_is_missing(monkeypatch):
+    calls: list[str] = []
+
+    def build_snapshot(**kwargs):
+        calls.append(kwargs["market"])
+        if kwargs["market"] == export_script.STATIC_DEFAULT_MARKET:
+            return {"status": "completed"}
+        return {"run_id": 77, "kwargs": kwargs}
+
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(run=build_snapshot),
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date: {"task": "price_refresh", "as_of_date": as_of_date.isoformat()},
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_resolve_latest_completed_us_trading_date",
+        lambda: date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        export_script.IBDIndustryService,
+        "load_from_csv",
+        lambda db, csv_path=None: 10105,
+    )
+    monkeypatch.setattr(universe_tasks, "refresh_stock_universe", SimpleNamespace(run=lambda: {"task": "universe_refresh"}))
+    monkeypatch.setattr(
+        fundamentals_tasks,
+        "refresh_all_fundamentals",
+        SimpleNamespace(run=lambda: {"task": "fundamentals_refresh"}),
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_upsert_feature_run_pointer",
+        lambda **_kwargs: calls.append("pointer"),
+    )
+
+    results, warnings = export_script._run_daily_refresh()  # noqa: SLF001 - intentional unit test coverage
+
+    assert calls == list(export_script.STATIC_EXPORT_MARKETS)
+    assert "default_market_pointer" not in results
+    assert warnings == ["No US feature snapshot produced a run id; 'latest_published' was not updated."]
+
+
 def test_run_daily_refresh_disables_serialized_lock_during_export(monkeypatch):
     calls: list[tuple[str, bool]] = []
     state = {"lock_disabled": False}

--- a/backend/tests/unit/test_feature_store_tasks.py
+++ b/backend/tests/unit/test_feature_store_tasks.py
@@ -10,6 +10,7 @@ from unittest.mock import ANY, patch
 import pytest
 from celery.exceptions import SoftTimeLimitExceeded
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from app.database import Base
@@ -18,6 +19,7 @@ from app.interfaces.tasks.feature_store_tasks import (
     _create_auto_scan_for_published_run,
     _enrich_feature_run_with_ibd_metadata,
     _fail_stale_feature_runs,
+    _upsert_feature_run_pointer,
     build_daily_snapshot,
 )
 from app.domain.scanning.defaults import get_default_scan_profile
@@ -292,6 +294,55 @@ def test_build_daily_snapshot_skip_if_published_repairs_requested_pointer():
         pointer_key="latest_published_market:HK",
         run_id=84,
     )
+
+
+def test_upsert_feature_run_pointer_retries_after_integrity_error():
+    pointer = SimpleNamespace(run_id=10)
+    query_results = [None, pointer]
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.added = []
+            self.commit_calls = 0
+            self.rollback_calls = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def query(self, _model):
+            return self
+
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def first(self):
+            return query_results.pop(0)
+
+        def add(self, obj):
+            self.added.append(obj)
+
+        def commit(self):
+            self.commit_calls += 1
+            if self.commit_calls == 1:
+                raise IntegrityError("insert", {}, Exception("duplicate"))
+
+        def rollback(self):
+            self.rollback_calls += 1
+
+    fake_session = _FakeSession()
+
+    _upsert_feature_run_pointer(
+        session_factory=lambda: fake_session,
+        pointer_key="latest_published_market:HK",
+        run_id=84,
+    )
+
+    assert fake_session.rollback_calls == 1
+    assert fake_session.commit_calls == 2
+    assert pointer.run_id == 84
 
 
 def test_build_daily_snapshot_reraises_soft_time_limit():

--- a/backend/tests/unit/test_feature_store_tasks.py
+++ b/backend/tests/unit/test_feature_store_tasks.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from celery.exceptions import SoftTimeLimitExceeded
@@ -233,6 +233,65 @@ def test_build_daily_snapshot_skip_if_published_requires_exact_signature_match()
         "universe_hash": "same-universe",
         "as_of_date": date(2026, 3, 16),
     }]
+
+
+def test_build_daily_snapshot_skip_if_published_repairs_requested_pointer():
+    class _CheckUoW:
+        def __init__(self) -> None:
+            self.universe = SimpleNamespace(resolve_symbols=lambda _universe_def: ["0700.HK"])
+            self.feature_runs = SimpleNamespace(
+                find_latest_published_exact=lambda **_kwargs: SimpleNamespace(
+                    id=84,
+                    as_of_date=date(2026, 3, 16),
+                )
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    fake_use_case = _FakeUseCase()
+
+    with patch(
+        "app.use_cases.feature_store.build_daily_snapshot._is_us_trading_day",
+        return_value=True,
+    ), patch(
+        "app.wiring.bootstrap.get_build_daily_snapshot_use_case",
+        return_value=fake_use_case,
+    ), patch(
+        "app.database.SessionLocal"
+    ), patch(
+        "app.infra.db.uow.SqlUnitOfWork",
+        return_value=_CheckUoW(),
+    ), patch(
+        "app.infra.tasks.progress_sink.CeleryProgressSink",
+        return_value=object(),
+    ), patch(
+        "app.domain.scanning.ports.NeverCancelledToken",
+        return_value=object(),
+    ), patch(
+        "app.interfaces.tasks.feature_store_tasks._create_auto_scan_for_published_run",
+        return_value="auto-scan-001",
+    ), patch(
+        "app.interfaces.tasks.feature_store_tasks._upsert_feature_run_pointer",
+    ) as mock_upsert:
+        result = _TASK_BODY(
+            _FakeTask(),
+            as_of_date_str="2026-03-16",
+            universe_name="market:hk",
+            market="HK",
+            publish_pointer_key="latest_published_market:HK",
+        )
+
+    assert result["status"] == "skipped"
+    assert result["existing_run_id"] == 84
+    mock_upsert.assert_called_once_with(
+        session_factory=ANY,
+        pointer_key="latest_published_market:HK",
+        run_id=84,
+    )
 
 
 def test_build_daily_snapshot_reraises_soft_time_limit():

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -119,6 +119,42 @@ def test_get_latest_published_run_falls_back_to_latest_published_when_pointer_is
     assert run.id == 2
 
 
+def test_get_latest_published_run_ignores_market_pointer_for_wrong_market(
+    service_and_session_factory,
+):
+    service, session_factory = service_and_session_factory
+    _insert_runs(
+        session_factory,
+        FeatureRun(
+            id=4,
+            as_of_date=date(2026, 3, 30),
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 3, 30, 21, 30, 0),
+            config_json={"universe": {"market": "US"}},
+        ),
+        FeatureRun(
+            id=5,
+            as_of_date=date(2026, 3, 31),
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 3, 31, 21, 30, 0),
+            config_json={"universe": {"market": "HK"}},
+        ),
+        pointer_run_id=5,
+        pointer_key="latest_published_market:US",
+    )
+
+    with session_factory() as db:
+        run = service._get_latest_published_run(  # noqa: SLF001 - intentional unit test coverage
+            db,
+            market="US",
+        )
+
+    assert run is not None
+    assert run.id == 4
+
+
 def test_export_writes_serializable_manifest_and_page_bundles(
     service_and_session_factory,
     monkeypatch,
@@ -490,6 +526,44 @@ def test_get_market_run_series_normalizes_market_to_uppercase(service_and_sessio
         )
 
     assert [run.id for run in market_runs] == [31, 30]
+
+
+def test_get_market_run_series_deduplicates_same_day_reruns(service_and_session_factory):
+    service, session_factory = service_and_session_factory
+    latest_us_run = FeatureRun(
+        id=41,
+        as_of_date=date(2026, 4, 3),
+        run_type="daily_snapshot",
+        status="published",
+        published_at=datetime(2026, 4, 3, 22, 30, 0),
+        config_json={"universe": {"market": "US"}},
+    )
+    rerun_same_day = FeatureRun(
+        id=40,
+        as_of_date=date(2026, 4, 3),
+        run_type="daily_snapshot",
+        status="published",
+        published_at=datetime(2026, 4, 3, 21, 30, 0),
+        config_json={"universe": {"market": "US"}},
+    )
+    previous_day = FeatureRun(
+        id=39,
+        as_of_date=date(2026, 4, 2),
+        run_type="daily_snapshot",
+        status="published",
+        published_at=datetime(2026, 4, 2, 21, 30, 0),
+        config_json={"universe": {"market": "US"}},
+    )
+    _insert_runs(session_factory, latest_us_run, rerun_same_day, previous_day)
+
+    with session_factory() as db:
+        market_runs = service._get_market_run_series(  # noqa: SLF001 - intentional unit test coverage
+            db=db,
+            market="US",
+            latest_run=latest_us_run,
+        )
+
+    assert [run.id for run in market_runs] == [41, 39]
 
 
 def test_build_groups_payload_requires_target_date(service_and_session_factory, monkeypatch):

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -566,6 +566,25 @@ def test_get_market_run_series_deduplicates_same_day_reruns(service_and_session_
     assert [run.id for run in market_runs] == [41, 39]
 
 
+def test_compute_breadth_metrics_uses_full_history_for_shifted_ranges(service_and_session_factory):
+    service, _session_factory = service_and_session_factory
+    all_dates = pd.date_range("2025-10-01", periods=200, freq="D")
+    canonical_dates = [ts.date() for ts in all_dates[-120:]]
+    closes = [100.0 + index for index, _ in enumerate(all_dates)]
+    price_data = {
+        "AAA": pd.DataFrame({"Close": closes}, index=all_dates),
+    }
+
+    metrics = service._compute_breadth_metrics_by_date(  # noqa: SLF001 - intentional unit test coverage
+        canonical_dates,
+        price_data,
+    )
+
+    oldest_history_date = canonical_dates[30]
+    assert metrics[oldest_history_date]["stocks_up_25pct_quarter"] == 1
+    assert metrics[oldest_history_date]["stocks_up_25pct_month"] == 1
+
+
 def test_build_groups_payload_requires_target_date(service_and_session_factory, monkeypatch):
     service, session_factory = service_and_session_factory
 

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -41,11 +41,16 @@ def service_and_session_factory():
         engine.dispose()
 
 
-def _insert_runs(session_factory, *runs: FeatureRun, pointer_run_id: int | None = None) -> None:
+def _insert_runs(
+    session_factory,
+    *runs: FeatureRun,
+    pointer_run_id: int | None = None,
+    pointer_key: str = "latest_published",
+) -> None:
     with session_factory() as db:
         db.add_all(runs)
         if pointer_run_id is not None:
-            db.add(FeatureRunPointer(key="latest_published", run_id=pointer_run_id))
+            db.add(FeatureRunPointer(key=pointer_key, run_id=pointer_run_id))
         db.commit()
 
 
@@ -128,6 +133,7 @@ def test_export_writes_serializable_manifest_and_page_bundles(
             run_type="daily_snapshot",
             status="published",
             published_at=datetime(2026, 3, 31, 21, 30, 0),
+            config_json={"universe": {"market": "US"}},
         ),
         pointer_run_id=7,
     )
@@ -300,6 +306,7 @@ def test_export_marks_optional_sections_unavailable_without_aborting(
             run_type="daily_snapshot",
             status="published",
             published_at=datetime(2026, 4, 2, 21, 30, 0),
+            config_json={"universe": {"market": "US"}},
         ),
         pointer_run_id=12,
     )
@@ -393,6 +400,27 @@ def test_build_breadth_payload_requires_target_date(service_and_session_factory,
             generated_at="2026-04-02T22:00:00Z",
             expected_as_of_date=date(2026, 4, 2),
         )
+
+
+def test_export_rejects_legacy_unscoped_run_for_market_bundle(
+    service_and_session_factory,
+    tmp_path,
+):
+    service, session_factory = service_and_session_factory
+    _insert_runs(
+        session_factory,
+        FeatureRun(
+            id=21,
+            as_of_date=date(2026, 4, 3),
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 4, 3, 21, 30, 0),
+        ),
+        pointer_run_id=21,
+    )
+
+    with pytest.raises(RuntimeError, match="No market-scoped published feature runs"):
+        service.export(tmp_path / "static-data")
 
 
 def test_build_groups_payload_requires_target_date(service_and_session_factory, monkeypatch):

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -423,6 +423,37 @@ def test_export_rejects_legacy_unscoped_run_for_market_bundle(
         service.export(tmp_path / "static-data")
 
 
+def test_serialize_history_bars_clamps_to_end_date_and_skips_nan_rows(service_and_session_factory):
+    service, _session_factory = service_and_session_factory
+    frame = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0, float("nan"), 104.0],
+            "High": [101.0, 102.0, 104.0, 105.0],
+            "Low": [99.0, 100.0, 102.0, 103.0],
+            "Close": [100.5, 101.5, 103.5, 104.5],
+            "Volume": [1000, 1100, 1200, 1300],
+        },
+        index=pd.to_datetime(["2026-03-01", "2026-04-01", "2026-04-02", "2026-04-03"]),
+    )
+
+    payload = service._serialize_history_bars(  # noqa: SLF001 - intentional unit test coverage
+        frame,
+        period_days=10,
+        end_date=date(2026, 4, 2),
+    )
+
+    assert payload == [
+        {
+            "date": "2026-04-01",
+            "open": 101.0,
+            "high": 102.0,
+            "low": 100.0,
+            "close": 101.5,
+            "volume": 1100,
+        },
+    ]
+
+
 def test_build_groups_payload_requires_target_date(service_and_session_factory, monkeypatch):
     service, session_factory = service_and_session_factory
 

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -454,6 +454,44 @@ def test_serialize_history_bars_clamps_to_end_date_and_skips_nan_rows(service_an
     ]
 
 
+def test_get_market_run_series_normalizes_market_to_uppercase(service_and_session_factory):
+    service, session_factory = service_and_session_factory
+    run_us_latest = FeatureRun(
+        id=31,
+        as_of_date=date(2026, 4, 3),
+        run_type="daily_snapshot",
+        status="published",
+        published_at=datetime(2026, 4, 3, 21, 30, 0),
+        config_json={"universe": {"market": "US"}},
+    )
+    run_us_previous = FeatureRun(
+        id=30,
+        as_of_date=date(2026, 4, 2),
+        run_type="daily_snapshot",
+        status="published",
+        published_at=datetime(2026, 4, 2, 21, 30, 0),
+        config_json={"universe": {"market": "US"}},
+    )
+    run_hk = FeatureRun(
+        id=29,
+        as_of_date=date(2026, 4, 1),
+        run_type="daily_snapshot",
+        status="published",
+        published_at=datetime(2026, 4, 1, 21, 30, 0),
+        config_json={"universe": {"market": "HK"}},
+    )
+    _insert_runs(session_factory, run_us_latest, run_us_previous, run_hk)
+
+    with session_factory() as db:
+        market_runs = service._get_market_run_series(  # noqa: SLF001 - intentional unit test coverage
+            db=db,
+            market="us",
+            latest_run=run_us_latest,
+        )
+
+    assert [run.id for run in market_runs] == [31, 30]
+
+
 def test_build_groups_payload_requires_target_date(service_and_session_factory, monkeypatch):
     service, session_factory = service_and_session_factory
 

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -187,15 +187,19 @@ def test_export_writes_serializable_manifest_and_page_bundles(
     result = service.export(output_dir)
 
     manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
-    scan = json.loads((output_dir / "scan" / "manifest.json").read_text(encoding="utf-8"))
-    breadth = json.loads((output_dir / "breadth.json").read_text(encoding="utf-8"))
-    groups = json.loads((output_dir / "groups.json").read_text(encoding="utf-8"))
-    home = json.loads((output_dir / "home.json").read_text(encoding="utf-8"))
+    scan = json.loads((output_dir / "markets" / "us" / "scan" / "manifest.json").read_text(encoding="utf-8"))
+    breadth = json.loads((output_dir / "markets" / "us" / "breadth.json").read_text(encoding="utf-8"))
+    groups = json.loads((output_dir / "markets" / "us" / "groups.json").read_text(encoding="utf-8"))
+    home = json.loads((output_dir / "markets" / "us" / "home.json").read_text(encoding="utf-8"))
 
     assert manifest["schema_version"] == STATIC_SITE_SCHEMA_VERSION
+    assert manifest["default_market"] == "US"
+    assert manifest["supported_markets"] == ["US"]
     assert manifest["features"]["charts"] is True
-    assert manifest["pages"]["scan"]["path"] == "scan/manifest.json"
+    assert manifest["pages"]["scan"]["path"] == "markets/us/scan/manifest.json"
     assert manifest["assets"]["charts"]["path"] == "charts/index.json"
+    assert manifest["markets"]["US"]["pages"]["scan"]["path"] == "markets/us/scan/manifest.json"
+    assert manifest["markets"]["US"]["assets"]["charts"]["path"] == "charts/index.json"
     assert "themes" not in manifest["features"]
     assert "themes" not in manifest["pages"]
     assert manifest["warnings"] == []
@@ -346,13 +350,15 @@ def test_export_marks_optional_sections_unavailable_without_aborting(
     result = service.export(output_dir)
 
     manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
-    breadth = json.loads((output_dir / "breadth.json").read_text(encoding="utf-8"))
-    groups = json.loads((output_dir / "groups.json").read_text(encoding="utf-8"))
-    home = json.loads((output_dir / "home.json").read_text(encoding="utf-8"))
+    breadth = json.loads((output_dir / "markets" / "us" / "breadth.json").read_text(encoding="utf-8"))
+    groups = json.loads((output_dir / "markets" / "us" / "groups.json").read_text(encoding="utf-8"))
+    home = json.loads((output_dir / "markets" / "us" / "home.json").read_text(encoding="utf-8"))
 
     assert result.manifest == manifest
     assert manifest["features"]["breadth"] is False
     assert manifest["features"]["groups"] is False
+    assert manifest["markets"]["US"]["features"]["breadth"] is False
+    assert manifest["markets"]["US"]["features"]["groups"] is False
     assert len(manifest["warnings"]) == 2
     assert breadth["available"] is False
     assert breadth["expected_as_of_date"] == "2026-04-02"

--- a/backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
+++ b/backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
@@ -236,6 +236,9 @@ class TestHappyPath:
         assert run.universe_hash is not None
         assert run.config is not None
         assert run.config["signature_version"] == 1
+        assert run.config["signature"]["signature_version"] == 1
+        assert run.config["publish_pointer_key"] == "latest_published"
+        assert run.config["universe"] == {}
 
     @_PATCH_TRADING_DAY
     def test_run_stats_include_passed_symbols(self, _mock_td):

--- a/frontend/src/App.static.test.jsx
+++ b/frontend/src/App.static.test.jsx
@@ -367,6 +367,7 @@ describe('App static mode', () => {
     expect(await screen.findByRole('heading', { name: 'Hong Kong Breadth' })).toBeInTheDocument();
     expect(window.location.hash).toContain('#/breadth');
     expect(window.location.hash).toContain('market=HK');
+    expect(window.localStorage.getItem('static-site:selected-market')).toBe('HK');
 
     const requestedUrls = globalThis.fetch.mock.calls.map(([url]) => String(url));
     expect(requestedUrls.some((url) => url.includes('/static-data/markets/hk/breadth.json'))).toBe(true);

--- a/frontend/src/App.static.test.jsx
+++ b/frontend/src/App.static.test.jsx
@@ -46,25 +46,55 @@ vi.mock('./components/Charts/BreadthChart', () => ({
 
 const staticPayloads = {
   'manifest.json': {
-    schema_version: 'static-site-v1',
+    schema_version: 'static-site-v2',
     generated_at: '2026-03-31T22:00:00Z',
     as_of_date: '2026-03-31',
+    default_market: 'US',
+    supported_markets: ['US', 'HK'],
     features: {
       scan: true,
       breadth: true,
       groups: true,
     },
     pages: {
-      home: { path: 'home.json' },
-      scan: { path: 'scan/manifest.json' },
-      breadth: { path: 'breadth.json' },
-      groups: { path: 'groups.json' },
+      home: { path: 'markets/us/home.json' },
+      scan: { path: 'markets/us/scan/manifest.json' },
+      breadth: { path: 'markets/us/breadth.json' },
+      groups: { path: 'markets/us/groups.json' },
+    },
+    markets: {
+      US: {
+        display_name: 'United States',
+        pages: {
+          home: { path: 'markets/us/home.json' },
+          scan: { path: 'markets/us/scan/manifest.json' },
+          breadth: { path: 'markets/us/breadth.json' },
+          groups: { path: 'markets/us/groups.json' },
+        },
+        assets: {
+          charts: { path: 'markets/us/charts/index.json' },
+        },
+      },
+      HK: {
+        display_name: 'Hong Kong',
+        pages: {
+          home: { path: 'markets/hk/home.json' },
+          scan: { path: 'markets/hk/scan/manifest.json' },
+          breadth: { path: 'markets/hk/breadth.json' },
+          groups: { path: 'markets/hk/groups.json' },
+        },
+        assets: {
+          charts: { path: 'markets/hk/charts/index.json' },
+        },
+      },
     },
     warnings: [],
   },
-  'home.json': {
+  'markets/us/home.json': {
     generated_at: '2026-03-31T22:00:00Z',
     as_of_date: '2026-03-31',
+    market: 'US',
+    market_display_name: 'United States',
     freshness: {
       scan_as_of_date: '2026-03-31',
       scan_run_id: 7,
@@ -77,7 +107,24 @@ const staticPayloads = {
     },
     top_groups: [{ industry_group: 'Semiconductors', rank: 1, top_symbol: 'NVDA' }],
   },
-  'scan/manifest.json': {
+  'markets/hk/home.json': {
+    generated_at: '2026-03-31T22:00:00Z',
+    as_of_date: '2026-03-31',
+    market: 'HK',
+    market_display_name: 'Hong Kong',
+    freshness: {
+      scan_as_of_date: '2026-03-31',
+      scan_run_id: 17,
+      breadth_latest_date: '2026-03-31',
+      groups_latest_date: '2026-03-31',
+    },
+    key_markets: [],
+    scan_summary: {
+      top_results: [{ symbol: '0700.HK', composite_score: 91.2, current_price: 398.4, rating: 'Buy' }],
+    },
+    top_groups: [{ industry_group: 'Internet', rank: 1, top_symbol: '0700.HK' }],
+  },
+  'markets/us/scan/manifest.json': {
     generated_at: '2026-03-31T22:00:00Z',
     as_of_date: '2026-03-31',
     run_id: 7,
@@ -105,21 +152,49 @@ const staticPayloads = {
         sort_order: 'desc',
       },
     ],
-    chunks: [{ path: 'scan/chunks/chunk-0001.json', count: 2 }],
+    chunks: [{ path: 'markets/us/scan/chunks/chunk-0001.json', count: 2 }],
     charts: {
-      path: 'charts/index.json',
+      path: 'markets/us/charts/index.json',
       limit: 200,
       symbols_total: 2,
       available: true,
     },
   },
-  'scan/chunks/chunk-0001.json': {
+  'markets/hk/scan/manifest.json': {
+    generated_at: '2026-03-31T22:00:00Z',
+    as_of_date: '2026-03-31',
+    run_id: 17,
+    sort: { field: 'composite_score', order: 'desc' },
+    default_page_size: 50,
+    rows_total: 1,
+    filter_options: {
+      ibd_industries: ['Internet'],
+      gics_sectors: ['Communication Services'],
+      ratings: ['Buy'],
+    },
+    initial_rows: [
+      { symbol: '0700.HK', company_name: 'Tencent Holdings', composite_score: 91.2, rating: 'Buy' },
+    ],
+    chunks: [{ path: 'markets/hk/scan/chunks/chunk-0001.json', count: 1 }],
+    charts: {
+      path: 'markets/hk/charts/index.json',
+      limit: 200,
+      symbols_total: 1,
+      available: true,
+    },
+  },
+  'markets/us/scan/chunks/chunk-0001.json': {
     rows: [
       { symbol: 'NVDA', company_name: 'NVIDIA Corporation', composite_score: 97.5, rating: 'Strong Buy' },
       { symbol: 'MSFT', company_name: 'Microsoft Corporation', composite_score: 89.2, rating: 'Buy' },
     ],
   },
-  'charts/index.json': {
+  'markets/hk/scan/chunks/chunk-0001.json': {
+    rows: [
+      { symbol: '0700.HK', company_name: 'Tencent Holdings', composite_score: 91.2, rating: 'Buy' },
+    ],
+  },
+  'markets/us/charts/index.json': {
     schema_version: 'static-charts-v1',
     generated_at: '2026-03-31T22:00:00Z',
     as_of_date: '2026-03-31',
@@ -131,7 +206,18 @@ const staticPayloads = {
       { symbol: 'MSFT', rank: 2, path: 'charts/MSFT.json' },
     ],
   },
-  'breadth.json': {
+  'markets/hk/charts/index.json': {
+    schema_version: 'static-charts-v1',
+    generated_at: '2026-03-31T22:00:00Z',
+    as_of_date: '2026-03-31',
+    limit: 200,
+    symbols_total: 1,
+    skipped_symbols: [],
+    symbols: [
+      { symbol: '0700.HK', rank: 1, path: 'charts/0700.HK.json' },
+    ],
+  },
+  'markets/us/breadth.json': {
     generated_at: '2026-03-31T22:00:00Z',
     published_at: '2026-03-31T22:00:00Z',
     payload: {
@@ -146,7 +232,22 @@ const staticPayloads = {
       history_90d: [{ date: '2026-03-31', stocks_up_4pct: 123, stocks_down_4pct: 42, ratio_5day: 1.5, ratio_10day: 1.8 }],
     },
   },
-  'groups.json': {
+  'markets/hk/breadth.json': {
+    generated_at: '2026-03-31T22:00:00Z',
+    published_at: '2026-03-31T22:00:00Z',
+    payload: {
+      current: {
+        date: '2026-03-31',
+        stocks_up_4pct: 54,
+        stocks_down_4pct: 12,
+        ratio_10day: 2.4,
+      },
+      chart_data: [],
+      spy_overlay: [],
+      history_90d: [{ date: '2026-03-31', stocks_up_4pct: 54, stocks_down_4pct: 12, ratio_5day: 2.1, ratio_10day: 2.4 }],
+    },
+  },
+  'markets/us/groups.json': {
     available: true,
     payload: {
       movers_period: '1w',
@@ -157,6 +258,20 @@ const staticPayloads = {
       movers: {
         gainers: [{ industry_group: 'Semiconductors', rank: 1, rank_change_1w: 3 }],
         losers: [{ industry_group: 'Retail', rank: 197, rank_change_1w: -5 }],
+      },
+    },
+  },
+  'markets/hk/groups.json': {
+    available: true,
+    payload: {
+      movers_period: '1w',
+      rankings: {
+        date: '2026-03-31',
+        rankings: [{ industry_group: 'Internet', rank: 1, avg_rs_rating: 88.1, num_stocks: 9, rank_change_1w: 1, rank_change_1m: 3, rank_change_3m: 5 }],
+      },
+      movers: {
+        gainers: [{ industry_group: 'Internet', rank: 1, rank_change_1w: 2 }],
+        losers: [{ industry_group: 'Property', rank: 44, rank_change_1w: -4 }],
       },
     },
   },
@@ -195,6 +310,7 @@ const renderStaticAppAtHash = async (hash) => {
 describe('App static mode', () => {
   beforeEach(() => {
     window.location.hash = '#/';
+    window.localStorage.clear();
   });
 
   afterEach(() => {
@@ -202,14 +318,15 @@ describe('App static mode', () => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     window.location.hash = '#/';
+    window.localStorage.clear();
   });
 
   it.each([
-    ['#/', 'Daily Market Snapshot'],
+    ['#/', 'United States Snapshot'],
     ['#/scan', 'Daily Scan'],
-    ['#/breadth', 'Market Breadth'],
-    ['#/groups', 'Industry Group Rankings'],
-    ['#/themes', 'Daily Market Snapshot'],
+    ['#/breadth', 'United States Breadth'],
+    ['#/groups', 'United States Group Rankings'],
+    ['#/themes', 'United States Snapshot'],
   ])('renders the static hash route %s without any /api requests', async (hash, heading) => {
     await renderStaticAppAtHash(hash);
 
@@ -239,8 +356,28 @@ describe('App static mode', () => {
   it('offers 1M and 3M ranges on the breadth page in the static route', async () => {
     await renderStaticAppAtHash('#/breadth');
 
-    expect(await screen.findByRole('heading', { name: 'Market Breadth' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'United States Breadth' })).toBeInTheDocument();
     expect(screen.getByTestId('breadth-chart-ranges')).toHaveTextContent('1M');
     expect(screen.getByTestId('breadth-chart-ranges')).toHaveTextContent('3M');
+  }, 10000);
+
+  it('honors the market query parameter and loads market-scoped breadth assets', async () => {
+    await renderStaticAppAtHash('#/breadth?market=HK');
+
+    expect(await screen.findByRole('heading', { name: 'Hong Kong Breadth' })).toBeInTheDocument();
+    expect(window.location.hash).toContain('#/breadth');
+    expect(window.location.hash).toContain('market=HK');
+
+    const requestedUrls = globalThis.fetch.mock.calls.map(([url]) => String(url));
+    expect(requestedUrls.some((url) => url.includes('/static-data/markets/hk/breadth.json'))).toBe(true);
+  }, 10000);
+
+  it('uses the persisted market selection when no query parameter is present', async () => {
+    window.localStorage.setItem('static-site:selected-market', 'HK');
+
+    await renderStaticAppAtHash('#/groups');
+
+    expect(await screen.findByRole('heading', { name: 'Hong Kong Group Rankings' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Static market selector' })).toHaveTextContent('Hong Kong');
   }, 10000);
 });

--- a/frontend/src/static/StaticAppShell.jsx
+++ b/frontend/src/static/StaticAppShell.jsx
@@ -4,10 +4,19 @@ import StaticHomePage from './pages/StaticHomePage';
 import StaticScanPage from './pages/StaticScanPage';
 import StaticBreadthPage from './pages/StaticBreadthPage';
 import StaticGroupsPage from './pages/StaticGroupsPage';
+import { StaticMarketProvider } from './StaticMarketContext';
+import { getStaticSupportedMarkets, useStaticManifest } from './dataClient';
 
-function StaticAppShell() {
+function StaticAppContent() {
+  const manifestQuery = useStaticManifest();
+  const supportedMarkets = getStaticSupportedMarkets(manifestQuery.data);
+  const defaultMarket = manifestQuery.data?.default_market || supportedMarkets[0] || 'US';
+
   return (
-    <Router>
+    <StaticMarketProvider
+      supportedMarkets={supportedMarkets}
+      defaultMarket={defaultMarket}
+    >
       <StaticLayout>
         <Routes>
           <Route path="/" element={<StaticHomePage />} />
@@ -17,6 +26,14 @@ function StaticAppShell() {
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </StaticLayout>
+    </StaticMarketProvider>
+  );
+}
+
+function StaticAppShell() {
+  return (
+    <Router>
+      <StaticAppContent />
     </Router>
   );
 }

--- a/frontend/src/static/StaticLayout.jsx
+++ b/frontend/src/static/StaticLayout.jsx
@@ -5,6 +5,9 @@ import {
   Button,
   Chip,
   Container,
+  FormControl,
+  MenuItem,
+  Select,
   Toolbar,
   Typography,
   IconButton,
@@ -15,6 +18,8 @@ import ShowChartIcon from '@mui/icons-material/ShowChart';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import { ColorModeContext } from '../contexts/ColorModeContext';
+import { useStaticMarket } from './StaticMarketContext';
+import { getStaticSupportedMarkets, resolveStaticMarketEntry, useStaticManifest } from './dataClient';
 
 const NAV_ITEMS = [
   { path: '/', label: 'Daily' },
@@ -27,6 +32,10 @@ function StaticLayout({ children }) {
   const location = useLocation();
   const theme = useTheme();
   const colorMode = useContext(ColorModeContext);
+  const manifestQuery = useStaticManifest();
+  const supportedMarkets = getStaticSupportedMarkets(manifestQuery.data);
+  const { selectedMarket, setSelectedMarket } = useStaticMarket();
+  const marketEntry = resolveStaticMarketEntry(manifestQuery.data, selectedMarket);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
@@ -42,6 +51,36 @@ function StaticLayout({ children }) {
             color="info"
             sx={{ ml: 1.5, height: 22, fontSize: '11px' }}
           />
+          <Box sx={{ ml: 1.5, minWidth: 140 }}>
+            <FormControl size="small" fullWidth>
+              <Select
+                value={marketEntry.market}
+                onChange={(event) => setSelectedMarket(event.target.value)}
+                displayEmpty
+                sx={{
+                  color: 'inherit',
+                  backgroundColor: 'rgba(255,255,255,0.12)',
+                  height: 30,
+                  '& .MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'rgba(255,255,255,0.35)',
+                  },
+                  '& .MuiSvgIcon-root': {
+                    color: 'inherit',
+                  },
+                }}
+                inputProps={{ 'aria-label': 'Static market selector' }}
+              >
+                {supportedMarkets.map((market) => {
+                  const label = manifestQuery.data?.markets?.[market]?.display_name || market;
+                  return (
+                    <MenuItem key={market} value={market}>
+                      {label}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            </FormControl>
+          </Box>
           <Box sx={{ flexGrow: 1 }} />
           {NAV_ITEMS.map((item) => {
             const isActive = location.pathname === item.path;

--- a/frontend/src/static/StaticMarketContext.jsx
+++ b/frontend/src/static/StaticMarketContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useState, useEffect } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export const STATIC_MARKET_STORAGE_KEY = 'static-site:selected-market';
@@ -45,7 +45,7 @@ export function StaticMarketProvider({
     }
   }, [defaultMarket, searchParams, selectedMarket, supportedMarkets]);
 
-  const setSelectedMarket = (market) => {
+  const setSelectedMarket = useCallback((market) => {
     const normalized = normalizeMarket(market, supportedMarkets, defaultMarket);
     setSelectedMarketState(normalized);
     if (typeof window !== 'undefined') {
@@ -59,12 +59,12 @@ export function StaticMarketProvider({
       nextParams.set('market', normalized);
     }
     setSearchParams(nextParams, { replace: true });
-  };
+  }, [defaultMarket, searchParams, setSearchParams, supportedMarkets]);
 
   const value = useMemo(() => ({
     selectedMarket,
     setSelectedMarket,
-  }), [selectedMarket]);
+  }), [selectedMarket, setSelectedMarket]);
 
   return (
     <StaticMarketContext.Provider value={value}>

--- a/frontend/src/static/StaticMarketContext.jsx
+++ b/frontend/src/static/StaticMarketContext.jsx
@@ -37,6 +37,9 @@ export function StaticMarketProvider({
       ? window.localStorage.getItem(STATIC_MARKET_STORAGE_KEY)
       : null;
     const nextMarket = normalizeMarket(fromQuery || fromStorage, supportedMarkets, defaultMarket);
+    if (typeof window !== 'undefined' && fromQuery) {
+      window.localStorage.setItem(STATIC_MARKET_STORAGE_KEY, nextMarket);
+    }
     if (nextMarket !== selectedMarket) {
       setSelectedMarketState(nextMarket);
     }

--- a/frontend/src/static/StaticMarketContext.jsx
+++ b/frontend/src/static/StaticMarketContext.jsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useMemo, useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export const STATIC_MARKET_STORAGE_KEY = 'static-site:selected-market';
+export const STATIC_DEFAULT_MARKET = 'US';
+
+const StaticMarketContext = createContext({
+  selectedMarket: STATIC_DEFAULT_MARKET,
+  setSelectedMarket: () => {},
+});
+
+const normalizeMarket = (value, supportedMarkets, defaultMarket) => {
+  const normalized = String(value || defaultMarket || STATIC_DEFAULT_MARKET).trim().toUpperCase();
+  if (Array.isArray(supportedMarkets) && supportedMarkets.length > 0) {
+    return supportedMarkets.includes(normalized) ? normalized : (supportedMarkets[0] || defaultMarket || STATIC_DEFAULT_MARKET);
+  }
+  return normalized || defaultMarket || STATIC_DEFAULT_MARKET;
+};
+
+export function StaticMarketProvider({
+  children,
+  supportedMarkets = [],
+  defaultMarket = STATIC_DEFAULT_MARKET,
+}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedMarket, setSelectedMarketState] = useState(() => {
+    const fromQuery = searchParams.get('market');
+    const fromStorage = typeof window !== 'undefined'
+      ? window.localStorage.getItem(STATIC_MARKET_STORAGE_KEY)
+      : null;
+    return normalizeMarket(fromQuery || fromStorage, supportedMarkets, defaultMarket);
+  });
+
+  useEffect(() => {
+    const fromQuery = searchParams.get('market');
+    const fromStorage = typeof window !== 'undefined'
+      ? window.localStorage.getItem(STATIC_MARKET_STORAGE_KEY)
+      : null;
+    const nextMarket = normalizeMarket(fromQuery || fromStorage, supportedMarkets, defaultMarket);
+    if (nextMarket !== selectedMarket) {
+      setSelectedMarketState(nextMarket);
+    }
+  }, [defaultMarket, searchParams, selectedMarket, supportedMarkets]);
+
+  const setSelectedMarket = (market) => {
+    const normalized = normalizeMarket(market, supportedMarkets, defaultMarket);
+    setSelectedMarketState(normalized);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STATIC_MARKET_STORAGE_KEY, normalized);
+    }
+
+    const nextParams = new URLSearchParams(searchParams);
+    if (normalized === (defaultMarket || STATIC_DEFAULT_MARKET)) {
+      nextParams.delete('market');
+    } else {
+      nextParams.set('market', normalized);
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  const value = useMemo(() => ({
+    selectedMarket,
+    setSelectedMarket,
+  }), [selectedMarket]);
+
+  return (
+    <StaticMarketContext.Provider value={value}>
+      {children}
+    </StaticMarketContext.Provider>
+  );
+}
+
+export const useStaticMarket = () => useContext(StaticMarketContext);

--- a/frontend/src/static/StaticMarketContext.test.jsx
+++ b/frontend/src/static/StaticMarketContext.test.jsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MemoryRouter, Routes, Route, useSearchParams } from 'react-router-dom';
+
+import {
+  STATIC_MARKET_STORAGE_KEY,
+  StaticMarketProvider,
+  useStaticMarket,
+} from './StaticMarketContext';
+
+function MarketHarness() {
+  const { selectedMarket, setSelectedMarket } = useStaticMarket();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  return (
+    <>
+      <div data-testid="selected-market">{selectedMarket}</div>
+      <div data-testid="search-params">{searchParams.toString()}</div>
+      <button type="button" onClick={() => setSelectedMarket('HK')}>
+        Switch to HK
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const next = new URLSearchParams(searchParams);
+          next.set('foo', 'bar');
+          setSearchParams(next, { replace: true });
+        }}
+      >
+        Set Foo
+      </button>
+    </>
+  );
+}
+
+function renderProvider(initialEntry = '/scan') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          path="*"
+          element={(
+            <StaticMarketProvider supportedMarkets={['US', 'HK']} defaultMarket="US">
+              <MarketHarness />
+            </StaticMarketProvider>
+          )}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('StaticMarketProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('persists a query-selected market as the new default', async () => {
+    const { unmount } = renderProvider('/breadth?market=HK');
+
+    expect(screen.getByTestId('selected-market')).toHaveTextContent('HK');
+    await waitFor(() => {
+      expect(window.localStorage.getItem(STATIC_MARKET_STORAGE_KEY)).toBe('HK');
+    });
+
+    unmount();
+    renderProvider('/breadth');
+
+    expect(screen.getByTestId('selected-market')).toHaveTextContent('HK');
+  });
+
+  it('preserves existing query params when switching markets', async () => {
+    renderProvider('/scan');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set Foo' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to HK' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-market')).toHaveTextContent('HK');
+    });
+    expect(screen.getByTestId('search-params')).toHaveTextContent('foo=bar&market=HK');
+    expect(window.localStorage.getItem(STATIC_MARKET_STORAGE_KEY)).toBe('HK');
+  });
+});

--- a/frontend/src/static/dataClient.js
+++ b/frontend/src/static/dataClient.js
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { getStaticDataUrl } from '../config/runtimeMode';
+import { STATIC_DEFAULT_MARKET } from './StaticMarketContext';
 
 export const fetchStaticJson = async (relativePath) => {
   const response = await fetch(getStaticDataUrl(relativePath), {
@@ -21,3 +22,43 @@ export const useStaticManifest = () => useQuery({
   staleTime: Infinity,
   gcTime: Infinity,
 });
+
+export const getStaticSupportedMarkets = (manifest) => {
+  if (Array.isArray(manifest?.supported_markets) && manifest.supported_markets.length > 0) {
+    return manifest.supported_markets;
+  }
+  if (manifest?.default_market) {
+    return [manifest.default_market];
+  }
+  return [STATIC_DEFAULT_MARKET];
+};
+
+export const resolveStaticMarketEntry = (manifest, selectedMarket) => {
+  const defaultMarket = String(manifest?.default_market || STATIC_DEFAULT_MARKET).toUpperCase();
+  const supportedMarkets = getStaticSupportedMarkets(manifest).map((market) => String(market).toUpperCase());
+  const normalizedMarket = String(selectedMarket || defaultMarket).toUpperCase();
+  const resolvedMarket = supportedMarkets.includes(normalizedMarket) ? normalizedMarket : defaultMarket;
+  const marketEntry = manifest?.markets?.[resolvedMarket];
+
+  if (marketEntry) {
+    return {
+      market: resolvedMarket,
+      display_name: marketEntry.display_name || resolvedMarket,
+      as_of_date: marketEntry.as_of_date || manifest?.as_of_date || null,
+      features: marketEntry.features || {},
+      pages: marketEntry.pages || {},
+      assets: marketEntry.assets || {},
+      freshness: marketEntry.freshness || {},
+    };
+  }
+
+  return {
+    market: resolvedMarket,
+    display_name: resolvedMarket,
+    as_of_date: manifest?.as_of_date || null,
+    features: manifest?.features || {},
+    pages: manifest?.pages || {},
+    assets: manifest?.assets || {},
+    freshness: manifest?.freshness || {},
+  };
+};

--- a/frontend/src/static/pages/StaticBreadthPage.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.jsx
@@ -15,7 +15,8 @@ import {
   Typography,
 } from '@mui/material';
 import BreadthChart from '../../components/Charts/BreadthChart';
-import { useStaticManifest, fetchStaticJson } from '../dataClient';
+import { useStaticManifest, fetchStaticJson, resolveStaticMarketEntry } from '../dataClient';
+import { useStaticMarket } from '../StaticMarketContext';
 
 const RANGE_DAYS = { '1M': 31, '3M': 90 };
 
@@ -34,15 +35,21 @@ function MetricCard({ label, value }) {
 
 function StaticBreadthPage() {
   const manifestQuery = useStaticManifest();
+  const { selectedMarket } = useStaticMarket();
+  const marketEntry = useMemo(
+    () => resolveStaticMarketEntry(manifestQuery.data, selectedMarket),
+    [manifestQuery.data, selectedMarket],
+  );
   const breadthQuery = useQuery({
-    queryKey: ['staticBreadth', manifestQuery.data?.pages?.breadth?.path],
-    queryFn: () => fetchStaticJson(manifestQuery.data.pages.breadth.path),
-    enabled: Boolean(manifestQuery.data?.pages?.breadth?.path),
+    queryKey: ['staticBreadth', marketEntry.pages?.breadth?.path],
+    queryFn: () => fetchStaticJson(marketEntry.pages.breadth.path),
+    enabled: Boolean(marketEntry.pages?.breadth?.path),
     staleTime: Infinity,
   });
   const [timeRange, setTimeRange] = useState('1M');
 
   const payload = breadthQuery.data?.payload || {};
+  const displayName = marketEntry.display_name;
   const filteredChartData = useMemo(() => {
     const allData = payload.chart_data || payload.history_90d || [];
     return allData.slice(-(RANGE_DAYS[timeRange] || 31));
@@ -74,7 +81,7 @@ function StaticBreadthPage() {
   return (
     <Box>
       <Typography variant="h5" sx={{ fontWeight: 700, letterSpacing: '-0.5px', mb: 0.5 }}>
-        Market Breadth
+        {displayName} Breadth
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2, fontSize: '12px' }}>
         Breadth snapshot published {breadthQuery.data.published_at || breadthQuery.data.generated_at}.

--- a/frontend/src/static/pages/StaticGroupsPage.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Alert,
@@ -14,9 +14,10 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import { useStaticManifest, fetchStaticJson } from '../dataClient';
+import { useStaticManifest, fetchStaticJson, resolveStaticMarketEntry } from '../dataClient';
 import StaticGroupDetailModal from '../StaticGroupDetailModal';
 import RankChangeCell from '../../components/shared/RankChangeCell';
+import { useStaticMarket } from '../StaticMarketContext';
 
 function MoversCard({ title, rows }) {
   return (
@@ -52,10 +53,15 @@ function MoversCard({ title, rows }) {
 
 function StaticGroupsPage() {
   const manifestQuery = useStaticManifest();
+  const { selectedMarket } = useStaticMarket();
+  const marketEntry = useMemo(
+    () => resolveStaticMarketEntry(manifestQuery.data, selectedMarket),
+    [manifestQuery.data, selectedMarket],
+  );
   const groupsQuery = useQuery({
-    queryKey: ['staticGroups', manifestQuery.data?.pages?.groups?.path],
-    queryFn: () => fetchStaticJson(manifestQuery.data.pages.groups.path),
-    enabled: Boolean(manifestQuery.data?.pages?.groups?.path),
+    queryKey: ['staticGroups', marketEntry.pages?.groups?.path],
+    queryFn: () => fetchStaticJson(marketEntry.pages.groups.path),
+    enabled: Boolean(marketEntry.pages?.groups?.path),
     staleTime: Infinity,
   });
   const [selectedGroup, setSelectedGroup] = useState(null);
@@ -85,7 +91,7 @@ function StaticGroupsPage() {
   return (
     <Box>
       <Typography variant="h5" sx={{ fontWeight: 700, letterSpacing: '-0.5px', mb: 0.5 }}>
-        Industry Group Rankings
+        {marketEntry.display_name} Group Rankings
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2, fontSize: '12px' }}>
         Latest ranking date: {payload.rankings?.date || '-'}.

--- a/frontend/src/static/pages/StaticGroupsPage.test.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.test.jsx
@@ -90,7 +90,7 @@ describe('StaticGroupsPage', () => {
   it('renders 1W movers and the 1W rank-change column', async () => {
     renderPage();
 
-    expect(await screen.findByRole('heading', { name: 'Industry Group Rankings' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'US Group Rankings' })).toBeInTheDocument();
     expect(screen.getByText('Top Gainers (1W)')).toBeInTheDocument();
     expect(screen.getByText('Top Losers (1W)')).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: '1W' })).toBeInTheDocument();

--- a/frontend/src/static/pages/StaticHomePage.jsx
+++ b/frontend/src/static/pages/StaticHomePage.jsx
@@ -14,7 +14,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import { useStaticManifest, fetchStaticJson } from '../dataClient';
+import { useStaticManifest, fetchStaticJson, resolveStaticMarketEntry } from '../dataClient';
 import { useStaticChartIndex } from '../chartClient';
 import PriceSparkline from '../../components/Scan/PriceSparkline';
 import RSSparkline from '../../components/Scan/RSSparkline';
@@ -23,6 +23,8 @@ import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import StaticChartViewerModal from '../StaticChartViewerModal';
 import RankChangeCell from '../../components/shared/RankChangeCell';
 import { getGroupRankColor } from '../../utils/colorUtils';
+import { formatLocalCurrency } from '../../utils/formatUtils';
+import { useStaticMarket } from '../StaticMarketContext';
 
 const EMPTY_RESULTS = [];
 
@@ -36,13 +38,18 @@ const formatNumber = (value, digits = 0) => {
 
 function StaticHomePage() {
   const manifestQuery = useStaticManifest();
+  const { selectedMarket } = useStaticMarket();
+  const marketEntry = useMemo(
+    () => resolveStaticMarketEntry(manifestQuery.data, selectedMarket),
+    [manifestQuery.data, selectedMarket],
+  );
   const homeQuery = useQuery({
-    queryKey: ['staticHome', manifestQuery.data?.pages?.home?.path],
-    queryFn: () => fetchStaticJson(manifestQuery.data.pages.home.path),
-    enabled: Boolean(manifestQuery.data?.pages?.home?.path),
+    queryKey: ['staticHome', marketEntry.pages?.home?.path],
+    queryFn: () => fetchStaticJson(marketEntry.pages.home.path),
+    enabled: Boolean(marketEntry.pages?.home?.path),
     staleTime: Infinity,
   });
-  const chartIndexQuery = useStaticChartIndex(manifestQuery.data?.assets?.charts?.path);
+  const chartIndexQuery = useStaticChartIndex(marketEntry.assets?.charts?.path);
 
   const [chartModalOpen, setChartModalOpen] = useState(false);
   const [selectedChartSymbol, setSelectedChartSymbol] = useState(null);
@@ -75,6 +82,7 @@ function StaticHomePage() {
 
   const home = homeQuery.data;
   const freshness = home?.freshness || {};
+  const marketDisplay = home?.market_display_name || marketEntry.display_name;
 
   const handleRowClick = (symbol) => {
     if (chartEnabledSymbols.has(symbol)) {
@@ -97,7 +105,7 @@ function StaticHomePage() {
         }}
       >
         <Typography variant="h5" sx={{ fontWeight: 700, letterSpacing: '-0.5px' }}>
-          Daily Market Snapshot
+          {marketDisplay} Snapshot
         </Typography>
         <Typography
           variant="caption"
@@ -124,7 +132,7 @@ function StaticHomePage() {
                   {item.display_name}
                 </Typography>
                 <Typography variant="body1" sx={{ mt: 0.5, fontFamily: 'monospace', fontWeight: 600 }}>
-                  {item.latest_close != null ? `$${formatNumber(item.latest_close, 2)}` : '-'}
+                  {formatLocalCurrency(item.latest_close, item.currency)}
                 </Typography>
                 <Box display="flex" alignItems="center" sx={{ mt: 0.5 }}>
                   {item.change_1d > 0 && <TrendingUpIcon sx={{ fontSize: 14, mr: 0.25, color: 'success.main' }} />}

--- a/frontend/src/static/pages/StaticScanPage.jsx
+++ b/frontend/src/static/pages/StaticScanPage.jsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import FilterPanel from '../../components/Scan/FilterPanel';
 import ResultsTable from '../../components/Scan/ResultsTable';
-import { useStaticManifest, fetchStaticJson } from '../dataClient';
+import { useStaticManifest, fetchStaticJson, resolveStaticMarketEntry } from '../dataClient';
 import { useStaticChartIndex } from '../chartClient';
 import {
   applyScanFilterDefaults,
@@ -25,15 +25,21 @@ import {
 import StaticChartViewerModal from '../StaticChartViewerModal';
 import ScreenSelector from '../components/ScreenSelector';
 import { usePresetScreens, buildFiltersFromPreset } from '../hooks/usePresetScreens';
+import { useStaticMarket } from '../StaticMarketContext';
 
 const HYDRATION_BATCH_SIZE = 2;
 
 function StaticScanPage() {
   const manifestQuery = useStaticManifest();
+  const { selectedMarket } = useStaticMarket();
+  const marketEntry = useMemo(
+    () => resolveStaticMarketEntry(manifestQuery.data, selectedMarket),
+    [manifestQuery.data, selectedMarket],
+  );
   const scanManifestQuery = useQuery({
-    queryKey: ['staticScanManifest', manifestQuery.data?.pages?.scan?.path],
-    queryFn: () => fetchStaticJson(manifestQuery.data.pages.scan.path),
-    enabled: Boolean(manifestQuery.data?.pages?.scan?.path),
+    queryKey: ['staticScanManifest', marketEntry.pages?.scan?.path],
+    queryFn: () => fetchStaticJson(marketEntry.pages.scan.path),
+    enabled: Boolean(marketEntry.pages?.scan?.path),
     staleTime: Infinity,
   });
   const chartIndexQuery = useStaticChartIndex(scanManifestQuery.data?.charts?.path);


### PR DESCRIPTION
## Summary
- publish and export market-scoped static data bundles for US, HK, JP, and TW under one static site
- add market-aware manifest resolution and a shared market selector in the static frontend
- fix market pointer repair on reruns, fail closed on unlabeled legacy runs, and persist query-selected markets

## Testing
- `backend/venv/bin/pytest -q backend/tests/unit/test_feature_store_tasks.py backend/tests/unit/test_static_site_export_service.py backend/tests/unit/test_export_static_site_script.py backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py`
- `cd frontend && npm run test:run -- src/App.static.test.jsx src/static/pages/StaticScanPage.test.jsx src/static/pages/StaticBreadthPage.test.jsx src/static/pages/StaticGroupsPage.test.jsx`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-market static site support: per-market exports, market-scoped pages/assets, and schema v2 manifest with supported/default market.
  * Per-market publish targets so snapshots can be published/recorded per market.

* **Improvements**
  * Market selector dropdown and market-aware routing/headers across static pages.
  * Dynamic market-specific titles, localized currency formatting, and improved default-market export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->