### PR TITLE
fix(weekly-reference): hydrate Yahoo fields in US bundle build

### DIFF
--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -230,6 +230,21 @@ def _build_us_bundle(
         )
     _print_snapshot_publish_summary(snapshot_stats)
 
+    # Yahoo hydration writes market_cap / growth metrics / eps_rating / ipo_date
+    # into stock_fundamentals so `export_weekly_reference_bundle` can merge them
+    # into the Finviz snapshot. Without this, the US bundle carries only what
+    # Finviz's screener returned, which regularly omits market_cap for delisted
+    # tickers and partial responses. The Asia bundle path gets this implicitly
+    # via `hybrid_service.fetch_fundamentals_batch`.
+    print("Starting Yahoo hydration for US published snapshot...", flush=True)
+    hydrate_stats = provider_snapshot_service.hydrate_published_snapshot(
+        db,
+        snapshot_key=snapshot_key,
+        progress_callback=_print_progress,
+    )
+    summary["fundamentals_hydrate"] = hydrate_stats
+    print(f"Hydration complete: {hydrate_stats}", flush=True)
+
     published_run = provider_snapshot_service.get_published_run(db, snapshot_key=snapshot_key)
     if published_run is None:
         raise RuntimeError("Published weekly fundamentals snapshot was not found after publish")

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -77,6 +77,12 @@ def test_build_weekly_reference_bundle_runs_us_publish_and_export(monkeypatch, t
                 "source_revision": "fundamentals_v1_us:20260404121000",
             },
         )(),
+        hydrate_published_snapshot=lambda db, snapshot_key, progress_callback=None: {
+            "hydrated": 20,
+            "yahoo_hydrated": 18,
+            "missing_prices": 0,
+            "missing_yahoo": 0,
+        },
     )
     monkeypatch.setattr(build_script, "get_stock_universe_service", lambda: stock_universe_service)
     monkeypatch.setattr(build_script, "get_provider_snapshot_service", lambda: provider_snapshot_service)
@@ -119,6 +125,13 @@ def test_build_weekly_reference_bundle_runs_us_publish_and_export(monkeypatch, t
     assert "Starting stock universe refresh from Finviz..." in stdout
     assert "[snapshot] 1/12 (8.3%) NYSE overview rows=20" in stdout
     assert "[publish] market=US coverage=100.00% (min=98.00%) missing_ratio=0.00% (max=0.50%)" in stdout
+    assert "Starting Yahoo hydration for US published snapshot..." in stdout
+    assert "Hydration complete:" in stdout
+    # Hydration must run before export so market_cap from stock_fundamentals
+    # is available at merge-time in export_weekly_reference_bundle.
+    hydrate_idx = stdout.index("Starting Yahoo hydration for US published snapshot...")
+    export_idx = stdout.index("Weekly reference bundle complete for US:")
+    assert hydrate_idx < export_idx
     assert "Weekly reference bundle complete for US:" in stdout
 
 


### PR DESCRIPTION
## Summary

- `_build_us_bundle` never called `hydrate_published_snapshot`, so the US weekly reference bundle shipped with whatever Finviz's screener returned — blank market_cap whenever Finviz omitted it, and no Yahoo-derived growth / eps_rating / ipo_date fields.
- The Asia bundle path (`_build_asia_bundle`) implicitly gets Yahoo coverage through `hybrid_service.fetch_fundamentals_batch`, which is why HK / JP / TW / IN market caps already populate on the static page while US stays blank.
- Closes the asymmetry by adding a single `hydrate_published_snapshot` call between publish and export.

## Changes

| File | Change |
|---|---|
| `backend/app/scripts/build_weekly_reference_bundle.py` | Call `provider_snapshot_service.hydrate_published_snapshot(...)` between `create_snapshot_run` and `export_weekly_reference_bundle` in `_build_us_bundle`; record stats under `summary["fundamentals_hydrate"]`; progress events stream via the existing `_print_progress` handler |
| `backend/tests/unit/test_weekly_reference_scripts.py` | Mock `hydrate_published_snapshot` on the US test's service stub; add assertions that the hydration print appears in the run output and that it precedes the export step |

## Why this is safe to merge independently of #108

The `hydrate_published_snapshot` function existed before #108 and runs correctly against the current `main` code — it already hydrates growth metrics, eps_rating, ipo_date, description, etc. for US tickers. It just doesn't backfill `market_cap` yet (that's what #108 adds via `YAHOO_ONLY_REQUIRED_KEYS` + the `fast_info` fallback). So merging this PR first delivers partial improvement (Yahoo-derived growth metrics in the US bundle), and merging #108 afterward completes the fix by wiring `market_cap` into the same hydration call.

## Test plan

- [x] Added assertion that `Starting Yahoo hydration for US published snapshot...` appears in run output
- [x] Added assertion that hydration runs **before** export (index check on stdout)
- [x] 32 tests pass in `tests/unit/test_weekly_reference_scripts.py` + `tests/unit/test_provider_snapshot_service.py`
- [ ] After merge: next weekly GH workflow run should show hydration stats in step summary and populate market_cap in the US bundle wherever `stock_fundamentals` has Yahoo-derived data (or wherever #108 has landed first to enable market_cap backfill specifically)
- [ ] Verify the public static site at the next release tag shows US market cap non-null on common tickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
