### PR TITLE
[codex] Optimize breadth and group rank backfills

### DIFF
--- a/backend/app/services/breadth_calculator_service.py
+++ b/backend/app/services/breadth_calculator_service.py
@@ -6,6 +6,7 @@ in the universe, including daily movers, multi-period ratios, and
 monthly/quarterly performance indicators.
 """
 import logging
+import math
 from collections import deque
 from typing import Dict, Optional, List
 from datetime import date, datetime, timedelta
@@ -312,7 +313,7 @@ class BreadthCalculatorService:
         prices_df = prices_df.sort_index()
         close = prices_df["Close"]
         pct_changes = {
-            days: close.pct_change(periods=days).mul(100).round(2).replace(
+            days: close.pct_change(periods=days, fill_method=None).mul(100).round(2).replace(
                 [float("inf"), float("-inf")],
                 0.0,
             )
@@ -349,7 +350,7 @@ class BreadthCalculatorService:
             value = series.iloc[latest_idx]
         except IndexError:
             return 0.0
-        if pd.isna(value):
+        if pd.isna(value) or not math.isfinite(float(value)):
             return 0.0
         return float(value)
 

--- a/backend/app/services/breadth_calculator_service.py
+++ b/backend/app/services/breadth_calculator_service.py
@@ -489,16 +489,10 @@ class BreadthCalculatorService:
         cache_only: bool,
     ) -> tuple[Dict[str, Optional[pd.DataFrame]], List[str]]:
         """Load batch price histories once, with optional cache misses fetched a single time."""
-        if cache_only:
-            price_data_by_symbol = self.price_cache.get_many_cached_only_fresh(
-                batch_symbols,
-                period="2y",
-            )
-        else:
-            price_data_by_symbol = self.price_cache.get_many_cached_only(
-                batch_symbols,
-                period="2y",
-            )
+        price_data_by_symbol = self.price_cache.get_many_cached_only_fresh(
+            batch_symbols,
+            period="2y",
+        )
         cache_miss_symbols: List[str] = []
 
         if cache_only:

--- a/backend/app/services/breadth_calculator_service.py
+++ b/backend/app/services/breadth_calculator_service.py
@@ -236,14 +236,11 @@ class BreadthCalculatorService:
                     if price_history is None or price_history.empty:
                         continue
 
-                    for calc_date in ordered_dates:
-                        stock_metrics = self._calculate_stock_metrics_from_prices(
-                            prices_df=price_history,
-                            end_date=calc_date,
-                        )
-                        if stock_metrics is None:
-                            continue
-
+                    stock_metrics_by_date = self._calculate_stock_metrics_by_date_from_prices(
+                        prices_df=price_history,
+                        calculation_dates=ordered_dates,
+                    )
+                    for calc_date, stock_metrics in stock_metrics_by_date.items():
                         daily_metrics = metrics_by_date[calc_date]
                         self._apply_stock_metrics(daily_metrics, stock_metrics)
                         daily_metrics['total_stocks_scanned'] += 1
@@ -253,25 +250,35 @@ class BreadthCalculatorService:
                         metrics_by_date[calc_date]['error_stocks'] += 1
 
         prior_counts = self._get_prior_breadth_counts(ordered_dates[0], limit=10)
+        existing_counts = self._get_existing_breadth_counts_by_date(
+            ordered_dates[0],
+            ordered_dates[-1],
+        )
         rolling_counts = deque(prior_counts, maxlen=10)
 
         processed_dates: list[date] = []
         error_dates: list[str] = []
 
-        for calc_date in ordered_dates:
-            metrics = metrics_by_date[calc_date]
-            ratios = self._calculate_ratios_from_counts(list(rolling_counts))
-            metrics['ratio_5day'] = ratios['ratio_5day']
-            metrics['ratio_10day'] = ratios['ratio_10day']
+        requested_dates = set(ordered_dates)
+        timeline_dates = sorted(set(existing_counts.keys()) | requested_dates)
+        for calc_date in timeline_dates:
+            if calc_date in requested_dates:
+                metrics = metrics_by_date[calc_date]
+                ratios = self._calculate_ratios_from_counts(list(rolling_counts))
+                metrics['ratio_5day'] = ratios['ratio_5day']
+                metrics['ratio_10day'] = ratios['ratio_10day']
 
-            if metrics['total_stocks_scanned'] > 0:
-                processed_dates.append(calc_date)
-                rolling_counts.append({
-                    'stocks_up_4pct': metrics['stocks_up_4pct'],
-                    'stocks_down_4pct': metrics['stocks_down_4pct'],
-                })
-            else:
-                error_dates.append(calc_date.strftime('%Y-%m-%d'))
+                if metrics['total_stocks_scanned'] > 0:
+                    processed_dates.append(calc_date)
+                    rolling_counts.append({
+                        'stocks_up_4pct': metrics['stocks_up_4pct'],
+                        'stocks_down_4pct': metrics['stocks_down_4pct'],
+                    })
+                else:
+                    error_dates.append(calc_date.strftime('%Y-%m-%d'))
+                continue
+
+            rolling_counts.append(existing_counts[calc_date])
 
         if processed_dates:
             total_duration_seconds = (datetime.now() - start_time).total_seconds()
@@ -292,6 +299,59 @@ class BreadthCalculatorService:
             'errors': len(error_dates),
             'error_dates': error_dates,
         }
+
+    def _calculate_stock_metrics_by_date_from_prices(
+        self,
+        prices_df: Optional[pd.DataFrame],
+        calculation_dates: List[date],
+    ) -> Dict[date, Dict]:
+        """Vectorized per-symbol breadth metrics for multiple dates."""
+        if prices_df is None or prices_df.empty or "Close" not in prices_df.columns:
+            return {}
+
+        prices_df = prices_df.sort_index()
+        close = prices_df["Close"]
+        pct_changes = {
+            days: close.pct_change(periods=days).mul(100).round(2).replace(
+                [float("inf"), float("-inf")],
+                0.0,
+            )
+            for days in (1, 21, 34, 63)
+        }
+
+        metrics_by_date: Dict[date, Dict] = {}
+        for calc_date in calculation_dates:
+            end_ts = self._timestamp_for_index(calc_date, prices_df.index)
+            latest_idx = prices_df.index.searchsorted(end_ts, side='right') - 1
+            if latest_idx < 69:
+                logger.debug(f"Insufficient cached data through {calc_date}: {latest_idx + 1} days")
+                continue
+
+            metrics_by_date[calc_date] = {
+                'pct_change_1d': self._pct_change_at_index(pct_changes[1], latest_idx),
+                'pct_change_21d': self._pct_change_at_index(pct_changes[21], latest_idx),
+                'pct_change_34d': self._pct_change_at_index(pct_changes[34], latest_idx),
+                'pct_change_63d': self._pct_change_at_index(pct_changes[63], latest_idx),
+            }
+
+        return metrics_by_date
+
+    @staticmethod
+    def _timestamp_for_index(item_date: date, index) -> pd.Timestamp:
+        timestamp = pd.Timestamp(item_date)
+        if isinstance(index, pd.DatetimeIndex) and index.tz is not None and timestamp.tz is None:
+            return timestamp.tz_localize(index.tz)
+        return timestamp
+
+    @staticmethod
+    def _pct_change_at_index(series: pd.Series, latest_idx: int) -> float:
+        try:
+            value = series.iloc[latest_idx]
+        except IndexError:
+            return 0.0
+        if pd.isna(value):
+            return 0.0
+        return float(value)
 
     def _calculate_stock_metrics_from_prices(
         self,
@@ -478,6 +538,21 @@ class BreadthCalculatorService:
             for record in ordered_records
         ]
 
+    def _get_existing_breadth_counts_by_date(self, start_date: date, end_date: date) -> Dict[date, Dict[str, int]]:
+        """Fetch existing breadth counts inside a sparse backfill window."""
+        records = self.db.query(MarketBreadth).filter(
+            MarketBreadth.date >= start_date,
+            MarketBreadth.date <= end_date,
+            MarketBreadth.market == self.market,
+        ).order_by(MarketBreadth.date.asc()).all()
+        return {
+            record.date: {
+                'stocks_up_4pct': record.stocks_up_4pct,
+                'stocks_down_4pct': record.stocks_down_4pct,
+            }
+            for record in records
+        }
+
     def _calculate_ratios_from_counts(self, prior_counts: List[Dict[str, int]]) -> Dict:
         """Calculate 5-day and 10-day ratios from prior daily counts."""
         if len(prior_counts) < 5:
@@ -630,35 +705,13 @@ class BreadthCalculatorService:
                 'error_dates': []
             }
 
-        logger.info(f"Filling {len(missing_dates)} missing breadth dates")
-
-        stats = {
-            'total_dates': len(missing_dates),
-            'processed': 0,
-            'errors': 0,
-            'error_dates': []
-        }
-
-        # Process oldest first for ratio calculation accuracy
-        for calc_date in sorted(missing_dates):
-            try:
-                # Calculate breadth for this date
-                metrics = self.calculate_daily_breadth(calculation_date=calc_date)
-
-                if metrics and metrics.get('total_stocks_scanned', 0) > 0:
-                    # Store the record
-                    self._store_breadth_record(calc_date, metrics)
-                    stats['processed'] += 1
-                    logger.debug(f"Filled gap for {calc_date}: {metrics['total_stocks_scanned']} stocks")
-                else:
-                    stats['errors'] += 1
-                    stats['error_dates'].append(calc_date.strftime('%Y-%m-%d'))
-                    logger.warning(f"No data for {calc_date}")
-
-            except Exception as e:
-                stats['errors'] += 1
-                stats['error_dates'].append(calc_date.strftime('%Y-%m-%d'))
-                logger.error(f"Error filling gap for {calc_date}: {e}")
+        ordered_dates = sorted(missing_dates)
+        logger.info(f"Filling {len(ordered_dates)} missing breadth dates")
+        stats = self.backfill_range(
+            ordered_dates[0],
+            ordered_dates[-1],
+            trading_dates=ordered_dates,
+        )
 
         logger.info(
             f"Gap-fill complete: {stats['processed']} processed, "

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -5,11 +5,13 @@ Calculates daily rankings based on average RS rating of constituent stocks.
 """
 import logging
 import statistics
