### PR TITLE
fix: restore US group rankings and scan group metadata

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -44,6 +44,7 @@ celery_app = Celery(
         'app.tasks.breadth_tasks',  # Market breadth tasks
         'app.tasks.fundamentals_tasks',  # Fundamental data caching tasks
         'app.tasks.group_rank_tasks',  # IBD group ranking tasks
+        'app.tasks.industry_tasks',  # Tracked IBD industry reference loading
         'app.tasks.theme_discovery_tasks',  # Theme discovery pipeline tasks
         'app.tasks.universe_tasks',  # Stock universe management tasks
         'app.tasks.telemetry_tasks',  # Weekly telemetry governance audit (asia.10.4)
@@ -277,6 +278,7 @@ _MARKET_SCOPED_DATA_FETCH_TASKS = (
 )
 
 _MARKET_JOB_TASKS = (
+    'app.tasks.industry_tasks.load_tracked_ibd_industry_groups',
     'app.tasks.breadth_tasks.calculate_daily_breadth',
     'app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill',
     'app.tasks.group_rank_tasks.calculate_daily_group_rankings',

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -102,6 +102,7 @@ class Settings(BaseSettings):
     tw_universe_allow_insecure_fallback: bool = False
     tw_universe_source_twse_url: str = "https://isin.twse.com.tw/isin/e_C_public.jsp?strMode=2"
     tw_universe_source_tpex_url: str = "https://isin.twse.com.tw/isin/e_C_public.jsp?strMode=4"
+    ibd_industry_csv_path: str = str(_PROJECT_ROOT / "data" / "IBD_industry_group.csv")
 
     # Per-market rate budget overrides. Each value is in requests-per-second
     # for that market specifically. None means "use universe-weighted division

--- a/backend/app/infra/db/repositories/scan_result_repo.py
+++ b/backend/app/infra/db/repositories/scan_result_repo.py
@@ -270,7 +270,12 @@ class SqlScanResultRepository(ScanResultRepository):
         ]
         return self.bulk_insert(rows)
 
-    def _load_symbol_enrichment(self, symbols: list[str]) -> dict[str, dict[str, Any]]:
+    def _load_symbol_enrichment(
+        self,
+        symbols: list[str],
+        *,
+        ranking_date: date | None = None,
+    ) -> dict[str, dict[str, Any]]:
         """Load enrichment fields used by scan result persistence in bulk."""
         if not symbols:
             return {}
@@ -327,7 +332,7 @@ class SqlScanResultRepository(ScanResultRepository):
             d = enrichment.setdefault(row.symbol, {})
             d["ibd_industry_group"] = row.industry_group
 
-        latest_rank_date = self._session.query(func.max(IBDGroupRank.date)).scalar()
+        latest_rank_date = ranking_date or self._session.query(func.max(IBDGroupRank.date)).scalar()
         rank_by_group: dict[str, int] = {}
         if latest_rank_date is not None:
             rank_rows = (
@@ -343,6 +348,64 @@ class SqlScanResultRepository(ScanResultRepository):
                 d["ibd_group_rank"] = rank_by_group.get(group_name)
 
         return enrichment
+
+    def backfill_ibd_metadata_for_scan(
+        self,
+        scan_id: str,
+        *,
+        ranking_date: date | None = None,
+    ) -> dict[str, Any]:
+        """Repair IBD classification/rank fields for an existing scan's rows."""
+        rows = (
+            self._session.query(ScanResult)
+            .filter(ScanResult.scan_id == scan_id)
+            .all()
+        )
+        if not rows:
+            return {
+                "scan_id": scan_id,
+                "ranking_date": ranking_date.isoformat() if ranking_date else None,
+                "total_rows": 0,
+                "updated_rows": 0,
+                "missing_industry_rows": 0,
+                "missing_rank_rows": 0,
+            }
+
+        enrichment = self._load_symbol_enrichment(
+            [row.symbol for row in rows],
+            ranking_date=ranking_date,
+        )
+        updated_rows = 0
+        missing_industry_rows = 0
+        missing_rank_rows = 0
+
+        for row in rows:
+            meta = enrichment.get(row.symbol, {})
+            industry_group = meta.get("ibd_industry_group")
+            group_rank = meta.get("ibd_group_rank")
+            if industry_group is None:
+                missing_industry_rows += 1
+            elif group_rank is None:
+                missing_rank_rows += 1
+
+            if row.ibd_industry_group != industry_group or row.ibd_group_rank != group_rank:
+                row.ibd_industry_group = industry_group
+                row.ibd_group_rank = group_rank
+                details = dict(row.details or {})
+                details["ibd_industry_group"] = industry_group
+                details["ibd_group_rank"] = group_rank
+                row.details = details
+                updated_rows += 1
+
+        self._session.flush()
+        return {
+            "scan_id": scan_id,
+            "ranking_date": ranking_date.isoformat() if ranking_date else None,
+            "total_rows": len(rows),
+            "updated_rows": updated_rows,
+            "missing_industry_rows": missing_industry_rows,
+            "missing_rank_rows": missing_rank_rows,
+        }
 
     def _enrich_raw_result(
         self,

--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -236,6 +236,143 @@ def _enrich_feature_run_with_ibd_metadata(
         db.close()
 
 
+def _feature_run_market(run) -> str | None:
+    config = getattr(run, "config_json", None) or {}
+    if not isinstance(config, dict):
+        return None
+    universe = config.get("universe")
+    if isinstance(universe, dict):
+        market = universe.get("market")
+        if market:
+            return str(market).upper()
+    return None
+
+
+def _resolve_latest_published_run_for_market(*, db, market: str) -> int | None:
+    from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer
+
+    normalized_market = market.upper()
+    pointer_key = f"latest_published_market:{normalized_market}"
+
+    pointer = (
+        db.query(FeatureRunPointer)
+        .filter(FeatureRunPointer.key == pointer_key)
+        .first()
+    )
+    if pointer is not None:
+        run = db.query(FeatureRun).filter(FeatureRun.id == pointer.run_id).first()
+        if run is not None and run.status == "published" and _feature_run_market(run) == normalized_market:
+            return run.id
+
+    fallback_pointer = (
+        db.query(FeatureRunPointer)
+        .filter(FeatureRunPointer.key == "latest_published")
+        .first()
+    )
+    if fallback_pointer is not None:
+        run = db.query(FeatureRun).filter(FeatureRun.id == fallback_pointer.run_id).first()
+        if run is not None and run.status == "published" and _feature_run_market(run) == normalized_market:
+            return run.id
+
+    published_runs = (
+        db.query(FeatureRun)
+        .filter(FeatureRun.status == "published")
+        .order_by(FeatureRun.published_at.desc(), FeatureRun.id.desc())
+        .all()
+    )
+    for run in published_runs:
+        if _feature_run_market(run) == normalized_market:
+            return run.id
+    return None
+
+
+def _repair_current_us_group_metadata(
+    *,
+    ranking_date: date,
+    session_factory=None,
+) -> dict[str, object]:
+    """Repair current US scan-facing IBD metadata after rankings are available."""
+    from app.database import SessionLocal
+    from app.infra.db.repositories.scan_result_repo import SqlScanResultRepository
+    from app.models.scan_result import Scan
+    from app.services.ui_snapshot_service import safe_publish_scan_bootstrap
+
+    session_factory = session_factory or SessionLocal
+    db = session_factory()
+    try:
+        feature_run_id = _resolve_latest_published_run_for_market(db=db, market="US")
+        feature_run_stats = None
+        if feature_run_id is not None:
+            feature_run_stats = _enrich_feature_run_with_ibd_metadata(
+                feature_run_id=feature_run_id,
+                ranking_date=ranking_date,
+                session_factory=session_factory,
+            )
+
+        completed_statuses = ("completed", "cancelled")
+        feature_scan_ids: list[str] = []
+        if feature_run_id is not None:
+            feature_scan_ids = [
+                scan_id
+                for scan_id, in (
+                    db.query(Scan.scan_id)
+                    .filter(
+                        Scan.feature_run_id == feature_run_id,
+                        Scan.universe_market == "US",
+                        Scan.status.in_(completed_statuses),
+                    )
+                    .order_by(Scan.started_at.desc(), Scan.id.desc())
+                    .limit(1)
+                    .all()
+                )
+            ]
+
+        legacy_scan_ids = [
+            scan_id
+            for scan_id, in (
+                db.query(Scan.scan_id)
+                .filter(
+                    Scan.feature_run_id.is_(None),
+                    Scan.universe_market == "US",
+                    Scan.status.in_(completed_statuses),
+                )
+                .order_by(Scan.started_at.desc(), Scan.id.desc())
+                .limit(1)
+                .all()
+            )
+        ]
+
+        scan_repo = SqlScanResultRepository(db)
+        repaired_legacy_scans = []
+        for scan_id in legacy_scan_ids:
+            repaired_legacy_scans.append(
+                scan_repo.backfill_ibd_metadata_for_scan(
+                    scan_id,
+                    ranking_date=ranking_date,
+                )
+            )
+        db.commit()
+
+        published_scan_ids = []
+        for scan_id in [*feature_scan_ids, *legacy_scan_ids]:
+            safe_publish_scan_bootstrap(scan_id)
+            published_scan_ids.append(scan_id)
+        safe_publish_scan_bootstrap()
+
+        return {
+            "market": "US",
+            "ranking_date": ranking_date.isoformat(),
+            "feature_run": feature_run_stats,
+            "legacy_scans": repaired_legacy_scans,
+            "published_scan_ids": published_scan_ids,
+        }
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
 def _create_auto_scan_for_published_run(
     *,
     feature_run_id: int,

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 
 from sqlalchemy import func
 
+from app.config import settings
 from app.database import SessionLocal
 from app.infra.db.models.feature_store import FeatureRunPointer
 from app.models.industry import IBDGroupRank
@@ -47,7 +48,7 @@ def _default_output_dir() -> Path:
 
 
 def _tracked_ibd_csv_path() -> Path:
-    return repo_root() / "data" / "IBD_industry_group.csv"
+    return Path(settings.ibd_industry_csv_path)
 
 
 def _resolve_latest_completed_us_trading_date() -> date:

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -37,6 +37,13 @@ class IncompleteGroupRankingCacheError(RuntimeError):
         super().__init__(reason)
 
 
+class MissingIBDIndustryMappingsError(RuntimeError):
+    """Raised when tracked IBD industry mappings have not been loaded."""
+
+    def __init__(self) -> None:
+        super().__init__("IBD industry mappings are not loaded")
+
+
 class IBDGroupRankService:
     """
     Service for calculating and managing IBD Industry Group Rankings.
@@ -90,16 +97,18 @@ class IBDGroupRankService:
         all_groups = IBDIndustryService.get_all_groups(db)
         if not all_groups:
             logger.error("No IBD industry groups found")
-            return []
+            raise MissingIBDIndustryMappingsError()
 
         logger.info(f"Found {len(all_groups)} IBD industry groups")
 
         # Pre-fetch ALL data upfront (SPY + all stock prices in single bulk fetch)
+        prefetch_kwargs = {"cache_only": cache_only}
+        if market is not None:
+            prefetch_kwargs["market"] = market
         spy_data, all_prices, active_symbols, market_caps, prefetch_stats = (
             self._prefetch_all_data(
                 db,
-                market=market,
-                cache_only=cache_only,
+                **prefetch_kwargs,
             )
         )
 

--- a/backend/app/services/ibd_industry_service.py
+++ b/backend/app/services/ibd_industry_service.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from sqlalchemy.orm import Session
 from sqlalchemy import delete
+from ..config import settings
 from ..models.industry import IBDIndustryGroup
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ class IBDIndustryService:
             Number of records loaded
         """
         if not csv_path:
-            csv_path = Path(__file__).parent.parent.parent.parent / "data" / "IBD_industry_group.csv"
+            csv_path = settings.ibd_industry_csv_path
 
         csv_path = Path(csv_path)
         if not csv_path.exists():

--- a/backend/app/services/ibd_industry_service.py
+++ b/backend/app/services/ibd_industry_service.py
@@ -171,5 +171,5 @@ class IBDIndustryService:
             records = db.query(IBDIndustryGroup.industry_group).distinct().all()
             return [r.industry_group for r in records]
         except Exception as e:
-            logger.error(f"Error getting all industry groups: {e}")
-            return []
+            logger.error(f"Error getting all industry groups: {e}", exc_info=True)
+            raise

--- a/backend/app/tasks/group_rank_tasks.py
+++ b/backend/app/tasks/group_rank_tasks.py
@@ -26,6 +26,7 @@ from ..services.market_activity_service import (
 )
 from ..services.ibd_group_rank_service import (
     IncompleteGroupRankingCacheError,
+    MissingIBDIndustryMappingsError,
 )
 from ..wiring.bootstrap import get_group_rank_service
 from ..utils.market_hours import is_trading_day, get_eastern_now
@@ -269,9 +270,12 @@ def calculate_daily_group_rankings(
 
         logger.info("=" * 60)
 
+        repair_stats = None
         try:
             from ..services.ui_snapshot_service import safe_publish_groups_bootstrap
+            from ..interfaces.tasks.feature_store_tasks import _repair_current_us_group_metadata
 
+            repair_stats = _repair_current_us_group_metadata(ranking_date=calc_date)
             safe_publish_groups_bootstrap()
         except Exception as snapshot_error:
             logger.warning("Group rankings snapshot publish failed: %s", snapshot_error)
@@ -294,6 +298,7 @@ def calculate_daily_group_rankings(
             'top_avg_rs': results[0]['avg_rs_rating'] if results else None,
             'calculation_duration_seconds': round(duration, 2),
             'cache_only': same_day_cache_only,
+            'metadata_repair': repair_stats,
             'timestamp': datetime.now().isoformat()
         }
 
@@ -329,6 +334,25 @@ def calculate_daily_group_rankings(
             'timestamp': datetime.now().isoformat(),
             'cache_only': True,
             'prefetch_stats': e.stats,
+        }
+    except MissingIBDIndustryMappingsError as e:
+        db.rollback()
+        logger.error("✗ Refusing to publish daily group rankings: %s", e)
+        logger.info("=" * 60)
+        _mark_market_activity_failed_safely(
+            db,
+            market=effective_market,
+            stage_key="groups",
+            lifecycle=activity_lifecycle,
+            task_name=getattr(self, "name", "calculate_daily_group_rankings"),
+            task_id=getattr(getattr(self, "request", None), "id", None),
+            message=str(e),
+        )
+        return {
+            'error': str(e),
+            'date': calc_date.strftime('%Y-%m-%d') if calc_date else None,
+            'timestamp': datetime.now().isoformat(),
+            'cache_only': same_day_cache_only,
         }
     except TRANSIENT_TASK_EXCEPTIONS as e:
         db.rollback()

--- a/backend/app/tasks/group_rank_tasks.py
+++ b/backend/app/tasks/group_rank_tasks.py
@@ -105,6 +105,16 @@ def _validate_same_day_cache_only_group_rankings(
     return None
 
 
+def _should_repair_current_us_metadata(
+    *,
+    calc_date: date,
+    today_et: date,
+    activity_lifecycle: str,
+) -> bool:
+    """Only repair live US surfaces for same-day or bootstrap ranking runs."""
+    return activity_lifecycle == "bootstrap" or calc_date == today_et
+
+
 @celery_app.task(
     bind=True,
     name='app.tasks.group_rank_tasks.calculate_daily_group_rankings',
@@ -271,11 +281,18 @@ def calculate_daily_group_rankings(
         logger.info("=" * 60)
 
         repair_stats = None
-        try:
-            from ..services.ui_snapshot_service import safe_publish_groups_bootstrap
+        if _should_repair_current_us_metadata(
+            calc_date=calc_date,
+            today_et=today_et,
+            activity_lifecycle=activity_lifecycle,
+        ):
             from ..interfaces.tasks.feature_store_tasks import _repair_current_us_group_metadata
 
             repair_stats = _repair_current_us_group_metadata(ranking_date=calc_date)
+
+        try:
+            from ..services.ui_snapshot_service import safe_publish_groups_bootstrap
+
             safe_publish_groups_bootstrap()
         except Exception as snapshot_error:
             logger.warning("Group rankings snapshot publish failed: %s", snapshot_error)

--- a/backend/app/tasks/industry_tasks.py
+++ b/backend/app/tasks/industry_tasks.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 
 from ..celery_app import celery_app
+from ..config import settings
 from ..database import SessionLocal
 from ..services.ibd_industry_service import IBDIndustryService
 from .market_queues import log_extra, normalize_market
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def _tracked_ibd_csv_path() -> Path:
-    return Path(__file__).resolve().parents[3] / "data" / "IBD_industry_group.csv"
+    return Path(settings.ibd_industry_csv_path)
 
 
 @celery_app.task(

--- a/backend/app/tasks/industry_tasks.py
+++ b/backend/app/tasks/industry_tasks.py
@@ -1,0 +1,63 @@
+"""Runtime tasks for tracked market reference datasets."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from pathlib import Path
+
+from ..celery_app import celery_app
+from ..database import SessionLocal
+from ..services.ibd_industry_service import IBDIndustryService
+from .market_queues import log_extra, normalize_market
+from .workload_coordination import serialized_market_workload
+
+logger = logging.getLogger(__name__)
+
+
+def _tracked_ibd_csv_path() -> Path:
+    return Path(__file__).resolve().parents[3] / "data" / "IBD_industry_group.csv"
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.industry_tasks.load_tracked_ibd_industry_groups",
+)
+@serialized_market_workload("load_tracked_ibd_industry_groups")
+def load_tracked_ibd_industry_groups(
+    self,
+    *,
+    market: str = "US",
+    activity_lifecycle: str | None = None,
+) -> dict:
+    """Load the tracked US IBD industry-group CSV into runtime tables."""
+    del activity_lifecycle  # reserved for parity with bootstrap task signatures
+
+    effective_market = normalize_market(market)
+    _log_extra = log_extra(market)
+    if effective_market != "US":
+        logger.info("Skipping tracked IBD industry load for unsupported market %s", market, extra=_log_extra)
+        return {
+            "status": "skipped",
+            "reason": "ibd_industry_mappings_are_us_only",
+            "market": effective_market,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    db = SessionLocal()
+    try:
+        csv_path = _tracked_ibd_csv_path()
+        loaded = IBDIndustryService.load_from_csv(db, csv_path=csv_path)
+        logger.info(
+            "Loaded tracked IBD industry mappings",
+            extra={"market": "us", "loaded_rows": loaded, "csv_path": str(csv_path)},
+        )
+        return {
+            "status": "loaded",
+            "market": effective_market,
+            "loaded_rows": loaded,
+            "csv_path": str(csv_path),
+            "timestamp": datetime.now().isoformat(),
+        }
+    finally:
+        db.close()

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -49,6 +49,7 @@ def _build_market_bootstrap_signatures(
     from app.tasks.cache_tasks import smart_refresh_cache
     from app.tasks.fundamentals_tasks import refresh_all_fundamentals
     from app.tasks.group_rank_tasks import calculate_daily_group_rankings
+    from app.tasks.industry_tasks import load_tracked_ibd_industry_groups
     from app.tasks.universe_tasks import (
         refresh_official_market_universe,
         refresh_stock_universe,
@@ -66,6 +67,15 @@ def _build_market_bootstrap_signatures(
                 activity_lifecycle="bootstrap",
             )
         ).set(queue=data_fetch_queue_for_market(market)),
+    ]
+    if market == "US":
+        signatures.append(
+            load_tracked_ibd_industry_groups.si(
+                market=market,
+                activity_lifecycle="bootstrap",
+            ).set(queue=market_jobs_queue_for_market(market))
+        )
+    signatures.extend([
         smart_refresh_cache.si(
             mode="full",
             market=market,
@@ -75,7 +85,7 @@ def _build_market_bootstrap_signatures(
             market=market,
             activity_lifecycle="bootstrap",
         ).set(queue=data_fetch_queue_for_market(market)),
-    ]
+    ])
     if market == "US":
         signatures.extend([
             calculate_daily_breadth_with_gapfill.si(

--- a/backend/tests/integration/test_scan_result_repo_enrichment.py
+++ b/backend/tests/integration/test_scan_result_repo_enrichment.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from app.database import Base
 from app.infra.db.repositories.scan_result_repo import SqlScanResultRepository
 from app.models.industry import IBDGroupRank, IBDIndustryGroup
-from app.models.scan_result import ScanResult
+from app.models.scan_result import Scan, ScanResult
 from app.models.stock import StockFundamental, StockIndustry
 
 
@@ -121,3 +121,72 @@ def test_persist_orchestrator_results_uses_ipo_screener_date_fallback(session: S
     assert row.ipo_date == "1986-03-13"
     assert row.gics_sector == "Technology"
     assert row.gics_industry == "Software"
+
+
+def test_backfill_ibd_metadata_for_existing_scan_rows(session: Session):
+    session.add(Scan(scan_id="scan-us-1", status="completed", universe_market="US"))
+    session.add_all(
+        [
+            ScanResult(
+                scan_id="scan-us-1",
+                symbol="AAPL",
+                composite_score=80.0,
+                rating="Buy",
+                details={},
+                ibd_industry_group=None,
+                ibd_group_rank=None,
+            ),
+            ScanResult(
+                scan_id="scan-us-1",
+                symbol="MSFT",
+                composite_score=79.0,
+                rating="Watch",
+                details={},
+                ibd_industry_group=None,
+                ibd_group_rank=None,
+            ),
+        ]
+    )
+    session.add_all(
+        [
+            IBDIndustryGroup(
+                symbol="AAPL",
+                industry_group="Computer-Hardware/Peripherals",
+            ),
+            IBDIndustryGroup(
+                symbol="MSFT",
+                industry_group="Software",
+            ),
+            IBDGroupRank(
+                industry_group="Computer-Hardware/Peripherals",
+                date=date(2026, 2, 19),
+                rank=5,
+                avg_rs_rating=80.0,
+            ),
+            IBDGroupRank(
+                industry_group="Software",
+                date=date(2026, 2, 19),
+                rank=9,
+                avg_rs_rating=74.0,
+            ),
+        ]
+    )
+    session.commit()
+
+    repo = SqlScanResultRepository(session)
+    stats = repo.backfill_ibd_metadata_for_scan("scan-us-1")
+
+    rows = (
+        session.query(ScanResult)
+        .filter(ScanResult.scan_id == "scan-us-1")
+        .order_by(ScanResult.symbol.asc())
+        .all()
+    )
+
+    assert stats["updated_rows"] == 2
+    assert rows[0].symbol == "AAPL"
+    assert rows[0].ibd_industry_group == "Computer-Hardware/Peripherals"
+    assert rows[0].ibd_group_rank == 5
+    assert rows[1].symbol == "MSFT"
+    assert rows[1].ibd_industry_group == "Software"
+    assert rows[1].ibd_group_rank == 9

--- a/backend/tests/unit/test_feature_store_tasks.py
+++ b/backend/tests/unit/test_feature_store_tasks.py
@@ -19,12 +19,14 @@ from app.interfaces.tasks.feature_store_tasks import (
     _create_auto_scan_for_published_run,
     _enrich_feature_run_with_ibd_metadata,
     _fail_stale_feature_runs,
+    _repair_current_us_group_metadata,
     _upsert_feature_run_pointer,
     build_daily_snapshot,
 )
 from app.domain.scanning.defaults import get_default_scan_profile
 from app.schemas.universe import UniverseType
-from app.infra.db.models.feature_store import FeatureRun, StockFeatureDaily
+from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer, StockFeatureDaily
+from app.models.scan_result import Scan
 from app.models.industry import IBDGroupRank, IBDIndustryGroup
 
 
@@ -600,6 +602,77 @@ def test_enrich_feature_run_with_ibd_metadata_updates_details_json():
     assert nvda.details_json["ibd_group_rank"] == 1
     assert msft.details_json["ibd_industry_group"] == "Software"
     assert msft.details_json["ibd_group_rank"] is None
+
+    engine.dispose()
+
+
+def test_repair_current_us_group_metadata_updates_latest_published_run_and_republishes_scan_snapshot():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            FeatureRun.__table__,
+            FeatureRunPointer.__table__,
+            StockFeatureDaily.__table__,
+            IBDIndustryGroup.__table__,
+            IBDGroupRank.__table__,
+            Scan.__table__,
+        ],
+    )
+    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    with session_factory() as db:
+        db.add(
+            FeatureRun(
+                id=31,
+                as_of_date=date(2026, 4, 2),
+                run_type="daily_snapshot",
+                status="published",
+                config_json={"universe": {"market": "US"}},
+            )
+        )
+        db.add(FeatureRunPointer(key="latest_published_market:US", run_id=31))
+        db.add(
+            StockFeatureDaily(
+                run_id=31,
+                symbol="NVDA",
+                as_of_date=date(2026, 4, 2),
+                composite_score=99.0,
+                overall_rating=5,
+                passes_count=4,
+                details_json={"symbol": "NVDA"},
+            )
+        )
+        db.add(Scan(scan_id="scan-us-1", status="completed", feature_run_id=31, universe_market="US"))
+        db.add(IBDIndustryGroup(symbol="NVDA", industry_group="Semiconductors"))
+        db.add(
+            IBDGroupRank(
+                industry_group="Semiconductors",
+                date=date(2026, 4, 2),
+                rank=1,
+                avg_rs_rating=95.0,
+            )
+        )
+        db.commit()
+
+    with patch(
+        "app.services.ui_snapshot_service.safe_publish_scan_bootstrap",
+        return_value=None,
+    ) as mock_publish:
+        stats = _repair_current_us_group_metadata(
+            ranking_date=date(2026, 4, 2),
+            session_factory=session_factory,
+        )
+
+    with session_factory() as db:
+        nvda = db.query(StockFeatureDaily).filter_by(run_id=31, symbol="NVDA").one()
+
+    assert stats["feature_run"]["run_id"] == 31
+    assert stats["feature_run"]["updated_rows"] == 1
+    assert nvda.details_json["ibd_industry_group"] == "Semiconductors"
+    assert nvda.details_json["ibd_group_rank"] == 1
+    assert mock_publish.call_args_list[0].args == ("scan-us-1",)
+    assert mock_publish.call_args_list[1].args == ()
 
     engine.dispose()
 

--- a/backend/tests/unit/test_group_rank_service.py
+++ b/backend/tests/unit/test_group_rank_service.py
@@ -361,6 +361,18 @@ def test_calculate_group_rankings_fails_explicitly_when_ibd_mappings_missing(db_
         service.calculate_group_rankings(db_session, date(2026, 3, 20), market="US")
 
 
+def test_calculate_group_rankings_propagates_group_lookup_failures(db_session, monkeypatch):
+    service = _make_group_rank_service()
+
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_all_groups",
+        lambda db: (_ for _ in ()).throw(RuntimeError("database unavailable")),
+    )
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        service.calculate_group_rankings(db_session, date(2026, 3, 20), market="US")
+
+
 def test_backfill_rankings_optimized_accepts_prefetch_stats_tuple(db_session, monkeypatch):
     service = _make_group_rank_service()
     price_data = _price_frame()

--- a/backend/tests/unit/test_group_rank_service.py
+++ b/backend/tests/unit/test_group_rank_service.py
@@ -12,6 +12,7 @@ from app.models.industry import IBDGroupRank
 from app.services.ibd_group_rank_service import (
     IBDGroupRankService,
     IncompleteGroupRankingCacheError,
+    MissingIBDIndustryMappingsError,
 )
 
 
@@ -346,6 +347,18 @@ def test_calculate_group_rankings_rejects_incomplete_cache_only_inputs(db_sessio
 
     assert excinfo.value.stats["cache_miss_symbols"] == 1
     store_rankings.assert_not_called()
+
+
+def test_calculate_group_rankings_fails_explicitly_when_ibd_mappings_missing(db_session, monkeypatch):
+    service = _make_group_rank_service()
+
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_all_groups",
+        lambda db: [],
+    )
+
+    with pytest.raises(MissingIBDIndustryMappingsError, match="IBD industry mappings are not loaded"):
+        service.calculate_group_rankings(db_session, date(2026, 3, 20), market="US")
 
 
 def test_backfill_rankings_optimized_accepts_prefetch_stats_tuple(db_session, monkeypatch):

--- a/backend/tests/unit/test_group_rank_tasks.py
+++ b/backend/tests/unit/test_group_rank_tasks.py
@@ -373,6 +373,10 @@ def test_daily_group_rankings_publishes_market_activity(monkeypatch):
     completed = []
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: started.append(kwargs))
     monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: completed.append(kwargs))
+    monkeypatch.setattr(
+        "app.interfaces.tasks.feature_store_tasks._repair_current_us_group_metadata",
+        lambda **_kwargs: {"status": "ok"},
+    )
 
     result = module.calculate_daily_group_rankings.run(market="US")
 
@@ -380,6 +384,7 @@ def test_daily_group_rankings_publishes_market_activity(monkeypatch):
     assert started[0]["stage_key"] == "groups"
     assert started[0]["lifecycle"] == "daily_refresh"
     assert completed[0]["stage_key"] == "groups"
+    assert result["metadata_repair"] == {"status": "ok"}
 
 
 def test_daily_group_rankings_skip_non_us_market(monkeypatch):
@@ -433,3 +438,82 @@ def test_daily_group_rankings_fail_explicitly_when_ibd_mappings_missing(monkeypa
 
     assert "error" in result
     assert "ibd industry mappings are not loaded" in result["error"].lower()
+
+
+def test_historical_group_rankings_do_not_repair_current_us_metadata(monkeypatch):
+    import app.tasks.group_rank_tasks as module
+    import app.services.ui_snapshot_service as snapshot_module
+
+    fake_db = MagicMock()
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    _patch_serialized_lock(monkeypatch)
+    monkeypatch.setattr(
+        module,
+        "get_eastern_now",
+        lambda: datetime(2026, 3, 20, 17, 40, 0),
+    )
+
+    fake_service = MagicMock()
+    fake_service.price_cache = MagicMock()
+    fake_service.calculate_group_rankings.return_value = [
+        {"industry_group": "Software", "avg_rs_rating": 95.0, "rank": 1, "num_stocks": 12}
+    ]
+    monkeypatch.setattr(module, "get_group_rank_service", lambda: fake_service)
+
+    repair_calls = []
+    publish_calls = []
+    monkeypatch.setattr(
+        "app.interfaces.tasks.feature_store_tasks._repair_current_us_group_metadata",
+        lambda **kwargs: repair_calls.append(kwargs) or {"status": "ok"},
+    )
+    monkeypatch.setattr(snapshot_module, "safe_publish_groups_bootstrap", lambda: publish_calls.append("published"))
+
+    result = module.calculate_daily_group_rankings.run("2026-03-19", market="US")
+
+    assert result["groups_ranked"] == 1
+    assert repair_calls == []
+    assert publish_calls == ["published"]
+    assert result["metadata_repair"] is None
+
+
+def test_daily_group_rankings_fail_when_current_metadata_repair_fails(monkeypatch):
+    import app.tasks.group_rank_tasks as module
+    import app.services.ui_snapshot_service as snapshot_module
+
+    fake_db = MagicMock()
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    _patch_serialized_lock(monkeypatch)
+    monkeypatch.setattr(module, "is_trading_day", lambda d: True)
+    monkeypatch.setattr(
+        module,
+        "get_eastern_now",
+        lambda: datetime(2026, 3, 20, 17, 40, 0),
+    )
+
+    fake_service = MagicMock()
+    fake_service.price_cache = MagicMock()
+    fake_service.price_cache.get_warmup_metadata.return_value = {
+        "status": "completed",
+        "count": 10000,
+        "total": 10000,
+        "completed_at": datetime.now().isoformat(),
+    }
+    fake_service.calculate_group_rankings.return_value = [
+        {"industry_group": "Software", "avg_rs_rating": 95.0, "rank": 1, "num_stocks": 12}
+    ]
+    monkeypatch.setattr(module, "get_group_rank_service", lambda: fake_service)
+    monkeypatch.setattr(
+        "app.interfaces.tasks.feature_store_tasks._repair_current_us_group_metadata",
+        MagicMock(side_effect=RuntimeError("repair failed")),
+    )
+    publish_snapshot = MagicMock()
+    monkeypatch.setattr(snapshot_module, "safe_publish_groups_bootstrap", publish_snapshot)
+    completed = MagicMock()
+    monkeypatch.setattr(module, "mark_market_activity_completed", completed)
+
+    result = module.calculate_daily_group_rankings.run(market="US")
+
+    assert "error" in result
+    assert "repair failed" in result["error"].lower()
+    completed.assert_not_called()
+    publish_snapshot.assert_not_called()

--- a/backend/tests/unit/test_group_rank_tasks.py
+++ b/backend/tests/unit/test_group_rank_tasks.py
@@ -7,6 +7,7 @@ import pytest
 from celery.exceptions import Retry, SoftTimeLimitExceeded
 
 from app.services.ibd_group_rank_service import IncompleteGroupRankingCacheError
+from app.services.ibd_group_rank_service import MissingIBDIndustryMappingsError
 
 
 def _patch_serialized_lock(monkeypatch):
@@ -402,3 +403,33 @@ def test_daily_group_rankings_skip_non_us_market(monkeypatch):
     assert result["status"] == "skipped"
     assert result["reason"] == "group_rankings_are_us_only"
     fake_service.calculate_group_rankings.assert_not_called()
+
+
+def test_daily_group_rankings_fail_explicitly_when_ibd_mappings_missing(monkeypatch):
+    import app.tasks.group_rank_tasks as module
+
+    fake_db = MagicMock()
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    _patch_serialized_lock(monkeypatch)
+    monkeypatch.setattr(module, "is_trading_day", lambda d: True)
+    monkeypatch.setattr(
+        module,
+        "get_eastern_now",
+        lambda: datetime(2026, 3, 20, 17, 40, 0),
+    )
+
+    fake_service = MagicMock()
+    fake_service.price_cache = MagicMock()
+    fake_service.price_cache.get_warmup_metadata.return_value = {
+        "status": "completed",
+        "count": 10000,
+        "total": 10000,
+        "completed_at": datetime.now().isoformat(),
+    }
+    fake_service.calculate_group_rankings.side_effect = MissingIBDIndustryMappingsError()
+    monkeypatch.setattr(module, "get_group_rank_service", lambda: fake_service)
+
+    result = module.calculate_daily_group_rankings.run(market="US")
+
+    assert "error" in result
+    assert "ibd industry mappings are not loaded" in result["error"].lower()

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -75,6 +75,60 @@ def test_non_us_primary_bootstrap_uses_market_scan_not_feature_snapshot(monkeypa
     ] == ["bootstrap"] * 3
 
 
+def test_us_primary_bootstrap_loads_ibd_mappings_before_prices(monkeypatch):
+    from app.tasks import runtime_bootstrap_tasks as module
+
+    monkeypatch.setattr(
+        "app.tasks.universe_tasks.refresh_stock_universe",
+        _FakeTask("app.tasks.universe_tasks.refresh_stock_universe"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.universe_tasks.refresh_official_market_universe",
+        _FakeTask("app.tasks.universe_tasks.refresh_official_market_universe"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.industry_tasks.load_tracked_ibd_industry_groups",
+        _FakeTask("app.tasks.industry_tasks.load_tracked_ibd_industry_groups"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.cache_tasks.smart_refresh_cache",
+        _FakeTask("app.tasks.cache_tasks.smart_refresh_cache"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.fundamentals_tasks.refresh_all_fundamentals",
+        _FakeTask("app.tasks.fundamentals_tasks.refresh_all_fundamentals"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill",
+        _FakeTask("app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.group_rank_tasks.calculate_daily_group_rankings",
+        _FakeTask("app.tasks.group_rank_tasks.calculate_daily_group_rankings"),
+    )
+    monkeypatch.setattr(
+        "app.interfaces.tasks.feature_store_tasks.build_daily_snapshot",
+        _FakeTask("app.interfaces.tasks.feature_store_tasks.build_daily_snapshot"),
+    )
+
+    signatures = module._build_market_bootstrap_signatures("US", include_initial_scan=True)
+    task_names = [signature.task for signature in signatures]
+
+    assert task_names == [
+        "app.tasks.universe_tasks.refresh_stock_universe",
+        "app.tasks.industry_tasks.load_tracked_ibd_industry_groups",
+        "app.tasks.cache_tasks.smart_refresh_cache",
+        "app.tasks.fundamentals_tasks.refresh_all_fundamentals",
+        "app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill",
+        "app.tasks.group_rank_tasks.calculate_daily_group_rankings",
+        "app.interfaces.tasks.feature_store_tasks.build_daily_snapshot",
+    ]
+    assert signatures[1].kwargs == {
+        "market": "US",
+        "activity_lifecycle": "bootstrap",
+    }
+
+
 def test_bootstrap_universe_name_uses_uppercase_market_code():
     from app.tasks import runtime_bootstrap_tasks as module
 

--- a/backend/tests/unit/test_settings_llm_keys.py
+++ b/backend/tests/unit/test_settings_llm_keys.py
@@ -1,4 +1,6 @@
 from app.config.settings import Settings
+from app.scripts import export_static_site
+from app.tasks import industry_tasks
 
 
 def test_zai_api_keys_list_prefers_multi_key_field() -> None:
@@ -20,3 +22,13 @@ def test_universe_source_timeout_seconds_must_be_positive() -> None:
         assert "universe_source_timeout_seconds must be > 0" in str(exc)
     else:
         raise AssertionError("Expected invalid universe_source_timeout_seconds to fail")
+
+
+def test_ibd_industry_csv_path_is_configurable(monkeypatch) -> None:
+    override = "/tmp/custom/ibd.csv"
+
+    monkeypatch.setattr(industry_tasks.settings, "ibd_industry_csv_path", override)
+    monkeypatch.setattr(export_static_site.settings, "ibd_industry_csv_path", override)
+
+    assert str(industry_tasks._tracked_ibd_csv_path()) == override
+    assert str(export_static_site._tracked_ibd_csv_path()) == override


### PR DESCRIPTION
## Summary
- load tracked IBD industry mappings into the live US runtime/bootstrap path
- make missing IBD mappings fail explicitly during US group ranking instead of silently returning empty results
- repair current US scan-facing metadata by re-enriching the latest published feature run, backfilling legacy scan results, and republishing scan bootstrap surfaces
- harden the repair flow so it only runs for same-day/bootstrap rankings and fails cleanly on repair errors

## Testing
- /Users/admin/StockScreenClaude/backend/venv/bin/pytest backend/tests/unit/test_runtime_bootstrap_tasks.py backend/tests/unit/test_group_rank_service.py backend/tests/unit/test_group_rank_tasks.py backend/tests/unit/test_feature_store_tasks.py backend/tests/integration/test_scan_result_repo_enrichment.py backend/tests/unit/test_groups_api_no_data.py -q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic backfill capability to update IBD industry metadata for scan results.
  * Introduced background task to load and refresh industry group mappings.
  * Implemented automated metadata repair during system bootstrap for consistency.

* **Improvements**
  * Enhanced error handling when industry mappings are unavailable, with clearer failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->