### PR TITLE
Add provider circuit breaker and per-market rate budgeting

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -137,7 +137,7 @@ class Settings(BaseSettings):
     yfinance_rate_limit: int = 1  # requests per second (aggregate across all markets)
     alphavantage_rate_limit: int = 25  # requests per day
     finviz_rate_limit_interval: float = 0.5  # seconds between finviz API calls
-    yfinance_batch_rate_limit_interval: float = 5.0  # seconds between yfinance batch downloads
+    yfinance_batch_rate_limit_interval: float = 2.0  # seconds between yfinance batch downloads
     yfinance_per_ticker_delay: float = 0.2  # Deprecated: bulk scheduled jobs should not use per-ticker fetches
     universe_source_timeout_seconds: int = 60
     universe_source_user_agent: str = (

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -197,6 +197,36 @@ class Settings(BaseSettings):
     yfinance_backoff_max_s_jp: int | None = None
     yfinance_backoff_max_s_tw: int | None = None
 
+    # Per-market parallel worker counts for finviz (which has no batch API,
+    # so concurrency is the only knob). Defaults live in
+    # RateBudgetPolicy.get_provider_workers; the per-market Redis rate
+    # limiter still serializes egress, so worker count only buys "fill the
+    # pipeline during HTTP RTT" — never raises req/sec to the upstream IP.
+    finviz_workers_us: int | None = None
+    finviz_workers_hk: int | None = None
+    finviz_workers_in: int | None = None
+    finviz_workers_jp: int | None = None
+    finviz_workers_tw: int | None = None
+
+    # Provider circuit breaker (services/provider_circuit_breaker.py).
+    # Trips when N consecutive batches/calls hit transient 429-style errors;
+    # short-circuits subsequent calls until cooldown elapses, then admits a
+    # single probe (half-open) before fully closing.
+    circuit_breaker_enabled: bool = True
+    circuit_breaker_threshold: int = 3  # consecutive 429s to trip
+    circuit_breaker_cooldown_us: int = 120  # seconds
+    circuit_breaker_cooldown_hk: int = 300
+    circuit_breaker_cooldown_in: int = 300
+    circuit_breaker_cooldown_jp: int = 300
+    circuit_breaker_cooldown_tw: int = 300
+
+    # yfinance HTTP session: when enabled, calls are routed through a
+    # process-wide curl_cffi session impersonating Chrome to dramatically
+    # reduce Yahoo's bot-detection 429s and reuse cookies/crumb across
+    # batches. Falls back silently if curl_cffi is not installed.
+    yfinance_use_curl_cffi: bool = True
+    yfinance_curl_cffi_impersonate: str = "chrome"
+
     # Scanning
     default_universe: str = "all"
     scan_batch_size: int = 20

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -37,6 +37,36 @@ def _finite_or_none(value: Any) -> Any:
     return value
 
 
+def _get_yf_session():
+    """Return the process-wide curl_cffi session (or ``None`` to fall back).
+
+    Centralised here so both ``yf.download`` and ``yf.Tickers`` callsites
+    stay in sync. Returns ``None`` when curl_cffi is unavailable or
+    disabled — callers must not pass a ``None`` session to yfinance, so
+    construct kwargs conditionally.
+    """
+    try:
+        from .yf_session import get_session
+        return get_session()
+    except Exception as exc:
+        logger.debug("yf_session import/get failed: %s", exc)
+        return None
+
+
+def _new_yf_tickers(symbols_str: str):
+    """Construct a ``yf.Tickers`` instance, attaching the curl_cffi session
+    when available. yfinance's older versions don't accept ``session`` on
+    Tickers; the try/except keeps us compatible with both."""
+    session = _get_yf_session()
+    if session is not None:
+        try:
+            return yf.Tickers(symbols_str, session=session)
+        except TypeError:
+            # Older yfinance: no session kwarg on Tickers; fall through.
+            pass
+    return yf.Tickers(symbols_str)
+
+
 class BulkDataFetcher:
     """
     Fetch data for multiple stocks efficiently using ``yf.download()``.
@@ -411,7 +441,7 @@ class BulkDataFetcher:
             # yf.download with group_by='ticker' returns MultiIndex columns: (ticker, OHLCV)
             # threads=False avoids threading issues inside Celery workers
             # progress=False suppresses the tqdm progress bar
-            raw = yf.download(
+            download_kwargs = dict(
                 tickers=symbols,
                 period=period,
                 group_by='ticker',
@@ -420,6 +450,10 @@ class BulkDataFetcher:
                 auto_adjust=False,
                 actions=True,
             )
+            session = _get_yf_session()
+            if session is not None:
+                download_kwargs["session"] = session
+            raw = yf.download(**download_kwargs)
 
             if raw is None or raw.empty:
                 logger.warning("yf.download returned empty DataFrame")
@@ -503,6 +537,9 @@ class BulkDataFetcher:
             from .rate_budget_policy import get_rate_budget_policy
             start_batch_size = get_rate_budget_policy().get_batch_size("yfinance", market)
 
+        from .provider_circuit_breaker import get_circuit_breaker
+        breaker = get_circuit_breaker()
+
         batch_size = max(
             self.MIN_PRICE_BATCH_SIZE,
             min(start_batch_size or self.DEFAULT_PRICE_BATCH_SIZE, self.MAX_PRICE_BATCH_SIZE),
@@ -512,6 +549,22 @@ class BulkDataFetcher:
         combined_results: Dict[str, Dict] = {}
         batch_start = 0
         while batch_start < len(symbols):
+            # Bail out early when the per-market circuit is open — no point
+            # spinning through 30+ second internal retries when we know the
+            # provider is throttling this market.
+            if market is not None and breaker.check("yfinance", market) == "open":
+                logger.warning(
+                    "Yahoo circuit open for market=%s; aborting price fetch "
+                    "(remaining %d/%d symbols)",
+                    market, len(symbols) - batch_start, len(symbols),
+                )
+                for symbol in symbols[batch_start:]:
+                    combined_results.setdefault(
+                        symbol,
+                        {**self._build_error_result(symbol, "circuit_open"), "error_kind": "circuit_open"},
+                    )
+                break
+
             batch_symbols = symbols[batch_start:batch_start + batch_size]
             batch_results = self._fetch_price_batch_with_retries(
                 batch_symbols,
@@ -525,11 +578,15 @@ class BulkDataFetcher:
                 success_streak = 0
                 batch_size = max(self.MIN_PRICE_BATCH_SIZE, batch_size // 2)
                 growth_cooldown_remaining = self.PRICE_BATCH_GROWTH_COOLDOWN_BATCHES
+                # Sustained transient failure → pulse the breaker. Threshold
+                # tripping is done after consecutive batches.
+                breaker.record_429("yfinance", market)
             else:
                 if growth_cooldown_remaining > 0:
                     growth_cooldown_remaining -= 1
                 if failure_rate < 0.02:
                     success_streak += 1
+                    breaker.record_success("yfinance", market)
                     if growth_cooldown_remaining == 0 and success_streak >= self.PRICE_BATCH_SUCCESS_STREAK_TO_GROW:
                         batch_size = min(
                             self.MAX_PRICE_BATCH_SIZE,
@@ -693,10 +750,29 @@ class BulkDataFetcher:
         total_batches = (len(symbols) + batch_size - 1) // batch_size
         consecutive_backoffs = 0  # Track consecutive rate-limited batches
 
+        # Circuit breaker check is per-batch — when open, skip remaining
+        # batches rather than spinning through dozens of independent retries.
+        from .provider_circuit_breaker import CircuitOpenError, get_circuit_breaker
+        breaker = get_circuit_breaker()
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(symbols))
             batch_symbols = symbols[start_idx:end_idx]
+
+            # Short-circuit doomed batches when the per-market breaker is open.
+            if market is not None and breaker.check("yfinance", market) == "open":
+                logger.warning(
+                    "Yahoo circuit open for market=%s; skipping remaining %d batches",
+                    market, total_batches - batch_num,
+                )
+                for symbol in symbols[start_idx:]:
+                    all_results.setdefault(symbol, {
+                        "has_error": True,
+                        "error": "circuit_open",
+                        "error_kind": "circuit_open",
+                    })
+                break
 
             logger.info(f"Processing batch {batch_num + 1}/{total_batches} ({len(batch_symbols)} symbols)")
 
@@ -704,7 +780,7 @@ class BulkDataFetcher:
 
             try:
                 # Use yf.Tickers for efficient batch fetching
-                tickers = yf.Tickers(' '.join(batch_symbols))
+                tickers = _new_yf_tickers(' '.join(batch_symbols))
 
                 for i, symbol in enumerate(batch_symbols):
                     try:
@@ -737,6 +813,7 @@ class BulkDataFetcher:
                             if market is not None:
                                 from .rate_budget_policy import get_rate_budget_policy
                                 get_rate_budget_policy().record_429("yfinance", market)
+                            breaker.record_429("yfinance", market)
 
                     # Rate limit between individual ticker fetches within batch
                     if i < len(batch_symbols) - 1 and delay_per_ticker > 0:
@@ -765,6 +842,10 @@ class BulkDataFetcher:
                 time.sleep(backoff_time)
             else:
                 consecutive_backoffs = 0  # Reset on successful batch
+                # Reset the circuit breaker counter so a healthy batch
+                # promptly closes a half-open circuit.
+                if batch_rate_limit_failures == 0:
+                    breaker.record_success("yfinance", market)
                 # Normal rate limit between batches
                 if batch_num < total_batches - 1:
                     if market is not None:
@@ -821,7 +902,7 @@ class BulkDataFetcher:
             """Fetch a single batch."""
             batch_results = {}
             try:
-                tickers = yf.Tickers(' '.join(batch_symbols))
+                tickers = _new_yf_tickers(' '.join(batch_symbols))
 
                 for i, symbol in enumerate(batch_symbols):
                     try:

--- a/backend/app/services/finviz_service.py
+++ b/backend/app/services/finviz_service.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TYPE_CHECKING, Dict, Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TYPE_CHECKING, Dict, List, Optional
 from finvizfinance.quote import finvizfinance
 
 from .finviz_parser import FinvizParser
@@ -17,6 +18,16 @@ if TYPE_CHECKING:
     from app.services.rate_limiter import RedisRateLimiter
 
 logger = logging.getLogger(__name__)
+
+
+_FINVIZ_RATE_LIMIT_INDICATORS = ("rate", "429", "too many", "limit", "throttl")
+
+
+def _is_finviz_rate_limit_error(exc: BaseException) -> bool:
+    """Return True when the exception text matches the throttle/rate-limit
+    pattern shared with bulk_data_fetcher's classifier."""
+    text = str(exc).lower()
+    return any(indicator in text for indicator in _FINVIZ_RATE_LIMIT_INDICATORS)
 
 
 class FinvizService:
@@ -32,20 +43,51 @@ class FinvizService:
         self.validator = FinvizValidator()
         self._rate_limiter = rate_limiter
 
-    def _rate_limited_call(self, func, *args, **kwargs):
+    def _rate_limited_call(self, func, *args, market: Optional[str] = None, **kwargs):
         """
         Execute a function with rate limiting via Redis-backed distributed limiter.
 
+        When ``market`` is supplied, uses the per-market provider key
+        (``finviz:us`` etc.) so cross-market refreshes don't starve each
+        other. When ``market`` is None, falls back to the legacy global
+        ``finviz`` key for backward compatibility with single-market scripts.
+
+        The provider circuit breaker is consulted before the wait — if the
+        market's circuit is open, raises ``CircuitOpenError`` immediately
+        instead of sleeping through the backoff. Transient
+        rate-limit/throttle errors detected by ``func`` are recorded against
+        the breaker after the call.
+
         Args:
             func: Function to execute
+            market: Optional market code for per-market rate budgeting
             *args, **kwargs: Arguments to pass to function
 
         Returns:
             Result from function
         """
         from ..config import settings
-        self._rate_limiter.wait("finviz", min_interval_s=settings.finviz_rate_limit_interval)
-        return func(*args, **kwargs)
+        from .provider_circuit_breaker import get_circuit_breaker
+
+        breaker = get_circuit_breaker()
+        # Raise CircuitOpenError when the market is paused; ``half_open_probe``
+        # falls through and is the single permitted probe call.
+        breaker.raise_if_open("finviz", market)
+
+        if market is not None:
+            self._rate_limiter.wait_for_market("finviz", market)
+        else:
+            self._rate_limiter.wait("finviz", min_interval_s=settings.finviz_rate_limit_interval)
+
+        try:
+            result = func(*args, **kwargs)
+        except Exception as exc:
+            if _is_finviz_rate_limit_error(exc):
+                breaker.record_429("finviz", market)
+            raise
+        else:
+            breaker.record_success("finviz", market)
+            return result
 
     def get_fundamentals(self, symbol: str) -> Optional[Dict]:
         """
@@ -252,7 +294,11 @@ class FinvizService:
         'Sales past 5Y': 'sales_past_5y',
     }
 
-    def get_finviz_only_fields(self, symbol: str) -> Optional[Dict]:
+    def get_finviz_only_fields(
+        self,
+        symbol: str,
+        market: Optional[str] = None,
+    ) -> Optional[Dict]:
         """
         Fetch ONLY the fields that are unique to finviz (not available in yfinance).
 
@@ -261,6 +307,7 @@ class FinvizService:
 
         Args:
             symbol: Stock ticker symbol
+            market: Optional market code for per-market rate budgeting
 
         Returns:
             Dict with finviz-only fields, or None if error
@@ -284,7 +331,7 @@ class FinvizService:
                     description = None
                 return fundament, description
 
-            finviz_data, description = self._rate_limited_call(fetch)
+            finviz_data, description = self._rate_limited_call(fetch, market=market)
 
             if not finviz_data:
                 return None
@@ -337,35 +384,99 @@ class FinvizService:
 
     def get_finviz_only_fields_batch(
         self,
-        symbols: list,
-        max_workers: int = 1,
+        symbols: List[str],
+        max_workers: Optional[int] = None,
+        market: Optional[str] = None,
     ) -> Dict[str, Optional[Dict]]:
         """
-        Fetch finviz-only fields for multiple symbols.
+        Fetch finviz-only fields for multiple symbols, in parallel.
 
-        Note: finvizfinance doesn't support batch fetching, so this is sequential
-        with rate limiting. However, it only fetches ~15 fields per stock.
+        finvizfinance has no batch endpoint, so each symbol is a separate
+        HTTP call. The Redis-backed ``RedisRateLimiter`` keyed on
+        ``finviz:<market>`` serializes egress globally across threads, so
+        increasing ``max_workers`` does not raise the request rate against
+        the upstream IP — it only fills idle time during in-flight HTTP
+        RTT (typical RTT ~1-2s vs. 0.5s rate-limit interval).
 
         Args:
             symbols: List of ticker symbols
-            max_workers: Number of concurrent workers (default 1 for safety)
+            max_workers: Number of concurrent workers. When ``None``,
+                resolved via ``RateBudgetPolicy.get_provider_workers`` for
+                the given market.
+            market: Market code (``US``, ``HK``, ...) used for per-market
+                rate budgeting and worker count resolution.
 
         Returns:
-            Dict mapping symbols to their finviz-only data
+            Dict mapping symbols to their finviz-only data (or ``None`` on
+            per-symbol error). Stops early and fills remaining symbols with
+            ``None`` if the circuit breaker opens mid-batch.
         """
-        results = {}
         total = len(symbols)
+        if total == 0:
+            return {}
 
-        logger.info(f"Fetching finviz-only fields for {total} symbols")
+        if max_workers is None:
+            from .rate_budget_policy import get_rate_budget_policy
+            max_workers = get_rate_budget_policy().get_provider_workers("finviz", market)
+        max_workers = max(1, int(max_workers))
 
-        for i, symbol in enumerate(symbols):
-            if i > 0 and i % 50 == 0:
-                logger.info(f"Progress: {i}/{total} symbols ({i/total*100:.1f}%)")
+        logger.info(
+            "Fetching finviz-only fields for %d symbols (workers=%d, market=%s)",
+            total, max_workers, market or "shared",
+        )
 
-            result = self.get_finviz_only_fields(symbol)
-            results[symbol] = result
+        results: Dict[str, Optional[Dict]] = {symbol: None for symbol in symbols}
 
-        success_count = len([r for r in results.values() if r is not None])
+        # Sequential path keeps the legacy code path bit-for-bit identical
+        # when the policy chooses 1 worker (e.g., non-US markets).
+        if max_workers == 1:
+            from .provider_circuit_breaker import CircuitOpenError
+            for i, symbol in enumerate(symbols):
+                if i > 0 and i % 50 == 0:
+                    logger.info(f"Progress: {i}/{total} symbols ({i/total*100:.1f}%)")
+                try:
+                    results[symbol] = self.get_finviz_only_fields(symbol, market=market)
+                except CircuitOpenError as exc:
+                    logger.warning(
+                        "Finviz batch aborted at %d/%d: %s", i, total, exc,
+                    )
+                    break
+            success_count = sum(1 for v in results.values() if v is not None)
+            logger.info(f"Finviz-only batch complete: {success_count}/{total} successful")
+            return results
+
+        from .provider_circuit_breaker import CircuitOpenError
+
+        circuit_open = False
+        completed = 0
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(self.get_finviz_only_fields, symbol, market=market): symbol
+                for symbol in symbols
+            }
+            for future in as_completed(futures):
+                symbol = futures[future]
+                try:
+                    results[symbol] = future.result()
+                except CircuitOpenError:
+                    # Once the breaker trips, everything else queued is
+                    # going to short-circuit too — log once, leave the
+                    # remaining slots as None and let callers decide.
+                    if not circuit_open:
+                        logger.warning(
+                            "Circuit open for finviz:%s; remaining symbols "
+                            "in batch will return None",
+                            (market or "shared").lower(),
+                        )
+                        circuit_open = True
+                    results[symbol] = None
+                except Exception as exc:
+                    logger.debug("finviz batch error for %s: %s", symbol, exc)
+                    results[symbol] = None
+                completed += 1
+                if completed % 50 == 0:
+                    logger.info(f"Progress: {completed}/{total} symbols")
+
+        success_count = sum(1 for v in results.values() if v is not None)
         logger.info(f"Finviz-only batch complete: {success_count}/{total} successful")