-from typing import Optional, Dict, List
+from dataclasses import dataclass
+from typing import Any, Optional, Dict, List
 from datetime import datetime, date, timedelta
 import pandas as pd
 from sqlalchemy.orm import Session
 from sqlalchemy import and_, desc
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from ..models.industry import IBDGroupRank
 from ..models.stock_universe import StockUniverse
@@ -42,6 +44,18 @@ class MissingIBDIndustryMappingsError(RuntimeError):
 
     def __init__(self) -> None:
         super().__init__("IBD industry mappings are not loaded")
+
+
+@dataclass(frozen=True)
+class GroupRankPrefetchData:
+    """Cached inputs shared by daily, backfill, and gap-fill group rank runs."""
+
+    benchmark_prices: Optional[pd.DataFrame]
+    prices_by_symbol: Dict[str, Optional[pd.DataFrame]]
+    active_symbols: set[str]
+    market_caps: Dict[str, float]
+    stats: Dict[str, Any]
+    symbols_by_group: Dict[str, List[str]]
 
 
 class IBDGroupRankService:
@@ -108,13 +122,14 @@ class IBDGroupRankService:
         )
 
         # Pre-fetch all data upfront (benchmark + all stock prices).
-        spy_data, all_prices, active_symbols, market_caps, prefetch_stats = (
+        prefetch = self._coerce_prefetch_data(
             self._prefetch_all_data(
                 db,
                 market=normalized_market,
                 cache_only=cache_only,
             )
         )
+        prefetch_stats = prefetch.stats
 
         if require_complete_cache:
             if not prefetch_stats.get("spy_cached"):
@@ -130,29 +145,37 @@ class IBDGroupRankService:
                     cache_miss_symbols, target_symbols, miss_ratio * 100,
                 )
 
-        if spy_data is None or spy_data.empty:
+        if prefetch.benchmark_prices is None or prefetch.benchmark_prices.empty:
             logger.error(
                 "Failed to get benchmark data for market %s", normalized_market,
             )
             return []
 
-        # Filter benchmark data to calculation_date for accurate historical rankings
-        if calculation_date < datetime.now().date():
-            spy_data_filtered = spy_data[spy_data.index.date <= calculation_date]
-        else:
-            spy_data_filtered = spy_data
-
-        # Prepare benchmark prices series (most recent first for RS calculator)
-        spy_prices = spy_data_filtered['Close'].sort_index(ascending=False)
+        rs_by_date = self._calculate_rs_by_symbol_for_dates(
+            prefetch,
+            [calculation_date],
+        )
+        rs_by_symbol = rs_by_date.get(calculation_date, {})
 
         # Calculate RS for each group using pre-fetched cached data
         group_metrics = []
 
         for group_name in all_groups:
             try:
-                metrics = self._calculate_group_rs_from_cache(
-                    db, group_name, spy_prices, all_prices, active_symbols, market_caps, calculation_date,
-                    market=normalized_market,
+                symbols = prefetch.symbols_by_group.get(group_name)
+                if symbols is None:
+                    symbols = self._get_validated_group_symbols(
+                        db,
+                        group_name,
+                        prefetch.active_symbols,
+                        market=normalized_market,
+                    )
+                metrics = self._calculate_group_metrics_from_rs(
+                    group_name,
+                    symbols,
+                    rs_by_symbol,
+                    prefetch.market_caps,
+                    calculation_date,
                 )
                 if metrics:
                     group_metrics.append(metrics)
@@ -309,41 +332,40 @@ class IBDGroupRankService:
         ``(industry_group, date, market)``.
         """
         try:
-            for metrics in group_metrics:
-                existing = db.query(IBDGroupRank).filter(
-                    and_(
-                        IBDGroupRank.industry_group == metrics['industry_group'],
-                        IBDGroupRank.date == calculation_date,
-                        IBDGroupRank.market == market,
-                    )
-                ).first()
+            values = [
+                self._ranking_values(calculation_date, metrics, market=market)
+                for metrics in group_metrics
+            ]
+            if not values:
+                db.commit()
+                return
 
-                if existing:
-                    existing.rank = metrics['rank']
-                    existing.avg_rs_rating = metrics['avg_rs_rating']
-                    existing.num_stocks = metrics['num_stocks']
-                    existing.num_stocks_rs_above_80 = metrics['num_stocks_rs_above_80']
-                    existing.top_symbol = metrics['top_symbol']
-                    existing.top_rs_rating = metrics['top_rs_rating']
-                    existing.median_rs_rating = metrics.get('median_rs_rating')
-                    existing.weighted_avg_rs_rating = metrics.get('weighted_avg_rs_rating')
-                    existing.rs_std_dev = metrics.get('rs_std_dev')
-                else:
-                    record = IBDGroupRank(
-                        market=market,
-                        industry_group=metrics['industry_group'],
-                        date=calculation_date,
-                        rank=metrics['rank'],
-                        avg_rs_rating=metrics['avg_rs_rating'],
-                        median_rs_rating=metrics.get('median_rs_rating'),
-                        weighted_avg_rs_rating=metrics.get('weighted_avg_rs_rating'),
-                        rs_std_dev=metrics.get('rs_std_dev'),
-                        num_stocks=metrics['num_stocks'],
-                        num_stocks_rs_above_80=metrics['num_stocks_rs_above_80'],
-                        top_symbol=metrics['top_symbol'],
-                        top_rs_rating=metrics['top_rs_rating'],
+            bind = db.get_bind()
+            if bind is not None and bind.dialect.name == "postgresql":
+                stmt = pg_insert(IBDGroupRank).values(values)
+                db.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=["industry_group", "date", "market"],
+                        set_={
+                            "rank": stmt.excluded.rank,
+                            "avg_rs_rating": stmt.excluded.avg_rs_rating,
+                            "median_rs_rating": stmt.excluded.median_rs_rating,
+                            "weighted_avg_rs_rating": stmt.excluded.weighted_avg_rs_rating,
+                            "rs_std_dev": stmt.excluded.rs_std_dev,
+                            "num_stocks": stmt.excluded.num_stocks,
+                            "num_stocks_rs_above_80": stmt.excluded.num_stocks_rs_above_80,
+                            "top_symbol": stmt.excluded.top_symbol,
+                            "top_rs_rating": stmt.excluded.top_rs_rating,
+                        },
                     )
-                    db.add(record)
+                )
+            else:
+                self._store_rankings_sqlalchemy_fallback(
+                    db,
+                    calculation_date,
+                    values,
+                    market=market,
+                )
 
             db.commit()
             logger.info(
@@ -355,6 +377,57 @@ class IBDGroupRankService:
             logger.error(f"Error storing rankings: {e}", exc_info=True)
             db.rollback()
             raise
+
+    @staticmethod
+    def _ranking_values(calculation_date: date, metrics: Dict, *, market: str) -> Dict[str, Any]:
+        return {
+            "market": market,
+            "industry_group": metrics["industry_group"],
+            "date": calculation_date,
+            "rank": metrics["rank"],
+            "avg_rs_rating": metrics["avg_rs_rating"],
+            "median_rs_rating": metrics.get("median_rs_rating"),
+            "weighted_avg_rs_rating": metrics.get("weighted_avg_rs_rating"),
+            "rs_std_dev": metrics.get("rs_std_dev"),
+            "num_stocks": metrics["num_stocks"],
+            "num_stocks_rs_above_80": metrics["num_stocks_rs_above_80"],
+            "top_symbol": metrics["top_symbol"],
+            "top_rs_rating": metrics["top_rs_rating"],
+        }
+
+    def _store_rankings_sqlalchemy_fallback(
+        self,
+        db: Session,
+        calculation_date: date,
+        values: List[Dict[str, Any]],
+        *,
+        market: str,
+    ) -> None:
+        """SQLite-compatible bulk upsert fallback for tests/local tools."""
+        group_names = [value["industry_group"] for value in values]
+        existing_records = db.query(IBDGroupRank).filter(
+            and_(
+                IBDGroupRank.industry_group.in_(group_names),
+                IBDGroupRank.date == calculation_date,
+                IBDGroupRank.market == market,
+            )
+        ).all()
+        existing_by_group = {record.industry_group: record for record in existing_records}
+
+        for value in values:
+            existing = existing_by_group.get(value["industry_group"])
+            if existing:
+                existing.rank = value["rank"]
+                existing.avg_rs_rating = value["avg_rs_rating"]
+                existing.num_stocks = value["num_stocks"]
+                existing.num_stocks_rs_above_80 = value["num_stocks_rs_above_80"]
+                existing.top_symbol = value["top_symbol"]
+                existing.top_rs_rating = value["top_rs_rating"]
+                existing.median_rs_rating = value.get("median_rs_rating")
+                existing.weighted_avg_rs_rating = value.get("weighted_avg_rs_rating")
+                existing.rs_std_dev = value.get("rs_std_dev")
+            else:
+                db.add(IBDGroupRank(**value))
 
     def get_current_rankings(
         self,
@@ -396,12 +469,14 @@ class IBDGroupRankService:
         if not rankings:
             return []
 
-        # Get historical dates for rank changes
+        # Calendar-day target offsets for rank changes. The lookup below picks
+        # the closest stored ranking within a small window; these are not exact
+        # trading-session offsets.
         period_days = {
-            '1w': 5,    # 5 trading days
-            '1m': 21,   # ~1 month
-            '3m': 63,   # ~3 months
-            '6m': 126,  # ~6 months
+            '1w': 5,
+            '1m': 21,
+            '3m': 63,
+            '6m': 126,
         }
 
         # Batch fetch all historical ranks in ONE query instead of 197*4=788 queries
@@ -489,7 +564,8 @@ class IBDGroupRankService:
         if not group_names or not period_days:
             return {}
 
-        # Calculate date range covering all periods (max period + 7-day buffer)
+        # Calculate calendar-date range covering all target offsets plus the
+        # closest-record match window.
         max_days = max(period_days.values())
         earliest_date = current_date - timedelta(days=max_days + 7)
 
@@ -526,7 +602,7 @@ class IBDGroupRankService:
             for period_name, days in period_days.items():
                 target_date = current_date - timedelta(days=days)
 
-                # Filter to records within 7-day window of target
+                # Filter to records within a 7-calendar-day window of target
                 candidates = [
                     (d, r) for d, r in history
                     if abs((d - target_date).days) <= 7
@@ -572,7 +648,7 @@ class IBDGroupRankService:
         # Current (most recent) data
         current = records[0]
 
-        # Get rank changes
+        # Get rank changes using calendar-day target offsets with closest-record matching.
         period_days = {'1w': 5, '1m': 21, '3m': 63, '6m': 126}
         rank_changes = {}
 
@@ -800,13 +876,28 @@ class IBDGroupRankService:
         count = count_above_80 or 0
         return round((count / total_count) * 100, 1)
 
+    @staticmethod
+    def _coerce_prefetch_data(prefetch: Any) -> GroupRankPrefetchData:
+        """Accept legacy test tuples while the service uses a named prefetch object."""
+        if isinstance(prefetch, GroupRankPrefetchData):
+            return prefetch
+        spy_data, all_prices, active_symbols, market_caps, stats = prefetch
+        return GroupRankPrefetchData(
+            benchmark_prices=spy_data,
+            prices_by_symbol=all_prices,
+            active_symbols=active_symbols,
+            market_caps=market_caps,
+            stats=stats,
+            symbols_by_group={},
+        )
+
     def _prefetch_all_data(
         self,
         db: Session,
         *,
         market: str | None = None,
         cache_only: bool = False,
-    ) -> tuple:
+    ) -> GroupRankPrefetchData:
         """
         Pre-fetch all data needed for backfill in one batch.
 
@@ -839,12 +930,19 @@ class IBDGroupRankService:
                 "Failed to get benchmark data (%s) for market %s",
                 benchmark_symbol, normalized_market,
             )
