### PR TITLE
feat: show company names in scan results tables

### DIFF
--- a/frontend/src/components/Scan/ResultsTable.jsx
+++ b/frontend/src/components/Scan/ResultsTable.jsx
@@ -40,7 +40,8 @@ import {
 } from '../../utils/formatUtils';
 
 // Row height constant for virtualization
-const ROW_HEIGHT = 32;
+const ROW_HEIGHT = 48;
+const SYMBOL_COLUMN_WIDTH = 210;
 
 // MCap column display modes. USD is the default per 3axp: cross-market
 // parity is the common case; local is one click away. Kept as constants
@@ -55,7 +56,7 @@ const columns = [
   { id: 'chart', label: '', sortable: false, width: 60 },
   // Width fits "0700.HK" + MarketBadge + FieldAvailabilityChip on a single
   // line without overflow (nowrap guards the rest).
-  { id: 'symbol', label: 'Sym', sortable: true, width: 130 },
+  { id: 'symbol', label: 'Sym', sortable: true, width: SYMBOL_COLUMN_WIDTH },
   { id: 'rs_trend', label: 'RS Trend', sortable: true, width: 110 },
   { id: 'price_change_1d', label: 'Price', sortable: true, width: 110 },
   { id: 'gics_sector', label: 'Sector', sortable: true, width: 80 },
@@ -156,13 +157,38 @@ const VirtualTableRow = memo(function VirtualTableRow({
         </TableCell>
       )}
 
-      <TableCell sx={{ fontWeight: 600, width: 130, minWidth: 130, whiteSpace: 'nowrap' }}>
-        {row.symbol}
-        <MarketBadge market={row.market} exchange={row.exchange} />
-        <FieldAvailabilityChip
-          fieldAvailability={row.field_availability}
-          growthMetricBasis={row.growth_metric_basis}
-        />
+      <TableCell
+        sx={{
+          width: SYMBOL_COLUMN_WIDTH,
+          minWidth: SYMBOL_COLUMN_WIDTH,
+          maxWidth: SYMBOL_COLUMN_WIDTH,
+          py: '4px',
+          overflow: 'hidden',
+        }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25, minWidth: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, whiteSpace: 'nowrap' }}>
+            <Typography component="span" variant="body2" sx={{ fontWeight: 600, lineHeight: 1.2, flexShrink: 0 }}>
+              {row.symbol}
+            </Typography>
+            <MarketBadge market={row.market} exchange={row.exchange} />
+            <FieldAvailabilityChip
+              fieldAvailability={row.field_availability}
+              growthMetricBasis={row.growth_metric_basis}
+            />
+          </Box>
+          {row.company_name ? (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              noWrap
+              title={row.company_name}
+              sx={{ display: 'block', lineHeight: 1.2, minWidth: 0 }}
+            >
+              {row.company_name}
+            </Typography>
+          ) : null}
+        </Box>
       </TableCell>
 
       <TableCell align="center" sx={{ p: '4px', width: 110, minWidth: 110 }}>
@@ -392,6 +418,11 @@ const VirtualTableRow = memo(function VirtualTableRow({
 }, (prevProps, nextProps) => {
   // Custom comparison - only re-render if the row data actually changed
   return prevProps.row.symbol === nextProps.row.symbol &&
+         prevProps.row.company_name === nextProps.row.company_name &&
+         prevProps.row.market === nextProps.row.market &&
+         prevProps.row.exchange === nextProps.row.exchange &&
+         prevProps.row.field_availability === nextProps.row.field_availability &&
+         prevProps.row.growth_metric_basis === nextProps.row.growth_metric_basis &&
          prevProps.row.composite_score === nextProps.row.composite_score &&
          prevProps.row.rs_rating === nextProps.row.rs_rating &&
          prevProps.row.current_price === nextProps.row.current_price &&
@@ -507,7 +538,7 @@ function ResultsTable({
           overflow: 'auto',
         }}
       >
-        <Table stickyHeader size="small" sx={{ minWidth: showActions ? 2493 : 2433 }}>
+        <Table stickyHeader size="small" sx={{ minWidth: showActions ? 2573 : 2513 }}>
           <TableHead>
             <TableRow>
               {visibleColumns.map((column) => (

--- a/frontend/src/components/Scan/ResultsTable.market.test.jsx
+++ b/frontend/src/components/Scan/ResultsTable.market.test.jsx
@@ -46,6 +46,15 @@ const tencentHk = {
   growth_metric_basis: null,
 };
 
+const longNameTw = {
+  ...tencentHk,
+  symbol: '2330.TW',
+  market: 'TW',
+  exchange: 'TWSE',
+  currency: 'TWD',
+  company_name: 'Taiwan Semiconductor Manufacturing Company Limited',
+};
+
 const defaultProps = {
   total: 1,
   page: 1,
@@ -60,6 +69,21 @@ const defaultProps = {
 };
 
 describe('ResultsTable — 3axp market / currency / USD toggle', () => {
+  it('renders the company name in the leading symbol cell when available', () => {
+    renderWithProviders(<ResultsTable {...defaultProps} results={[tencentHk]} />);
+
+    const symbolCell = screen.getByText('0700.HK').closest('td');
+    expect(symbolCell).not.toBeNull();
+    expect(within(symbolCell).getByText('Tencent')).toBeInTheDocument();
+  });
+
+  it('preserves the full long company name in the symbol cell title', () => {
+    renderWithProviders(<ResultsTable {...defaultProps} results={[longNameTw]} />);
+
+    const nameElement = screen.getByText('Taiwan Semiconductor Manufacturing Company Limited');
+    expect(nameElement).toHaveAttribute('title', 'Taiwan Semiconductor Manufacturing Company Limited');
+  });
+
   it('renders the HK market badge next to a suffixed symbol', () => {
     renderWithProviders(<ResultsTable {...defaultProps} results={[tencentHk]} />);
     expect(screen.getByText('0700.HK')).toBeInTheDocument();
@@ -105,5 +129,14 @@ describe('ResultsTable — 3axp market / currency / USD toggle', () => {
     expect(screen.queryByTestId('market-badge-US')).not.toBeInTheDocument();
     // Price cell falls back to $ prefix when currency is null.
     expect(screen.getByText('$410.50')).toBeInTheDocument();
+  });
+
+  it('falls back to symbol-only when company_name is absent', () => {
+    const unnamedRow = { ...tencentHk, company_name: null };
+    renderWithProviders(<ResultsTable {...defaultProps} results={[unnamedRow]} />);
+
+    const symbolCell = screen.getByText('0700.HK').closest('td');
+    expect(symbolCell).not.toBeNull();
+    expect(within(symbolCell).queryByText('Tencent')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/static/pages/StaticScanPage.test.jsx
+++ b/frontend/src/static/pages/StaticScanPage.test.jsx
@@ -191,6 +191,109 @@ describe('StaticScanPage', () => {
     });
   });
 
+  it('passes company_name through to the shared results table before and after hydration', async () => {
+    const chunkRequest = deferred();
+
+    globalThis.fetch = vi.fn(async (url) => {
+      const path = String(url).split('/static-data/')[1];
+
+      if (path === 'manifest.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            pages: {
+              scan: {
+                path: 'scan/manifest.json',
+              },
+            },
+          }),
+        };
+      }
+
+      if (path === 'scan/manifest.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            generated_at: '2026-04-01T00:00:00Z',
+            as_of_date: '2026-03-31',
+            run_id: 9,
+            sort: { field: 'composite_score', order: 'desc' },
+            default_page_size: 50,
+            rows_total: 2,
+            default_filters: { minVolume: 100000000 },
+            default_filtered_rows_total: 1,
+            filter_options: {
+              ibd_industries: ['Semiconductors'],
+              gics_sectors: ['Technology'],
+              ratings: ['Strong Buy'],
+            },
+            initial_rows: [
+              { symbol: 'NVDA', company_name: 'NVIDIA Corporation', composite_score: 97.5, volume: 150000000 },
+            ],
+            chunks: [{ path: 'scan/chunks/chunk-0001.json', count: 2 }],
+            charts: {
+              path: 'charts/index.json',
+              limit: 200,
+              symbols_total: 1,
+              available: true,
+            },
+          }),
+        };
+      }
+
+      if (path === 'charts/index.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            symbols: [{ symbol: 'NVDA', rank: 1, path: 'charts/NVDA.json' }],
+          }),
+        };
+      }
+
+      if (path === 'scan/chunks/chunk-0001.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: () => chunkRequest.promise,
+        };
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      };
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(resultsTableSpy).toHaveBeenCalled();
+    });
+
+    expect(resultsTableSpy.mock.calls.at(-1)?.[0]?.results?.[0]?.company_name).toBe('NVIDIA Corporation');
+
+    await act(async () => {
+      chunkRequest.resolve({
+        rows: [
+          { symbol: 'NVDA', company_name: 'NVIDIA Corporation', composite_score: 97.5, volume: 150000000 },
+          { symbol: 'MSFT', company_name: 'Microsoft Corporation', composite_score: 89.2, volume: 120000000 },
+        ],
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      const latestResults = resultsTableSpy.mock.calls.at(-1)?.[0]?.results ?? [];
+      expect(latestResults).toHaveLength(2);
+      expect(latestResults[0].company_name).toBe('NVIDIA Corporation');
+      expect(latestResults[1].company_name).toBe('Microsoft Corporation');
+    });
+  });
+
   it('normalizes exported filter options before rendering the filter panel', async () => {
     globalThis.fetch = vi.fn(async (url) => {
       const path = String(url).split('/static-data/')[1];


### PR DESCRIPTION
## Summary
- show company names under the ticker in the shared scan results symbol cell
- apply the same rendering to the static scan page through the shared `ResultsTable`
- widen the symbol column and increase virtual row height so the second line remains visible

## Testing
- `cd frontend && npm run test -- src/components/Scan/ResultsTable.market.test.jsx src/components/Scan/ResultsTable.test.jsx src/static/pages/StaticScanPage.test.jsx`
- `cd frontend && npm run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Symbol cells in results table now display company names for additional context
  * Increased row spacing for improved readability and visual clarity
  * Optimized table column sizing and layout structure

* **Tests**
  * Added test coverage for symbol cell rendering and company name display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->