-
         return results

--- a/backend/app/services/finviz_service.py
+++ b/backend/app/services/finviz_service.py
@@ -13,6 +13,7 @@ from finvizfinance.quote import finvizfinance
 
 from .finviz_parser import FinvizParser
 from .finviz_validator import FinvizValidator
+from .provider_circuit_breaker import CircuitOpenError
 
 if TYPE_CHECKING:
     from app.services.rate_limiter import RedisRateLimiter
@@ -378,6 +379,12 @@ class FinvizService:
 
             return result
 
+        except CircuitOpenError:
+            # Let the breaker signal propagate so batch/phase loops can
+            # short-circuit. The broad ``except Exception`` below would
+            # otherwise swallow it and return ``None``, making every
+            # ``except CircuitOpenError`` handler in callers dead code.
+            raise
         except Exception as e:
             logger.warning(f"Error fetching finviz-only fields for {symbol}: {e}")
             return None
@@ -430,7 +437,6 @@ class FinvizService:
         # Sequential path keeps the legacy code path bit-for-bit identical
         # when the policy chooses 1 worker (e.g., non-US markets).
         if max_workers == 1:
-            from .provider_circuit_breaker import CircuitOpenError
             for i, symbol in enumerate(symbols):
                 if i > 0 and i % 50 == 0:
                     logger.info(f"Progress: {i}/{total} symbols ({i/total*100:.1f}%)")
