### PR TITLE
Add Daily Snapshot and Digest tabs to MarketScan page

### DIFF
--- a/frontend/src/components/Layout/Layout.jsx
+++ b/frontend/src/components/Layout/Layout.jsx
@@ -6,11 +6,10 @@ import {
   Container,
   Drawer,
   Fab,
-  FormControl,
   InputBase,
-  InputLabel,
+  ListItemText,
+  Menu,
   MenuItem,
-  Select,
   Toolbar,
   Typography,
   IconButton,
@@ -21,6 +20,7 @@ import ShowChartIcon from '@mui/icons-material/ShowChart';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import SettingsIcon from '@mui/icons-material/Settings';
+import PersonIcon from '@mui/icons-material/Person';
 import MonitorHeartIcon from '@mui/icons-material/MonitorHeart';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import { ColorModeContext } from '../../contexts/ColorModeContext';
@@ -50,13 +50,13 @@ function TickerSearch() {
       value={tickerInput}
       onChange={(e) => setTickerInput(e.target.value)}
       onKeyDown={handleTickerSubmit}
-      placeholder="TICKER ↵"
+      placeholder="TICKER"
       size="small"
       inputProps={{ 'aria-label': 'Go to ticker' }}
       sx={{
         px: 1.5,
         py: 0.25,
-        width: 300,
+        width: 150,
         fontSize: '15px',
         backgroundColor: 'rgba(255,255,255,0.15)',
         borderRadius: 1,
@@ -64,7 +64,6 @@ function TickerSearch() {
         '& input::placeholder': {
           color: 'rgba(255,255,255,0.7)',
           opacity: 1,
-          fontStyle: 'italic',
           letterSpacing: '1px',
         },
       }}
@@ -93,15 +92,24 @@ function Layout({ children }) {
   const assistantAvailable = features.chatbot && (!auth?.required || auth?.authenticated);
 
   const navItems = [
-    { path: '/', label: 'Routine' },
-    { path: '/scan', label: 'Scanner' },
+    { path: '/', label: 'Daily' },
+    { path: '/scan', label: 'Scan' },
     { path: '/breadth', label: 'Breadth' },
-    { path: '/groups', label: 'Group Rankings' },
+    { path: '/groups', label: 'Groups' },
     { path: '/digest', label: 'Digest' },
-    { path: '/validation', label: 'Validation' },
+    { path: '/validation', label: 'Backtest' },
     ...(features.themes ? [{ path: '/themes', label: 'Themes' }] : []),
     ...(features.chatbot ? [{ path: '/chatbot', label: 'Assistant' }] : []),
   ];
+
+  const [profileMenuAnchor, setProfileMenuAnchor] = useState(null);
+  const profileMenuOpen = Boolean(profileMenuAnchor);
+  const profileOptions = profiles.length
+    ? profiles
+    : [{ profile: activeProfile, label: activeProfileDetail?.label || activeProfile }];
+  const activeProfileLabel = profileOptions.find((p) => p.profile === activeProfile)?.label
+    || activeProfileDetail?.label
+    || activeProfile;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
@@ -116,35 +124,6 @@ function Layout({ children }) {
           </Box>
           <Box sx={{ flexGrow: 1 }} />
           <TickerSearch />
-          <Box sx={{ ml: 1.5, minWidth: 150 }}>
-            <FormControl size="small" fullWidth variant="outlined">
-              <InputLabel id="strategy-profile-label" sx={{ color: 'rgba(255,255,255,0.8)' }}>
-                Profile
-              </InputLabel>
-              <Select
-                labelId="strategy-profile-label"
-                value={activeProfile}
-                label="Profile"
-                onChange={(event) => setActiveProfile(event.target.value)}
-                sx={{
-                  color: 'inherit',
-                  backgroundColor: 'rgba(255,255,255,0.12)',
-                  '& .MuiOutlinedInput-notchedOutline': {
-                    borderColor: 'rgba(255,255,255,0.35)',
-                  },
-                  '& .MuiSvgIcon-root': {
-                    color: 'inherit',
-                  },
-                }}
-              >
-                {(profiles.length ? profiles : [{ profile: activeProfile, label: activeProfileDetail?.label || activeProfile }]).map((profile) => (
-                  <MenuItem key={profile.profile} value={profile.profile}>
-                    {profile.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Box>
           <Box sx={{ flexGrow: 1 }} />
           {navItems.map((item) => {
             const isActive = location.pathname === item.path;
@@ -172,9 +151,41 @@ function Layout({ children }) {
               </Button>
             );
           })}
+          <IconButton
+            sx={{ ml: 1 }}
+            onClick={(event) => setProfileMenuAnchor(event.currentTarget)}
+            color="inherit"
+            title={`Profile: ${activeProfileLabel}`}
+            aria-label="Select strategy profile"
+            aria-haspopup="menu"
+            aria-expanded={profileMenuOpen}
+            size="small"
+          >
+            <PersonIcon fontSize="small" />
+          </IconButton>
+          <Menu
+            anchorEl={profileMenuAnchor}
+            open={profileMenuOpen}
+            onClose={() => setProfileMenuAnchor(null)}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          >
+            {profileOptions.map((profile) => (
+              <MenuItem
+                key={profile.profile}
+                selected={profile.profile === activeProfile}
+                onClick={() => {
+                  setActiveProfile(profile.profile);
+                  setProfileMenuAnchor(null);
+                }}
+              >
+                <ListItemText primary={profile.label} />
+              </MenuItem>
+            ))}
+          </Menu>
           {features.tasks && (
             <IconButton
-              sx={{ ml: 1 }}
+              sx={{ ml: 0.5 }}
               onClick={() => setSettingsOpen(true)}
               color="inherit"
               title="Scheduled Tasks"

--- a/frontend/src/components/MarketScan/DailyMarketSnapshotTab.jsx
+++ b/frontend/src/components/MarketScan/DailyMarketSnapshotTab.jsx
@@ -1,0 +1,357 @@
+import { useMemo, useState } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Grid,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+
+import { getWatchlist } from '../../api/marketScan';
+import { getScanBootstrap } from '../../api/scans';
+import { getCurrentRankings } from '../../api/groups';
+import { fetchPriceHistory, priceHistoryKeys, PRICE_HISTORY_STALE_TIME } from '../../api/priceHistory';
+import PriceSparkline from '../Scan/PriceSparkline';
+import RSSparkline from '../Scan/RSSparkline';
+import ChartViewerModal from '../Scan/ChartViewerModal';
+import RankChangeCell from '../shared/RankChangeCell';
+import { getGroupRankColor } from '../../utils/colorUtils';
+import { formatLocalCurrency } from '../../utils/formatUtils';
+
+const EMPTY_ROWS = [];
+
+function formatNumber(value, digits = 0) {
+  if (value == null) return '-';
+  return Number(value).toLocaleString(undefined, {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  });
+}
+
+function DailyMarketSnapshotTab() {
+  const watchlistQuery = useQuery({
+    queryKey: ['marketScan', 'key_markets'],
+    queryFn: () => getWatchlist('key_markets'),
+  });
+
+  const scanBootstrapQuery = useQuery({
+    queryKey: ['scanBootstrap', 'latest'],
+    queryFn: () => getScanBootstrap(),
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const groupsQuery = useQuery({
+    queryKey: ['groupRankings', 'dailySnapshot', 10],
+    queryFn: () => getCurrentRankings(10),
+    staleTime: 60_000,
+  });
+
+  const watchlistSymbols = useMemo(
+    () => watchlistQuery.data?.symbols ?? EMPTY_ROWS,
+    [watchlistQuery.data],
+  );
+  const keyMarketHistories = useQueries({
+    queries: watchlistSymbols.map((entry) => ({
+      queryKey: priceHistoryKeys.symbol(entry.symbol, '3mo'),
+      queryFn: () => fetchPriceHistory(entry.symbol, '3mo'),
+      staleTime: PRICE_HISTORY_STALE_TIME,
+      enabled: Boolean(entry.symbol),
+    })),
+  });
+
+  const keyMarkets = useMemo(() => (
+    watchlistSymbols.map((entry, idx) => {
+      const history = keyMarketHistories[idx]?.data ?? [];
+      const closes = history.map((h) => h.close).filter((c) => c != null);
+      const latestClose = closes.length ? closes[closes.length - 1] : null;
+      const priorClose = closes.length >= 2 ? closes[closes.length - 2] : null;
+      const change1d = latestClose != null && priorClose
+        ? ((latestClose - priorClose) / priorClose) * 100
+        : null;
+      return {
+        symbol: entry.symbol,
+        display_name: entry.display_name || entry.symbol,
+        closes,
+        latestClose,
+        change1d,
+      };
+    })
+  ), [watchlistSymbols, keyMarketHistories]);
+
+  const scanPayload = scanBootstrapQuery.data?.payload;
+  const scanId = scanPayload?.selected_scan?.scan_id
+    ?? scanPayload?.results_page?.scan_id
+    ?? null;
+  const scanAsOfDate = scanPayload?.selected_scan?.as_of_date
+    ?? scanPayload?.results_page?.as_of_date
+    ?? null;
+  const topResults = useMemo(() => {
+    const all = scanPayload?.results_page?.results ?? EMPTY_ROWS;
+    return all
+      .filter((row) => (row.dollar_volume ?? row.avg_dollar_volume ?? 0) >= 100_000_000)
+      .slice(0, 20);
+  }, [scanPayload]);
+
+  const topGroups = (groupsQuery.data?.rankings ?? EMPTY_ROWS).slice(0, 10);
+  const groupsDate = groupsQuery.data?.date ?? null;
+
+  const [chartModalOpen, setChartModalOpen] = useState(false);
+  const [selectedSymbol, setSelectedSymbol] = useState(null);
+
+  const isInitialLoading =
+    watchlistQuery.isLoading || scanBootstrapQuery.isLoading || groupsQuery.isLoading;
+
+  if (isInitialLoading) {
+    return (
+      <Box display="flex" justifyContent="center" py={8}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (scanBootstrapQuery.isError && groupsQuery.isError) {
+    return <Alert severity="error">Failed to load the daily snapshot.</Alert>;
+  }
+
+  const handleRowClick = (symbol) => {
+    if (!scanId) return;
+    setSelectedSymbol(symbol);
+    setChartModalOpen(true);
+  };
+
+  return (
+    <Box sx={{ height: '100%', overflow: 'auto', pr: 1 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          columnGap: 2,
+          rowGap: 0.5,
+          mb: 2,
+        }}
+      >
+        <Typography variant="h5" sx={{ fontWeight: 700, letterSpacing: '-0.5px' }}>
+          Daily Snapshot
+        </Typography>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ fontFamily: 'monospace', fontSize: '11px' }}
+        >
+          {`Scan ${scanAsOfDate || '-'} · Groups ${groupsDate || '-'}`}
+        </Typography>
+      </Box>
+
+      <Grid container spacing={1.5} sx={{ mb: 2 }}>
+        {keyMarkets.map((item) => {
+          const trend = item.closes.length >= 2
+            ? (item.closes[item.closes.length - 1] > item.closes[0] ? 1
+              : item.closes[item.closes.length - 1] < item.closes[0] ? -1 : 0)
+            : 0;
+          return (
+            <Grid item xs={6} sm={4} md={2.4} key={item.symbol}>
+              <Paper elevation={0} sx={{ p: 1.5, height: '100%', border: '1px solid', borderColor: 'divider' }}>
+                <Typography variant="body2" sx={{ fontWeight: 600, fontSize: '13px' }}>
+                  {item.symbol}
+                </Typography>
+                <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '10px' }}>
+                  {item.display_name}
+                </Typography>
+                <Typography variant="body1" sx={{ mt: 0.5, fontFamily: 'monospace', fontWeight: 600 }}>
+                  {formatLocalCurrency(item.latestClose, 'USD')}
+                </Typography>
+                <Box display="flex" alignItems="center" sx={{ mt: 0.5 }}>
+                  {item.change1d > 0 && <TrendingUpIcon sx={{ fontSize: 14, mr: 0.25, color: 'success.main' }} />}
+                  {item.change1d < 0 && <TrendingDownIcon sx={{ fontSize: 14, mr: 0.25, color: 'error.main' }} />}
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: item.change1d > 0 ? 'success.main' : item.change1d < 0 ? 'error.main' : 'text.secondary',
+                      fontFamily: 'monospace',
+                      fontWeight: 600,
+                      fontSize: '12px',
+                    }}
+                  >
+                    {item.change1d != null
+                      ? `${item.change1d > 0 ? '+' : ''}${formatNumber(item.change1d, 2)}%`
+                      : '-'}
+                  </Typography>
+                </Box>
+                {item.closes.length > 1 ? (
+                  <Box sx={{ mt: 0.75 }}>
+                    <PriceSparkline
+                      data={item.closes}
+                      trend={trend}
+                      change1d={null}
+                      width="100%"
+                      height={36}
+                      showChange={false}
+                    />
+                  </Box>
+                ) : null}
+              </Paper>
+            </Grid>
+          );
+        })}
+      </Grid>
+
+      <Paper elevation={0} sx={{ p: 1.5, mb: 2, border: '1px solid', borderColor: 'divider' }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: '13px', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 0.5 }}>
+          Top Scan Candidates
+        </Typography>
+        <Typography variant="caption" color="text.disabled" sx={{ mb: 1, display: 'block', fontSize: '10px' }}>
+          Dollar volume &gt; $100M. Click a row for chart details.
+        </Typography>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell align="center">Symbol</TableCell>
+                <TableCell align="center">Score</TableCell>
+                <TableCell align="center">Price</TableCell>
+                <TableCell align="center">Rating</TableCell>
+                <TableCell align="center">Price Trend</TableCell>
+                <TableCell align="center">RS Trend</TableCell>
+                <TableCell align="center">IBD Group</TableCell>
+                <TableCell align="center">Grp Rank</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {topResults.map((row) => (
+                <TableRow
+                  key={row.symbol}
+                  hover
+                  tabIndex={0}
+                  onClick={() => handleRowClick(row.symbol)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      handleRowClick(row.symbol);
+                    }
+                  }}
+                  sx={{ cursor: scanId ? 'pointer' : 'default' }}
+                >
+                  <TableCell align="center" sx={{ fontWeight: 600 }}>{row.symbol}</TableCell>
+                  <TableCell align="center">{formatNumber(row.composite_score, 1)}</TableCell>
+                  <TableCell align="center">{row.current_price != null ? `$${formatNumber(row.current_price, 2)}` : '-'}</TableCell>
+                  <TableCell align="center">{row.rating}</TableCell>
+                  <TableCell align="center">
+                    {row.price_sparkline_data ? (
+                      <Box display="flex" justifyContent="center">
+                        <PriceSparkline
+                          data={row.price_sparkline_data}
+                          trend={row.price_trend}
+                          change1d={row.price_change_1d}
+                          industry={row.ibd_industry_group}
+                          width={130}
+                          height={28}
+                        />
+                      </Box>
+                    ) : '-'}
+                  </TableCell>
+                  <TableCell align="center">
+                    {row.rs_sparkline_data ? (
+                      <Box display="flex" justifyContent="center">
+                        <RSSparkline
+                          data={row.rs_sparkline_data}
+                          trend={row.rs_trend}
+                          width={78}
+                          height={20}
+                        />
+                      </Box>
+                    ) : '-'}
+                  </TableCell>
+                  <TableCell align="center" sx={{
+                    color: 'text.secondary', fontSize: '12px',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 140,
+                  }}>
+                    {row.ibd_industry_group || '-'}
+                  </TableCell>
+                  <TableCell align="center" sx={{
+                    fontFamily: 'monospace',
+                    fontWeight: row.ibd_group_rank && row.ibd_group_rank <= 20 ? 600 : 400,
+                    color: getGroupRankColor(row.ibd_group_rank),
+                  }}>
+                    {row.ibd_group_rank ?? '-'}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {topResults.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={8} align="center" sx={{ color: 'text.disabled', py: 2 }}>
+                    No high-volume candidates in the latest scan.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      <Paper elevation={0} sx={{ p: 1.5, border: '1px solid', borderColor: 'divider' }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: '13px', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 0.5 }}>
+          Top 10 Groups
+        </Typography>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell align="center">Rank</TableCell>
+                <TableCell>Group</TableCell>
+                <TableCell align="right">1W</TableCell>
+                <TableCell>Top Stock</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {topGroups.map((group) => (
+                <TableRow key={group.industry_group}>
+                  <TableCell align="center" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>{group.rank}</TableCell>
+                  <TableCell>{group.industry_group}</TableCell>
+                  <TableCell align="right"><RankChangeCell value={group.rank_change_1w} /></TableCell>
+                  <TableCell sx={{ fontWeight: 500, fontFamily: 'monospace', fontSize: '11px' }}>
+                    {group.top_symbol || '-'}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {topGroups.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} align="center" sx={{ color: 'text.disabled', py: 2 }}>
+                    No group rankings available.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      {scanId && (
+        <ChartViewerModal
+          open={chartModalOpen}
+          onClose={() => setChartModalOpen(false)}
+          initialSymbol={selectedSymbol}
+          scanId={scanId}
+          filters={{}}
+          sortBy="composite_score"
+          sortOrder="desc"
+          currentPageResults={topResults}
+        />
+      )}
+    </Box>
+  );
+}
+
+export default DailyMarketSnapshotTab;

--- a/frontend/src/components/MarketScan/DigestTab.jsx
+++ b/frontend/src/components/MarketScan/DigestTab.jsx
@@ -1,0 +1,7 @@
+import DigestPage from '../../pages/DigestPage';
+
+function DigestTab() {
+  return <DigestPage />;
+}
+
+export default DigestTab;

--- a/frontend/src/pages/MarketScanPage.jsx
+++ b/frontend/src/pages/MarketScanPage.jsx
@@ -4,6 +4,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Box, Tabs, Tab, Paper } from '@mui/material';
 import KeyMarketsTab from '../components/MarketScan/KeyMarketsTab';
+import DailyMarketSnapshotTab from '../components/MarketScan/DailyMarketSnapshotTab';
+import DigestTab from '../components/MarketScan/DigestTab';
 import ThemesTab from '../components/MarketScan/ThemesTab';
 import WatchlistsTab from '../components/MarketScan/WatchlistsTab';
 import StockbeeMmTab from '../components/MarketScan/StockbeeMmTab';
@@ -14,6 +16,8 @@ function MarketScanPage() {
   const [selectedTab, setSelectedTab] = useState(0);
   const subTabs = useMemo(() => ([
     { id: 'key_markets', label: 'Key Markets', render: () => <KeyMarketsTab /> },
+    { id: 'daily_snapshot', label: 'Daily Snapshot', render: () => <DailyMarketSnapshotTab /> },
+    { id: 'digest', label: 'Digest', render: () => <DigestTab /> },
     ...(features.themes
       ? [{ id: 'themes', label: 'Themes', render: () => <ThemesTab /> }]
       : []),

--- a/frontend/src/pages/MarketScanPage.test.jsx
+++ b/frontend/src/pages/MarketScanPage.test.jsx
@@ -18,6 +18,14 @@ vi.mock('../components/MarketScan/KeyMarketsTab', () => ({
   default: () => <div>key-markets</div>,
 }));
 
+vi.mock('../components/MarketScan/DailyMarketSnapshotTab', () => ({
+  default: () => <div>daily-snapshot-tab</div>,
+}));
+
+vi.mock('../components/MarketScan/DigestTab', () => ({
+  default: () => <div>digest-tab</div>,
+}));
+
 vi.mock('../components/MarketScan/ThemesTab', () => ({
   default: () => <div>themes-tab</div>,
 }));
@@ -40,6 +48,8 @@ describe('MarketScanPage capability gating', () => {
 
     expect(screen.queryByRole('tab', { name: 'Themes' })).not.toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Key Markets' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Daily Snapshot' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Digest' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Watchlists' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Stockbee MM' })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
This PR adds two new tabs to the MarketScan page: "Daily Snapshot" and "Digest", along with UI improvements to the main navigation layout.

## Key Changes

### New Components
- **DailyMarketSnapshotTab**: A comprehensive market overview component featuring:
  - Key markets display with 3-month price sparklines and 1-day change indicators
  - Top scan candidates table (filtered by $100M+ dollar volume) with price/RS trends and IBD group rankings
  - Top 10 industry groups rankings with 1-week rank changes
  - Interactive chart modal for detailed symbol analysis
  - Data fetched from watchlist, scan bootstrap, and group rankings APIs

- **DigestTab**: A wrapper component that renders the existing DigestPage within the MarketScan tab interface

### Layout Improvements
- Replaced the profile selector dropdown with a compact icon button menu (PersonIcon) in the top navigation
- Simplified navigation labels: "Routine" → "Daily", "Scanner" → "Scan", "Group Rankings" → "Groups", "Validation" → "Backtest"
- Reduced ticker search input width from 300px to 150px
- Removed italic styling from ticker search placeholder
- Converted profile selection from a FormControl/Select to a Menu-based dropdown for better space efficiency

### Page Updates
- Updated MarketScanPage to include the new tabs in the tab navigation
- Added test mocks for the new components

## Implementation Details
- DailyMarketSnapshotTab uses React Query for data fetching with appropriate stale times and error handling
- Implements keyboard accessibility for table rows (Enter/Space key support)
- Uses MUI components for consistent styling and responsive grid layouts
- Includes proper loading states and error boundaries
- Leverages existing utility functions (formatLocalCurrency, getGroupRankColor) and shared components (PriceSparkline, RSSparkline, ChartViewerModal)

https://claude.ai/code/session_01XpKaoMz72NvdJCXLVjFZLy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