-            return None, {}, set(), {}, {
-                "target_symbols": 0,
-                "symbols_with_prices": 0,
-                "cache_miss_symbols": 0,
-                "spy_cached": False,
-            }
+            return GroupRankPrefetchData(
+                benchmark_prices=None,
+                prices_by_symbol={},
+                active_symbols=set(),
+                market_caps={},
+                stats={
+                    "target_symbols": 0,
+                    "symbols_with_prices": 0,
+                    "cache_miss_symbols": 0,
+                    "spy_cached": False,
+                },
+                symbols_by_group={},
+            )
 
         logger.info(f"Fetched benchmark {benchmark_symbol}: {len(spy_data)} days")
 
@@ -859,6 +957,7 @@ class IBDGroupRankService:
         # 3. Collect ALL unique symbols across ALL groups for this market
         all_groups = IBDIndustryService.get_all_groups(db, market=normalized_market)
         symbols_to_fetch = set()
+        symbols_by_group: Dict[str, List[str]] = {}
         skipped_unsupported_symbols = set()
 
         for group in all_groups:
@@ -871,6 +970,7 @@ class IBDGroupRankService:
                     skipped_unsupported_symbols.add(symbol)
                     continue
                 validated.append(symbol)
+            symbols_by_group[group] = validated
             symbols_to_fetch.update(validated)
 
         logger.info(
@@ -903,7 +1003,14 @@ class IBDGroupRankService:
             "skipped_unsupported_symbols": len(skipped_unsupported_symbols),
         }
 
-        return spy_data, all_prices, active_symbols, market_caps, stats
+        return GroupRankPrefetchData(
+            benchmark_prices=spy_data,
+            prices_by_symbol=all_prices,
+            active_symbols=active_symbols,
+            market_caps=market_caps,
+            stats=stats,
+            symbols_by_group=symbols_by_group,
+        )
 
     def _delete_rankings_for_range(
         self,
@@ -1042,6 +1149,162 @@ class IBDGroupRankService:
             'top_rs_rating': round(top_rs, 2) if top_rs > 0 else None,
         }
 
+    def _calculate_rs_by_symbol_for_dates(
+        self,
+        prefetch: GroupRankPrefetchData,
+        calculation_dates: List[date],
+    ) -> Dict[date, Dict[str, float]]:
+        """Precompute RS ratings once per symbol/date for group aggregation."""
+        ordered_dates = sorted(calculation_dates)
+        result: Dict[date, Dict[str, float]] = {calc_date: {} for calc_date in ordered_dates}
+        benchmark_close = self._close_series(prefetch.benchmark_prices)
+        if benchmark_close is None:
+            return result
+
+        periods = self.rs_calculator.PERIODS
+        max_period = max(periods.keys())
+        benchmark_returns = self._period_returns(benchmark_close, periods.keys())
+        benchmark_positions = self._positions_by_date(benchmark_close.index, ordered_dates)
+
+        for symbol, prices in prefetch.prices_by_symbol.items():
+            close = self._close_series(prices)
+            if close is None:
+                continue
+
+            symbol_returns = self._period_returns(close, periods.keys())
+            symbol_positions = self._positions_by_date(close.index, ordered_dates)
+            for calc_date in ordered_dates:
+                latest_idx = symbol_positions.get(calc_date, -1)
+                if latest_idx < max_period - 1:
+                    continue
+
+                benchmark_idx = benchmark_positions.get(calc_date, -1)
+                weighted_performance = 0.0
+                total_weight = 0.0
+                for period, weight in periods.items():
+                    if benchmark_idx < period - 1:
+                        continue
+                    stock_return = self._series_value_at(symbol_returns[period], latest_idx)
+                    benchmark_return = self._series_value_at(benchmark_returns[period], benchmark_idx)
+                    if stock_return is None or benchmark_return is None:
+                        continue
+                    weighted_performance += (stock_return - benchmark_return) * weight
+                    total_weight += weight
+
+                if total_weight == 0:
+                    continue
+
+                relative_performance = weighted_performance / total_weight
+                rs_rating = self._scale_relative_performance_to_rs(relative_performance)
+                if rs_rating > 0:
+                    result[calc_date][symbol] = rs_rating
+
+        return result
+
+    @staticmethod
+    def _close_series(prices: Optional[pd.DataFrame]) -> Optional[pd.Series]:
+        if prices is None or prices.empty or "Close" not in prices.columns:
+            return None
+        close = prices["Close"].sort_index()
+        return close
+
+    @staticmethod
+    def _period_returns(close: pd.Series, periods) -> Dict[int, pd.Series]:
+        return {
+            period: close.pct_change(periods=period - 1)
+            for period in periods
+        }
+
+    @staticmethod
+    def _positions_by_date(index, calculation_dates: List[date]) -> Dict[date, int]:
+        positions: Dict[date, int] = {}
+        for calc_date in calculation_dates:
+            exclusive_end = pd.Timestamp(calc_date) + pd.Timedelta(days=1)
+            if isinstance(index, pd.DatetimeIndex) and index.tz is not None and exclusive_end.tz is None:
+                exclusive_end = exclusive_end.tz_localize(index.tz)
+            positions[calc_date] = index.searchsorted(exclusive_end, side="left") - 1
+        return positions
+
+    @staticmethod
+    def _series_value_at(series: pd.Series, index: int) -> Optional[float]:
+        try:
+            value = series.iloc[index]
+        except IndexError:
+            return None
+        if pd.isna(value):
+            return None
+        return float(value)
+
+    @staticmethod
+    def _scale_relative_performance_to_rs(relative_performance: float) -> float:
+        if relative_performance >= 0:
+            rs_rating = min(100, 50 + (relative_performance * 100))
+        else:
+            rs_rating = max(0, 50 + (relative_performance * 100))
+        return round(rs_rating, 2)
+
+    def _calculate_group_metrics_from_rs(
+        self,
+        group_name: str,
+        symbols: List[str],
+        rs_by_symbol: Dict[str, float],
+        market_caps: Dict[str, float],
+        calculation_date: date,
+    ) -> Optional[Dict]:
+        """Aggregate precomputed per-symbol RS ratings into one group metric row."""
+        if not symbols:
+            logger.debug(f"No validated symbols found for group: {group_name}")
+            return None
+
+        rs_ratings = []
+        top_symbol = None
+        top_rs = -1
+        rs_above_80_count = 0
+        weighted_sum = 0.0
+        weighted_total = 0.0
+
+        for symbol in symbols:
+            rs_rating = rs_by_symbol.get(symbol)
+            if rs_rating is None or rs_rating <= 0:
+                continue
+
+            rs_ratings.append(rs_rating)
+            if rs_rating > top_rs:
+                top_rs = rs_rating
+                top_symbol = symbol
+            if rs_rating >= 80:
+                rs_above_80_count += 1
+
+            market_cap = market_caps.get(symbol)
+            if market_cap:
+                weighted_sum += rs_rating * market_cap
+                weighted_total += market_cap
+
+        if len(rs_ratings) < 3:
+            logger.debug(
+                f"Insufficient data for group {group_name}: "
+                f"only {len(rs_ratings)} stocks with valid RS"
+            )
+            return None
+
+        avg_rs = sum(rs_ratings) / len(rs_ratings)
+        median_rs = statistics.median(rs_ratings)
+        rs_std_dev = statistics.pstdev(rs_ratings) if len(rs_ratings) > 1 else None
+        weighted_avg_rs = (weighted_sum / weighted_total) if weighted_total > 0 else None
+
+        return {
+            'industry_group': group_name,
+            'date': calculation_date,
+            'avg_rs_rating': round(avg_rs, 2),
+            'median_rs_rating': round(median_rs, 2),
+            'weighted_avg_rs_rating': round(weighted_avg_rs, 2) if weighted_avg_rs is not None else None,
+            'rs_std_dev': round(rs_std_dev, 2) if rs_std_dev is not None else None,
+            'num_stocks': len(rs_ratings),
+            'num_stocks_rs_above_80': rs_above_80_count,
+            'top_symbol': top_symbol,
+            'top_rs_rating': round(top_rs, 2) if top_rs > 0 else None,
+        }
+
     def backfill_rankings_optimized(
         self,
         db: Session,
@@ -1080,11 +1343,11 @@ class IBDGroupRankService:
         )
 
         # 2. Pre-fetch ALL data upfront
