### PR TITLE
fix(groups): surface group-rank calculation failures in dynamic UI

### DIFF
--- a/backend/app/api/v1/groups.py
+++ b/backend/app/api/v1/groups.py
@@ -345,13 +345,17 @@ async def get_calculation_status(task_id: str):
                 return CalculationStatusResponse(
                     task_id=task_id,
                     status="failed",
-                    error=result.get('error', 'Unknown error')
+                    error=(result or {}).get('error', 'Unknown error'),
+                    reason_code=(result or {}).get('reason_code'),
                 )
         elif task_result.state == 'FAILURE':
+            from ...tasks.group_rank_tasks import GroupRankReasonCode
+
             return CalculationStatusResponse(
                 task_id=task_id,
                 status="failed",
-                error=str(task_result.result) if task_result.result else "Task failed"
+                error=str(task_result.result) if task_result.result else "Task failed",
+                reason_code=GroupRankReasonCode.UNKNOWN,
             )
         else:
             # Handle other states (RETRY, REVOKED, etc.)

--- a/backend/app/schemas/groups.py
+++ b/backend/app/schemas/groups.py
@@ -136,6 +136,14 @@ class CalculationStatusResponse(BaseModel):
     status: str = Field(..., description="Task status: queued, running, completed, failed")
     result: Optional[CalculationResponse] = Field(None, description="Result when completed")
     error: Optional[str] = Field(None, description="Error message when failed")
+    reason_code: Optional[str] = Field(
+        None,
+        description=(
+            "Machine-readable failure category when status='failed'. "
+            "Known codes: warmup_incomplete, missing_ibd_mappings, "
+            "invalid_date, no_groups_ranked, unknown."
+        ),
+    )
 
 
 class BackfillRequest(BaseModel):

--- a/backend/app/tasks/group_rank_tasks.py
+++ b/backend/app/tasks/group_rank_tasks.py
@@ -34,6 +34,16 @@ from .workload_coordination import serialized_market_workload
 
 logger = logging.getLogger(__name__)
 TRANSIENT_TASK_EXCEPTIONS = (ConnectionError, TimeoutError, OSError)