@@ -444,8 +450,6 @@ class FinvizService:
             success_count = sum(1 for v in results.values() if v is not None)
             logger.info(f"Finviz-only batch complete: {success_count}/{total} successful")
             return results
-
-        from .provider_circuit_breaker import CircuitOpenError
 
         circuit_open = False
         completed = 0

--- a/backend/app/services/hybrid_fundamentals_service.py
+++ b/backend/app/services/hybrid_fundamentals_service.py
@@ -278,29 +278,26 @@ class HybridFundamentalsService:
 
             finviz_total = len(finviz_eligible)
             finviz_success = 0
-            # Phase 3 is US-only (per routing policy above); use the per-market
-            # finviz worker policy and bail early when the circuit opens.
-            from .provider_circuit_breaker import CircuitOpenError, get_circuit_breaker
-            breaker = get_circuit_breaker()
+            # Phase 3 is US-only (per routing policy above); the breaker check
+            # inside ``_rate_limited_call`` is the single gate. An additional
+            # ``breaker.check()`` here would mutate state — it can promote
+            # open→half_open and consume the single probe before the actual
+            # call runs, leaving the probe wasted (and, in the no-Redis
+            # fallback, permanently wedging the circuit).
+            from .provider_circuit_breaker import CircuitOpenError
 
             for i, symbol in enumerate(finviz_eligible):
                 # Resolve the symbol's market for per-market rate budgeting;
                 # finviz routing already constrained this to supported markets.
                 symbol_market = (market_by_symbol or {}).get(symbol) or "US"
-                if breaker.check("finviz", symbol_market) == "open":
-                    logger.warning(
-                        "Phase 3 aborted at %d/%d: finviz circuit open for %s",
-                        i, finviz_total, symbol_market,
-                    )
-                    break
                 try:
                     finviz_data = self.finviz_service.get_finviz_only_fields(
                         symbol, market=symbol_market,
                     )
                 except CircuitOpenError:
                     logger.warning(
-                        "Phase 3 aborted at %d/%d: circuit opened mid-batch",
-                        i, finviz_total,
+                        "Phase 3 aborted at %d/%d: circuit open for finviz:%s",
+                        i, finviz_total, symbol_market.lower(),
                     )
                     break
                 if finviz_data:

--- a/backend/app/services/hybrid_fundamentals_service.py
+++ b/backend/app/services/hybrid_fundamentals_service.py
@@ -278,8 +278,31 @@ class HybridFundamentalsService:
 
             finviz_total = len(finviz_eligible)
             finviz_success = 0
+            # Phase 3 is US-only (per routing policy above); use the per-market
+            # finviz worker policy and bail early when the circuit opens.
+            from .provider_circuit_breaker import CircuitOpenError, get_circuit_breaker
+            breaker = get_circuit_breaker()
+
             for i, symbol in enumerate(finviz_eligible):
-                finviz_data = self.finviz_service.get_finviz_only_fields(symbol)
+                # Resolve the symbol's market for per-market rate budgeting;
+                # finviz routing already constrained this to supported markets.
+                symbol_market = (market_by_symbol or {}).get(symbol) or "US"
+                if breaker.check("finviz", symbol_market) == "open":
+                    logger.warning(
+                        "Phase 3 aborted at %d/%d: finviz circuit open for %s",
+                        i, finviz_total, symbol_market,
+                    )
+                    break
+                try:
+                    finviz_data = self.finviz_service.get_finviz_only_fields(
+                        symbol, market=symbol_market,
+                    )
+                except CircuitOpenError:
+                    logger.warning(
+                        "Phase 3 aborted at %d/%d: circuit opened mid-batch",
+                        i, finviz_total,
+                    )
+                    break
                 if finviz_data:
                     results[symbol].update(finviz_data)
                     finviz_success += 1
@@ -348,23 +371,29 @@ class HybridFundamentalsService:
         self,
         symbols: List[str],
         include_technicals: bool = True,
