### PR TITLE
[codex] Add bootstrap runtime progress and scan refresh guard

### DIFF
--- a/backend/app/api/v1/scans.py
+++ b/backend/app/api/v1/scans.py
@@ -24,6 +24,7 @@ from ...schemas.scanning import (
     ScanStatusResponse,
     SetupDetailsResponse,
 )
+from ...schemas.universe import IndexName
 from ...schemas.ui_view_snapshot import UISnapshotEnvelope
 from ...services.market_activity_service import get_runtime_activity_status
 from ...wiring.bootstrap import (
@@ -47,6 +48,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 SCAN_BLOCKING_ACTIVITY_STAGES = {"prices", "fundamentals"}
 SCAN_BLOCKING_ACTIVITY_STATUSES = {"queued", "running"}
+SCAN_GUARD_MARKET_BY_INDEX = {
+    IndexName.SP500.value: "US",
+    IndexName.HSI.value: "HK",
+    IndexName.NIKKEI225.value: "JP",
+    IndexName.TAIEX.value: "TW",
+}
 
 
 def _get_market_refresh_conflict_detail(uow: Any, market: str | None) -> dict[str, object] | None:
@@ -90,8 +97,10 @@ def _get_market_refresh_conflict_detail(uow: Any, market: str | None) -> dict[st
 def _resolve_scan_guard_market(universe_def: Any) -> str | None:
     if getattr(universe_def, "market", None):
         return universe_def.market.value
-    if getattr(universe_def, "exchange", None) or getattr(universe_def, "index", None):
+    if getattr(universe_def, "exchange", None):
         return "US"
+    if getattr(universe_def, "index", None):
+        return SCAN_GUARD_MARKET_BY_INDEX.get(universe_def.index.value)
     return None
 
 

--- a/backend/app/api/v1/scans.py
+++ b/backend/app/api/v1/scans.py
@@ -26,6 +26,7 @@ from ...schemas.scanning import (
 )
 from ...schemas.universe import IndexName
 from ...schemas.ui_view_snapshot import UISnapshotEnvelope
+from ...database import SessionLocal
 from ...services.market_activity_service import get_runtime_activity_status
 from ...wiring.bootstrap import (
     get_uow,
@@ -56,15 +57,16 @@ SCAN_GUARD_MARKET_BY_INDEX = {
 }
 
 
-def _get_market_refresh_conflict_detail(uow: Any, market: str | None) -> dict[str, object] | None:
+def _get_market_refresh_conflict_detail(market: str | None) -> dict[str, object] | None:
     if not market:
         return None
 
-    session = getattr(uow, "session", None)
-    if session is None or not hasattr(session, "query"):
-        return None
+    session = SessionLocal()
+    try:
+        runtime_activity = get_runtime_activity_status(session)
+    finally:
+        session.close()
 
-    runtime_activity = get_runtime_activity_status(session)
     normalized_market = str(market).upper()
     conflicting_activity = [
         item
@@ -167,10 +169,7 @@ async def create_scan(
         from ...services.universe_compat_metrics import record_legacy_universe_usage
 
         record_legacy_universe_usage(universe_resolution.legacy_value)
-    market_refresh_conflict = _get_market_refresh_conflict_detail(
-        uow,
-        _resolve_scan_guard_market(universe_def),
-    )
+    market_refresh_conflict = _get_market_refresh_conflict_detail(_resolve_scan_guard_market(universe_def))
     if market_refresh_conflict is not None:
         raise HTTPException(status_code=409, detail=market_refresh_conflict)
     cmd = CreateScanCommand(

--- a/backend/app/api/v1/scans.py
+++ b/backend/app/api/v1/scans.py
@@ -25,6 +25,7 @@ from ...schemas.scanning import (
     SetupDetailsResponse,
 )
 from ...schemas.ui_view_snapshot import UISnapshotEnvelope
+from ...services.market_activity_service import get_runtime_activity_status
 from ...wiring.bootstrap import (
     get_uow,
     get_create_scan_use_case,
@@ -44,6 +45,54 @@ from ...use_cases.scanning.create_scan import ActiveScanConflictError
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+SCAN_BLOCKING_ACTIVITY_STAGES = {"prices", "fundamentals"}
+SCAN_BLOCKING_ACTIVITY_STATUSES = {"queued", "running"}
+
+
+def _get_market_refresh_conflict_detail(uow: Any, market: str | None) -> dict[str, object] | None:
+    if not market:
+        return None
+
+    session = getattr(uow, "session", None)
+    if session is None or not hasattr(session, "query"):
+        return None
+
+    runtime_activity = get_runtime_activity_status(session)
+    normalized_market = str(market).upper()
+    conflicting_activity = [
+        item
+        for item in runtime_activity.get("markets", [])
+        if str(item.get("market", "")).upper() == normalized_market
+        and item.get("stage_key") in SCAN_BLOCKING_ACTIVITY_STAGES
+        and item.get("status") in SCAN_BLOCKING_ACTIVITY_STATUSES
+    ]
+    if not conflicting_activity:
+        return None
+
+    active_stages = sorted({str(item.get("stage_key")) for item in conflicting_activity if item.get("stage_key")})
+    lifecycle = conflicting_activity[0].get("lifecycle")
+    stage_labels = ", ".join(
+        item.get("stage_label") or str(item.get("stage_key")).replace("_", " ").title()
+        for item in conflicting_activity
+    )
+    return {
+        "code": "market_refresh_active",
+        "message": (
+            f"{normalized_market} {stage_labels.lower()} is running or queued. "
+            "Wait for it to finish before starting a scan."
+        ),
+        "market": normalized_market,
+        "active_stages": active_stages,
+        "lifecycle": lifecycle,
+    }
+
+
+def _resolve_scan_guard_market(universe_def: Any) -> str | None:
+    if getattr(universe_def, "market", None):
+        return universe_def.market.value
+    if getattr(universe_def, "exchange", None) or getattr(universe_def, "index", None):
+        return "US"
+    return None
 
 
 @router.get("/bootstrap", response_model=UISnapshotEnvelope)
@@ -109,6 +158,12 @@ async def create_scan(
         from ...services.universe_compat_metrics import record_legacy_universe_usage
 
         record_legacy_universe_usage(universe_resolution.legacy_value)
+    market_refresh_conflict = _get_market_refresh_conflict_detail(
+        uow,
+        _resolve_scan_guard_market(universe_def),
+    )
+    if market_refresh_conflict is not None:
+        raise HTTPException(status_code=409, detail=market_refresh_conflict)
     cmd = CreateScanCommand(
         universe_def=universe_def,
         universe_label=universe_def.label(),

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -99,16 +99,19 @@ def _save_market_activity(
             existing_payload = None
     if preserve_existing_statuses and isinstance(existing_payload, dict):
         existing_status = existing_payload.get("status")
-        payload_status = payload.get("status")
-        same_task = existing_payload.get("task_id") == payload.get("task_id")
-        same_stage = existing_payload.get("stage_key") == payload.get("stage_key")
-        existing_terminal = existing_status in {"completed", "failed"}
-        stale_queue_downgrade = existing_status == "running" and payload_status == "queued"
-        stale_owner = not same_task or not same_stage
-        if existing_status in preserve_existing_statuses and (
-            stale_owner or existing_terminal or stale_queue_downgrade
-        ):
-            return existing_payload
+        if existing_status in preserve_existing_statuses:
+            payload_status = payload.get("status")
+            same_task = existing_payload.get("task_id") == payload.get("task_id")
+            same_stage = existing_payload.get("stage_key") == payload.get("stage_key")
+            same_owner = same_task and same_stage
+
+            if existing_status == "running":
+                if payload_status == "queued" or not same_owner:
+                    return existing_payload
+            elif existing_status in {"completed", "failed"}:
+                incoming_new_cycle = payload_status in {"queued", "running"} and not same_owner
+                if not incoming_new_cycle:
+                    return existing_payload
     encoded = json.dumps(payload)
     if setting is None:
         setting = AppSetting(

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -226,6 +226,54 @@ def mark_market_activity_started(
     )
 
 
+def mark_market_activity_progress(
+    db: Session,
+    *,
+    market: str,
+    stage_key: str,
+    lifecycle: str | None = None,
+    task_name: str | None = None,
+    task_id: str | None = None,
+    percent: float | None = None,
+    current: int | None = None,
+    total: int | None = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    existing = _load_market_activity(db, market)
+    if isinstance(existing, dict):
+        existing_task_id = existing.get("task_id")
+        existing_stage_key = existing.get("stage_key")
+        existing_status = existing.get("status")
+        if existing_status in {"completed", "failed"}:
+            return existing
+        if existing_task_id and task_id and existing_task_id != task_id:
+            return existing
+        if existing_stage_key and existing_stage_key != stage_key:
+            return existing
+        stage_key = existing_stage_key or stage_key
+        lifecycle = lifecycle or existing.get("lifecycle")
+        task_name = task_name or existing.get("task_name")
+        task_id = task_id or existing_task_id
+        message = message or existing.get("message")
+
+    return _save_market_activity(
+        db,
+        market,
+        _activity_payload(
+            market=market,
+            stage_key=stage_key,
+            lifecycle=lifecycle,
+            status="running",
+            task_name=task_name,
+            task_id=task_id,
+            percent=percent,
+            current=current,
+            total=total,
+            message=message,
+        ),
+    )
+
+
 def mark_market_activity_completed(
     db: Session,
     *,

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -97,14 +97,18 @@ def _save_market_activity(
             existing_payload = json.loads(setting.value)
         except (json.JSONDecodeError, TypeError):
             existing_payload = None
-    if (
-        preserve_existing_statuses
-        and isinstance(existing_payload, dict)
-        and existing_payload.get("task_id")
-        and existing_payload.get("task_id") == payload.get("task_id")
-        and existing_payload.get("status") in preserve_existing_statuses
-    ):
-        return existing_payload
+    if preserve_existing_statuses and isinstance(existing_payload, dict):
+        existing_status = existing_payload.get("status")
+        payload_status = payload.get("status")
+        same_task = existing_payload.get("task_id") == payload.get("task_id")
+        same_stage = existing_payload.get("stage_key") == payload.get("stage_key")
+        existing_terminal = existing_status in {"completed", "failed"}
+        stale_queue_downgrade = existing_status == "running" and payload_status == "queued"
+        stale_owner = not same_task or not same_stage
+        if existing_status in preserve_existing_statuses and (
+            stale_owner or existing_terminal or stale_queue_downgrade
+        ):
+            return existing_payload
     encoded = json.dumps(payload)
     if setting is None:
         setting = AppSetting(
@@ -223,6 +227,7 @@ def mark_market_activity_started(
             total=total,
             message=message,
         ),
+        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 
@@ -271,6 +276,7 @@ def mark_market_activity_progress(
             total=total,
             message=message,
         ),
+        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 
@@ -302,6 +308,7 @@ def mark_market_activity_completed(
             total=total,
             message=message,
         ),
+        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 
@@ -333,6 +340,7 @@ def mark_market_activity_failed(
             total=total,
             message=message,
         ),
+        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 

--- a/backend/app/tasks/fundamentals_tasks.py
+++ b/backend/app/tasks/fundamentals_tasks.py
@@ -30,6 +30,7 @@ from ..services.hybrid_fundamentals_service import HybridFundamentalsService
 from ..services.market_activity_service import (
     mark_market_activity_completed,
     mark_market_activity_failed,
+    mark_market_activity_progress,
     mark_market_activity_started,
 )
 from ..services.ticker_validation_service import TickerValidationService
@@ -38,6 +39,8 @@ from .data_fetch_lock import serialized_data_fetch
 
 logger = logging.getLogger(__name__)
 TRANSIENT_TASK_EXCEPTIONS = (ConnectionError, TimeoutError, OSError)
+PROGRESS_PUBLISH_EVERY_STOCKS = 25
+PROGRESS_PUBLISH_EVERY_SECONDS = 2.0
 
 
 def _retry_transient_failure(task, task_name: str, exc: Exception) -> None:
@@ -66,6 +69,67 @@ def _mark_market_activity_failed_safely(db, **kwargs) -> None:
             },
             exc_info=True,
         )
+
+
+def _mark_market_activity_progress_safely(db, **kwargs) -> None:
+    try:
+        mark_market_activity_progress(db, **kwargs)
+    except Exception:
+        logger.warning(
+            "Failed to publish market activity progress for fundamentals task",
+            extra={
+                "market": kwargs.get("market"),
+                "stage_key": kwargs.get("stage_key"),
+                "task_id": kwargs.get("task_id"),
+            },
+            exc_info=True,
+        )
+
+
+def _maybe_publish_fundamentals_progress(
+    db,
+    *,
+    market: str,
+    lifecycle: str,
+    task_name: str,
+    task_id: str | None,
+    current: int,
+    total: int,
+    message: str,
+    progress_state: dict[str, float | int],
+    force: bool = False,
+) -> None:
+    if total <= 0:
+        return
+
+    now = time.monotonic()
+    last_current = int(progress_state.get("last_current") or 0)
+    last_time = float(progress_state.get("last_time") or 0.0)
+    should_publish = force or current >= total
+    if not should_publish:
+        should_publish = (
+            (last_current == 0 and current > 0)
+            or
+            (current - last_current) >= PROGRESS_PUBLISH_EVERY_STOCKS
+            or (now - last_time) >= PROGRESS_PUBLISH_EVERY_SECONDS
+        )
+    if not should_publish:
+        return
+
+    _mark_market_activity_progress_safely(
+        db,
+        market=market,
+        stage_key="fundamentals",
+        lifecycle=lifecycle,
+        task_name=task_name,
+        task_id=task_id,
+        current=current,
+        total=total,
+        percent=round((current / total) * 100, 1),
+        message=message,
+    )
+    progress_state["last_current"] = current
+    progress_state["last_time"] = now
 
 
 def _run_snapshot_pipeline(db, *, publish: bool) -> Dict:
@@ -150,6 +214,12 @@ def refresh_all_fundamentals(
     db = SessionLocal()
     start_time = time.time()
     ticker_validation_service = get_ticker_validation_service()
+    task_name = getattr(self, "name", "refresh_all_fundamentals")
+    task_id = getattr(getattr(self, "request", None), "id", None)
+    progress_state: dict[str, float | int] = {
+        "last_current": 0,
+        "last_time": time.monotonic(),
+    }
 
     try:
         mark_market_activity_started(
@@ -157,8 +227,8 @@ def refresh_all_fundamentals(
             market=effective_market,
             stage_key="fundamentals",
             lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "refresh_all_fundamentals"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
+            task_name=task_name,
+            task_id=task_id,
             message="Refreshing fundamentals",
         )
         if settings.provider_snapshot_cutover_enabled:
@@ -181,8 +251,8 @@ def refresh_all_fundamentals(
                 market=effective_market,
                 stage_key="fundamentals",
                 lifecycle=activity_lifecycle,
-                task_name=getattr(self, "name", "refresh_all_fundamentals"),
-                task_id=getattr(getattr(self, "request", None), "id", None),
+                task_name=task_name,
+                task_id=task_id,
                 message="Fundamentals refresh completed",
             )
             return response
@@ -200,8 +270,8 @@ def refresh_all_fundamentals(
                 market=effective_market,
                 stage_key="fundamentals",
                 lifecycle=activity_lifecycle,
-                task_name=getattr(self, "name", "refresh_all_fundamentals"),
-                task_id=getattr(getattr(self, "request", None), "id", None),
+                task_name=task_name,
+                task_id=task_id,
                 message="No active stocks found",
             )
             return {
@@ -278,9 +348,34 @@ def refresh_all_fundamentals(
                     error_message=error_msg,
                     data_source=TickerValidationService.SOURCE_YFINANCE,
                     triggered_by=TickerValidationService.TRIGGER_FUNDAMENTALS_REFRESH,
-                    task_id=self.request.id if self.request else None,
-                )
+                        task_id=self.request.id if self.request else None,
+                    )
                 continue
+
+            _maybe_publish_fundamentals_progress(
+                db,
+                market=effective_market,
+                lifecycle=activity_lifecycle,
+                task_name=task_name,
+                task_id=task_id,
+                current=i + 1,
+                total=total_stocks,
+                message="Refreshing fundamentals",
+                progress_state=progress_state,
+            )
+
+        _maybe_publish_fundamentals_progress(
+            db,
+            market=effective_market,
+            lifecycle=activity_lifecycle,
+            task_name=task_name,
+            task_id=task_id,
+            current=total_stocks,
+            total=total_stocks,
+            message="Refreshing fundamentals",
+            progress_state=progress_state,
+            force=True,
+        )
 
         duration = time.time() - start_time
 
@@ -305,9 +400,9 @@ def refresh_all_fundamentals(
             market=effective_market,
             stage_key="fundamentals",
             lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "refresh_all_fundamentals"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
-            current=stats['updated'],
+            task_name=task_name,
+            task_id=task_id,
+            current=total_stocks,
             total=total_stocks,
             message="Fundamentals refresh completed",
         )
@@ -332,8 +427,8 @@ def refresh_all_fundamentals(
             market=effective_market,
             stage_key="fundamentals",
             lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "refresh_all_fundamentals"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
+            task_name=task_name,
+            task_id=task_id,
             message="Soft time limit exceeded",
         )
         raise
@@ -344,8 +439,8 @@ def refresh_all_fundamentals(
             market=effective_market,
             stage_key="fundamentals",
             lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "refresh_all_fundamentals"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
+            task_name=task_name,
+            task_id=task_id,
             message=str(e),
         )
         _retry_transient_failure(self, "refresh_all_fundamentals", e)
@@ -357,8 +452,8 @@ def refresh_all_fundamentals(
             market=effective_market,
             stage_key="fundamentals",
             lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "refresh_all_fundamentals"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
+            task_name=task_name,
+            task_id=task_id,
             message=str(e),
         )
         return {
@@ -652,6 +747,7 @@ def refresh_all_fundamentals_hybrid(
     include_finviz: bool = True,
     yfinance_batch_size: int = 50,
     market: str | None = None,
+    activity_lifecycle: str | None = None,
 ):
     """
     HYBRID fundamental refresh - optimized for speed.
@@ -685,8 +781,25 @@ def refresh_all_fundamentals_hybrid(
     db = SessionLocal()
     start_time = time.time()
     ticker_validation_service = get_ticker_validation_service()
+    effective_market = normalize_market(market) if market is not None else "US"
+    activity_lifecycle = activity_lifecycle or "weekly_refresh"
+    task_name = getattr(self, "name", "refresh_all_fundamentals_hybrid")
+    task_id = getattr(getattr(self, "request", None), "id", None)
+    progress_state: dict[str, float | int] = {
+        "last_current": 0,
+        "last_time": time.monotonic(),
+    }
 
     try:
+        mark_market_activity_started(
+            db,
+            market=effective_market,
+            stage_key="fundamentals",
+            lifecycle=activity_lifecycle,
+            task_name=task_name,
+            task_id=task_id,
+            message="Refreshing fundamentals",
+        )
         if settings.provider_snapshot_cutover_enabled or settings.provider_snapshot_ingestion_enabled:
             publish = settings.provider_snapshot_cutover_enabled
             logger.info(
@@ -705,6 +818,15 @@ def refresh_all_fundamentals_hybrid(
             if publish and result.get("snapshot", {}).get("published"):
                 eps_task = calculate_eps_rating_percentiles.delay()
                 response["eps_rating_task_id"] = eps_task.id
+            mark_market_activity_completed(
+                db,
+                market=effective_market,
+                stage_key="fundamentals",
+                lifecycle=activity_lifecycle,
+                task_name=task_name,
+                task_id=task_id,
+                message="Fundamentals refresh completed",
+            )
             return response
 
         # Get all active stocks from universe (market-filtered when scoped)
@@ -715,6 +837,15 @@ def refresh_all_fundamentals_hybrid(
 
         if not universe_stocks:
             logger.warning("No active stocks found in universe", extra=_log_extra)
+            _mark_market_activity_failed_safely(
+                db,
+                market=effective_market,
+                stage_key="fundamentals",
+                lifecycle=activity_lifecycle,
+                task_name=task_name,
+                task_id=task_id,
+                message="No active stocks found",
+            )
             return {
                 'error': 'No active stocks found',
                 'timestamp': datetime.now().isoformat()
@@ -751,6 +882,17 @@ def refresh_all_fundamentals_hybrid(
             if current > 0:
                 eta = (elapsed / current) * (total - current) / 60
                 logger.info(f"Hybrid progress: {current}/{total} ({pct:.1f}%), ETA: {eta:.1f} min")
+            _maybe_publish_fundamentals_progress(
+                db,
+                market=effective_market,
+                lifecycle=activity_lifecycle,
+                task_name=task_name,
+                task_id=task_id,
+                current=current,
+                total=total,
+                message="Refreshing fundamentals",
+                progress_state=progress_state,
+            )
 
         # Fetch all fundamentals using hybrid approach
         all_data = hybrid_service.fetch_fundamentals_batch(
@@ -811,6 +953,29 @@ def refresh_all_fundamentals_hybrid(
         logger.info("Queuing EPS Rating Percentiles calculation...")
         eps_task = calculate_eps_rating_percentiles.delay()
         logger.info(f"EPS Rating Percentiles task queued: {eps_task.id}")
+        _maybe_publish_fundamentals_progress(
+            db,
+            market=effective_market,
+            lifecycle=activity_lifecycle,
+            task_name=task_name,
+            task_id=task_id,
+            current=total_stocks,
+            total=total_stocks,
+            message="Refreshing fundamentals",
+            progress_state=progress_state,
+            force=True,
+        )
+        mark_market_activity_completed(
+            db,
+            market=effective_market,
+            stage_key="fundamentals",
+            lifecycle=activity_lifecycle,
+            task_name=task_name,
+            task_id=task_id,
+            current=total_stocks,
+            total=total_stocks,
+            message="Fundamentals refresh completed",
+        )
 
         return {
             'mode': 'hybrid',
@@ -829,6 +994,15 @@ def refresh_all_fundamentals_hybrid(
 
     except Exception as e:
         logger.error(f"Fatal error in hybrid fundamental refresh: {e}", exc_info=True)
+        _mark_market_activity_failed_safely(
+            db,
+            market=effective_market,
+            stage_key="fundamentals",
+            lifecycle=activity_lifecycle,
+            task_name=task_name,
+            task_id=task_id,
+            message=str(e),
+        )
         return {
             'error': str(e),
             'timestamp': datetime.now().isoformat()

--- a/backend/app/tasks/fundamentals_tasks.py
+++ b/backend/app/tasks/fundamentals_tasks.py
@@ -992,6 +992,7 @@ def refresh_all_fundamentals_hybrid(
 
     except Exception as e:
         logger.error(f"Fatal error in hybrid fundamental refresh: {e}", exc_info=True)
+        db.rollback()
         _mark_market_activity_failed_safely(
             db,
             market=effective_market,

--- a/backend/app/tasks/fundamentals_tasks.py
+++ b/backend/app/tasks/fundamentals_tasks.py
@@ -295,9 +295,8 @@ def refresh_all_fundamentals(
 
         # Process each stock with rate limiting (2 seconds between calls)
         for i, stock in enumerate(universe_stocks):
+            symbol = stock.symbol
             try:
-                symbol = stock.symbol
-
                 # Log progress every 50 stocks
                 if (i + 1) % 50 == 0:
                     logger.info(f"Progress: {i + 1}/{total_stocks} ({(i+1)/total_stocks*100:.1f}%)")
@@ -346,23 +345,22 @@ def refresh_all_fundamentals(
                     symbol=symbol,
                     error_type=error_type,
                     error_message=error_msg,
-                    data_source=TickerValidationService.SOURCE_YFINANCE,
-                    triggered_by=TickerValidationService.TRIGGER_FUNDAMENTALS_REFRESH,
+                        data_source=TickerValidationService.SOURCE_YFINANCE,
+                        triggered_by=TickerValidationService.TRIGGER_FUNDAMENTALS_REFRESH,
                         task_id=self.request.id if self.request else None,
                     )
-                continue
-
-            _maybe_publish_fundamentals_progress(
-                db,
-                market=effective_market,
-                lifecycle=activity_lifecycle,
-                task_name=task_name,
-                task_id=task_id,
-                current=i + 1,
-                total=total_stocks,
-                message="Refreshing fundamentals",
-                progress_state=progress_state,
-            )
+            finally:
+                _maybe_publish_fundamentals_progress(
+                    db,
+                    market=effective_market,
+                    lifecycle=activity_lifecycle,
+                    task_name=task_name,
+                    task_id=task_id,
+                    current=i + 1,
+                    total=total_stocks,
+                    message="Refreshing fundamentals",
+                    progress_state=progress_state,
+                )
 
         _maybe_publish_fundamentals_progress(
             db,

--- a/backend/tests/unit/test_fundamentals_tasks.py
+++ b/backend/tests/unit/test_fundamentals_tasks.py
@@ -256,3 +256,99 @@ def test_refresh_all_fundamentals_publishes_market_activity(monkeypatch):
     assert started[0]["lifecycle"] == "weekly_refresh"
     assert completed[0]["stage_key"] == "fundamentals"
     assert completed[0]["market"] == "US"
+
+
+def test_refresh_all_fundamentals_publishes_running_progress(monkeypatch):
+    import app.tasks.fundamentals_tasks as module
+
+    fake_db = MagicMock()
+    stocks = [SimpleNamespace(symbol=f"SYM{i}", market="US") for i in range(30)]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.filter.return_value.all.return_value = stocks
+    fake_query.filter.return_value.all.return_value = stocks
+    fake_db.query.return_value = fake_query
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    _patch_serialized_lock(monkeypatch)
+    monkeypatch.setattr(module.settings, "provider_snapshot_cutover_enabled", False)
+    monkeypatch.setattr(
+        module,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_fundamentals=lambda *args, **kwargs: {"symbol": kwargs.get("symbol", "SYM")}),
+    )
+    monkeypatch.setattr(module, "get_ticker_validation_service", lambda: MagicMock())
+    monkeypatch.setattr(
+        module.calculate_eps_rating_percentiles,
+        "delay",
+        lambda: SimpleNamespace(id="eps-task-id"),
+    )
+
+    progress_updates = []
+    monkeypatch.setattr(module, "mark_market_activity_progress", lambda *args, **kwargs: progress_updates.append(kwargs))
+
+    result = module.refresh_all_fundamentals.run(market="US")
+
+    assert result["updated"] == 30
+    assert progress_updates
+    assert progress_updates[0]["market"] == "US"
+    assert progress_updates[0]["stage_key"] == "fundamentals"
+    assert all(update["total"] == 30 for update in progress_updates)
+    assert any(update["current"] < update["total"] for update in progress_updates)
+    assert any(update["percent"] > 0 for update in progress_updates)
+
+
+def test_refresh_all_fundamentals_hybrid_publishes_running_progress(monkeypatch):
+    import app.tasks.fundamentals_tasks as module
+
+    fake_db = MagicMock()
+    stocks = [
+        SimpleNamespace(symbol="AAPL", market="US"),
+        SimpleNamespace(symbol="MSFT", market="US"),
+    ]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.filter.return_value.all.return_value = stocks
+    fake_query.filter.return_value.all.return_value = stocks
+    fake_db.query.return_value = fake_query
+
+    _patch_serialized_lock(monkeypatch)
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(module.settings, "provider_snapshot_cutover_enabled", False)
+    monkeypatch.setattr(module.settings, "provider_snapshot_ingestion_enabled", False)
+    monkeypatch.setattr(module, "get_fundamentals_cache", lambda: MagicMock())
+    monkeypatch.setattr(module, "get_ticker_validation_service", lambda: MagicMock())
+    monkeypatch.setattr(
+        module.calculate_eps_rating_percentiles,
+        "delay",
+        lambda: SimpleNamespace(id="eps-task-id"),
+    )
+
+    progress_updates = []
+    monkeypatch.setattr(module, "mark_market_activity_progress", lambda *args, **kwargs: progress_updates.append(kwargs))
+
+    class _HybridStub:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        @staticmethod
+        def fetch_fundamentals_batch(symbols, **kwargs):
+            kwargs["progress_callback"](1, 2)
+            return {symbol: {"symbol": symbol} for symbol in symbols}
+
+        @staticmethod
+        def store_all_caches(*args, **kwargs):
+            return {
+                "fundamentals_stored": 2,
+                "quarterly_stored": 2,
+                "failed": 0,
+            }
+
+    monkeypatch.setattr(module, "HybridFundamentalsService", _HybridStub)
+
+    result = module.refresh_all_fundamentals_hybrid.run(include_finviz=False, market="US")
+
+    assert result["updated"] == 2
+    assert progress_updates
+    assert progress_updates[0]["market"] == "US"
+    assert progress_updates[0]["stage_key"] == "fundamentals"
+    assert progress_updates[0]["current"] == 1
+    assert progress_updates[0]["total"] == 2
+    assert progress_updates[0]["percent"] == pytest.approx(50.0)

--- a/backend/tests/unit/test_fundamentals_tasks.py
+++ b/backend/tests/unit/test_fundamentals_tasks.py
@@ -352,3 +352,41 @@ def test_refresh_all_fundamentals_hybrid_publishes_running_progress(monkeypatch)
     assert progress_updates[0]["current"] == 1
     assert progress_updates[0]["total"] == 2
     assert progress_updates[0]["percent"] == pytest.approx(50.0)
+
+
+def test_refresh_all_fundamentals_progress_counts_failed_iterations(monkeypatch):
+    import app.tasks.fundamentals_tasks as module
+
+    fake_db = MagicMock()
+    stocks = [SimpleNamespace(symbol=f"SYM{i}", market="US") for i in range(30)]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.filter.return_value.all.return_value = stocks
+    fake_query.filter.return_value.all.return_value = stocks
+    fake_db.query.return_value = fake_query
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    _patch_serialized_lock(monkeypatch)
+    monkeypatch.setattr(module.settings, "provider_snapshot_cutover_enabled", False)
+
+    fake_cache = MagicMock()
+    fake_cache.get_fundamentals.side_effect = RuntimeError("provider unavailable")
+    monkeypatch.setattr(module, "get_fundamentals_cache", lambda: fake_cache)
+
+    validation_service = MagicMock()
+    validation_service.classify_error.return_value = ("provider_error", "provider unavailable")
+    monkeypatch.setattr(module, "get_ticker_validation_service", lambda: validation_service)
+    monkeypatch.setattr(
+        module.calculate_eps_rating_percentiles,
+        "delay",
+        lambda: SimpleNamespace(id="eps-task-id"),
+    )
+
+    progress_updates = []
+    monkeypatch.setattr(module, "mark_market_activity_progress", lambda *args, **kwargs: progress_updates.append(kwargs))
+
+    result = module.refresh_all_fundamentals.run(market="US")
+
+    assert result["failed"] == 30
+    assert progress_updates
+    assert any(update["current"] < update["total"] for update in progress_updates)
+    assert progress_updates[-1]["current"] == 30
+    assert progress_updates[-1]["total"] == 30

--- a/backend/tests/unit/test_fundamentals_tasks.py
+++ b/backend/tests/unit/test_fundamentals_tasks.py
@@ -354,6 +354,37 @@ def test_refresh_all_fundamentals_hybrid_publishes_running_progress(monkeypatch)
     assert progress_updates[0]["percent"] == pytest.approx(50.0)
 
 
+def test_refresh_all_fundamentals_hybrid_rolls_back_before_failure_publish(monkeypatch):
+    import app.tasks.fundamentals_tasks as module
+
+    fake_db = MagicMock()
+    stocks = [SimpleNamespace(symbol="AAPL", market="US")]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.filter.return_value.all.return_value = stocks
+    fake_query.filter.return_value.all.return_value = stocks
+    fake_db.query.return_value = fake_query
+
+    _patch_serialized_lock(monkeypatch)
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(module.settings, "provider_snapshot_cutover_enabled", False)
+    monkeypatch.setattr(module.settings, "provider_snapshot_ingestion_enabled", False)
+
+    class _HybridBoom:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        @staticmethod
+        def fetch_fundamentals_batch(*args, **kwargs):
+            raise RuntimeError("hybrid fetch failed")
+
+    monkeypatch.setattr(module, "HybridFundamentalsService", _HybridBoom)
+
+    result = module.refresh_all_fundamentals_hybrid.run(include_finviz=False, market="US")
+
+    fake_db.rollback.assert_called_once()
+    assert result["error"] == "hybrid fetch failed"
+
+
 def test_refresh_all_fundamentals_progress_counts_failed_iterations(monkeypatch):
     import app.tasks.fundamentals_tasks as module
 

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -212,6 +212,93 @@ def test_mark_market_activity_progress_does_not_overwrite_completed_record(
     assert us_market["percent"] == 100.0
 
 
+def test_mark_market_activity_progress_does_not_overwrite_newer_running_task(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_started(
+        db_session,
+        market="US",
+        stage_key="fundamentals",
+        lifecycle="bootstrap",
+        task_name="refresh_all_fundamentals",
+        task_id="new-task",
+        message="Refreshing fundamentals",
+    )
+    module.mark_market_activity_progress(
+        db_session,
+        market="US",
+        stage_key="fundamentals",
+        task_name="refresh_all_fundamentals",
+        task_id="stale-task",
+        current=25,
+        total=100,
+        percent=25.0,
+        message="Refreshing fundamentals",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=True, enabled=["US"], state="running"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    us_market = next(item for item in payload["markets"] if item["market"] == "US")
+    assert us_market["status"] == "running"
+    assert us_market["task_id"] == "new-task"
+    assert us_market["current"] is None
+    assert us_market["percent"] is None
+
+
+def test_mark_market_activity_completed_still_advances_same_task_running_record(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_started(
+        db_session,
+        market="US",
+        stage_key="fundamentals",
+        lifecycle="bootstrap",
+        task_name="refresh_all_fundamentals",
+        task_id="task-us",
+        current=25,
+        total=100,
+        percent=25.0,
+        message="Refreshing fundamentals",
+    )
+    module.mark_market_activity_completed(
+        db_session,
+        market="US",
+        stage_key="fundamentals",
+        lifecycle="bootstrap",
+        task_name="refresh_all_fundamentals",
+        task_id="task-us",
+        current=100,
+        total=100,
+        message="Fundamentals refresh completed",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=False, enabled=["US"], state="ready"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    us_market = next(item for item in payload["markets"] if item["market"] == "US")
+    assert us_market["status"] == "completed"
+    assert us_market["task_id"] == "task-us"
+    assert us_market["current"] == 100
+    assert us_market["percent"] == 100.0
+
+
 def test_runtime_activity_status_marks_primary_ready_with_secondary_bootstrap_running(
     db_session,
     monkeypatch,

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -299,6 +299,98 @@ def test_mark_market_activity_completed_still_advances_same_task_running_record(
     assert us_market["percent"] == 100.0
 
 
+def test_mark_market_activity_started_allows_new_same_stage_run_after_completion(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_completed(
+        db_session,
+        market="US",
+        stage_key="prices",
+        lifecycle="daily_refresh",
+        task_name="smart_refresh_cache",
+        task_id="day-1-task",
+        current=100,
+        total=100,
+        message="Price refresh completed",
+    )
+    module.mark_market_activity_started(
+        db_session,
+        market="US",
+        stage_key="prices",
+        lifecycle="daily_refresh",
+        task_name="smart_refresh_cache",
+        task_id="day-2-task",
+        current=5,
+        total=100,
+        percent=5.0,
+        message="Refreshing prices",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=False, enabled=["US"], state="ready"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    us_market = next(item for item in payload["markets"] if item["market"] == "US")
+    assert us_market["status"] == "running"
+    assert us_market["task_id"] == "day-2-task"
+    assert us_market["stage_key"] == "prices"
+    assert us_market["current"] == 5
+    assert us_market["percent"] == 5.0
+
+
+def test_mark_market_activity_started_allows_next_stage_after_completion(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_completed(
+        db_session,
+        market="US",
+        stage_key="universe",
+        lifecycle="bootstrap",
+        task_name="refresh_stock_universe",
+        task_id="universe-task",
+        current=100,
+        total=100,
+        message="Universe refresh completed",
+    )
+    module.mark_market_activity_started(
+        db_session,
+        market="US",
+        stage_key="prices",
+        lifecycle="bootstrap",
+        task_name="smart_refresh_cache",
+        task_id="prices-task",
+        current=10,
+        total=200,
+        percent=5.0,
+        message="Refreshing prices",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=True, enabled=["US"], state="running"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    us_market = next(item for item in payload["markets"] if item["market"] == "US")
+    assert us_market["status"] == "running"
+    assert us_market["task_id"] == "prices-task"
+    assert us_market["stage_key"] == "prices"
+    assert us_market["current"] == 10
+    assert us_market["percent"] == 5.0
+
+
 def test_runtime_activity_status_marks_primary_ready_with_secondary_bootstrap_running(
     db_session,
     monkeypatch,

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -126,6 +126,92 @@ def test_runtime_activity_status_marks_running_stage_without_real_percent_as_ind
     assert us_market["percent"] is None
 
 
+def test_mark_market_activity_progress_updates_running_record_with_determinate_progress(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_started(
+        db_session,
+        market="US",
+        stage_key="fundamentals",
+        lifecycle="bootstrap",
+        task_name="refresh_all_fundamentals",
+        task_id="task-us",
+        message="Refreshing fundamentals",
+    )
+    module.mark_market_activity_progress(
+        db_session,
+        market="US",
+        stage_key="fundamentals",
+        task_name="refresh_all_fundamentals",
+        task_id="task-us",
+        current=25,
+        total=100,
+        percent=25.0,
+        message="Refreshing fundamentals",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=True, enabled=["US"], state="running"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    us_market = next(item for item in payload["markets"] if item["market"] == "US")
+    assert us_market["status"] == "running"
+    assert us_market["progress_mode"] == "determinate"
+    assert us_market["current"] == 25
+    assert us_market["total"] == 100
+    assert us_market["percent"] == 25.0
+
+
+def test_mark_market_activity_progress_does_not_overwrite_completed_record(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_completed(
+        db_session,
+        market="US",
+        stage_key="fundamentals",
+        lifecycle="bootstrap",
+        task_name="refresh_all_fundamentals",
+        task_id="task-us",
+        current=100,
+        total=100,
+        message="Fundamentals refresh completed",
+    )
+    module.mark_market_activity_progress(
+        db_session,
+        market="US",
+        stage_key="fundamentals",
+        task_name="refresh_all_fundamentals",
+        task_id="task-us",
+        current=99,
+        total=100,
+        percent=99.0,
+        message="Refreshing fundamentals",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=False, enabled=["US"], state="ready"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    us_market = next(item for item in payload["markets"] if item["market"] == "US")
+    assert us_market["status"] == "completed"
+    assert us_market["current"] == 100
+    assert us_market["percent"] == 100.0
+
+
 def test_runtime_activity_status_marks_primary_ready_with_secondary_bootstrap_running(
     db_session,
     monkeypatch,

--- a/backend/tests/unit/test_scan_create_endpoint.py
+++ b/backend/tests/unit/test_scan_create_endpoint.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import httpx
 import pytest
 import pytest_asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from app.main import app
 from app.services import server_auth
@@ -18,9 +18,6 @@ from app.use_cases.scanning.create_scan import (
 
 
 class _FakeUoW:
-    def __init__(self):
-        self.session = None
-
     def __enter__(self):
         return self
 
@@ -293,7 +290,6 @@ async def test_create_scan_returns_409_when_another_scan_is_active(client):
 @pytest.mark.asyncio
 async def test_create_scan_returns_409_when_market_prices_refresh_is_active(client):
     fake_uow = _FakeUoW()
-    fake_uow.session = MagicMock()
     fake_use_case = _FakeCreateScanUseCase(
         CreateScanResult(
             scan_id="scan-hk",
@@ -352,7 +348,6 @@ async def test_create_scan_returns_409_when_market_prices_refresh_is_active(clie
 @pytest.mark.asyncio
 async def test_create_scan_returns_409_when_market_fundamentals_refresh_is_queued(client):
     fake_uow = _FakeUoW()
-    fake_uow.session = MagicMock()
     fake_use_case = _FakeCreateScanUseCase(
         CreateScanResult(
             scan_id="scan-us",
@@ -410,7 +405,6 @@ async def test_create_scan_returns_409_when_market_fundamentals_refresh_is_queue
 @pytest.mark.asyncio
 async def test_create_scan_allows_non_core_runtime_activity_for_market(client):
     fake_uow = _FakeUoW()
-    fake_uow.session = MagicMock()
     fake_use_case = _FakeCreateScanUseCase(
         CreateScanResult(
             scan_id="scan-hk-ok",
@@ -463,7 +457,6 @@ async def test_create_scan_allows_non_core_runtime_activity_for_market(client):
 @pytest.mark.asyncio
 async def test_create_scan_allows_other_market_refresh_activity(client):
     fake_uow = _FakeUoW()
-    fake_uow.session = MagicMock()
     fake_use_case = _FakeCreateScanUseCase(
         CreateScanResult(
             scan_id="scan-hk-ok",
@@ -516,7 +509,6 @@ async def test_create_scan_allows_other_market_refresh_activity(client):
 @pytest.mark.asyncio
 async def test_create_scan_returns_409_for_us_exchange_when_us_refresh_is_active(client):
     fake_uow = _FakeUoW()
-    fake_uow.session = MagicMock()
     fake_use_case = _FakeCreateScanUseCase(
         CreateScanResult(
             scan_id="scan-nyse",
@@ -569,10 +561,21 @@ async def test_create_scan_returns_409_for_us_exchange_when_us_refresh_is_active
     assert fake_use_case.received_cmd is None
 
 
+@pytest.mark.parametrize(
+    ("index_name", "market"),
+    [
+        ("HSI", "HK"),
+        ("NIKKEI225", "JP"),
+        ("TAIEX", "TW"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_create_scan_returns_409_for_hk_index_when_hk_refresh_is_active(client):
+async def test_create_scan_returns_409_for_index_when_mapped_market_refresh_is_active(
+    client,
+    index_name,
+    market,
+):
     fake_uow = _FakeUoW()
-    fake_uow.session = MagicMock()
     fake_use_case = _FakeCreateScanUseCase(
         CreateScanResult(
             scan_id="scan-hsi",
@@ -590,10 +593,10 @@ async def test_create_scan_returns_409_for_hk_index_when_hk_refresh_is_active(cl
             "app.api.v1.scans.get_runtime_activity_status",
             return_value={
                 "bootstrap": {},
-                "summary": {"active_market_count": 1, "active_markets": ["HK"], "status": "active"},
+                "summary": {"active_market_count": 1, "active_markets": [market], "status": "active"},
                 "markets": [
                     {
-                        "market": "HK",
+                        "market": market,
                         "lifecycle": "daily_refresh",
                         "stage_key": "prices",
                         "stage_label": "Price Refresh",
@@ -612,7 +615,7 @@ async def test_create_scan_returns_409_for_hk_index_when_hk_refresh_is_active(cl
         ):
             response = await client.post(
                 "/api/v1/scans",
-                json={"universe_def": {"type": "index", "index": "HSI"}},
+                json={"universe_def": {"type": "index", "index": index_name}},
             )
     finally:
         app.dependency_overrides.pop(get_uow, None)
@@ -621,6 +624,6 @@ async def test_create_scan_returns_409_for_hk_index_when_hk_refresh_is_active(cl
     assert response.status_code == 409
     payload = response.json()
     assert payload["detail"]["code"] == "market_refresh_active"
-    assert payload["detail"]["market"] == "HK"
+    assert payload["detail"]["market"] == market
     assert payload["detail"]["active_stages"] == ["prices"]
     assert fake_use_case.received_cmd is None

--- a/backend/tests/unit/test_scan_create_endpoint.py
+++ b/backend/tests/unit/test_scan_create_endpoint.py
@@ -567,3 +567,60 @@ async def test_create_scan_returns_409_for_us_exchange_when_us_refresh_is_active
     assert payload["detail"]["code"] == "market_refresh_active"
     assert payload["detail"]["market"] == "US"
     assert fake_use_case.received_cmd is None
+
+
+@pytest.mark.asyncio
+async def test_create_scan_returns_409_for_hk_index_when_hk_refresh_is_active(client):
+    fake_uow = _FakeUoW()
+    fake_uow.session = MagicMock()
+    fake_use_case = _FakeCreateScanUseCase(
+        CreateScanResult(
+            scan_id="scan-hsi",
+            status="queued",
+            total_stocks=80,
+            is_duplicate=False,
+            feature_run_id=None,
+        )
+    )
+
+    app.dependency_overrides[get_uow] = lambda: fake_uow
+    app.dependency_overrides[get_create_scan_use_case] = lambda: fake_use_case
+    try:
+        with patch(
+            "app.api.v1.scans.get_runtime_activity_status",
+            return_value={
+                "bootstrap": {},
+                "summary": {"active_market_count": 1, "active_markets": ["HK"], "status": "active"},
+                "markets": [
+                    {
+                        "market": "HK",
+                        "lifecycle": "daily_refresh",
+                        "stage_key": "prices",
+                        "stage_label": "Price Refresh",
+                        "status": "running",
+                        "progress_mode": "determinate",
+                        "percent": 25.0,
+                        "current": 20,
+                        "total": 80,
+                        "message": "Refreshing prices",
+                        "task_name": "smart_refresh_cache",
+                        "task_id": "task-hk",
+                        "updated_at": "2026-04-18T00:00:00Z",
+                    }
+                ],
+            },
+        ):
+            response = await client.post(
+                "/api/v1/scans",
+                json={"universe_def": {"type": "index", "index": "HSI"}},
+            )
+    finally:
+        app.dependency_overrides.pop(get_uow, None)
+        app.dependency_overrides.pop(get_create_scan_use_case, None)
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert payload["detail"]["code"] == "market_refresh_active"
+    assert payload["detail"]["market"] == "HK"
+    assert payload["detail"]["active_stages"] == ["prices"]
+    assert fake_use_case.received_cmd is None

--- a/backend/tests/unit/test_scan_create_endpoint.py
+++ b/backend/tests/unit/test_scan_create_endpoint.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import httpx
 import pytest
 import pytest_asyncio
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from app.main import app
 from app.services import server_auth
@@ -18,6 +18,9 @@ from app.use_cases.scanning.create_scan import (
 
 
 class _FakeUoW:
+    def __init__(self):
+        self.session = None
+
     def __enter__(self):
         return self
 
@@ -285,3 +288,282 @@ async def test_create_scan_returns_409_when_another_scan_is_active(client):
     assert payload["detail"]["code"] == "scan_already_active"
     assert payload["detail"]["active_scan"]["scan_id"] == "scan-active"
     assert payload["detail"]["active_scan"]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_create_scan_returns_409_when_market_prices_refresh_is_active(client):
+    fake_uow = _FakeUoW()
+    fake_uow.session = MagicMock()
+    fake_use_case = _FakeCreateScanUseCase(
+        CreateScanResult(
+            scan_id="scan-hk",
+            status="queued",
+            total_stocks=1200,
+            is_duplicate=False,
+            feature_run_id=None,
+        )
+    )
+
+    app.dependency_overrides[get_uow] = lambda: fake_uow
+    app.dependency_overrides[get_create_scan_use_case] = lambda: fake_use_case
+    try:
+        with patch(
+            "app.api.v1.scans.get_runtime_activity_status",
+            return_value={
+                "bootstrap": {},
+                "summary": {"active_market_count": 1, "active_markets": ["HK"], "status": "active"},
+                "markets": [
+                    {
+                        "market": "HK",
+                        "lifecycle": "daily_refresh",
+                        "stage_key": "prices",
+                        "stage_label": "Price Refresh",
+                        "status": "running",
+                        "progress_mode": "determinate",
+                        "percent": 40.0,
+                        "current": 400,
+                        "total": 1000,
+                        "message": "Refreshing prices",
+                        "task_name": "smart_refresh_cache",
+                        "task_id": "task-hk",
+                        "updated_at": "2026-04-18T00:00:00Z",
+                    }
+                ],
+            },
+        ):
+            response = await client.post(
+                "/api/v1/scans",
+                json={"universe_def": {"type": "market", "market": "HK"}},
+            )
+    finally:
+        app.dependency_overrides.pop(get_uow, None)
+        app.dependency_overrides.pop(get_create_scan_use_case, None)
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert payload["detail"]["code"] == "market_refresh_active"
+    assert payload["detail"]["market"] == "HK"
+    assert payload["detail"]["active_stages"] == ["prices"]
+    assert payload["detail"]["lifecycle"] == "daily_refresh"
+    assert "wait for it to finish" in payload["detail"]["message"].lower()
+    assert fake_use_case.received_cmd is None
+
+
+@pytest.mark.asyncio
+async def test_create_scan_returns_409_when_market_fundamentals_refresh_is_queued(client):
+    fake_uow = _FakeUoW()
+    fake_uow.session = MagicMock()
+    fake_use_case = _FakeCreateScanUseCase(
+        CreateScanResult(
+            scan_id="scan-us",
+            status="queued",
+            total_stocks=3200,
+            is_duplicate=False,
+            feature_run_id=None,
+        )
+    )
+
+    app.dependency_overrides[get_uow] = lambda: fake_uow
+    app.dependency_overrides[get_create_scan_use_case] = lambda: fake_use_case
+    try:
+        with patch(
+            "app.api.v1.scans.get_runtime_activity_status",
+            return_value={
+                "bootstrap": {},
+                "summary": {"active_market_count": 1, "active_markets": ["US"], "status": "active"},
+                "markets": [
+                    {
+                        "market": "US",
+                        "lifecycle": "bootstrap",
+                        "stage_key": "fundamentals",
+                        "stage_label": "Fundamentals Refresh",
+                        "status": "queued",
+                        "progress_mode": "indeterminate",
+                        "percent": None,
+                        "current": None,
+                        "total": None,
+                        "message": "Queued fundamentals refresh",
+                        "task_name": "refresh_all_fundamentals",
+                        "task_id": "task-us",
+                        "updated_at": "2026-04-18T00:00:00Z",
+                    }
+                ],
+            },
+        ):
+            response = await client.post(
+                "/api/v1/scans",
+                json={"universe_def": {"type": "market", "market": "US"}},
+            )
+    finally:
+        app.dependency_overrides.pop(get_uow, None)
+        app.dependency_overrides.pop(get_create_scan_use_case, None)
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert payload["detail"]["code"] == "market_refresh_active"
+    assert payload["detail"]["market"] == "US"
+    assert payload["detail"]["active_stages"] == ["fundamentals"]
+    assert payload["detail"]["lifecycle"] == "bootstrap"
+    assert fake_use_case.received_cmd is None
+
+
+@pytest.mark.asyncio
+async def test_create_scan_allows_non_core_runtime_activity_for_market(client):
+    fake_uow = _FakeUoW()
+    fake_uow.session = MagicMock()
+    fake_use_case = _FakeCreateScanUseCase(
+        CreateScanResult(
+            scan_id="scan-hk-ok",
+            status="queued",
+            total_stocks=1200,
+            is_duplicate=False,
+            feature_run_id=None,
+        )
+    )
+
+    app.dependency_overrides[get_uow] = lambda: fake_uow
+    app.dependency_overrides[get_create_scan_use_case] = lambda: fake_use_case
+    try:
+        with patch(
+            "app.api.v1.scans.get_runtime_activity_status",
+            return_value={
+                "bootstrap": {},
+                "summary": {"active_market_count": 1, "active_markets": ["HK"], "status": "active"},
+                "markets": [
+                    {
+                        "market": "HK",
+                        "lifecycle": "daily_refresh",
+                        "stage_key": "breadth",
+                        "stage_label": "Breadth Calculation",
+                        "status": "running",
+                        "progress_mode": "indeterminate",
+                        "percent": None,
+                        "current": None,
+                        "total": None,
+                        "message": "Calculating breadth",
+                        "task_name": "refresh_market_breadth",
+                        "task_id": "task-hk",
+                        "updated_at": "2026-04-18T00:00:00Z",
+                    }
+                ],
+            },
+        ):
+            response = await client.post(
+                "/api/v1/scans",
+                json={"universe_def": {"type": "market", "market": "HK"}},
+            )
+    finally:
+        app.dependency_overrides.pop(get_uow, None)
+        app.dependency_overrides.pop(get_create_scan_use_case, None)
+
+    assert response.status_code == 200
+    assert fake_use_case.received_cmd.universe_market == "HK"
+
+
+@pytest.mark.asyncio
+async def test_create_scan_allows_other_market_refresh_activity(client):
+    fake_uow = _FakeUoW()
+    fake_uow.session = MagicMock()
+    fake_use_case = _FakeCreateScanUseCase(
+        CreateScanResult(
+            scan_id="scan-hk-ok",
+            status="queued",
+            total_stocks=1200,
+            is_duplicate=False,
+            feature_run_id=None,
+        )
+    )
+
+    app.dependency_overrides[get_uow] = lambda: fake_uow
+    app.dependency_overrides[get_create_scan_use_case] = lambda: fake_use_case
+    try:
+        with patch(
+            "app.api.v1.scans.get_runtime_activity_status",
+            return_value={
+                "bootstrap": {},
+                "summary": {"active_market_count": 1, "active_markets": ["US"], "status": "active"},
+                "markets": [
+                    {
+                        "market": "US",
+                        "lifecycle": "daily_refresh",
+                        "stage_key": "prices",
+                        "stage_label": "Price Refresh",
+                        "status": "running",
+                        "progress_mode": "determinate",
+                        "percent": 55.0,
+                        "current": 550,
+                        "total": 1000,
+                        "message": "Refreshing prices",
+                        "task_name": "smart_refresh_cache",
+                        "task_id": "task-us",
+                        "updated_at": "2026-04-18T00:00:00Z",
+                    }
+                ],
+            },
+        ):
+            response = await client.post(
+                "/api/v1/scans",
+                json={"universe_def": {"type": "market", "market": "HK"}},
+            )
+    finally:
+        app.dependency_overrides.pop(get_uow, None)
+        app.dependency_overrides.pop(get_create_scan_use_case, None)
+
+    assert response.status_code == 200
+    assert fake_use_case.received_cmd.universe_market == "HK"
+
+
+@pytest.mark.asyncio
+async def test_create_scan_returns_409_for_us_exchange_when_us_refresh_is_active(client):
+    fake_uow = _FakeUoW()
+    fake_uow.session = MagicMock()
+    fake_use_case = _FakeCreateScanUseCase(
+        CreateScanResult(
+            scan_id="scan-nyse",
+            status="queued",
+            total_stocks=500,
+            is_duplicate=False,
+            feature_run_id=None,
+        )
+    )
+
+    app.dependency_overrides[get_uow] = lambda: fake_uow
+    app.dependency_overrides[get_create_scan_use_case] = lambda: fake_use_case
+    try:
+        with patch(
+            "app.api.v1.scans.get_runtime_activity_status",
+            return_value={
+                "bootstrap": {},
+                "summary": {"active_market_count": 1, "active_markets": ["US"], "status": "active"},
+                "markets": [
+                    {
+                        "market": "US",
+                        "lifecycle": "daily_refresh",
+                        "stage_key": "prices",
+                        "stage_label": "Price Refresh",
+                        "status": "running",
+                        "progress_mode": "determinate",
+                        "percent": 55.0,
+                        "current": 550,
+                        "total": 1000,
+                        "message": "Refreshing prices",
+                        "task_name": "smart_refresh_cache",
+                        "task_id": "task-us",
+                        "updated_at": "2026-04-18T00:00:00Z",
+                    }
+                ],
+            },
+        ):
+            response = await client.post(
+                "/api/v1/scans",
+                json={"universe_def": {"type": "exchange", "exchange": "NYSE"}},
+            )
+    finally:
+        app.dependency_overrides.pop(get_uow, None)
+        app.dependency_overrides.pop(get_create_scan_use_case, None)
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert payload["detail"]["code"] == "market_refresh_active"
+    assert payload["detail"]["market"] == "US"
+    assert fake_use_case.received_cmd is None

--- a/frontend/src/components/App/BootstrapSetupScreen.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.jsx
@@ -27,6 +27,32 @@ const STATUS_COLOR = {
   failed: 'error',
   idle: 'default',
 };
+const STAGE_LOCAL_PROGRESS_LABELS = new Set(['Price Refresh', 'Fundamentals Refresh']);
+
+function formatCount(value) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function resolveStageLocalProgress(activity) {
+  if (!activity || activity.progress_mode !== 'determinate' || activity.percent === null || activity.percent === undefined) {
+    return null;
+  }
+  const stageLabel = activity.stage_label || '';
+  if (!STAGE_LOCAL_PROGRESS_LABELS.has(stageLabel)) {
+    return null;
+  }
+  return {
+    percent: Math.max(0, Math.min(100, Number(activity.percent))),
+    detail: (
+      activity.current !== null
+      && activity.current !== undefined
+      && activity.total !== null
+      && activity.total !== undefined
+    )
+      ? `${formatCount(activity.current)} / ${formatCount(activity.total)} stocks`
+      : null,
+  };
+}
 
 function normalizeEnabled(primaryMarket, enabledMarkets) {
   const next = enabledMarkets.includes(primaryMarket)
@@ -81,14 +107,18 @@ export default function BootstrapSetupScreen({
     () => marketActivity.find((market) => market.market === (primaryMarket || selectedPrimary)) ?? marketActivity[0],
     [marketActivity, primaryMarket, selectedPrimary]
   );
+  const stageLocalProgress = resolveStageLocalProgress(primaryActivity);
   const bootstrapProgressMode = (
-    bootstrap?.progress_mode
-    || primaryActivity?.progress_mode
-    || 'indeterminate'
+    stageLocalProgress ? 'determinate' : (
+      bootstrap?.progress_mode
+      || primaryActivity?.progress_mode
+      || 'indeterminate'
+    )
   );
   const bootstrapPercent = (
     bootstrapProgressMode === 'determinate'
-      ? Math.max(0, Math.min(100, Number(bootstrap?.percent ?? primaryActivity?.percent ?? 0)))
+      ? (stageLocalProgress?.percent
+        ?? Math.max(0, Math.min(100, Number(bootstrap?.percent ?? primaryActivity?.percent ?? 0))))
       : null
   );
 
@@ -182,6 +212,11 @@ export default function BootstrapSetupScreen({
                       value={bootstrapProgressMode === 'determinate' ? bootstrapPercent : undefined}
                       aria-label="Bootstrap progress"
                     />
+                    {stageLocalProgress?.detail && (
+                      <Typography variant="caption" color="text.secondary">
+                        {stageLocalProgress.detail}
+                      </Typography>
+                    )}
                     <Typography variant="body2" color="text.secondary">
                       {bootstrap?.message || primaryActivity?.message || 'Preparing primary market data.'}
                     </Typography>

--- a/frontend/src/components/App/BootstrapSetupScreen.test.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.test.jsx
@@ -22,7 +22,7 @@ describe('BootstrapSetupScreen', () => {
           primary_market: 'US',
           current_stage: 'Price Refresh',
           progress_mode: 'determinate',
-          percent: 42,
+          percent: 25,
           message: 'Refreshing prices',
           background_warning: 'Additional data loading continues in the background.',
         },
@@ -33,6 +33,8 @@ describe('BootstrapSetupScreen', () => {
             status: 'running',
             progress_mode: 'determinate',
             percent: 42,
+            current: 420,
+            total: 1000,
             message: 'Refreshing prices',
           },
           {
@@ -60,6 +62,7 @@ describe('BootstrapSetupScreen', () => {
 
     expect(screen.getByText('Price Refresh')).toBeInTheDocument();
     expect(screen.getByText('42%')).toBeInTheDocument();
+    expect(screen.getByText('420 / 1,000 stocks')).toBeInTheDocument();
     expect(screen.getAllByText(/Refreshing prices/).length).toBeGreaterThan(0);
     expect(screen.getByText(/Additional data loading continues in the background/)).toBeInTheDocument();
     expect(screen.getByText('Enabled market queue')).toBeInTheDocument();
@@ -109,5 +112,48 @@ describe('BootstrapSetupScreen', () => {
     expect(screen.getByText('Fundamentals Refresh')).toBeInTheDocument();
     expect(screen.getByText('Refreshing fundamentals')).toBeInTheDocument();
     expect(screen.queryByText('0%')).not.toBeInTheDocument();
+  });
+
+  it('renders determinate fundamentals progress from the primary market activity row', () => {
+    useRuntimeActivityMock.mockReturnValue({
+      data: {
+        bootstrap: {
+          primary_market: 'US',
+          current_stage: 'Fundamentals Refresh',
+          progress_mode: 'determinate',
+          percent: 40,
+          message: 'Refreshing fundamentals',
+          background_warning: 'Additional data loading continues in the background.',
+        },
+        markets: [
+          {
+            market: 'US',
+            stage_label: 'Fundamentals Refresh',
+            status: 'running',
+            progress_mode: 'determinate',
+            percent: 75,
+            current: 750,
+            total: 1000,
+            message: 'Refreshing fundamentals',
+          },
+        ],
+      },
+    });
+
+    renderWithProviders(
+      <BootstrapSetupScreen
+        primaryMarket="US"
+        enabledMarkets={['US']}
+        supportedMarkets={['US', 'HK', 'JP', 'TW']}
+        bootstrapState="running"
+        isStartingBootstrap={false}
+        bootstrapError={null}
+        onStartBootstrap={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    expect(screen.getByText('750 / 1,000 stocks')).toBeInTheDocument();
+    expect(screen.getByText('Fundamentals Refresh')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/scan/components/ScanControlBar.jsx
+++ b/frontend/src/features/scan/components/ScanControlBar.jsx
@@ -220,8 +220,12 @@ export default function ScanControlBar({
           </Button>
         ) : (
           refreshConflict ? (
-            <Tooltip title={refreshConflict.message}>
-              <span>
+            <Tooltip title={refreshConflict.message} describeChild>
+              <span
+                tabIndex={0}
+                aria-label={refreshConflict.message}
+                style={{ display: 'inline-flex' }}
+              >
                 <Button
                   variant="contained"
                   size="small"

--- a/frontend/src/features/scan/components/ScanControlBar.jsx
+++ b/frontend/src/features/scan/components/ScanControlBar.jsx
@@ -14,6 +14,7 @@ import {
   Paper,
   Select,
   TextField,
+  Tooltip,
 } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
@@ -69,6 +70,7 @@ export default function ScanControlBar({
   onCustomFiltersChange,
   createScanError,
   cancelScanError,
+  refreshConflict = null,
 }) {
   const controlsDisabled = createScanPending || scanStatus === 'running';
   const scopeOptions = universeMarket ? UNIVERSE_SCOPES_BY_MARKET[universeMarket] ?? [] : [];
@@ -76,7 +78,14 @@ export default function ScanControlBar({
   const startDisabled =
     createScanPending
     || !universeMarket
-    || (needsScope && !universeScope);
+    || (needsScope && !universeScope)
+    || Boolean(refreshConflict);
+  const createScanErrorMessage = typeof createScanError === 'string'
+    ? createScanError
+    : createScanError?.message;
+  const cancelScanErrorMessage = typeof cancelScanError === 'string'
+    ? cancelScanError
+    : cancelScanError?.message;
 
   return (
     <Paper elevation={1} sx={{ p: 1.5, mb: 2 }}>
@@ -210,15 +219,31 @@ export default function ScanControlBar({
             Cancel
           </Button>
         ) : (
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={createScanPending ? <CircularProgress size={14} /> : <PlayArrowIcon />}
-            onClick={onStartScan}
-            disabled={startDisabled}
-          >
-            Scan
-          </Button>
+          refreshConflict ? (
+            <Tooltip title={refreshConflict.message}>
+              <span>
+                <Button
+                  variant="contained"
+                  size="small"
+                  startIcon={createScanPending ? <CircularProgress size={14} /> : <PlayArrowIcon />}
+                  onClick={onStartScan}
+                  disabled={startDisabled}
+                >
+                  Scan
+                </Button>
+              </span>
+            </Tooltip>
+          ) : (
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={createScanPending ? <CircularProgress size={14} /> : <PlayArrowIcon />}
+              onClick={onStartScan}
+              disabled={startDisabled}
+            >
+              Scan
+            </Button>
+          )
         )}
 
         {currentScanId && statusData && (
@@ -307,14 +332,14 @@ export default function ScanControlBar({
         </Box>
       </Collapse>
 
-      {createScanError && (
+      {createScanErrorMessage && (
         <Alert severity="error" sx={{ mt: 1 }}>
-          Error: {createScanError.message}
+          Error: {createScanErrorMessage}
         </Alert>
       )}
-      {cancelScanError && (
+      {cancelScanErrorMessage && (
         <Alert severity="error" sx={{ mt: 1 }}>
-          Error: {cancelScanError.message}
+          Error: {cancelScanErrorMessage}
         </Alert>
       )}
       {scanStatus === 'cancelled' && (

--- a/frontend/src/features/scan/pages/ScanPageContainer.jsx
+++ b/frontend/src/features/scan/pages/ScanPageContainer.jsx
@@ -17,6 +17,7 @@ import ChartViewerModal from '../../../components/Scan/ChartViewerModal';
 import { buildFilterParams, getStableFilterKey } from '../../../utils/filterUtils';
 import { fetchPriceHistory, priceHistoryKeys, PRICE_HISTORY_STALE_TIME } from '../../../api/priceHistory';
 import { useFilterPresets } from '../../../hooks/useFilterPresets';
+import { useRuntimeActivity } from '../../../hooks/useRuntimeActivity';
 import { useRuntime } from '../../../contexts/RuntimeContext';
 import { useStrategyProfile } from '../../../contexts/StrategyProfileContext';
 import { DEFAULT_SCAN_DEFAULTS } from '../../../constants/scanDefaults';
@@ -29,6 +30,43 @@ import { useScanFilterPresets } from '../hooks/useScanFilterPresets';
 import { buildUniverseDef, parseLegacyUniverseDefault } from '../universeSelection';
 
 const INITIAL_UNIVERSE_SELECTION = parseLegacyUniverseDefault(DEFAULT_SCAN_DEFAULTS.universe);
+const SCAN_BLOCKING_ACTIVITY_STAGES = new Set(['prices', 'fundamentals']);
+const SCAN_BLOCKING_ACTIVITY_STATUSES = new Set(['queued', 'running']);
+
+function buildRefreshConflict(activity, market) {
+  if (!market || market === 'TEST') {
+    return null;
+  }
+
+  const marketActivity = (activity?.markets ?? []).find((item) => (
+    item?.market === market
+    && SCAN_BLOCKING_ACTIVITY_STAGES.has(item.stage_key)
+    && SCAN_BLOCKING_ACTIVITY_STATUSES.has(item.status)
+  ));
+  if (!marketActivity) {
+    return null;
+  }
+
+  const stageLabel = (marketActivity.stage_label || marketActivity.stage_key || 'refresh').toLowerCase();
+  const statusLabel = marketActivity.status === 'queued' ? 'queued' : 'running';
+  return {
+    market,
+    stageKey: marketActivity.stage_key,
+    status: marketActivity.status,
+    lifecycle: marketActivity.lifecycle ?? null,
+    message: `${market} ${stageLabel} is ${statusLabel}. Wait for it to finish before starting a scan.`,
+  };
+}
+
+function getMutationErrorMessage(error) {
+  if (!error) {
+    return null;
+  }
+  return error?.response?.data?.detail?.message
+    || error?.response?.data?.message
+    || error?.message
+    || 'Failed to start scan.';
+}
 
 function ScanPage() {
   const { runtimeReady, uiSnapshots, scanDefaults } = useRuntime();
@@ -60,6 +98,7 @@ function ScanPage() {
 
   const snapshotEnabled = runtimeReady && Boolean(uiSnapshots?.scan);
   const initialQueriesEnabled = runtimeReady && (!snapshotEnabled || initialBootstrapSettled);
+  const runtimeActivityQuery = useRuntimeActivity({ enabled: runtimeReady });
 
   useEffect(() => {
     if (!runtimeReady) {
@@ -328,8 +367,19 @@ function ScanPage() {
     () => normalizeScanFilterOptions(filterOptionsData),
     [filterOptionsData]
   );
+  const refreshConflict = useMemo(
+    () => buildRefreshConflict(runtimeActivityQuery.data, universeMarket),
+    [runtimeActivityQuery.data, universeMarket]
+  );
+  const createScanError = useMemo(() => {
+    const message = getMutationErrorMessage(createScanMutation.error);
+    return message ? { message } : null;
+  }, [createScanMutation.error]);
 
   const handleStartScan = () => {
+    if (refreshConflict) {
+      return;
+    }
     const universeDef = buildUniverseDef(universeMarket, universeScope);
     if (!universeDef) {
       return;
@@ -525,8 +575,9 @@ function ScanPage() {
         statusData={statusData}
         customFilters={customFilters}
         onCustomFiltersChange={setCustomFilters}
-        createScanError={createScanMutation.error}
+        createScanError={createScanError}
         cancelScanError={cancelScanMutation.error}
+        refreshConflict={refreshConflict}
       />
 
       {(scanStatus === 'completed' || scanStatus === 'cancelled') && (

--- a/frontend/src/pages/ScanPage.test.jsx
+++ b/frontend/src/pages/ScanPage.test.jsx
@@ -281,6 +281,43 @@ describe('ScanPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('adds keyboard focus semantics to the disabled scan control wrapper when refresh is blocked', async () => {
+    runtimeState.runtimeReady = true;
+    runtimeState.scanDefaults = {
+      ...DEFAULT_SCAN_DEFAULTS,
+      universe: 'market:us',
+    };
+    useRuntimeActivityMock.mockReturnValue({
+      data: {
+        bootstrap: {},
+        summary: { active_market_count: 1, active_markets: ['US'], status: 'active' },
+        markets: [
+          {
+            market: 'US',
+            stage_key: 'prices',
+            stage_label: 'Price Refresh',
+            status: 'running',
+            lifecycle: 'daily_refresh',
+            progress_mode: 'determinate',
+            percent: 30,
+            current: 300,
+            total: 1000,
+            message: 'Refreshing prices',
+          },
+        ],
+      },
+    });
+
+    renderWithProviders(<ScanPage />);
+
+    const scanButton = await screen.findByRole('button', { name: 'Scan' });
+    expect(scanButton.parentElement).toHaveAttribute('tabindex', '0');
+    expect(scanButton.parentElement).toHaveAttribute(
+      'aria-label',
+      'US price refresh is running. Wait for it to finish before starting a scan.'
+    );
+  });
+
   it('disables scan creation with a hover warning when fundamentals refresh is active for the selected market', async () => {
     const user = userEvent.setup();
     runtimeState.runtimeReady = true;

--- a/frontend/src/pages/ScanPage.test.jsx
+++ b/frontend/src/pages/ScanPage.test.jsx
@@ -1,5 +1,6 @@
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
 
 import ScanPage from './ScanPage';
 import { DEFAULT_SCAN_DEFAULTS } from '../constants/scanDefaults';
@@ -13,9 +14,14 @@ const runtimeState = {
   },
   scanDefaults: DEFAULT_SCAN_DEFAULTS,
 };
+const useRuntimeActivityMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../contexts/RuntimeContext', () => ({
   useRuntime: () => runtimeState,
+}));
+
+vi.mock('../hooks/useRuntimeActivity', () => ({
+  useRuntimeActivity: (...args) => useRuntimeActivityMock(...args),
 }));
 
 vi.mock('../contexts/StrategyProfileContext', () => ({
@@ -61,6 +67,14 @@ beforeEach(() => {
   runtimeState.runtimeReady = false;
   runtimeState.uiSnapshots = { scan: false };
   runtimeState.scanDefaults = DEFAULT_SCAN_DEFAULTS;
+  useRuntimeActivityMock.mockReset();
+  useRuntimeActivityMock.mockReturnValue({
+    data: {
+      bootstrap: {},
+      summary: { active_market_count: 0, active_markets: [], status: 'idle' },
+      markets: [],
+    },
+  });
   scanApi.getScanBootstrap.mockResolvedValue(null);
   scanApi.getScanStatus.mockResolvedValue({ status: 'completed' });
   scanApi.getScanResults.mockResolvedValue({ total: 0, results: [] });
@@ -225,5 +239,114 @@ describe('ScanPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/Results:\s*1 stocks/i)).toBeInTheDocument();
     });
+  });
+
+  it('disables scan creation with a hover warning when prices refresh is active for the selected market', async () => {
+    const user = userEvent.setup();
+    runtimeState.runtimeReady = true;
+    runtimeState.scanDefaults = {
+      ...DEFAULT_SCAN_DEFAULTS,
+      universe: 'market:us',
+    };
+    useRuntimeActivityMock.mockReturnValue({
+      data: {
+        bootstrap: {},
+        summary: { active_market_count: 1, active_markets: ['US'], status: 'active' },
+        markets: [
+          {
+            market: 'US',
+            stage_key: 'prices',
+            stage_label: 'Price Refresh',
+            status: 'running',
+            lifecycle: 'daily_refresh',
+            progress_mode: 'determinate',
+            percent: 30,
+            current: 300,
+            total: 1000,
+            message: 'Refreshing prices',
+          },
+        ],
+      },
+    });
+
+    renderWithProviders(<ScanPage />);
+
+    const scanButton = await screen.findByRole('button', { name: 'Scan' });
+    expect(scanButton).toBeDisabled();
+
+    await user.hover(scanButton.parentElement);
+
+    expect(
+      await screen.findByText('US price refresh is running. Wait for it to finish before starting a scan.')
+    ).toBeInTheDocument();
+  });
+
+  it('disables scan creation with a hover warning when fundamentals refresh is active for the selected market', async () => {
+    const user = userEvent.setup();
+    runtimeState.runtimeReady = true;
+    runtimeState.scanDefaults = {
+      ...DEFAULT_SCAN_DEFAULTS,
+      universe: 'market:us',
+    };
+    useRuntimeActivityMock.mockReturnValue({
+      data: {
+        bootstrap: {},
+        summary: { active_market_count: 1, active_markets: ['US'], status: 'active' },
+        markets: [
+          {
+            market: 'US',
+            stage_key: 'fundamentals',
+            stage_label: 'Fundamentals Refresh',
+            status: 'queued',
+            lifecycle: 'bootstrap',
+            progress_mode: 'indeterminate',
+            percent: null,
+            current: null,
+            total: null,
+            message: 'Queued fundamentals refresh',
+          },
+        ],
+      },
+    });
+
+    renderWithProviders(<ScanPage />);
+
+    const scanButton = await screen.findByRole('button', { name: 'Scan' });
+    expect(scanButton).toBeDisabled();
+
+    await user.hover(scanButton.parentElement);
+
+    expect(
+      await screen.findByText('US fundamentals refresh is queued. Wait for it to finish before starting a scan.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the backend market-refresh conflict message if a scan request loses the polling race', async () => {
+    runtimeState.runtimeReady = true;
+    runtimeState.scanDefaults = {
+      ...DEFAULT_SCAN_DEFAULTS,
+      universe: 'market:us',
+    };
+    scanApi.createScan.mockRejectedValueOnce({
+      response: {
+        status: 409,
+        data: {
+          detail: {
+            code: 'market_refresh_active',
+            message: 'US fundamentals refresh is running. Wait for it to finish before starting a scan.',
+          },
+        },
+      },
+      message: 'Request failed with status code 409',
+    });
+
+    renderWithProviders(<ScanPage />);
+
+    const scanButton = await screen.findByRole('button', { name: 'Scan' });
+    fireEvent.click(scanButton);
+
+    expect(
+      await screen.findByText('Error: US fundamentals refresh is running. Wait for it to finish before starting a scan.')
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- show determinate bootstrap progress for price and fundamentals downloads using runtime activity
- block scan creation while the selected market is refreshing prices or fundamentals
- fix review regressions for non-US index scan guards and failed-iteration fundamentals progress

## What Changed
- added running progress publishing for fundamentals refresh tasks and kept price refresh on the existing heartbeat path
- updated the bootstrap screen to display active stage progress and stock counts for price/fundamentals work
- added a backend `409 market_refresh_active` guard on scan creation and surfaced the conflict cleanly in the scan UI
- disabled the live `Scan` button with a hover tooltip when the selected market has active price/fundamentals refresh work
- corrected scan-guard market resolution for HK/JP/TW index universes
- made fundamentals progress advance on processed symbols even when individual fetches fail

## Why
Users could not tell how much bootstrap price/fundamentals loading had completed, and scans could still be started against a market whose core data was actively refreshing. Review also identified a guard bug for non-US index scopes and a progress gap when fundamentals iterations failed.

## Validation
- `source backend/venv/bin/activate && pytest backend/tests/unit/test_market_activity_service.py backend/tests/unit/test_fundamentals_tasks.py backend/tests/unit/test_scan_create_endpoint.py -q`
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && cd frontend && npm run test:run -- src/components/App/BootstrapSetupScreen.test.jsx src/pages/ScanPage.test.jsx`
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && cd frontend && npx eslint src/components/App/BootstrapSetupScreen.jsx src/components/App/BootstrapSetupScreen.test.jsx src/features/scan/pages/ScanPageContainer.jsx src/features/scan/components/ScanControlBar.jsx src/pages/ScanPage.test.jsx`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conflict detection preventing scan creation during active market price or fundamentals refreshes, with clear messaging.
  * Enhanced market activity progress tracking with stock-level detail (current/total counts).
  * Added UI warnings and tooltips indicating when scans are blocked due to market refresh activity.

* **Tests**
  * Added comprehensive tests for market refresh conflict detection and market activity progress updates.
  * Added UI tests validating scan blocking behavior and error messaging during market refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->