-        spy_data, all_prices, active_symbols, market_caps, _prefetch_stats = (
+        prefetch = self._coerce_prefetch_data(
             self._prefetch_all_data(db, market=normalized_market)
         )
 
-        if spy_data is None or spy_data.empty:
+        if prefetch.benchmark_prices is None or prefetch.benchmark_prices.empty:
             logger.error("Cannot proceed without SPY data")
             return {
                 'start_date': start_date.isoformat(),
@@ -1097,7 +1360,10 @@ class IBDGroupRankService:
                 'error': 'Failed to fetch SPY benchmark data',
             }
 
-        all_groups = IBDIndustryService.get_all_groups(db, market=normalized_market)
+        all_groups = list(prefetch.symbols_by_group) or IBDIndustryService.get_all_groups(
+            db,
+            market=normalized_market,
+        )
 
         # 3. Generate trading dates using the target market's calendar.
         from ..wiring.bootstrap import get_market_calendar_service
@@ -1112,36 +1378,26 @@ class IBDGroupRankService:
 
         logger.info(
             f"Processing {len(dates_to_process)} trading days with "
-            f"{len(all_prices)} symbols across {len(all_groups)} groups"
+            f"{len(prefetch.prices_by_symbol)} symbols across {len(all_groups)} groups"
         )
 
         processed = 0
         errors = 0
+        rs_by_date = self._calculate_rs_by_symbol_for_dates(prefetch, dates_to_process)
 
         # 4. Process each date using cached data
         for calc_date in dates_to_process:
             try:
-                # Filter SPY to calculation_date
-                spy_filtered = spy_data[spy_data.index.date <= calc_date]
-                if spy_filtered.empty:
-                    logger.warning(f"No SPY data for {calc_date}")
-                    errors += 1
-                    continue
-
-                spy_prices = spy_filtered['Close'].sort_index(ascending=False)
-
                 # Calculate RS for each group from cache
                 group_metrics = []
+                rs_by_symbol = rs_by_date.get(calc_date, {})
                 for group_name in all_groups:
-                    metrics = self._calculate_group_rs_from_cache(
-                        db,
+                    metrics = self._calculate_group_metrics_from_rs(
                         group_name,
-                        spy_prices,
-                        all_prices,
-                        active_symbols,
-                        market_caps,
+                        prefetch.symbols_by_group.get(group_name, []),
+                        rs_by_symbol,
+                        prefetch.market_caps,
                         calc_date,
-                        market=normalized_market,
                     )
                     if metrics:
                         group_metrics.append(metrics)
@@ -1413,11 +1669,11 @@ class IBDGroupRankService:
         start_time = datetime.now()
 
         # Pre-fetch ALL data upfront
-        spy_data, all_prices, active_symbols, market_caps, _prefetch_stats = (
+        prefetch = self._coerce_prefetch_data(
             self._prefetch_all_data(db, market=normalized_market)
         )
 
-        if spy_data is None or spy_data.empty:
+        if prefetch.benchmark_prices is None or prefetch.benchmark_prices.empty:
             logger.error("Cannot proceed without SPY data")
             return {
                 'total_dates': len(missing_dates),
@@ -1427,7 +1683,10 @@ class IBDGroupRankService:
                 'error': 'Failed to fetch SPY benchmark data',
             }
 
-        all_groups = IBDIndustryService.get_all_groups(db, market=normalized_market)
+        all_groups = list(prefetch.symbols_by_group) or IBDIndustryService.get_all_groups(
+            db,
+            market=normalized_market,
+        )
 
         stats = {
             'total_dates': len(missing_dates),
@@ -1436,29 +1695,20 @@ class IBDGroupRankService:
             'errors': 0,
         }
 
+        rs_by_date = self._calculate_rs_by_symbol_for_dates(prefetch, missing_dates)
+
         for calc_date in missing_dates:
             try:
-                # Filter SPY to calculation_date
-                spy_filtered = spy_data[spy_data.index.date <= calc_date]
-                if spy_filtered.empty:
-                    logger.warning(f"No SPY data for {calc_date}")
-                    stats['errors'] += 1
-                    continue
-
-                spy_prices = spy_filtered['Close'].sort_index(ascending=False)
-
                 # Calculate RS for each group from cache
                 group_metrics = []
+                rs_by_symbol = rs_by_date.get(calc_date, {})
                 for group_name in all_groups:
-                    metrics = self._calculate_group_rs_from_cache(
-                        db,
+                    metrics = self._calculate_group_metrics_from_rs(
                         group_name,
-                        spy_prices,
-                        all_prices,
-                        active_symbols,
-                        market_caps,
+                        prefetch.symbols_by_group.get(group_name, []),
+                        rs_by_symbol,
+                        prefetch.market_caps,
                         calc_date,
-                        market=normalized_market,
                     )
                     if metrics:
                         group_metrics.append(metrics)

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -160,20 +160,18 @@ class IBDGroupRankService:
 
         # Calculate RS for each group using pre-fetched cached data
         group_metrics = []
+        symbols_by_group = self._symbols_by_group_for_run(
+            db,
+            all_groups,
+            prefetch,
+            market=normalized_market,
+        )
 
         for group_name in all_groups:
             try:
-                symbols = prefetch.symbols_by_group.get(group_name)
-                if symbols is None:
-                    symbols = self._get_validated_group_symbols(
-                        db,
-                        group_name,
-                        prefetch.active_symbols,
-                        market=normalized_market,
-                    )
                 metrics = self._calculate_group_metrics_from_rs(
                     group_name,
-                    symbols,
+                    symbols_by_group.get(group_name, []),
                     rs_by_symbol,
                     prefetch.market_caps,
                     calculation_date,
@@ -892,6 +890,28 @@ class IBDGroupRankService:
             symbols_by_group={},
         )
 
+    def _symbols_by_group_for_run(
+        self,
+        db: Session,
+        group_names: List[str],
+        prefetch: GroupRankPrefetchData,
+        *,
+        market: str,
+    ) -> Dict[str, List[str]]:
+        """Return prefetched group symbols, or build them once for legacy prefetch tuples."""
+        symbols_by_group: Dict[str, List[str]] = {}
+        for group_name in group_names:
+            if group_name in prefetch.symbols_by_group:
+                symbols_by_group[group_name] = prefetch.symbols_by_group[group_name]
+            else:
+                symbols_by_group[group_name] = self._get_validated_group_symbols(
+                    db,
+                    group_name,
+                    prefetch.active_symbols,
+                    market=market,
+                )
+        return symbols_by_group
+
     def _prefetch_all_data(
         self,
         db: Session,
@@ -1384,6 +1404,12 @@ class IBDGroupRankService:
 
         processed = 0
         errors = 0
+        symbols_by_group = self._symbols_by_group_for_run(
+            db,
+            all_groups,
+            prefetch,
+            market=normalized_market,
+        )
         rs_by_date = self._calculate_rs_by_symbol_for_dates(prefetch, dates_to_process)
 
         # 4. Process each date using cached data
@@ -1395,7 +1421,7 @@ class IBDGroupRankService:
                 for group_name in all_groups:
                     metrics = self._calculate_group_metrics_from_rs(
                         group_name,
-                        prefetch.symbols_by_group.get(group_name, []),
+                        symbols_by_group.get(group_name, []),
                         rs_by_symbol,
                         prefetch.market_caps,
                         calc_date,
@@ -1696,6 +1722,12 @@ class IBDGroupRankService:
             'errors': 0,
         }
 
+        symbols_by_group = self._symbols_by_group_for_run(
+            db,
+            all_groups,
+            prefetch,
+            market=normalized_market,
+        )
         rs_by_date = self._calculate_rs_by_symbol_for_dates(prefetch, missing_dates)
 
         for calc_date in missing_dates:
@@ -1706,7 +1738,7 @@ class IBDGroupRankService:
                 for group_name in all_groups:
                     metrics = self._calculate_group_metrics_from_rs(
                         group_name,
-                        prefetch.symbols_by_group.get(group_name, []),
+                        symbols_by_group.get(group_name, []),
                         rs_by_symbol,
                         prefetch.market_caps,
                         calc_date,

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -4,6 +4,7 @@ Service for calculating and managing IBD Industry Group Rankings.
 Calculates daily rankings based on average RS rating of constituent stocks.
 """
 import logging
+import math
 import statistics
 from dataclasses import dataclass
 from typing import Any, Optional, Dict, List
@@ -1211,7 +1212,7 @@ class IBDGroupRankService:
     @staticmethod
     def _period_returns(close: pd.Series, periods) -> Dict[int, pd.Series]:
         return {
-            period: close.pct_change(periods=period - 1)
+            period: close.pct_change(periods=period - 1, fill_method=None)
             for period in periods
         }
 
@@ -1231,7 +1232,7 @@ class IBDGroupRankService:
             value = series.iloc[index]
         except IndexError:
             return None
-        if pd.isna(value):
+        if pd.isna(value) or not math.isfinite(float(value)):
             return None
         return float(value)
 

--- a/backend/tests/unit/test_breadth_calculator_service.py
+++ b/backend/tests/unit/test_breadth_calculator_service.py
@@ -144,7 +144,7 @@ def test_calculate_daily_breadth_preserves_historical_fetch_fallback(monkeypatch
     ]
 
     price_cache = MagicMock()
-    price_cache.get_many_cached_only.return_value = {
+    price_cache.get_many_cached_only_fresh.return_value = {
         "AAA": _make_price_df(date(2026, 3, 19), 100.0),
         "BBB": None,
     }
@@ -161,6 +161,8 @@ def test_calculate_daily_breadth_preserves_historical_fetch_fallback(monkeypatch
     assert metrics["total_stocks_scanned"] == 2
     assert metrics["cache_miss_stocks"] == 1
     assert metrics["skipped_stocks"] == 0
+    price_cache.get_many_cached_only_fresh.assert_called_once_with(["AAA", "BBB"], period="2y")
+    price_cache.get_many_cached_only.assert_not_called()
     price_cache.get_historical_data.assert_called_once_with(symbol="BBB", period="2y")
 
 
@@ -211,7 +213,7 @@ def test_backfill_range_reuses_loaded_histories_and_computes_chronological_ratio
     bbb_df.loc[pd.Timestamp(date(2026, 3, 13)), "Close"] = 100.0
 
     price_cache = MagicMock()
-    price_cache.get_many_cached_only.return_value = {"AAA": aaa_df, "BBB": None}
+    price_cache.get_many_cached_only_fresh.return_value = {"AAA": aaa_df, "BBB": None}
     price_cache.get_historical_data.return_value = bbb_df
     service = BreadthCalculatorService(db, price_cache)
     trading_dates = [date(2026, 3, 12), date(2026, 3, 13)]
@@ -224,7 +226,8 @@ def test_backfill_range_reuses_loaded_histories_and_computes_chronological_ratio
         "errors": 0,
         "error_dates": [],
     }
-    price_cache.get_many_cached_only.assert_called_once_with(["AAA", "BBB"], period="2y")
+    price_cache.get_many_cached_only_fresh.assert_called_once_with(["AAA", "BBB"], period="2y")
+    price_cache.get_many_cached_only.assert_not_called()
     price_cache.get_historical_data.assert_called_once_with(symbol="BBB", period="2y")
 
     stored = db.query(MarketBreadth).filter(
@@ -265,6 +268,7 @@ def test_backfill_range_fallback_uses_market_calendar(monkeypatch):
         "errors": 1,
         "error_dates": ["2026-03-13"],
     }
+    price_cache.get_many_cached_only_fresh.assert_not_called()
     price_cache.get_many_cached_only.assert_not_called()
 
 
@@ -279,7 +283,7 @@ def test_backfill_range_is_idempotent_for_existing_records(monkeypatch):
     down_df.loc[pd.Timestamp(date(2026, 3, 12)), "Close"] = 95.0
 
     price_cache = MagicMock()
-    price_cache.get_many_cached_only.side_effect = [
+    price_cache.get_many_cached_only_fresh.side_effect = [
         {"AAA": up_df},
         {"AAA": down_df},
     ]
@@ -380,6 +384,38 @@ def test_fill_gaps_delegates_to_single_backfill_range_call(monkeypatch):
     )
 
 
+def test_fill_gaps_refreshes_stale_cached_prices_before_counting():
+    db = _make_db_session()
+    db.add(StockUniverse(symbol="AAA", is_active=True, status=UNIVERSE_STATUS_ACTIVE))
+    db.commit()
+
+    trading_date = date(2026, 3, 12)
+    fresh_df = _flat_price_df(trading_date)
+    fresh_df.loc[pd.Timestamp(trading_date), "Close"] = 105.0
+
+    price_cache = MagicMock()
+    price_cache.get_many_cached_only.side_effect = AssertionError(
+        "gap fill must not use stale cache-only price data"
+    )
+    price_cache.get_many_cached_only_fresh.return_value = {"AAA": None}
+    price_cache.get_historical_data.return_value = fresh_df
+    service = BreadthCalculatorService(db, price_cache)
+
+    result = service.fill_gaps([trading_date])
+
+    assert result == {
+        "total_dates": 1,
+        "processed": 1,
+        "errors": 0,
+        "error_dates": [],
+    }
+    price_cache.get_many_cached_only_fresh.assert_called_once_with(["AAA"], period="2y")
+    price_cache.get_historical_data.assert_called_once_with(symbol="AAA", period="2y")
+    row = db.query(MarketBreadth).filter(MarketBreadth.date == trading_date).one()
+    assert row.stocks_up_4pct == 1
+    assert row.total_stocks_scanned == 1
+
+
 def test_backfill_range_sparse_dates_include_existing_intervening_counts_in_ratios():
     db = _make_db_session()
     db.add_all([
@@ -414,7 +450,7 @@ def test_backfill_range_sparse_dates_include_existing_intervening_counts_in_rati
         bbb_df.loc[pd.Timestamp(item_date), "Close"] = bbb_close
 
     price_cache = MagicMock()
-    price_cache.get_many_cached_only.return_value = {"AAA": aaa_df, "BBB": bbb_df}
+    price_cache.get_many_cached_only_fresh.return_value = {"AAA": aaa_df, "BBB": bbb_df}
     service = BreadthCalculatorService(db, price_cache)
 
     result = service.backfill_range(
@@ -457,7 +493,7 @@ def test_backfill_range_vectorized_changes_preserve_rounded_thresholds():
         price_data[symbol] = frame
 
     price_cache = MagicMock()
-    price_cache.get_many_cached_only.return_value = price_data
+    price_cache.get_many_cached_only_fresh.return_value = price_data
     service = BreadthCalculatorService(db, price_cache)
 
     result = service.backfill_range(latest_date, latest_date, trading_dates=[latest_date])

--- a/backend/tests/unit/test_breadth_calculator_service.py
+++ b/backend/tests/unit/test_breadth_calculator_service.py
@@ -29,11 +29,52 @@ def _make_price_df(end_date: date, base_close: float = 100.0) -> pd.DataFrame:
     )
 
 
+def _flat_price_df(end_date: date, close: float = 100.0, periods: int = 80) -> pd.DataFrame:
+    index = pd.bdate_range(end=end_date, periods=periods)
+    closes = [close] * len(index)
+    return pd.DataFrame(
+        {
+            "Open": closes,
+            "High": closes,
+            "Low": closes,
+            "Close": closes,
+            "Volume": [1_000_000] * len(index),
+        },
+        index=index,
+    )
+
+
 def _make_db_session():
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine, tables=[StockUniverse.__table__, MarketBreadth.__table__])
     testing_session_local = sessionmaker(bind=engine)
     return testing_session_local()
+
+
+def _add_breadth_row(
+    db,
+    row_date: date,
+    *,
+    up: int,
+    down: int,
+    total: int = 2,
+) -> None:
+    db.add(MarketBreadth(
+        date=row_date,
+        stocks_up_4pct=up,
+        stocks_down_4pct=down,
+        ratio_5day=None,
+        ratio_10day=None,
+        stocks_up_25pct_quarter=0,
+        stocks_down_25pct_quarter=0,
+        stocks_up_25pct_month=0,
+        stocks_down_25pct_month=0,
+        stocks_up_50pct_month=0,
+        stocks_down_50pct_month=0,
+        stocks_up_13pct_34days=0,
+        stocks_down_13pct_34days=0,
+        total_stocks_scanned=total,
+    ))
 
 
 def test_calculate_daily_breadth_uses_bulk_cached_prices(monkeypatch):
@@ -162,28 +203,18 @@ def test_backfill_range_reuses_loaded_histories_and_computes_chronological_ratio
         ))
     db.commit()
 
-    aaa_df = _make_price_df(date(2026, 3, 20), 100.0)
-    aaa_df.attrs["symbol"] = "AAA"
-    bbb_df = _make_price_df(date(2026, 3, 20), 200.0)
-    bbb_df.attrs["symbol"] = "BBB"
+    aaa_df = _flat_price_df(date(2026, 3, 13))
+    bbb_df = _flat_price_df(date(2026, 3, 13))
+    aaa_df.loc[pd.Timestamp(date(2026, 3, 12)), "Close"] = 105.0
+    aaa_df.loc[pd.Timestamp(date(2026, 3, 13)), "Close"] = 110.0
+    bbb_df.loc[pd.Timestamp(date(2026, 3, 12)), "Close"] = 95.0
+    bbb_df.loc[pd.Timestamp(date(2026, 3, 13)), "Close"] = 100.0
 
     price_cache = MagicMock()
     price_cache.get_many_cached_only.return_value = {"AAA": aaa_df, "BBB": None}
     price_cache.get_historical_data.return_value = bbb_df
     service = BreadthCalculatorService(db, price_cache)
     trading_dates = [date(2026, 3, 12), date(2026, 3, 13)]
-
-    def fake_stock_metrics(prices_df, end_date):
-        symbol = prices_df.attrs["symbol"]
-        if end_date == trading_dates[0]:
-            if symbol == "AAA":
-                return {"pct_change_1d": 5.0, "pct_change_21d": 0.0, "pct_change_34d": 0.0, "pct_change_63d": 0.0}
-            return {"pct_change_1d": -5.0, "pct_change_21d": 0.0, "pct_change_34d": 0.0, "pct_change_63d": 0.0}
-        if symbol == "AAA":
-            return {"pct_change_1d": 5.0, "pct_change_21d": 0.0, "pct_change_34d": 0.0, "pct_change_63d": 0.0}
-        return {"pct_change_1d": 4.5, "pct_change_21d": 0.0, "pct_change_34d": 0.0, "pct_change_63d": 0.0}
-
-    monkeypatch.setattr(service, "_calculate_stock_metrics_from_prices", fake_stock_metrics)
 
     result = service.backfill_range(trading_dates[0], trading_dates[-1], trading_dates=trading_dates)
 
@@ -242,36 +273,19 @@ def test_backfill_range_is_idempotent_for_existing_records(monkeypatch):
     db.add(StockUniverse(symbol="AAA", is_active=True, status=UNIVERSE_STATUS_ACTIVE))
     db.commit()
 
-    aaa_df = _make_price_df(date(2026, 3, 20), 100.0)
-    aaa_df.attrs["symbol"] = "AAA"
+    up_df = _flat_price_df(date(2026, 3, 12))
+    up_df.loc[pd.Timestamp(date(2026, 3, 12)), "Close"] = 105.0
+    down_df = _flat_price_df(date(2026, 3, 12))
+    down_df.loc[pd.Timestamp(date(2026, 3, 12)), "Close"] = 95.0
 
     price_cache = MagicMock()
-    price_cache.get_many_cached_only.return_value = {"AAA": aaa_df}
+    price_cache.get_many_cached_only.side_effect = [
+        {"AAA": up_df},
+        {"AAA": down_df},
+    ]
     service = BreadthCalculatorService(db, price_cache)
     trading_date = date(2026, 3, 12)
-
-    monkeypatch.setattr(
-        service,
-        "_calculate_stock_metrics_from_prices",
-        lambda prices_df, end_date: {
-            "pct_change_1d": 5.0,
-            "pct_change_21d": 0.0,
-            "pct_change_34d": 0.0,
-            "pct_change_63d": 0.0,
-        },
-    )
     service.backfill_range(trading_date, trading_date, trading_dates=[trading_date])
-
-    monkeypatch.setattr(
-        service,
-        "_calculate_stock_metrics_from_prices",
-        lambda prices_df, end_date: {
-            "pct_change_1d": -5.0,
-            "pct_change_21d": 0.0,
-            "pct_change_34d": 0.0,
-            "pct_change_63d": 0.0,
-        },
-    )
     service.backfill_range(trading_date, trading_date, trading_dates=[trading_date])
 
     records = db.query(MarketBreadth).filter(MarketBreadth.date == trading_date).all()
@@ -325,3 +339,123 @@ def test_backfill_range_cache_only_skips_historical_fetch_fallback(monkeypatch):
     assert result["errors"] == 0
     price_cache.get_many_cached_only_fresh.assert_called_once_with(["AAA", "BBB"], period="2y")
     price_cache.get_historical_data.assert_not_called()
+
+
+def test_fill_gaps_delegates_to_single_backfill_range_call(monkeypatch):
+    db = _make_db_session()
+    price_cache = MagicMock()
+    service = BreadthCalculatorService(db, price_cache)
+    expected = {
+        "total_dates": 2,
+        "processed": 2,
+        "errors": 0,
+        "error_dates": [],
+    }
+    backfill_range = MagicMock(return_value=expected)
+    monkeypatch.setattr(service, "backfill_range", backfill_range)
+    monkeypatch.setattr(
+        service,
+        "calculate_daily_breadth",
+        MagicMock(side_effect=AssertionError("fill_gaps should use range backfill")),
+    )
+
+    result = service.fill_gaps([date(2026, 3, 16), date(2026, 3, 12)])
+
+    assert result == expected
+    backfill_range.assert_called_once_with(
+        date(2026, 3, 12),
+        date(2026, 3, 16),
+        trading_dates=[date(2026, 3, 12), date(2026, 3, 16)],
+    )
+
+
+def test_backfill_range_sparse_dates_include_existing_intervening_counts_in_ratios():
+    db = _make_db_session()
+    db.add_all([
+        StockUniverse(symbol="AAA", is_active=True, status=UNIVERSE_STATUS_ACTIVE),
+        StockUniverse(symbol="BBB", is_active=True, status=UNIVERSE_STATUS_ACTIVE),
+    ])
+
+    for prior_date in [
+        date(2026, 2, 26),
+        date(2026, 2, 27),
+        date(2026, 3, 2),
+        date(2026, 3, 3),
+        date(2026, 3, 4),
+        date(2026, 3, 5),
+        date(2026, 3, 6),
+        date(2026, 3, 9),
+        date(2026, 3, 10),
+        date(2026, 3, 11),
+    ]:
+        _add_breadth_row(db, prior_date, up=1, down=1)
+    _add_breadth_row(db, date(2026, 3, 13), up=10, down=1)
+    db.commit()
+
+    aaa_df = _flat_price_df(date(2026, 3, 16))
+    bbb_df = _flat_price_df(date(2026, 3, 16))
+    for item_date, aaa_close, bbb_close in (
+        (date(2026, 3, 12), 105.0, 95.0),
+        (date(2026, 3, 13), 100.0, 100.0),
+        (date(2026, 3, 16), 105.0, 95.0),
+    ):
+        aaa_df.loc[pd.Timestamp(item_date), "Close"] = aaa_close
+        bbb_df.loc[pd.Timestamp(item_date), "Close"] = bbb_close
+
+    price_cache = MagicMock()
+    price_cache.get_many_cached_only.return_value = {"AAA": aaa_df, "BBB": bbb_df}
+    service = BreadthCalculatorService(db, price_cache)
+
+    result = service.backfill_range(
+        date(2026, 3, 12),
+        date(2026, 3, 16),
+        trading_dates=[date(2026, 3, 12), date(2026, 3, 16)],
+    )
+
+    assert result["processed"] == 2
+    rows = {
+        row.date: row
+        for row in db.query(MarketBreadth)
+        .filter(MarketBreadth.date.in_([date(2026, 3, 12), date(2026, 3, 16)]))
+        .all()
+    }
+    assert rows[date(2026, 3, 12)].ratio_5day == 1.0
+    assert rows[date(2026, 3, 16)].ratio_5day == 2.8
+
+
+def test_backfill_range_vectorized_changes_preserve_rounded_thresholds():
+    db = _make_db_session()
+    symbols = ["UP4", "UP13", "UP25", "UP50"]
+    db.add_all([
+        StockUniverse(symbol=symbol, is_active=True, status=UNIVERSE_STATUS_ACTIVE)
+        for symbol in symbols
+    ])
+    db.commit()
+
+    latest_date = date(2026, 3, 20)
+    latest_closes = {
+        "UP4": 103.995,
+        "UP13": 112.995,
+        "UP25": 124.995,
+        "UP50": 149.995,
+    }
+    price_data = {}
+    for symbol, latest_close in latest_closes.items():
+        frame = _flat_price_df(latest_date)
+        frame.loc[pd.Timestamp(latest_date), "Close"] = latest_close
+        price_data[symbol] = frame
+
+    price_cache = MagicMock()
+    price_cache.get_many_cached_only.return_value = price_data
+    service = BreadthCalculatorService(db, price_cache)
+
+    result = service.backfill_range(latest_date, latest_date, trading_dates=[latest_date])
+
+    assert result["processed"] == 1
+    row = db.query(MarketBreadth).filter(MarketBreadth.date == latest_date).one()
+    assert row.total_stocks_scanned == 4
+    assert row.stocks_up_4pct == 4
+    assert row.stocks_up_13pct_34days == 3
+    assert row.stocks_up_25pct_month == 2
+    assert row.stocks_up_25pct_quarter == 2
+    assert row.stocks_up_50pct_month == 1

--- a/backend/tests/unit/test_breadth_calculator_service.py
+++ b/backend/tests/unit/test_breadth_calculator_service.py
@@ -295,7 +295,7 @@ def test_backfill_range_is_idempotent_for_existing_records(monkeypatch):
     assert records[0].stocks_down_4pct == 1
 
 
-def test_backfill_range_cache_only_skips_historical_fetch_fallback(monkeypatch):
+def test_backfill_range_cache_only_skips_historical_fetch_fallback():
     db = _make_db_session()
     db.add_all([
         StockUniverse(symbol="AAA", is_active=True, status=UNIVERSE_STATUS_ACTIVE),
@@ -303,12 +303,9 @@ def test_backfill_range_cache_only_skips_historical_fetch_fallback(monkeypatch):
     ])
     db.commit()
 
-    aaa_df = _make_price_df(date(2026, 3, 20), 100.0)
-    aaa_df.attrs["symbol"] = "AAA"
-
     price_cache = MagicMock()
     price_cache.get_many_cached_only_fresh.return_value = {
-        "AAA": aaa_df,
+        "AAA": _make_price_df(date(2026, 3, 20), 100.0),
         "BBB": None,
     }
     price_cache.get_historical_data.side_effect = AssertionError(
@@ -316,16 +313,6 @@ def test_backfill_range_cache_only_skips_historical_fetch_fallback(monkeypatch):
     )
     service = BreadthCalculatorService(db, price_cache)
     trading_date = date(2026, 3, 12)
-    monkeypatch.setattr(
-        service,
-        "_calculate_stock_metrics_from_prices",
-        lambda prices_df, end_date: {
-            "pct_change_1d": 5.0,
-            "pct_change_21d": 0.0,
-            "pct_change_34d": 0.0,
-            "pct_change_63d": 0.0,
-        },
-    )
 
     result = service.backfill_range(
         trading_date,
@@ -339,6 +326,30 @@ def test_backfill_range_cache_only_skips_historical_fetch_fallback(monkeypatch):
     assert result["errors"] == 0
     price_cache.get_many_cached_only_fresh.assert_called_once_with(["AAA", "BBB"], period="2y")
     price_cache.get_historical_data.assert_not_called()
+
+
+def test_vectorized_stock_metrics_preserve_invalid_close_semantics():
+    service = BreadthCalculatorService(MagicMock(), MagicMock())
+    latest_date = date(2026, 3, 20)
+
+    previous_nan = _flat_price_df(latest_date)
+    previous_nan.iloc[-2, previous_nan.columns.get_loc("Close")] = float("nan")
+    previous_nan.loc[pd.Timestamp(latest_date), "Close"] = 105.0
+
+    current_nan = _flat_price_df(latest_date)
+    current_nan.iloc[-2, current_nan.columns.get_loc("Close")] = 125.0
+    current_nan.loc[pd.Timestamp(latest_date), "Close"] = float("nan")
+
+    previous_zero = _flat_price_df(latest_date)
+    previous_zero.iloc[-2, previous_zero.columns.get_loc("Close")] = 0.0
+    previous_zero.loc[pd.Timestamp(latest_date), "Close"] = 105.0
+
+    for prices in (previous_nan, current_nan, previous_zero):
+        metrics = service._calculate_stock_metrics_by_date_from_prices(
+            prices,
+            [latest_date],
+        )
+        assert metrics[latest_date]["pct_change_1d"] == 0.0
 
 
 def test_fill_gaps_delegates_to_single_backfill_range_call(monkeypatch):

--- a/backend/tests/unit/test_group_rank_service.py
+++ b/backend/tests/unit/test_group_rank_service.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import pandas as pd
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
 from app.database import Base
@@ -15,6 +15,7 @@ from app.services.ibd_group_rank_service import (
     IncompleteGroupRankingCacheError,
     MissingIBDIndustryMappingsError,
 )
+from app.services import ibd_group_rank_service as group_rank_module
 
 
 def _add_rank(session, group, rank_date, rank):
@@ -184,6 +185,27 @@ def _price_frame() -> pd.DataFrame:
     )
 
 
+def _trend_price_frame(
+    *,
+    end: str = "2026-03-20",
+    periods: int = 260,
+    start_close: float = 100.0,
+    daily_return: float = 0.001,
+) -> pd.DataFrame:
+    dates = pd.date_range(end=end, periods=periods, freq="B")
+    closes = [start_close * ((1 + daily_return) ** idx) for idx in range(periods)]
+    return pd.DataFrame(
+        {
+            "Open": closes,
+            "High": closes,
+            "Low": closes,
+            "Close": closes,
+            "Volume": 1_000_000,
+        },
+        index=dates,
+    )
+
+
 def test_prefetch_all_data_uses_cached_only_prices_for_same_day(db_session, monkeypatch):
     service = _make_group_rank_service()
     spy_data = _price_frame()
@@ -220,16 +242,17 @@ def test_prefetch_all_data_uses_cached_only_prices_for_same_day(db_session, monk
         lambda db, symbols: {"AAPL": 1_000_000_000},
     )
 
-    spy, all_prices, active_symbols, market_caps, stats = service._prefetch_all_data(
+    prefetch = service._prefetch_all_data(
         db_session,
         cache_only=True,
     )
 
-    assert spy is spy_data
-    assert all_prices == {"AAPL": aapl_data}
-    assert active_symbols == {"AAPL"}
-    assert market_caps == {"AAPL": 1_000_000_000}
-    assert stats == {
+    assert prefetch.benchmark_prices is spy_data
+    assert prefetch.prices_by_symbol == {"AAPL": aapl_data}
+    assert prefetch.active_symbols == {"AAPL"}
+    assert prefetch.market_caps == {"AAPL": 1_000_000_000}
+    assert prefetch.symbols_by_group == {"Software": ["AAPL"]}
+    assert prefetch.stats == {
         "target_symbols": 1,
         "symbols_with_prices": 1,
         "cache_miss_symbols": 0,
@@ -275,16 +298,17 @@ def test_prefetch_all_data_treats_stale_same_day_cache_as_missing(db_session, mo
         lambda db, symbols: {"AAPL": 1_000_000_000},
     )
 
-    spy, all_prices, active_symbols, market_caps, stats = service._prefetch_all_data(
+    prefetch = service._prefetch_all_data(
         db_session,
         cache_only=True,
     )
 
-    assert spy is spy_data
-    assert all_prices == {"AAPL": None}
-    assert active_symbols == {"AAPL"}
-    assert market_caps == {"AAPL": 1_000_000_000}
-    assert stats == {
+    assert prefetch.benchmark_prices is spy_data
+    assert prefetch.prices_by_symbol == {"AAPL": None}
+    assert prefetch.active_symbols == {"AAPL"}
+    assert prefetch.market_caps == {"AAPL": 1_000_000_000}
+    assert prefetch.symbols_by_group == {"Software": ["AAPL"]}
+    assert prefetch.stats == {
         "target_symbols": 1,
         "symbols_with_prices": 0,
         "cache_miss_symbols": 1,
@@ -329,16 +353,17 @@ def test_prefetch_all_data_uses_fetch_capable_prices_for_historical(db_session, 
         lambda db, symbols: {"AAPL": 1_000_000_000},
     )
 
-    spy, all_prices, active_symbols, market_caps, stats = service._prefetch_all_data(
+    prefetch = service._prefetch_all_data(
         db_session,
         cache_only=False,
     )
 
-    assert spy is spy_data
-    assert all_prices == {"AAPL": aapl_data}
-    assert active_symbols == {"AAPL"}
-    assert market_caps == {"AAPL": 1_000_000_000}
-    assert stats == {
+    assert prefetch.benchmark_prices is spy_data
+    assert prefetch.prices_by_symbol == {"AAPL": aapl_data}
+    assert prefetch.active_symbols == {"AAPL"}
+    assert prefetch.market_caps == {"AAPL": 1_000_000_000}
+    assert prefetch.symbols_by_group == {"Software": ["AAPL"]}
+    assert prefetch.stats == {
         "target_symbols": 1,
         "symbols_with_prices": 1,
         "cache_miss_symbols": 0,
@@ -383,15 +408,16 @@ def test_prefetch_all_data_skips_unsupported_suffix_symbols(db_session, monkeypa
         lambda db, symbols: {"AAPL": 1_000_000_000},
     )
 
-    _spy, all_prices, active_symbols, _market_caps, stats = service._prefetch_all_data(
+    prefetch = service._prefetch_all_data(
         db_session,
         cache_only=False,
     )
 
-    assert active_symbols == {"AAPL", "MZYX-U"}
-    assert all_prices == {"AAPL": aapl_data}
-    assert stats["target_symbols"] == 1
-    assert stats["skipped_unsupported_symbols"] == 1
+    assert prefetch.active_symbols == {"AAPL", "MZYX-U"}
+    assert prefetch.prices_by_symbol == {"AAPL": aapl_data}
+    assert prefetch.symbols_by_group == {"Software": ["AAPL"]}
+    assert prefetch.stats["target_symbols"] == 1
+    assert prefetch.stats["skipped_unsupported_symbols"] == 1
     price_cache.get_many.assert_called_once_with(["AAPL"], period="2y")
 
 
@@ -432,6 +458,80 @@ def test_calculate_group_rankings_rejects_incomplete_cache_only_inputs(db_sessio
 
     assert excinfo.value.stats["cache_miss_symbols"] == 1
     store_rankings.assert_not_called()
+
+
+def test_store_rankings_bulk_loads_existing_rows_once_for_sqlite_fallback():
+    service = _make_group_rank_service()
+    db_session = _make_session()
+    engine = db_session.get_bind()
+    query_counts = {"select": 0}
+
+    def count_selects(_conn, _cursor, statement, _parameters, _context, _executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            query_counts["select"] += 1
+
+    try:
+        db_session.add(
+            IBDGroupRank(
+                industry_group="Software",
+                date=date(2026, 3, 20),
+                rank=9,
+                avg_rs_rating=70.0,
+                num_stocks=3,
+                num_stocks_rs_above_80=1,
+                top_symbol="OLD",
+                top_rs_rating=80.0,
+            )
+        )
+        db_session.commit()
+
+        event.listen(engine, "before_cursor_execute", count_selects)
+        service._store_rankings(
+            db_session,
+            date(2026, 3, 20),
+            [
+                {
+                    "industry_group": "Software",
+                    "rank": 1,
+                    "avg_rs_rating": 91.0,
+                    "median_rs_rating": 90.0,
+                    "weighted_avg_rs_rating": 92.0,
+                    "rs_std_dev": 1.5,
+                    "num_stocks": 4,
+                    "num_stocks_rs_above_80": 3,
+                    "top_symbol": "AAPL",
+                    "top_rs_rating": 99.0,
+                },
+                {
+                    "industry_group": "Semiconductors",
+                    "rank": 2,
+                    "avg_rs_rating": 88.0,
+                    "median_rs_rating": 87.0,
+                    "weighted_avg_rs_rating": 89.0,
+                    "rs_std_dev": 2.5,
+                    "num_stocks": 5,
+                    "num_stocks_rs_above_80": 4,
+                    "top_symbol": "NVDA",
+                    "top_rs_rating": 98.0,
+                },
+            ],
+        )
+        event.remove(engine, "before_cursor_execute", count_selects)
+
+        rows = db_session.query(IBDGroupRank).order_by(IBDGroupRank.rank).all()
+
+        assert query_counts["select"] == 1
+        assert len(rows) == 2
+        assert rows[0].industry_group == "Software"
+        assert rows[0].top_symbol == "AAPL"
+        assert rows[1].industry_group == "Semiconductors"
+    finally:
+        try:
+            event.remove(engine, "before_cursor_execute", count_selects)
+        except Exception:
+            pass
+        db_session.rollback()
+        db_session.close()
 
 
 def test_calculate_group_rankings_fails_explicitly_when_ibd_mappings_missing(db_session, monkeypatch):
@@ -620,6 +720,105 @@ def test_fill_gaps_optimized_accepts_prefetch_stats_tuple(db_session, monkeypatc
     assert stats["errors"] == 1
     assert prefetch_kwargs["market"] == "HK"
     assert group_kwargs["market"] == "HK"
+
+
+def test_fill_gaps_optimized_uses_prefetched_group_symbols_without_inner_lookup(db_session, monkeypatch):
+    service = _make_group_rank_service()
+    price_data = _price_frame()
+    symbols = ["AAA", "BBB", "CCC"]
+    prefetch = group_rank_module.GroupRankPrefetchData(
+        benchmark_prices=price_data,
+        prices_by_symbol={symbol: price_data for symbol in symbols},
+        active_symbols=set(symbols),
+        market_caps={symbol: 1_000_000_000 for symbol in symbols},
+        stats={
+            "target_symbols": 3,
+            "symbols_with_prices": 3,
+            "cache_miss_symbols": 0,
+            "spy_cached": True,
+            "skipped_unsupported_symbols": 0,
+        },
+        symbols_by_group={"Software": symbols},
+    )
+    monkeypatch.setattr(service, "_prefetch_all_data", lambda db, **kw: prefetch)
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_all_groups",
+        lambda db, **kw: ["Software"],
+    )
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_group_symbols",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("optimized gapfill should reuse prefetched symbols_by_group")
+        ),
+    )
+
+    stats = service.fill_gaps_optimized(db_session, [date(2026, 3, 20)], market="US")
+
+    assert stats["processed"] == 1
+    row = db_session.query(IBDGroupRank).filter(
+        IBDGroupRank.date == date(2026, 3, 20),
+        IBDGroupRank.industry_group == "Software",
+    ).one()
+    assert row.rank == 1
+    assert row.num_stocks == 3
+    assert row.avg_rs_rating == 50.0
+
+
+def test_vectorized_group_rs_matches_legacy_cache_path_and_excludes_short_history(
+    db_session,
+    monkeypatch,
+):
+    service = _make_group_rank_service()
+    calculation_date = date(2026, 3, 20)
+    symbols = ["AAA", "BBB", "CCC", "NEW"]
+    benchmark_prices = _trend_price_frame(daily_return=0.0004)
+    prices_by_symbol = {
+        "AAA": _trend_price_frame(start_close=100.0, daily_return=0.0020),
+        "BBB": _trend_price_frame(start_close=80.0, daily_return=0.0011),
+        "CCC": _trend_price_frame(start_close=120.0, daily_return=-0.0002),
+        "NEW": _trend_price_frame(start_close=50.0, daily_return=0.0040, periods=200),
+    }
+    market_caps = {
+        "AAA": 10_000_000_000,
+        "BBB": 5_000_000_000,
+        "CCC": 1_000_000_000,
+        "NEW": 50_000_000_000,
+    }
+    active_symbols = set(symbols)
+    monkeypatch.setattr(
+        service,
+        "_get_validated_group_symbols",
+        lambda *_args, **_kwargs: symbols,
+    )
+    legacy_metrics = service._calculate_group_rs_from_cache(
+        db_session,
+        "Software",
+        benchmark_prices["Close"].sort_index(ascending=False),
+        prices_by_symbol,
+        active_symbols,
+        market_caps,
+        calculation_date,
+    )
+    prefetch = group_rank_module.GroupRankPrefetchData(
+        benchmark_prices=benchmark_prices,
+        prices_by_symbol=prices_by_symbol,
+        active_symbols=active_symbols,
+        market_caps=market_caps,
+        stats={},
+        symbols_by_group={"Software": symbols},
+    )
+
+    rs_by_date = service._calculate_rs_by_symbol_for_dates(prefetch, [calculation_date])
+    vectorized_metrics = service._calculate_group_metrics_from_rs(
+        "Software",
+        symbols,
+        rs_by_date[calculation_date],
+        market_caps,
+        calculation_date,
+    )
+
+    assert set(rs_by_date[calculation_date]) == {"AAA", "BBB", "CCC"}
+    assert vectorized_metrics == legacy_metrics
 
 
 def test_get_current_rankings_can_target_explicit_date():

--- a/backend/tests/unit/test_group_rank_service.py
+++ b/backend/tests/unit/test_group_rank_service.py
@@ -821,6 +821,68 @@ def test_vectorized_group_rs_matches_legacy_cache_path_and_excludes_short_histor
     assert vectorized_metrics == legacy_metrics
 
 
+def test_vectorized_group_rs_preserves_invalid_period_return_semantics(
+    db_session,
+    monkeypatch,
+):
+    service = _make_group_rank_service()
+    calculation_date = date(2026, 3, 20)
+    symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    benchmark_prices = _trend_price_frame(daily_return=0.0004)
+    prices_by_symbol = {
+        "AAA": _trend_price_frame(start_close=100.0, daily_return=0.0020),
+        "BBB": _trend_price_frame(start_close=80.0, daily_return=0.0011),
+        "CCC": _trend_price_frame(start_close=120.0, daily_return=-0.0002),
+        "DDD": _trend_price_frame(start_close=90.0, daily_return=0.0017),
+        "EEE": _trend_price_frame(start_close=70.0, daily_return=0.0009),
+    }
+    prices_by_symbol["BBB"].iloc[-63, prices_by_symbol["BBB"].columns.get_loc("Close")] = 0.0
+    prices_by_symbol["DDD"].iloc[-1, prices_by_symbol["DDD"].columns.get_loc("Close")] = float("nan")
+    prices_by_symbol["EEE"].iloc[-63, prices_by_symbol["EEE"].columns.get_loc("Close")] = float("nan")
+    market_caps = {
+        "AAA": 10_000_000_000,
+        "BBB": 5_000_000_000,
+        "CCC": 1_000_000_000,
+        "DDD": 7_000_000_000,
+        "EEE": 2_000_000_000,
+    }
+    active_symbols = set(symbols)
+    monkeypatch.setattr(
+        service,
+        "_get_validated_group_symbols",
+        lambda *_args, **_kwargs: symbols,
+    )
+    legacy_metrics = service._calculate_group_rs_from_cache(
+        db_session,
+        "Software",
+        benchmark_prices["Close"].sort_index(ascending=False),
+        prices_by_symbol,
+        active_symbols,
+        market_caps,
+        calculation_date,
+    )
+    prefetch = group_rank_module.GroupRankPrefetchData(
+        benchmark_prices=benchmark_prices,
+        prices_by_symbol=prices_by_symbol,
+        active_symbols=active_symbols,
+        market_caps=market_caps,
+        stats={},
+        symbols_by_group={"Software": symbols},
+    )
+
+    rs_by_date = service._calculate_rs_by_symbol_for_dates(prefetch, [calculation_date])
+    vectorized_metrics = service._calculate_group_metrics_from_rs(
+        "Software",
+        symbols,
+        rs_by_date[calculation_date],
+        market_caps,
+        calculation_date,
+    )
+
+    assert set(rs_by_date[calculation_date]) == {"AAA", "BBB", "CCC", "EEE"}
+    assert vectorized_metrics == legacy_metrics
+
+
 def test_get_current_rankings_can_target_explicit_date():
     service = _make_group_rank_service()
     db_session = _make_session()

--- a/backend/tests/unit/test_group_rank_service.py
+++ b/backend/tests/unit/test_group_rank_service.py
@@ -692,6 +692,59 @@ def test_backfill_rankings_checks_existing_rows_by_market(db_session, monkeypatc
     assert calculate_calls == [date(2026, 3, 17)]
 
 
+def test_backfill_optimized_legacy_prefetch_tuple_falls_back_to_validated_group_symbols(
+    db_session,
+    monkeypatch,
+):
+    service = _make_group_rank_service()
+    price_data = _price_frame()
+    symbols = ["AAA", "BBB", "CCC"]
+
+    class _FakeCalendarService:
+        def is_trading_day(self, market, day):
+            assert market == "US"
+            return day == date(2026, 3, 20)
+
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_market_calendar_service",
+        lambda: _FakeCalendarService(),
+    )
+    monkeypatch.setattr(
+        service,
+        "_prefetch_all_data",
+        lambda db, **kw: (
+            price_data,
+            {symbol: price_data for symbol in symbols},
+            set(symbols),
+            {symbol: 1_000_000_000 for symbol in symbols},
+            {"target_symbols": 3, "symbols_with_prices": 3, "cache_miss_symbols": 0, "spy_cached": True},
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_all_groups",
+        lambda db, **kw: ["Software"],
+    )
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_group_symbols",
+        lambda db, group, **kw: symbols if group == "Software" else [],
+    )
+
+    stats = service.backfill_rankings_optimized(
+        db_session,
+        date(2026, 3, 20),
+        date(2026, 3, 20),
+        market="US",
+    )
+
+    assert stats["processed"] == 1
+    row = db_session.query(IBDGroupRank).filter(
+        IBDGroupRank.date == date(2026, 3, 20),
+        IBDGroupRank.industry_group == "Software",
+    ).one()
+    assert row.rank == 1
+    assert row.num_stocks == 3
+
+
 def test_fill_gaps_optimized_accepts_prefetch_stats_tuple(db_session, monkeypatch):
     service = _make_group_rank_service()
     price_data = _price_frame()


### PR DESCRIPTION
## Summary
- optimize breadth gap fill to use the batched backfill path and preserve sparse-date rolling ratios
- vectorize breadth percentage-change calculations while preserving rounded threshold and invalid-price semantics
- bulk upsert group-rank rows and reuse prefetched group symbols in optimized backfill/gapfill
- precompute group-rank RS inputs per symbol/date before group aggregation
- update rank-change comments to reflect calendar-day target windows without changing calculations

## Review Follow-up
- fixed code-review finding where vectorized `pct_change` could forward-fill NaNs or produce non-finite returns differently from the old scalar paths
- added invalid-close regression coverage for breadth and group RS parity

## Validation
- `cd backend && source venv/bin/activate && pytest tests/unit/test_breadth_calculator_service.py tests/unit/test_breadth_tasks.py tests/unit/test_group_rank_service.py tests/unit/test_group_rank_tasks.py -q` -> 59 passed
- `git diff --check` -> clean
- `python -m compileall backend/app/services/breadth_calculator_service.py backend/app/services/ibd_group_rank_service.py` -> clean
- `make gates` -> passed

## Notes
- no API, Celery task signature, database schema, or response-shape changes
- full group-rank backfill delete-and-recalculate semantics are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized breadth calculation to efficiently compute stock metrics across multiple dates in one pass.
  * Improved group ranking computation with bulk database operations and precomputed metrics.
  * Enhanced gap-filling logic with better handling of sparse data and existing records.

* **Tests**
  * Extended test coverage for new calculation flows and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->