-        finviz_workers: int = 2,
+        finviz_workers: Optional[int] = None,
         progress_callback=None,
         market_by_symbol: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Dict]:
         """
         Fetch fundamentals with parallel finviz fetching for faster performance.
 
-        WARNING: Using multiple workers for finviz may trigger rate limiting.
-        Use with caution and monitor for errors.
+        The Redis-backed rate limiter still serializes egress per market, so
+        ``finviz_workers > 1`` does not raise the request rate above the
+        configured cadence — it only fills idle time during HTTP RTT. The
+        provider circuit breaker pauses the market entirely on sustained
+        429s.
 
         Args:
             symbols: List of ticker symbols
             include_technicals: Whether to calculate technical indicators
-            finviz_workers: Number of parallel workers for finviz (default 2)
+            finviz_workers: Number of parallel workers for finviz. When
+                ``None``, resolved per-market via
+                ``RateBudgetPolicy.get_provider_workers``.
             progress_callback: Optional progress callback
             market_by_symbol: Optional mapping ``{symbol: market}`` forwarded
-                to cadence-aware quarterly growth extraction.
+                to cadence-aware quarterly growth extraction and to
+                per-market finviz rate budgeting.
 
         Returns:
             Dict mapping symbols to their fundamental data
@@ -407,37 +436,44 @@ class HybridFundamentalsService:
             if progress_callback:
                 progress_callback(int(total * 0.4), total)
 
-        # Phase 3: Parallel finviz fetching
-        logger.info(f"Phase 3: Parallel finviz fetching ({finviz_workers} workers)...")
+        # Phase 3: Parallel finviz fetching, grouped by market so the
+        # per-market rate limiter and circuit breaker apply correctly.
+        from . import provider_routing_policy as routing_policy
+        from .rate_budget_policy import get_rate_budget_policy
 
-        # Split symbols into chunks for workers
-        chunk_size = (len(symbols) + finviz_workers - 1) // finviz_workers
-        chunks = [symbols[i:i + chunk_size] for i in range(0, len(symbols), chunk_size)]
+        market_by_symbol = market_by_symbol or {}
+        eligible_by_market: Dict[str, List[str]] = {}
+        for symbol in symbols:
+            market = market_by_symbol.get(symbol) or "US"
+            if not routing_policy.is_supported(market, routing_policy.PROVIDER_FINVIZ):
+                continue
+            eligible_by_market.setdefault(market, []).append(symbol)
 
-        def fetch_finviz_chunk(chunk_symbols: List[str]) -> Dict[str, Dict]:
-            """Fetch finviz data for a chunk of symbols."""
-            chunk_results = {}
-            # Create a separate FinvizService instance for thread safety
-            finviz = FinvizService(rate_limiter=self._finviz_rate_limiter)
-            for symbol in chunk_symbols:
-                data = finviz.get_finviz_only_fields(symbol)
-                chunk_results[symbol] = data or {}
-            return chunk_results
+        policy = get_rate_budget_policy()
+        completed = 0
+        for market, market_symbols in eligible_by_market.items():
+            workers = (
+                finviz_workers
+                if finviz_workers is not None
+                else policy.get_provider_workers("finviz", market)
+            )
+            logger.info(
+                "Phase 3: finviz for market=%s (%d symbols, workers=%d)",
+                market, len(market_symbols), workers,
+            )
+            market_results = self.finviz_service.get_finviz_only_fields_batch(
+                market_symbols,
+                max_workers=workers,
+                market=market,
+            )
+            for symbol, data in market_results.items():
+                if data:
+                    results[symbol].update(data)
 
-        with ThreadPoolExecutor(max_workers=finviz_workers) as executor:
-            futures = {executor.submit(fetch_finviz_chunk, chunk): chunk for chunk in chunks}
-
-            completed = 0
-            for future in as_completed(futures):
-                chunk_results = future.result()
-                for symbol, data in chunk_results.items():
-                    if data:
-                        results[symbol].update(data)
-
-                completed += len(futures[future])
-                if progress_callback:
-                    phase3_progress = 0.4 + (completed / total) * 0.6
-                    progress_callback(int(total * phase3_progress), total)
+            completed += len(market_symbols)
+            if progress_callback:
+                phase3_progress = 0.4 + (completed / total) * 0.6
+                progress_callback(int(total * phase3_progress), total)
 
         # Add metadata
         for symbol in symbols:

--- a/backend/app/services/provider_circuit_breaker.py
+++ b/backend/app/services/provider_circuit_breaker.py
@@ -1,0 +1,399 @@
+"""Provider×market circuit breaker for transient 429 storms.
+
+When an upstream provider (yfinance, finviz) sustains 429s for a single
+market, every in-flight batch independently sleeps through its exponential
+backoff. The breaker stores `closed | open | half_open` state in Redis so
+all Celery workers agree, and short-circuits doomed calls until the
+cooldown expires. State is per-(provider, market), so an open circuit on
+``finviz:hk`` doesn't pause ``finviz:us``.
+
+Falls back silently to a no-op (always-closed) when Redis is unavailable
+— callers continue to use the underlying rate-limiter backoff in that
+case.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Optional
+
+from ..config import settings
+from ..tasks.market_queues import market_suffix
+from .rate_limiter import RateLimitTimeoutError
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitOpenError(RateLimitTimeoutError):
+    """Raised when the breaker for (provider, market) is open.
+
+    Subclasses ``RateLimitTimeoutError`` so existing call sites that catch
+    the latter continue to handle this gracefully; new code can match the
+    subclass to log "circuit open, skipping" cleanly.
+    """
+
+    def __init__(self, provider: str, market: Optional[str], reopens_in_s: float):
+        self.provider = provider
+        self.market = market
+        self.reopens_in_s = reopens_in_s
+        super().__init__(
+            f"Circuit open for {provider}:{market_suffix(market)}; "
+            f"reopens in {reopens_in_s:.1f}s"
+        )
+
+
+# Lua script: atomically read state and auto-promote open→half_open after
+# cooldown. Returns the resolved state plus seconds-until-reopen for the
+# error path. Half-open promotion uses SETNX so only one probe gets through.
+#
+# KEYS[1] = state hash key (e.g., "circuit:finviz:us")
+# KEYS[2] = half-open probe lock key
+# ARGV[1] = current epoch seconds (string)
+# ARGV[2] = cooldown seconds (string)
+#
+# Returns: ARRAY {state_string, reopens_in_s_string}
+_LUA_CHECK = """
+local state = redis.call('HGET', KEYS[1], 'state')
+if not state or state == 'closed' then
+    return {'closed', '0'}
+end
+
+local opened_at = tonumber(redis.call('HGET', KEYS[1], 'opened_at') or '0')
+local cooldown = tonumber(ARGV[2])
+local now = tonumber(ARGV[1])
+local elapsed = now - opened_at
+local remaining = cooldown - elapsed
+
+if state == 'open' then
+    if elapsed >= cooldown then
+        -- Promote to half_open. Set the probe lock; if SETNX wins we admit.
+        redis.call('HSET', KEYS[1], 'state', 'half_open')
+        local got = redis.call('SET', KEYS[2], '1', 'NX', 'EX', math.ceil(cooldown))
+        if got then
+            return {'half_open_probe', '0'}
+        else
+            return {'open', tostring(cooldown)}
+        end
+    else
+        return {'open', tostring(remaining)}
+    end
+end
+
+if state == 'half_open' then
+    -- Already half-open; only one caller may proceed at a time.
+    local got = redis.call('SET', KEYS[2], '1', 'NX', 'EX', math.ceil(cooldown))
+    if got then
+        return {'half_open_probe', '0'}
+    else
+        return {'open', tostring(math.max(remaining, 1))}
+    end
+end
+
+return {'closed', '0'}
+"""
+
+
+class ProviderCircuitBreaker:
+    """Distributed (provider, market) circuit breaker on top of Redis."""
+
+    _COOLDOWN_DEFAULTS_S = {
+        "US": 120,
+        "HK": 300,
+        "IN": 300,
+        "JP": 300,
+        "TW": 300,
+    }
+
+    def __init__(self, redis_client_factory=None):
+        self._redis_client_factory = redis_client_factory
+        self._fallback_lock = threading.Lock()
+        self._fallback_state: dict[str, dict] = {}
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+    @property
+    def enabled(self) -> bool:
+        return bool(getattr(settings, "circuit_breaker_enabled", True))
+
+    @property
+    def threshold(self) -> int:
+        return int(getattr(settings, "circuit_breaker_threshold", 3) or 3)
+
+    def cooldown_s(self, market: Optional[str]) -> int:
+        if market:
+            attr = f"circuit_breaker_cooldown_{market.lower()}"
+            override = getattr(settings, attr, None)
+            # Explicit ``is not None`` so a configured ``0`` cooldown
+            # (typically only used in tests) is honoured.
+            if override is not None:
+                return int(override)
+            return self._COOLDOWN_DEFAULTS_S.get(market.upper(), 300)
+        return 120
+
+    # ------------------------------------------------------------------
+    # Key helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def state_key(provider: str, market: Optional[str]) -> str:
+        return f"circuit:{provider}:{market_suffix(market)}"
+
+    @staticmethod
+    def probe_key(provider: str, market: Optional[str]) -> str:
+        return f"circuit:{provider}:{market_suffix(market)}:probe"
+
+    @staticmethod
+    def events_key(provider: str, market: Optional[str], day: Optional[str] = None) -> str:
+        from datetime import datetime
+        day = day or datetime.now().strftime("%Y%m%d")
+        return f"circuit:events:{provider}:{market_suffix(market)}:{day}"
+
+    # ------------------------------------------------------------------
+    # Redis access
+    # ------------------------------------------------------------------
+    def _redis(self):
+        if self._redis_client_factory is not None:
+            try:
+                return self._redis_client_factory()
+            except Exception:
+                return None
+        try:
+            from .redis_pool import get_redis_client
+            return get_redis_client()
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
+    # State machine
+    # ------------------------------------------------------------------
+    def check(self, provider: str, market: Optional[str]) -> str:
+        """Return resolved state: ``closed``, ``open``, or ``half_open_probe``.
+
+        ``open`` means callers should bail (raise ``CircuitOpenError`` or
+        skip). ``half_open_probe`` admits exactly one probe call; the
+        caller must invoke ``record_success`` or ``record_429`` afterwards
+        so the breaker can transition.
+        """
+        if not self.enabled:
+            return "closed"
+        client = self._redis()
+        if client is None:
+            return self._fallback_check(provider, market)
+        state_key = self.state_key(provider, market)
+        probe_key = self.probe_key(provider, market)
+        cooldown = self.cooldown_s(market)
+        try:
+            result = client.eval(
+                _LUA_CHECK, 2, state_key, probe_key,
+                str(time.time()), str(cooldown),
+            )
+            state, _remaining = self._decode_check_result(result)
+            return state
+        except Exception as exc:
+            logger.debug("CircuitBreaker.check: Redis error (%s); treating as closed", exc)
+            return "closed"
+
+    def raise_if_open(self, provider: str, market: Optional[str]) -> str:
+        """Like ``check`` but raises ``CircuitOpenError`` when open.
+
+        Returns the resolved state when the call may proceed (``closed`` or
+        ``half_open_probe``).
+        """
+        state = self.check(provider, market)
+        if state == "open":
+            raise CircuitOpenError(provider, market, float(self.cooldown_s(market)))
+        return state
+
+    def record_429(self, provider: str, market: Optional[str]) -> None:
+        """Increment consecutive-429 counter; trip to ``open`` at threshold."""
+        if not self.enabled:
+            return
+        client = self._redis()
+        if client is None:
+            self._fallback_record_429(provider, market)
+            return
+        state_key = self.state_key(provider, market)
+        events_key = self.events_key(provider, market)
+        threshold = self.threshold
+        cooldown = self.cooldown_s(market)
+        ttl = max(int(cooldown * 2), 60)
+        try:
+            pipe = client.pipeline()
+            pipe.hincrby(state_key, "consecutive_429", 1)
+            pipe.hget(state_key, "state")
+            pipe.expire(state_key, ttl)
+            results = pipe.execute()
+            consecutive = int(results[0] or 0)
+            current_state = (results[1] or b"closed")
+            if isinstance(current_state, bytes):
+                current_state = current_state.decode()
+
+            if current_state == "half_open":
+                # Probe failed → reopen and reset opened_at so the cooldown
+                # window restarts.
+                self._transition(client, state_key, "half_open", "open", consecutive)
+                pipe2 = client.pipeline()
+                pipe2.hset(state_key, mapping={"opened_at": str(time.time())})
+                pipe2.delete(self.probe_key(provider, market))
+                pipe2.incr(events_key)
+                pipe2.expire(events_key, 90 * 86400)
+                pipe2.expire(state_key, ttl)
+                pipe2.execute()
+                logger.info(
+                    "CircuitBreaker: half-open probe failed for %s:%s; "
+                    "reopening (consecutive_429=%d)",
+                    provider, market_suffix(market), consecutive,
+                )
+                return
+
+            if current_state != "open" and consecutive >= threshold:
+                pipe2 = client.pipeline()
+                pipe2.hset(state_key, mapping={
+                    "state": "open",
+                    "opened_at": str(time.time()),
+                })
+                pipe2.incr(events_key)
+                pipe2.expire(events_key, 90 * 86400)
+                pipe2.expire(state_key, ttl)
+                pipe2.execute()
+                logger.warning(
+                    "CircuitBreaker: tripping OPEN for %s:%s (consecutive_429=%d, "
+                    "threshold=%d, cooldown=%ds)",
+                    provider, market_suffix(market),
+                    consecutive, threshold, cooldown,
+                )
+        except Exception as exc:
+            logger.debug("CircuitBreaker.record_429: Redis error: %s", exc)
+
+    def record_success(self, provider: str, market: Optional[str]) -> None:
+        """Reset counter; promote half_open → closed when applicable."""
+        if not self.enabled:
+            return
+        client = self._redis()
+        if client is None:
+            self._fallback_record_success(provider, market)
+            return
+        state_key = self.state_key(provider, market)
+        try:
+            current_state = client.hget(state_key, "state")
+            if isinstance(current_state, bytes):
+                current_state = current_state.decode()
+
+            if current_state == "half_open":
+                self._transition(client, state_key, "half_open", "closed", 0)
+                client.delete(self.probe_key(provider, market))
+                logger.info(
+                    "CircuitBreaker: closing %s:%s after successful probe",
+                    provider, market_suffix(market),
+                )
+                events_key = self.events_key(provider, market)
+                client.incr(events_key)
+                client.expire(events_key, 90 * 86400)
+            elif current_state == "closed" or current_state is None:
+                # Reset the consecutive counter so transient single 429s
+                # don't accumulate forever.
+                client.hset(state_key, "consecutive_429", 0)
+        except Exception as exc:
+            logger.debug("CircuitBreaker.record_success: Redis error: %s", exc)
+
+    def reset(self, provider: str, market: Optional[str]) -> None:
+        """Force-reset state (admin/test helper)."""
+        client = self._redis()
+        if client is None:
+            self._fallback_state.pop(self._fallback_key(provider, market), None)
+            return
+        try:
+            client.delete(self.state_key(provider, market))
+            client.delete(self.probe_key(provider, market))
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _decode_check_result(result) -> tuple[str, float]:
+        try:
+            state, remaining = result[0], result[1]
+            if isinstance(state, bytes):
+                state = state.decode()
+            if isinstance(remaining, bytes):
+                remaining = remaining.decode()
+            return state, float(remaining)
+        except Exception:
+            return "closed", 0.0
+
+    def _transition(self, client, state_key: str, from_state: str, to_state: str, consecutive: int) -> None:
+        try:
+            client.hset(state_key, mapping={
+                "state": to_state,
+                "consecutive_429": str(consecutive),
+            })
+        except Exception as exc:
+            logger.debug("CircuitBreaker._transition: %s", exc)
+
+    # --- in-process fallback (Redis-unavailable) ----------------------
+    def _fallback_key(self, provider: str, market: Optional[str]) -> str:
+        return self.state_key(provider, market)
+
+    def _fallback_check(self, provider: str, market: Optional[str]) -> str:
+        with self._fallback_lock:
+            entry = self._fallback_state.get(self._fallback_key(provider, market))
+            if not entry:
+                return "closed"
+            state = entry["state"]
+            if state == "open":
+                if time.time() - entry["opened_at"] >= self.cooldown_s(market):
+                    entry["state"] = "half_open"
+                    entry["probe_taken"] = True
+                    return "half_open_probe"
+                return "open"
+            if state == "half_open":
+                if entry.get("probe_taken"):
+                    return "open"
+                entry["probe_taken"] = True
+                return "half_open_probe"
+            return "closed"
+
+    def _fallback_record_429(self, provider: str, market: Optional[str]) -> None:
+        with self._fallback_lock:
+            key = self._fallback_key(provider, market)
+            entry = self._fallback_state.setdefault(
+                key,
+                {"state": "closed", "consecutive_429": 0, "opened_at": 0.0},
+            )
+            entry["consecutive_429"] += 1
+            if entry["state"] == "half_open":
+                entry["state"] = "open"
+                entry["opened_at"] = time.time()
+                entry.pop("probe_taken", None)
+            elif entry["consecutive_429"] >= self.threshold:
+                entry["state"] = "open"
+                entry["opened_at"] = time.time()
+
+    def _fallback_record_success(self, provider: str, market: Optional[str]) -> None:
+        with self._fallback_lock:
+            key = self._fallback_key(provider, market)
+            entry = self._fallback_state.get(key)
+            if not entry:
+                return
+            if entry["state"] == "half_open":
+                entry["state"] = "closed"
+            entry["consecutive_429"] = 0
+            entry.pop("probe_taken", None)
+
+
+# Module-level singleton
+_default_breaker: Optional[ProviderCircuitBreaker] = None
+_default_breaker_lock = threading.Lock()
+
+
+def get_circuit_breaker() -> ProviderCircuitBreaker:
+    """Return the process-wide ProviderCircuitBreaker singleton."""
+    global _default_breaker
+    if _default_breaker is None:
+        with _default_breaker_lock:
+            if _default_breaker is None:
+                _default_breaker = ProviderCircuitBreaker()
+    return _default_breaker

