### PR TITLE
fix: normalize yfinance price batch defaults

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -117,9 +117,8 @@ class Settings(BaseSettings):
     finviz_rate_limit_jp: float | None = None
     finviz_rate_limit_tw: float | None = None
 
-    # Per-market batch sizes for yfinance bulk downloads. Smaller batches for
-    # non-US markets reduce the blast radius of any single batch hitting
-    # provider hiccups. Defaults shipped via RateBudgetPolicy._DEFAULT_BATCH_SIZE.
+    # Per-market batch sizes for yfinance bulk downloads. Defaults ship via
+    # RateBudgetPolicy._DEFAULT_BATCH_SIZE and may be overridden per market.
     yfinance_batch_size_us: int | None = None
     yfinance_batch_size_hk: int | None = None
     yfinance_batch_size_jp: int | None = None

--- a/backend/app/services/rate_budget_policy.py
+++ b/backend/app/services/rate_budget_policy.py
@@ -50,10 +50,10 @@ class RateBudgetPolicy:
         "sec_edgar": 0.15,     # 10 req/sec
     }
 
-    # Per-market batch sizes — smaller for non-US markets given slower
-    # exchange data and less yfinance batch reliability. 9.3 will tune.
+    # Per-market batch sizes. Keep the defaults uniform unless operators
+    # explicitly override them via settings.
     _DEFAULT_BATCH_SIZE: Dict[str, Dict[str, int]] = {
-        "yfinance": {"US": 50, "HK": 25, "JP": 25, "TW": 20},
+        "yfinance": {"US": 50, "HK": 50, "JP": 50, "TW": 50},
         "finviz":   {"US": 100, "HK": 50, "JP": 50, "TW": 50},
     }
 

--- a/backend/tests/unit/test_rate_budget_policy.py
+++ b/backend/tests/unit/test_rate_budget_policy.py
@@ -89,7 +89,7 @@ class TestRateInterval:
 
 class TestBatchSize:
     @pytest.mark.parametrize("market,expected_default", [
-        ("US", 50), ("HK", 25), ("JP", 25), ("TW", 20),
+        ("US", 50), ("HK", 50), ("JP", 50), ("TW", 50),
     ])
     def test_default_batch_sizes(self, market, expected_default):
         with patch("app.services.rate_budget_policy.settings") as mock_settings:


### PR DESCRIPTION
## Summary
- change the default yfinance price batch size to `50` for `US`, `HK`, `JP`, and `TW`
- keep per-market env overrides in place so explicit `YFINANCE_BATCH_SIZE_*` settings still win
- update settings comments and the rate-budget policy test to match the new shared default

## Testing
- `backend/venv/bin/pytest backend/tests/unit/test_rate_budget_policy.py -q`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized data fetching batch sizes for Hong Kong, Japan, and Taiwan markets to improve consistency and performance across all supported regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->