### PR TITLE
[codex] Fix taxonomy data dir resolution in container runtime

### DIFF
--- a/backend/app/services/market_taxonomy_service.py
+++ b/backend/app/services/market_taxonomy_service.py
@@ -46,7 +46,7 @@ class MarketTaxonomyService:
     """Load market-aware group/theme mappings from committed CSV files."""
 
     def __init__(self, *, data_dir: Path | None = None) -> None:
-        self._data_dir = data_dir or Path(__file__).resolve().parents[3] / "data"
+        self._data_dir = data_dir or self._default_data_dir()
         self._loaded = False
         self._entries: dict[str, dict[str, MarketTaxonomyEntry]] = {
             "US": {},
@@ -54,6 +54,30 @@ class MarketTaxonomyService:
             "JP": {},
             "TW": {},
         }
+
+    @staticmethod
+    def _default_data_dir(*, service_path: Path | None = None) -> Path:
+        resolved_path = (service_path or Path(__file__)).resolve()
+        candidates: list[Path] = []
+        for parent_index in (3, 2):
+            try:
+                candidates.append(resolved_path.parents[parent_index] / "data")
+            except IndexError:
+                continue
+        candidates.append(Path.cwd() / "data")
+
+        required_files = (
+            "IBD_industry_group.csv",
+            "hk-deep.csv",
+            "kabutan_themes_en.csv",
+            "taiwan-deep.csv",
+        )
+        unique_candidates = list(dict.fromkeys(candidates))
+        best_candidate = max(
+            unique_candidates,
+            key=lambda candidate: sum((candidate / filename).exists() for filename in required_files),
+        )
+        return best_candidate
 
     def refresh(self) -> None:
         self._entries = {"US": {}, "HK": {}, "JP": {}, "TW": {}}

--- a/backend/tests/unit/test_market_taxonomy_service.py
+++ b/backend/tests/unit/test_market_taxonomy_service.py
@@ -52,3 +52,16 @@ def test_market_taxonomy_service_normalizes_hk_jp_and_tw_symbols(tmp_path):
     assert tpex.symbol == "8069.TWO"
     assert tpex.industry_group == "Computer Peripherals"
     assert tpex.themes_list() == []
+
+
+def test_market_taxonomy_service_default_data_dir_prefers_container_app_data(tmp_path):
+    runtime_root = tmp_path / "runtime"
+    service_path = runtime_root / "app" / "app" / "services" / "market_taxonomy_service.py"
+    app_data = runtime_root / "app" / "data"
+    app_data.mkdir(parents=True)
+    _write_csv(app_data / "IBD_industry_group.csv", "AAPL,Computer-Hardware/Peripherals\n")
+    _write_csv(app_data / "hk-deep.csv", "Symbol,EM Industry (EN),Theme (EN)\n700,Internet Services,AI Infrastructure\n")
+
+    resolved = MarketTaxonomyService._default_data_dir(service_path=service_path)
+
+    assert resolved == app_data


### PR DESCRIPTION
## Summary
- resolve the default market taxonomy data directory by selecting the repo `data/` path that actually contains the taxonomy CSVs
- fix Docker/container runtime lookups so HK/JP/TW taxonomy enrichment no longer fails when the service path resolves under `/app/app/...`
- add regression coverage for the container layout path selection

## Why
Recent HK scans were failing during enrichment because `MarketTaxonomyService` resolved the default data dir to `/data`, then tried to open `/data/IBD_industry_group.csv`. In the container, the committed CSVs are mounted under `/app/data`, so the service failed before it could load HK taxonomy rows that already exist in `hk-deep.csv`.

## Impact
This unblocks taxonomy-backed industry group and theme enrichment for containerized scan workers and backend processes, including recent HK IPO symbols that are already present in the committed CSVs.

## Validation
- `cd backend && source venv/bin/activate && pytest tests/unit/test_market_taxonomy_service.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced data directory detection logic to intelligently locate required data files across multiple environment configurations, improving compatibility with different deployment setups.

* **Tests**
  * Added test coverage for data directory resolution behavior to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->