--- a/backend/app/services/rate_budget_policy.py
+++ b/backend/app/services/rate_budget_policy.py
@@ -44,7 +44,11 @@ class RateBudgetPolicy:
     # Used for providers without an explicit global setting.
     _DEFAULT_GLOBAL_INTERVALS_S: Dict[str, float] = {
         "yfinance": 1.0,
-        "yfinance:batch": 5.0,
+        # Tightened from 5.0s → 2.0s. yf.download is one HTTP round-trip
+        # per batch; 2s spacing between batches is well under any plausible
+        # per-batch rate cap, and the adaptive shrink + circuit breaker
+        # handle the failure mode if Yahoo objects.
+        "yfinance:batch": 2.0,
         "finviz": 0.5,
         "alpha_vantage": 3.0,  # 25 req/day → ~3s spacing if batched
         "sec_edgar": 0.15,     # 10 req/sec
@@ -53,8 +57,25 @@ class RateBudgetPolicy:
     # Per-market batch sizes. Keep the defaults uniform unless operators
     # explicitly override them via settings.
     _DEFAULT_BATCH_SIZE: Dict[str, Dict[str, int]] = {
-        "yfinance": {"US": 50, "HK": 50, "IN": 50, "JP": 50, "TW": 50},
+        # US bumped to 150 — Yahoo accepts batches up to MAX_PRICE_BATCH_SIZE
+        # (200) and the adaptive shrink in fetch_prices_in_batches halves the
+        # batch on transient failure, so this is safe.
+        "yfinance": {"US": 150, "HK": 50, "IN": 50, "JP": 50, "TW": 50},
         "finviz":   {"US": 100, "HK": 50, "IN": 50, "JP": 50, "TW": 50},
+    }
+
+    # Per-market default worker counts for providers that benefit from
+    # concurrency. The Redis rate limiter still serializes egress, so this
+    # only fills idle time during in-flight HTTP RTT — total req/sec to the
+    # upstream IP stays at the configured cadence.
+    _DEFAULT_PROVIDER_WORKERS: Dict[str, Dict[str, int]] = {
+        # finvizfinance has no batch endpoint; concurrency is the only
+        # speedup lever. US gets more workers because its rate-limit
+        # interval is 0.5s and per-call RTT is typically ~1-2s.
+        "finviz": {"US": 4, "HK": 2, "IN": 2, "JP": 2, "TW": 2},
+        # yfinance batch is already a single bulk HTTP call; threading
+        # there caused fork issues in Celery workers, so default to 1.
+        "yfinance": {"US": 1, "HK": 1, "IN": 1, "JP": 1, "TW": 1},
     }
 
     # Per-market backoff caps. Non-US markets get longer caps because
@@ -273,6 +294,36 @@ class RateBudgetPolicy:
         if override is not None and override > 0:
             return int(override)
         return self._DEFAULT_BATCH_SIZE.get(provider, {}).get(normalized, 50)
+
+    # ------------------------------------------------------------------
+    # Worker count per provider × market
+    # ------------------------------------------------------------------
+    def get_provider_workers(self, provider: str, market: Optional[str]) -> int:
+        """Return the number of parallel workers to use for ``provider`` calls
+        targeting ``market``.
+
+        Resolution: ``settings.<provider>_workers_<market>`` env override →
+        built-in default → 1.
+
+        The Redis rate limiter still serializes egress globally for the
+        provider×market key, so this number does not increase req/sec —
+        it only fills idle time during HTTP RTT.
+        """
+        normalized = normalize_market(market)
+        if normalized == SHARED_SENTINEL:
+            normalized = "US"
+
+        attr_provider = provider.replace(":", "_")
+        attr = f"{attr_provider}_workers_{normalized.lower()}"
+        override = getattr(settings, attr, None)
+        if override is not None:
+            try:
+                value = int(override)
+                if value > 0:
+                    return value
+            except (TypeError, ValueError):
+                logger.warning("RateBudgetPolicy: invalid workers override %s=%r", attr, override)
+        return self._DEFAULT_PROVIDER_WORKERS.get(provider, {}).get(normalized, 1)
 
     # ------------------------------------------------------------------
     # Backoff parameters

--- a/backend/app/services/yf_session.py
+++ b/backend/app/services/yf_session.py
@@ -1,0 +1,93 @@
+"""Process-wide curl_cffi session for yfinance calls.
+
+Yahoo Finance's bot detection routinely 429s plain `requests`-based
+clients. ``curl_cffi`` impersonates a real browser's TLS fingerprint and
+keeps cookies/crumb across calls, which dramatically reduces 429 rate and
+also avoids the per-process crumb refetch cost yfinance otherwise pays on
+every cold call.
+
+The session is a module-level singleton initialised lazily on first use.
+Each Celery worker process gets its own session — safe because the
+project runs Celery with ``--pool=solo`` (per CLAUDE.md), so there's no
+fork-after-init concern.
+
+When ``settings.yfinance_use_curl_cffi`` is False or ``curl_cffi`` is not
+installed, ``get_session()`` returns ``None`` and yfinance falls back to
+its default ``requests``-based path.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_session_lock = threading.Lock()
+_session = None  # type: ignore[var-annotated]
+_session_init_attempted = False
+
+
+def get_session():
+    """Return the shared curl_cffi session, or ``None`` to fall back.
+
+    Thread-safe lazy init. The first call attempts to import ``curl_cffi``
+    and build a session; subsequent calls return the cached object.
+    Failure to import or construct is logged once and the function then
+    consistently returns ``None`` so callers can safely
+    ``kw["session"] = sess if sess is not None else …``.
+    """
+    global _session, _session_init_attempted
+    if _session_init_attempted:
+        return _session
+
+    with _session_lock:
+        if _session_init_attempted:
+            return _session
+        _session_init_attempted = True
+        _session = _build_session()
+        return _session
+
+
+def reset_session() -> None:
+    """Clear the cached session (test helper)."""
+    global _session, _session_init_attempted
+    with _session_lock:
+        _session = None
+        _session_init_attempted = False
+
+
+def _build_session():
+    try:
+        from ..config import settings
+    except Exception as exc:
+        logger.debug("yf_session: settings unavailable (%s); skipping curl_cffi", exc)
+        return None
+
+    if not getattr(settings, "yfinance_use_curl_cffi", True):
+        logger.info("yf_session: curl_cffi disabled by settings")
+        return None
+
+    impersonate = getattr(settings, "yfinance_curl_cffi_impersonate", "chrome") or "chrome"
+
+    try:
+        from curl_cffi import requests as curl_requests  # type: ignore
+    except Exception as exc:
+        logger.info(
+            "yf_session: curl_cffi not available (%s); yfinance will use default session",
+            exc,
+        )
+        return None
+
+    try:
+        session = curl_requests.Session(impersonate=impersonate)
+        logger.info(
+            "yf_session: built curl_cffi session (impersonate=%s)", impersonate,
+        )
+        return session
+    except Exception as exc:
+        logger.warning(
+            "yf_session: failed to build curl_cffi session (%s); falling back",
+            exc,
+        )
+        return None

--- a/backend/requirements-runtime.txt
+++ b/backend/requirements-runtime.txt
@@ -7,6 +7,7 @@ pydantic==2.5.3
 pydantic-settings==2.1.0
 python-dotenv==1.0.0
 yfinance==0.2.66
+curl_cffi>=0.7.0
 pandas==2.2.0
 pandas-market-calendars>=4.5.0
 numpy==1.26.3

--- a/backend/requirements-server.txt
+++ b/backend/requirements-server.txt
@@ -7,6 +7,7 @@ pydantic==2.5.3
 pydantic-settings==2.1.0
 python-dotenv==1.0.0
 yfinance==0.2.66
+curl_cffi>=0.7.0
 pandas==2.2.0
 pandas-market-calendars>=4.5.0
 numpy==1.26.3

--- a/backend/tests/unit/test_finviz_service_parallel.py
+++ b/backend/tests/unit/test_finviz_service_parallel.py
@@ -56,7 +56,7 @@ class TestPerMarketRouting:
         limiter = _RecordingLimiter()
         service = FinvizService(rate_limiter=limiter)
 
-        with patch("finvizfinance.quote.finvizfinance") as mock_finviz:
+        with patch("app.services.finviz_service.finvizfinance") as mock_finviz:
             stock = MagicMock()
             stock.flag = True
             stock.ticker_fundament.return_value = {}
@@ -75,7 +75,7 @@ class TestPerMarketRouting:
 
         # ``settings`` is imported lazily inside ``_rate_limited_call``;
         # patch the singleton attribute so the deferred import sees it.
-        with patch("finvizfinance.quote.finvizfinance") as mock_finviz, \
+        with patch("app.services.finviz_service.finvizfinance") as mock_finviz, \
              patch.object(settings_singleton, "finviz_rate_limit_interval", 0.5):
             stock = MagicMock()
             stock.flag = True
@@ -96,7 +96,7 @@ class TestParallelBatch:
         service = FinvizService(rate_limiter=limiter)
 
         symbols = [f"S{i}" for i in range(8)]
-        with patch("finvizfinance.quote.finvizfinance") as mock_finviz:
+        with patch("app.services.finviz_service.finvizfinance") as mock_finviz:
             stock = MagicMock()
             stock.flag = True
             stock.ticker_fundament.return_value = {}
@@ -107,6 +107,9 @@ class TestParallelBatch:
             )
 
         assert set(results.keys()) == set(symbols)
+        # Confirm the mock was actually invoked — guards against the patch
+        # target silently missing the real binding.
+        assert mock_finviz.call_count == len(symbols)
         # Verified parallelism: at some point >1 thread was inside the limiter.
         assert limiter.concurrent_max >= 2, (
             f"Expected concurrent threads, only saw {limiter.concurrent_max}"
@@ -120,7 +123,7 @@ class TestParallelBatch:
         service = FinvizService(rate_limiter=limiter)
 
         symbols = ["A", "B", "C"]
-        with patch("finvizfinance.quote.finvizfinance") as mock_finviz:
+        with patch("app.services.finviz_service.finvizfinance") as mock_finviz:
             stock = MagicMock()
             stock.flag = True
             stock.ticker_fundament.return_value = {}
@@ -135,7 +138,7 @@ class TestParallelBatch:
         service = FinvizService(rate_limiter=limiter)
 
         symbols = ["A", "B"]
-        with patch("finvizfinance.quote.finvizfinance") as mock_finviz, \
+        with patch("app.services.finviz_service.finvizfinance") as mock_finviz, \
              patch("app.services.rate_budget_policy.get_rate_budget_policy") as get_policy:
             mock_policy = MagicMock()
             mock_policy.get_provider_workers.return_value = 2

--- a/backend/tests/unit/test_finviz_service_parallel.py
+++ b/backend/tests/unit/test_finviz_service_parallel.py
@@ -1,0 +1,182 @@
+"""Parallel finviz batch and per-market wiring tests."""
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.finviz_service import FinvizService
+
+
+class _RecordingLimiter:
+    """Stand-in for ``RedisRateLimiter`` that records the keys it serialised on."""
+
+    def __init__(self):
+        self.market_calls: list[tuple[str, str]] = []
+        self.legacy_calls: list[tuple[str, float]] = []
+        self.concurrent_max = 0
+        self._inflight = 0
+        self._lock = threading.Lock()
+
+    def wait_for_market(self, provider, market, timeout_s=120.0):
+        with self._lock:
+            self.market_calls.append((provider, market))
+            self._inflight += 1
+            self.concurrent_max = max(self.concurrent_max, self._inflight)
+        # Tiny delay so threads can actually overlap during the test.
+        import time
+        time.sleep(0.005)
+        with self._lock:
+            self._inflight -= 1
+        return 0.0
+
+    def wait(self, key, min_interval_s=0.0, timeout_s=120.0):
+        self.legacy_calls.append((key, min_interval_s))
+        return 0.0
+
+
+@pytest.fixture(autouse=True)
+def _disable_breaker():
+    """Ensure the circuit breaker stays closed throughout these tests."""
+    with patch("app.services.provider_circuit_breaker.settings") as s:
+        s.circuit_breaker_enabled = False
+        s.circuit_breaker_threshold = 100
+        for market in ("us", "hk", "in", "jp", "tw"):
+            setattr(s, f"circuit_breaker_cooldown_{market}", 60)
+        # Reset the singleton so it picks up the patched settings.
+        import app.services.provider_circuit_breaker as cb_mod
+        cb_mod._default_breaker = None
+        yield
+        cb_mod._default_breaker = None
+
+
+class TestPerMarketRouting:
+    def test_market_kwarg_routes_to_per_market_key(self):
+        limiter = _RecordingLimiter()
+        service = FinvizService(rate_limiter=limiter)
+
+        with patch("finvizfinance.quote.finvizfinance") as mock_finviz:
+            stock = MagicMock()
+            stock.flag = True
+            stock.ticker_fundament.return_value = {}
+            stock.ticker_description.return_value = "desc"
+            mock_finviz.return_value = stock
+            service.get_finviz_only_fields("AAPL", market="US")
+
+        assert limiter.market_calls == [("finviz", "US")]
+        assert limiter.legacy_calls == []
+
+    def test_no_market_falls_back_to_legacy_key(self):
+        from app.config import settings as settings_singleton
+
+        limiter = _RecordingLimiter()
+        service = FinvizService(rate_limiter=limiter)
+
+        # ``settings`` is imported lazily inside ``_rate_limited_call``;
+        # patch the singleton attribute so the deferred import sees it.
+        with patch("finvizfinance.quote.finvizfinance") as mock_finviz, \
+             patch.object(settings_singleton, "finviz_rate_limit_interval", 0.5):
+            stock = MagicMock()
+            stock.flag = True
+            stock.ticker_fundament.return_value = {}
+            stock.ticker_description.return_value = "desc"
+            mock_finviz.return_value = stock
+            service.get_finviz_only_fields("AAPL")
+
+        assert limiter.market_calls == []
+        assert len(limiter.legacy_calls) == 1
+        assert limiter.legacy_calls[0][0] == "finviz"
+        assert limiter.legacy_calls[0][1] == 0.5
+
+
+class TestParallelBatch:
+    def test_batch_uses_threadpool_when_workers_gt_1(self):
+        limiter = _RecordingLimiter()
+        service = FinvizService(rate_limiter=limiter)
+
+        symbols = [f"S{i}" for i in range(8)]
+        with patch("finvizfinance.quote.finvizfinance") as mock_finviz:
+            stock = MagicMock()
+            stock.flag = True
+            stock.ticker_fundament.return_value = {}
+            stock.ticker_description.return_value = "desc"
+            mock_finviz.return_value = stock
+            results = service.get_finviz_only_fields_batch(
+                symbols, max_workers=4, market="US",
+            )
+
+        assert set(results.keys()) == set(symbols)
+        # Verified parallelism: at some point >1 thread was inside the limiter.
+        assert limiter.concurrent_max >= 2, (
+            f"Expected concurrent threads, only saw {limiter.concurrent_max}"
+        )
+        # All threads serialised on the same per-market key.
+        keys = {(p, m) for p, m in limiter.market_calls}
+        assert keys == {("finviz", "US")}
+
+    def test_batch_with_workers_1_is_sequential(self):
+        limiter = _RecordingLimiter()
+        service = FinvizService(rate_limiter=limiter)
+
+        symbols = ["A", "B", "C"]
+        with patch("finvizfinance.quote.finvizfinance") as mock_finviz:
+            stock = MagicMock()
+            stock.flag = True
+            stock.ticker_fundament.return_value = {}
+            stock.ticker_description.return_value = "desc"
+            mock_finviz.return_value = stock
+            service.get_finviz_only_fields_batch(symbols, max_workers=1, market="US")
+
+        assert limiter.concurrent_max == 1
+
+    def test_batch_resolves_workers_via_policy_when_none(self):
+        limiter = _RecordingLimiter()
+        service = FinvizService(rate_limiter=limiter)
+
+        symbols = ["A", "B"]
+        with patch("finvizfinance.quote.finvizfinance") as mock_finviz, \
+             patch("app.services.rate_budget_policy.get_rate_budget_policy") as get_policy:
+            mock_policy = MagicMock()
+            mock_policy.get_provider_workers.return_value = 2
+            get_policy.return_value = mock_policy
+            stock = MagicMock()
+            stock.flag = True
+            stock.ticker_fundament.return_value = {}
+            stock.ticker_description.return_value = "desc"
+            mock_finviz.return_value = stock
+            service.get_finviz_only_fields_batch(symbols, market="HK")
+
+        mock_policy.get_provider_workers.assert_called_with("finviz", "HK")
+
+
+class TestRateBudgetPolicyWorkers:
+    def test_get_provider_workers_defaults(self):
+        from app.services.rate_budget_policy import RateBudgetPolicy
+
+        policy = RateBudgetPolicy()
+        with patch("app.services.rate_budget_policy.settings") as s:
+            # Make all settings overrides None so policy uses defaults.
+            for attr in ("finviz_workers_us", "finviz_workers_hk",
+                         "finviz_workers_jp", "finviz_workers_tw",
+                         "finviz_workers_in"):
+                setattr(s, attr, None)
+            # Defaults: US=4, others=2 per _DEFAULT_PROVIDER_WORKERS.
+            assert policy.get_provider_workers("finviz", "US") == 4
+            assert policy.get_provider_workers("finviz", "HK") == 2
+
+    def test_get_provider_workers_honours_settings_override(self):
+        from app.services.rate_budget_policy import RateBudgetPolicy
+
+        policy = RateBudgetPolicy()
+        with patch("app.services.rate_budget_policy.settings") as s:
+            s.finviz_workers_us = 8
+            assert policy.get_provider_workers("finviz", "US") == 8
+
+    def test_get_provider_workers_unknown_provider_returns_one(self):
+        from app.services.rate_budget_policy import RateBudgetPolicy
+
+        policy = RateBudgetPolicy()
+        with patch("app.services.rate_budget_policy.settings") as s:
+            s.bogus_workers_us = None
+            assert policy.get_provider_workers("bogus", "US") == 1

--- a/backend/tests/unit/test_provider_circuit_breaker.py
+++ b/backend/tests/unit/test_provider_circuit_breaker.py
@@ -1,0 +1,187 @@
+"""Unit tests for ProviderCircuitBreaker.
+
+Tests the state machine semantics (closed → open → half_open → closed/open)
+using the in-process fallback path (Redis unavailable). The Lua-script
+Redis path is exercised in integration smoke; here we focus on the logic
+that is portable across both paths.
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from app.services.provider_circuit_breaker import (
+    CircuitOpenError,
+    ProviderCircuitBreaker,
+)
+
+
+def _no_redis() -> ProviderCircuitBreaker:
+    """Return a breaker pinned to the in-process fallback path."""
+    return ProviderCircuitBreaker(redis_client_factory=lambda: None)
+
+
+class TestStateMachine:
+    def test_starts_closed(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 3
+            s.circuit_breaker_cooldown_us = 60
+            breaker = _no_redis()
+            assert breaker.check("finviz", "US") == "closed"
+
+    def test_trips_to_open_at_threshold(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 3
+            s.circuit_breaker_cooldown_us = 60
+            breaker = _no_redis()
+            for _ in range(3):
+                breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "open"
+
+    def test_below_threshold_stays_closed(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 3
+            s.circuit_breaker_cooldown_us = 60
+            breaker = _no_redis()
+            breaker.record_429("finviz", "US")
+            breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "closed"
+
+    def test_success_resets_consecutive_counter(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 3
+            s.circuit_breaker_cooldown_us = 60
+            breaker = _no_redis()
+            breaker.record_429("finviz", "US")
+            breaker.record_429("finviz", "US")
+            breaker.record_success("finviz", "US")
+            # Two more 429s should not trip — counter was reset.
+            breaker.record_429("finviz", "US")
+            breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "closed"
+
+    def test_open_promotes_to_half_open_after_cooldown(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 2
+            s.circuit_breaker_cooldown_us = 0  # immediate cooldown
+            breaker = _no_redis()
+            breaker.record_429("finviz", "US")
+            breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "half_open_probe"
+
+    def test_half_open_only_admits_one_probe(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 2
+            s.circuit_breaker_cooldown_us = 0
+            breaker = _no_redis()
+            breaker.record_429("finviz", "US")
+            breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "half_open_probe"
+            # Second check during half-open without success/429 should refuse.
+            assert breaker.check("finviz", "US") == "open"
+
+    def test_half_open_success_closes_circuit(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 2
+            s.circuit_breaker_cooldown_us = 0
+            breaker = _no_redis()
+            breaker.record_429("finviz", "US")
+            breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "half_open_probe"
+            breaker.record_success("finviz", "US")
+            assert breaker.check("finviz", "US") == "closed"
+
+    def test_half_open_failure_reopens(self):
+        # Use a non-zero cooldown so we can observe the "open" gate before
+        # the auto-promotion path fires again.
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 2
+            s.circuit_breaker_cooldown_us = 0  # first promotion immediate
+            breaker = _no_redis()
+            breaker.record_429("finviz", "US")
+            breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "half_open_probe"
+            # Once the probe fires, raise the cooldown so a subsequent 429
+            # actually pauses the breaker rather than instantly re-promoting.
+            s.circuit_breaker_cooldown_us = 60
+            breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "open"
+
+    def test_disabled_breaker_always_closed(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = False
+            s.circuit_breaker_threshold = 1
+            s.circuit_breaker_cooldown_us = 60
+            breaker = _no_redis()
+            for _ in range(10):
+                breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "closed"
+
+
+class TestPerMarketIsolation:
+    def test_different_markets_dont_share_state(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 2
+            s.circuit_breaker_cooldown_us = 60
+            s.circuit_breaker_cooldown_hk = 60
+            breaker = _no_redis()
+            # Trip US.
+            breaker.record_429("finviz", "US")
+            breaker.record_429("finviz", "US")
+            assert breaker.check("finviz", "US") == "open"
+            # HK still closed.
+            assert breaker.check("finviz", "HK") == "closed"
+
+    def test_different_providers_dont_share_state(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 2
+            s.circuit_breaker_cooldown_us = 60
+            breaker = _no_redis()
+            breaker.record_429("yfinance", "US")
+            breaker.record_429("yfinance", "US")
+            assert breaker.check("yfinance", "US") == "open"
+            assert breaker.check("finviz", "US") == "closed"
+
+
+class TestRaiseIfOpen:
+    def test_raises_when_open(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 1
+            s.circuit_breaker_cooldown_us = 60
+            breaker = _no_redis()
+            breaker.record_429("finviz", "US")
+            with pytest.raises(CircuitOpenError) as exc_info:
+                breaker.raise_if_open("finviz", "US")
+            assert exc_info.value.provider == "finviz"
+            assert exc_info.value.market == "US"
+
+    def test_returns_when_closed(self):
+        with patch("app.services.provider_circuit_breaker.settings") as s:
+            s.circuit_breaker_enabled = True
+            s.circuit_breaker_threshold = 3
+            s.circuit_breaker_cooldown_us = 60
+            breaker = _no_redis()
+            assert breaker.raise_if_open("finviz", "US") == "closed"
+
+
+class TestKeyHelpers:
+    def test_state_key_format(self):
+        assert ProviderCircuitBreaker.state_key("finviz", "US") == "circuit:finviz:us"
+        assert ProviderCircuitBreaker.state_key("yfinance", "HK") == "circuit:yfinance:hk"
+        assert ProviderCircuitBreaker.state_key("finviz", None) == "circuit:finviz:shared"
+
+    def test_probe_key_distinct_from_state(self):
+        assert ProviderCircuitBreaker.probe_key("finviz", "US") != ProviderCircuitBreaker.state_key("finviz", "US")

--- a/backend/tests/unit/test_rate_budget_policy.py
+++ b/backend/tests/unit/test_rate_budget_policy.py
@@ -89,7 +89,10 @@ class TestRateInterval:
 
 class TestBatchSize:
     @pytest.mark.parametrize("market,expected_default", [
-        ("US", 50), ("HK", 50), ("JP", 50), ("TW", 50),
+        # US bumped to 150 in steady-crunching-candle: Yahoo accepts up to
+        # MAX_PRICE_BATCH_SIZE (200) and the adaptive shrink halves on
+        # transient failure. Non-US markets stay at 50 (smaller universes).
+        ("US", 150), ("HK", 50), ("JP", 50), ("TW", 50),
     ])
     def test_default_batch_sizes(self, market, expected_default):
         with patch("app.services.rate_budget_policy.settings") as mock_settings:


### PR DESCRIPTION
## Summary

Implements a distributed circuit breaker for transient provider rate-limiting (429 errors) and adds per-market rate budgeting to prevent cross-market starvation. The circuit breaker trips after N consecutive 429s, short-circuits doomed calls during cooldown, and auto-recovers via a half-open probe state. Per-market rate limiting ensures that a 429 storm on one market (e.g., finviz:HK) doesn't pause unaffected markets (e.g., finviz:US).

## Key Changes

- **Provider Circuit Breaker** (`provider_circuit_breaker.py`):
  - Distributed state machine (closed → open → half-open → closed/open) stored in Redis
  - Per-(provider, market) isolation: `finviz:us` circuit open doesn't affect `finviz:hk`
  - Lua script for atomic state checks and auto-promotion after cooldown
  - Falls back silently to in-process state when Redis unavailable
  - Configurable threshold (default 3 consecutive 429s) and per-market cooldown windows (US: 120s, others: 300s)
  - Raises `CircuitOpenError` (subclass of `RateLimitTimeoutError`) when open

- **Per-Market Rate Limiting**:
  - `RedisRateLimiter.wait_for_market(provider, market)` routes to market-specific keys (`finviz:us`, `finviz:hk`, etc.)
  - `FinvizService.get_finviz_only_fields()` and batch methods accept optional `market` parameter
  - `HybridFundamentalsService` passes market context through finviz calls and respects circuit breaker state
  - `BulkDataFetcher.fetch_prices_in_batches()` checks circuit breaker and bails early when market is open

- **Parallel Finviz Fetching**:
  - `FinvizService.get_finviz_only_fields_batch()` uses `ThreadPoolExecutor` for concurrent symbol fetching
  - Worker count resolved via `RateBudgetPolicy.get_provider_workers()` when not explicitly provided
  - Per-market defaults: US=4 workers, others=2 (Redis rate limiter still serializes egress, so concurrency only fills HTTP RTT idle time)
  - Stops early and fills remaining symbols with `None` if circuit opens mid-batch

- **Rate Budget Policy Updates**:
  - Increased yfinance US batch size from 50 → 150 (adaptive shrink handles transient failures)
  - Tightened yfinance:batch interval from 5.0s → 2.0s (one HTTP round-trip per batch)
  - Added per-market worker count defaults for finviz

- **yfinance curl_cffi Integration** (`yf_session.py`):
  - Process-wide lazy-initialized curl_cffi session to impersonate browser TLS fingerprint
  - Reduces 429 rate and avoids per-call crumb refetch cost
  - Falls back silently when curl_cffi unavailable or disabled
  - Thread-safe singleton (safe for Celery solo pool)

- **Configuration** (`settings.py`):
  - `circuit_breaker_enabled`, `circuit_breaker_threshold`
  - Per-market cooldown overrides: `circuit_breaker_cooldown_{market}`
  - Per-market finviz worker overrides: `finviz_workers_{market}`
  - `yfinance_use_curl_cffi`, `yfinance_curl_cffi_impersonate`

- **Tests**:
  - Unit tests for circuit breaker state machine (closed → open → half-open transitions)
  - Per-market and per-provider isolation tests
  - Parallel finviz batch tests verifying threadpool concurrency and per-market serialization
  - Rate budget policy worker count resolution tests

## Notable Implementation Details

- Circuit breaker state is per-(provider, market), enabling independent recovery windows
- Half-open state admits exactly one probe call via Redis SETNX; concurrent probes are rejected

https://claude.ai/code/session_01VcFsC26pTs5ytzUrW5JgGG
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