+
+
+class GroupRankReasonCode:
+    INVALID_DATE = "invalid_date"
+    WARMUP_INCOMPLETE = "warmup_incomplete"
+    MISSING_IBD_MAPPINGS = "missing_ibd_mappings"
+    NO_GROUPS_RANKED = "no_groups_ranked"
+    UNKNOWN = "unknown"
+
+
 _ALLOW_SAME_DAY_WARMUP_BYPASS: ContextVar[bool] = ContextVar(
     "allow_same_day_group_rank_warmup_bypass",
     default=False,
@@ -175,7 +185,11 @@ def calculate_daily_group_rankings(
             logger.info(f"Calculating group rankings for: {calc_date}")
         except ValueError as e:
             logger.error(f"Invalid date format: {calculation_date}. Use YYYY-MM-DD")
-            return {'error': 'Invalid date format', 'timestamp': datetime.now().isoformat()}
+            return {
+                'error': 'Invalid date format',
+                'reason_code': GroupRankReasonCode.INVALID_DATE,
+                'timestamp': datetime.now().isoformat(),
+            }
     else:
         calc_date = today_et
 
@@ -229,6 +243,7 @@ def calculate_daily_group_rankings(
                     )
                     return {
                         'error': completeness_error,
+                        'reason_code': GroupRankReasonCode.WARMUP_INCOMPLETE,
                         'date': calc_date.strftime('%Y-%m-%d'),
                         'timestamp': datetime.now().isoformat(),
                         'cache_only': True,
@@ -264,6 +279,8 @@ def calculate_daily_group_rankings(
                 'date': calc_date.strftime('%Y-%m-%d'),
                 'groups_ranked': 0,
                 'warning': 'No groups could be ranked',
+                'error': 'No groups could be ranked (insufficient price data or all groups below 3-stock threshold)',
+                'reason_code': GroupRankReasonCode.NO_GROUPS_RANKED,
                 'calculation_duration_seconds': round(duration, 2),
                 'timestamp': datetime.now().isoformat()
             }
@@ -347,6 +364,7 @@ def calculate_daily_group_rankings(
         )
         return {
             'error': str(e),
+            'reason_code': GroupRankReasonCode.WARMUP_INCOMPLETE,
             'date': calc_date.strftime('%Y-%m-%d') if calc_date else None,
             'timestamp': datetime.now().isoformat(),
             'cache_only': True,
@@ -367,6 +385,7 @@ def calculate_daily_group_rankings(
         )
         return {
             'error': str(e),
+            'reason_code': GroupRankReasonCode.MISSING_IBD_MAPPINGS,
             'date': calc_date.strftime('%Y-%m-%d') if calc_date else None,
             'timestamp': datetime.now().isoformat(),
             'cache_only': same_day_cache_only,
@@ -398,6 +417,7 @@ def calculate_daily_group_rankings(
         )
         return {
             'error': str(e),
+            'reason_code': GroupRankReasonCode.UNKNOWN,
             'date': calc_date.strftime('%Y-%m-%d') if calc_date else None,
             'timestamp': datetime.now().isoformat()
         }

--- a/backend/app/tasks/group_rank_tasks.py
+++ b/backend/app/tasks/group_rank_tasks.py
@@ -263,23 +263,24 @@ def calculate_daily_group_rankings(
         duration = time.time() - start_time
 
         if not results:
-            logger.warning(f"No groups ranked for {calc_date}")
-            mark_market_activity_completed(
+            no_groups_message = (
+                "No groups could be ranked (insufficient price data or all groups below 3-stock threshold)"
+            )
+            logger.warning("No groups ranked for %s", calc_date)
+            _mark_market_activity_failed_safely(
                 db,
                 market=effective_market,
                 stage_key="groups",
                 lifecycle=activity_lifecycle,
                 task_name=getattr(self, "name", "calculate_daily_group_rankings"),
                 task_id=getattr(getattr(self, "request", None), "id", None),
-                current=0,
-                total=0,
-                message="No groups ranked",
+                message=no_groups_message,
             )
             return {
                 'date': calc_date.strftime('%Y-%m-%d'),
                 'groups_ranked': 0,
                 'warning': 'No groups could be ranked',
-                'error': 'No groups could be ranked (insufficient price data or all groups below 3-stock threshold)',
+                'error': no_groups_message,
                 'reason_code': GroupRankReasonCode.NO_GROUPS_RANKED,
                 'calculation_duration_seconds': round(duration, 2),
                 'timestamp': datetime.now().isoformat()

--- a/frontend/src/pages/GroupRankingsPage.jsx
+++ b/frontend/src/pages/GroupRankingsPage.jsx
@@ -63,6 +63,13 @@ const MARKET_LABELS = {
   TW: 'TW',
 };
 
+const REASON_HINTS = {
+  warmup_incomplete: 'Wait for the post-close cache warmup to finish, then retry.',
+  missing_ibd_mappings: 'Load IBD industry group mappings into the database first.',
+  no_groups_ranked: 'Run a price-data backfill so stocks have at least 252 days of history.',
+  invalid_date: 'Provide a valid YYYY-MM-DD date.',
+};
+
 // Helper to format rank change with color
 const RankChangeCell = ({ value }) => {
   if (value === null || value === undefined) {
@@ -504,6 +511,7 @@ function GroupRankingsPage() {
   const [order, setOrder] = useState('asc');
   const [isCalculating, setIsCalculating] = useState(false);
   const [calculationTaskId, setCalculationTaskId] = useState(null);
+  const [calculationError, setCalculationError] = useState(null);
   const [showHistoricalRanks, setShowHistoricalRanks] = useState(false); // Toggle between change vs actual rank
   const [bootstrapSettled, setBootstrapSettled] = useState(false);
   const snapshotEnabled = runtimeReady && Boolean(uiSnapshots?.groups);
@@ -602,9 +610,14 @@ function GroupRankingsPage() {
       setCalculationTaskId(null);
       setIsCalculating(false);
       if (calcStatus.status === 'completed') {
+        setCalculationError(null);
         refetchRankings();
       } else {
-        console.error('Calculation failed:', calcStatus.error);
+        const baseMessage = calcStatus.error || 'Calculation failed. See server logs for details.';
+        const hint = REASON_HINTS[calcStatus.reason_code];
+        const message = hint ? `${baseMessage} — ${hint}` : baseMessage;
+        console.error('Calculation failed:', message);
+        setCalculationError(message);
       }
     }
   }, [calcStatus, refetchRankings]);
@@ -624,11 +637,13 @@ function GroupRankingsPage() {
       return;
     }
     setIsCalculating(true);
+    setCalculationError(null);
     try {
       const response = await triggerCalculation(null);
       setCalculationTaskId(response.task_id);
     } catch (error) {
       console.error('Calculation error:', error);
+      setCalculationError(error?.response?.data?.detail || error?.message || 'Failed to queue calculation task.');
       setIsCalculating(false);
     }
   };
@@ -702,6 +717,14 @@ function GroupRankingsPage() {
     );
   }
 
+  const renderCalculationErrorAlert = (sx) => (
+    calculationError ? (
+      <Alert severity="error" sx={sx} onClose={() => setCalculationError(null)}>
+        Calculation failed: {calculationError}
+      </Alert>
+    ) : null
+  );
+
   if (errorRankings) {
     return (
       <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
@@ -721,6 +744,7 @@ function GroupRankingsPage() {
         <Alert severity="error">
           Error loading rankings: {errorRankings.message}
         </Alert>
+        {renderCalculationErrorAlert({ mt: 1 })}
       </Container>
     );
   }
@@ -744,6 +768,8 @@ function GroupRankingsPage() {
         </Box>
       )}
       </Box>
+
+      {renderCalculationErrorAlert({ mb: 1.5 })}
 
       {isLoadingRankings ? (
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">


### PR DESCRIPTION
## Summary

- Makes Group Rankings calculation failures visible to the user instead of failing silently. The Celery task `calculate_daily_group_rankings` has three early-return paths (warmup gate incomplete, missing IBD mappings, insufficient price data) that return `{error: ...}` dicts. Celery reports `SUCCESS`, so the polling UI saw `status=failed` but only wrote to `console.error` — users clicked Refresh and nothing appeared to happen.
- Tags every error-return with a machine-readable `reason_code` from a new `GroupRankReasonCode` constant class, propagated through `CalculationStatusResponse.reason_code` to the frontend.
- Frontend renders a dismissible `Alert` with the error message plus a `REASON_HINTS` remediation tip (e.g., "Wait for the post-close cache warmup to finish, then retry.").

## Rationale

Diagnosed while investigating a user-reported symptom: "rankings fail to generate, even after bootstrap or manual trigger." The separate "static page shows only 1 period of rank data" symptom is not a code bug — it's a data-depth problem (`_get_historical_ranks_batch` needs `IBDGroupRank` rows ~5/21/63/126 trading days back, within ±7 days). That's fixed operationally via `POST /v1/groups/rankings/backfill` with a 180-day window and is not part of this PR.

## Changes

**Backend**
- `backend/app/tasks/group_rank_tasks.py`: add `GroupRankReasonCode` class; tag 5 early-return dicts (`invalid_date`, `warmup_incomplete` ×2, `no_groups_ranked`, `missing_ibd_mappings`, `unknown`). Also adds `error` + `reason_code` to the "no groups ranked" branch so the frontend can treat it as a failure (previously it was a silent "success with 0 groups").
- `backend/app/schemas/groups.py`: add optional `reason_code: Optional[str]` to `CalculationStatusResponse`.
- `backend/app/api/v1/groups.py`: propagate `reason_code` from the Celery result dict through the `/rankings/calculate/status/{task_id}` response. Defensive null-guard on `result` for the `SUCCESS` state (handles edge cases like revoked tasks). On the `FAILURE` state, emits `reason_code=UNKNOWN`.

**Frontend**
- `frontend/src/pages/GroupRankingsPage.jsx`: add `calculationError` state + `REASON_HINTS` lookup; render a dismissible `<Alert>` on both the `errorRankings` and normal-path returns via a single `renderCalculationErrorAlert(sx)` helper (no duplicated JSX). Surface axios errors from `triggerCalculation()` in the catch block instead of silent `console.error`.

## Test plan

- [x] `python -m py_compile` on the 3 backend files → OK
- [x] `pytest backend/tests/unit/test_group_rank_tasks.py backend/tests/unit/test_groups_api_no_data.py backend/tests/unit/test_group_rank_service.py` → **32 passed**
- [x] `npx eslint frontend/src/pages/GroupRankingsPage.jsx` → No issues found
- [ ] Manual: clear Redis cache-warmup metadata, click `Refresh` on `/groups` → expect Alert with "Cache warmup not complete ... — Wait for the post-close cache warmup to finish, then retry."
- [ ] Manual: on a healthy environment, click `Refresh` → expect success, table refetches, no Alert shown.
- [ ] Manual: stop Celery worker, click `Refresh` → expect error Alert with the axios/HTTP detail.

## Backwards compatibility

- `reason_code` is `Optional[str]` with a default of `None`; existing clients see no change.
- Older frontends (pre-this-change) that don't know about `reason_code` simply ignore it.
- Newer frontends against older backends see `reason_code === undefined`, `REASON_HINTS[undefined]` is `undefined`, and the `hint ? \`${msg} — ${hint}\` : msg` ternary falls through cleanly to just the raw error message. Graceful degradation, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error reporting for group rankings calculations with machine-readable failure codes.
  * Group ranking calculation errors now display contextual, user-friendly hints based on specific failure reasons (invalid date, incomplete cache warmup, missing mappings, no data ranked).
  * Added dismissible error alerts to the rankings page for enhanced user feedback and error visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->