### PR TITLE
Fix market breadth surfaces and scan refresh recovery

### DIFF
--- a/backend/app/api/v1/breadth.py
+++ b/backend/app/api/v1/breadth.py
@@ -25,11 +25,24 @@ from ...schemas.breadth import (
     BreadthSummary
 )
 from ...schemas.ui_view_snapshot import UISnapshotEnvelope
+from ...tasks.market_queues import SUPPORTED_MARKETS
 from ...wiring.bootstrap import get_ui_snapshot_service
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+SUPPORTED_BREADTH_MARKETS = set(SUPPORTED_MARKETS)
+
+
+def _normalize_market_param(market: str | None) -> str:
+    normalized = str(market or "US").strip().upper()
+    if normalized not in SUPPORTED_BREADTH_MARKETS:
+        supported = ", ".join(SUPPORTED_MARKETS)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported market '{market}'. Expected one of: {supported}.",
+        )
+    return normalized
 
 
 def _require_task_controls() -> None:
@@ -41,14 +54,18 @@ def _require_task_controls() -> None:
 
 
 @router.get("/current", response_model=BreadthResponse)
-async def get_current_breadth(db: Session = Depends(get_db)):
+async def get_current_breadth(
+    market: str = Query("US", description="Market code: US, HK, IN, JP, or TW"),
+    db: Session = Depends(get_db),
+):
     """
     Get the most recent market breadth data.
 
     Returns the latest breadth snapshot from the database.
     """
+    normalized_market = _normalize_market_param(market)
     breadth = db.query(MarketBreadth).filter(
-        MarketBreadth.market == "US",
+        MarketBreadth.market == normalized_market,
     ).order_by(
         MarketBreadth.date.desc()
     ).first()
@@ -56,18 +73,25 @@ async def get_current_breadth(db: Session = Depends(get_db)):
     if not breadth:
         raise HTTPException(
             status_code=404,
-            detail="No breadth data available. Run a calculation first."
+            detail=f"No breadth data available for market {normalized_market}. Run a calculation first."
         )
 
     return breadth
 
 
 @router.get("/bootstrap", response_model=UISnapshotEnvelope)
-async def get_breadth_bootstrap(snapshot_service=Depends(get_ui_snapshot_service)):
+async def get_breadth_bootstrap(
+    market: str = Query("US", description="Market code: US, HK, IN, JP, or TW"),
+    snapshot_service=Depends(get_ui_snapshot_service),
+):
     """Return the published breadth bootstrap snapshot if available."""
-    snapshot = snapshot_service.get_breadth_bootstrap()
+    normalized_market = _normalize_market_param(market)
+    snapshot = snapshot_service.get_breadth_bootstrap(market=normalized_market)
     if snapshot is None:
-        raise HTTPException(status_code=404, detail="No published breadth bootstrap snapshot is available")
+        raise HTTPException(
+            status_code=404,
+            detail=f"No published breadth bootstrap snapshot is available for market {normalized_market}",
+        )
     return UISnapshotEnvelope(**snapshot.to_dict())
 
 
@@ -76,6 +100,7 @@ async def get_historical_breadth(
     start_date: date = Query(..., description="Start date (YYYY-MM-DD)"),
     end_date: date = Query(..., description="End date (YYYY-MM-DD)"),
     limit: int = Query(365, ge=1, le=730, description="Maximum number of records"),
+    market: str = Query("US", description="Market code: US, HK, IN, JP, or TW"),
     db: Session = Depends(get_db)
 ):
     """
@@ -104,11 +129,13 @@ async def get_historical_breadth(
             detail=f"Date range cannot exceed 730 days (2 years)"
         )
 
+    normalized_market = _normalize_market_param(market)
+
     # Query breadth data
     breadth_records = db.query(MarketBreadth).filter(
         MarketBreadth.date >= start_date,
         MarketBreadth.date <= end_date,
-        MarketBreadth.market == "US",
+        MarketBreadth.market == normalized_market,
     ).order_by(
         MarketBreadth.date.desc()
     ).limit(limit).all()
@@ -116,7 +143,7 @@ async def get_historical_breadth(
     if not breadth_records:
         raise HTTPException(
             status_code=404,
-            detail=f"No breadth data found for date range {start_date} to {end_date}"
+            detail=f"No breadth data found for market {normalized_market} date range {start_date} to {end_date}"
         )
 
     return breadth_records
@@ -126,6 +153,7 @@ async def get_historical_breadth(
 async def get_indicator_trend(
     indicator: str,
     days: int = Query(30, ge=1, le=730, description="Number of days to retrieve"),
+    market: str = Query("US", description="Market code: US, HK, IN, JP, or TW"),
     db: Session = Depends(get_db)
 ):
     """
@@ -156,13 +184,14 @@ async def get_indicator_trend(
         )
 
     # Get recent breadth data
+    normalized_market = _normalize_market_param(market)
     end_date = datetime.now().date()
     start_date = end_date - timedelta(days=days)
 
     breadth_records = db.query(MarketBreadth).filter(
         MarketBreadth.date >= start_date,
         MarketBreadth.date <= end_date,
-        MarketBreadth.market == "US",
+        MarketBreadth.market == normalized_market,
     ).order_by(
         MarketBreadth.date.asc()
     ).all()
@@ -170,7 +199,7 @@ async def get_indicator_trend(
     if not breadth_records:
         raise HTTPException(
             status_code=404,
-            detail=f"No breadth data found for the last {days} days"
+            detail=f"No breadth data found for market {normalized_market} in the last {days} days"
         )
 
     # Extract indicator values
@@ -184,6 +213,7 @@ async def get_indicator_trend(
 
     return TrendResponse(
         indicator=indicator,
+        market=normalized_market,
         data=data_points,
         total_points=len(data_points)
     )
@@ -193,6 +223,7 @@ async def get_indicator_trend(
 async def trigger_calculation(
     request: CalculationRequest,
     background_tasks: BackgroundTasks,
+    market: str | None = Query(None, description="Optional market override: US, HK, IN, JP, or TW"),
     db: Session = Depends(get_db)
 ):
     """
@@ -208,6 +239,7 @@ async def trigger_calculation(
         Status and task information
     """
     _require_task_controls()
+    normalized_market = _normalize_market_param(market or request.market)
     calculation_date = request.calculation_date
 
     # Validate date format if provided
@@ -223,12 +255,12 @@ async def trigger_calculation(
     # Trigger background task
     from ...tasks.breadth_tasks import calculate_daily_breadth
 
-    background_tasks.add_task(calculate_daily_breadth, calculation_date)
+    background_tasks.add_task(calculate_daily_breadth, calculation_date, market=normalized_market)
 
     date_str = calculation_date or "today"
     return CalculationResponse(
         status="started",
-        message=f"Breadth calculation triggered for {date_str}",
+        message=f"Breadth calculation triggered for {normalized_market} {date_str}",
         task_id=None  # Background tasks don't return task IDs
     )
 
@@ -236,6 +268,7 @@ async def trigger_calculation(
 @router.post("/backfill", response_model=BackfillResponse)
 async def trigger_backfill(
     request: BackfillRequest,
+    market: str | None = Query(None, description="Optional market override: US, HK, IN, JP, or TW"),
     db: Session = Depends(get_db)
 ):
     """
@@ -251,6 +284,7 @@ async def trigger_backfill(
         Task information for tracking progress
     """
     _require_task_controls()
+    normalized_market = _normalize_market_param(market or request.market)
     # Validate date format
     try:
         start = datetime.strptime(request.start_date, "%Y-%m-%d").date()
@@ -283,48 +317,61 @@ async def trigger_backfill(
     # Trigger Celery task
     from ...tasks.breadth_tasks import backfill_breadth_data
 
-    task = backfill_breadth_data.delay(request.start_date, request.end_date)
+    task = backfill_breadth_data.delay(request.start_date, request.end_date, market=normalized_market)
 
-    logger.info(f"Backfill task triggered: {task.id} for {request.start_date} to {request.end_date}")
+    logger.info(
+        "Backfill task triggered: %s for %s to %s market=%s",
+        task.id,
+        request.start_date,
+        request.end_date,
+        normalized_market,
+    )
 
     return BackfillResponse(
         status="started",
-        message=f"Backfill task started for {request.start_date} to {request.end_date}",
+        message=f"Backfill task started for {normalized_market} {request.start_date} to {request.end_date}",
         task_id=task.id,
         dates_to_process=estimated_trading_days
     )
 
 
 @router.get("/summary", response_model=BreadthSummary)
-async def get_breadth_summary(db: Session = Depends(get_db)):
+async def get_breadth_summary(
+    market: str = Query("US", description="Market code: US, HK, IN, JP, or TW"),
+    db: Session = Depends(get_db),
+):
     """
     Get summary statistics for available breadth data.
 
     Returns information about the breadth data coverage,
     including date ranges and record counts.
     """
-    # Get total record count (US scope — non-US partitions have their own surfaces)
+    normalized_market = _normalize_market_param(market)
+
+    # Get total record count for the requested market partition.
     total_records = db.query(func.count(MarketBreadth.id)).filter(
-        MarketBreadth.market == "US",
+        MarketBreadth.market == normalized_market,
     ).scalar() or 0
 
     if total_records == 0:
         return BreadthSummary(
+            market=normalized_market,
             latest_date=None,
             total_records=0,
             date_range_start=None,
             date_range_end=None
         )
 
-    # Get date range (US scope)
+    # Get date range
     min_date = db.query(func.min(MarketBreadth.date)).filter(
-        MarketBreadth.market == "US",
+        MarketBreadth.market == normalized_market,
     ).scalar()
     max_date = db.query(func.max(MarketBreadth.date)).filter(
-        MarketBreadth.market == "US",
+        MarketBreadth.market == normalized_market,
     ).scalar()
 
     return BreadthSummary(
+        market=normalized_market,
         latest_date=max_date,
         total_records=total_records,
         date_range_start=min_date,

--- a/backend/app/api/v1/cache.py
+++ b/backend/app/api/v1/cache.py
@@ -32,6 +32,7 @@ from ...tasks.cache_tasks import (
     force_refresh_stale_intraday,
     smart_refresh_cache
 )
+from ...tasks.market_queues import SHARED_SENTINEL, data_fetch_queue_for_market, normalize_market
 from ...wiring.bootstrap import get_data_fetch_lock, get_price_cache
 from ...utils.market_hours import format_market_status, is_market_open
 from ...database import SessionLocal
@@ -40,13 +41,27 @@ from ...models.stock import StockFundamental
 router = APIRouter(prefix="/cache", tags=["cache"])
 
 
-def _get_running_refresh_response() -> SmartRefreshResponse | None:
+def _normalize_refresh_market(market: str | None) -> str | None:
+    """Validate and normalize an optional market for manual refresh routes."""
+    if market is None:
+        return None
+    normalized = normalize_market(market)
+    return None if normalized == SHARED_SENTINEL else normalized
+
+
+def _get_running_refresh_response(market: str | None = None) -> SmartRefreshResponse | None:
     """Return the active refresh task when a data-fetch job is already running.
 
-    Checks across all market lock keys so per-market Beat tasks are visible.
+    Market-scoped manual refreshes only conflict with the same market. Legacy
+    shared calls preserve the old global duplicate check.
     """
     lock = get_data_fetch_lock()
-    running = lock.get_any_current_task()
+    normalized_market = _normalize_refresh_market(market)
+    running = (
+        lock.get_current_task(market=normalized_market)
+        if normalized_market is not None
+        else lock.get_any_current_task()
+    )
     if not running:
         return None
 
@@ -59,17 +74,21 @@ def _get_running_refresh_response() -> SmartRefreshResponse | None:
 
 def _queue_manual_smart_refresh(mode: str, market: str | None = None) -> SmartRefreshResponse:
     """Queue a smart refresh after rejecting duplicate active refreshes."""
-    running_response = _get_running_refresh_response()
+    normalized_market = _normalize_refresh_market(market)
+    running_response = _get_running_refresh_response(normalized_market)
     if running_response is not None:
         return running_response
 
     task_kwargs = {"mode": mode}
-    if market is not None:
-        task_kwargs["market"] = market
+    task_options = {}
+    if normalized_market is not None:
+        task_kwargs["market"] = normalized_market
+        task_options["queue"] = data_fetch_queue_for_market(normalized_market)
 
     task = smart_refresh_cache.apply_async(
         kwargs=task_kwargs,
         headers={"origin": "manual"},
+        **task_options,
     )
     mode_desc = (
         "full universe (skips recently refreshed)"
@@ -454,6 +473,8 @@ async def smart_refresh(request: SmartRefreshRequest):
     """
     try:
         return _queue_manual_smart_refresh(mode=request.mode, market=request.market)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     except Exception as e:
         raise HTTPException(

--- a/backend/app/api/v1/cache.py
+++ b/backend/app/api/v1/cache.py
@@ -474,7 +474,7 @@ async def smart_refresh(request: SmartRefreshRequest):
     try:
         return _queue_manual_smart_refresh(mode=request.mode, market=request.market)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
     except Exception as e:
         raise HTTPException(

--- a/backend/app/api/v1/scans.py
+++ b/backend/app/api/v1/scans.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from typing import List, Literal, Any
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 import logging
 
+from ...schemas.cache import SmartRefreshResponse
 from ...schemas.scanning import (
     ExplainResponse,
     FilterOptionsResponse,
@@ -55,6 +56,13 @@ SCAN_GUARD_MARKET_BY_INDEX = {
     IndexName.NIKKEI225.value: "JP",
     IndexName.TAIEX.value: "TW",
 }
+
+
+class ScanCacheRefreshRequest(BaseModel):
+    """Request payload for scan-facing cache refresh recovery."""
+
+    market: str
+    mode: Literal["auto", "full"] = "full"
 
 
 def _get_market_refresh_conflict_detail(market: str | None) -> dict[str, object] | None:
@@ -217,6 +225,17 @@ async def create_scan(
         feature_run_id=result.feature_run_id,
         universe_def=universe_def,
     )
+
+
+@router.post("/refresh-cache", response_model=SmartRefreshResponse)
+async def refresh_scan_cache(request: ScanCacheRefreshRequest):
+    """Queue a manual market data refresh from the scan workflow."""
+    from .cache import _queue_manual_smart_refresh
+
+    try:
+        return _queue_manual_smart_refresh(mode=request.mode, market=request.market)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 def _build_universe_def(request: ScanCreateRequest):

--- a/backend/app/api/v1/scans.py
+++ b/backend/app/api/v1/scans.py
@@ -29,6 +29,7 @@ from ...schemas.universe import IndexName
 from ...schemas.ui_view_snapshot import UISnapshotEnvelope
 from ...database import SessionLocal
 from ...services.market_activity_service import get_runtime_activity_status
+from ...tasks.market_queues import SUPPORTED_MARKETS
 from ...wiring.bootstrap import (
     get_uow,
     get_create_scan_use_case,
@@ -63,6 +64,18 @@ class ScanCacheRefreshRequest(BaseModel):
 
     market: str
     mode: Literal["auto", "full"] = "full"
+
+
+def _normalize_scan_refresh_market(market: str) -> str:
+    """Require an explicit market partition for scan recovery refreshes."""
+    normalized = str(market or "").strip().upper()
+    if normalized not in SUPPORTED_MARKETS:
+        supported = ", ".join(SUPPORTED_MARKETS)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported market '{market}'. Expected one of: {supported}.",
+        )
+    return normalized
 
 
 def _get_market_refresh_conflict_detail(market: str | None) -> dict[str, object] | None:
@@ -233,7 +246,8 @@ async def refresh_scan_cache(request: ScanCacheRefreshRequest):
     from .cache import _queue_manual_smart_refresh
 
     try:
-        return _queue_manual_smart_refresh(mode=request.mode, market=request.market)
+        market = _normalize_scan_refresh_market(request.market)
+        return _queue_manual_smart_refresh(mode=request.mode, market=market)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/backend/app/domain/analytics/scope.py
+++ b/backend/app/domain/analytics/scope.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional
 
-POLICY_VERSION: str = "2026.04.20.1"
+POLICY_VERSION: str = "2026.04.26.1"
 
 _US_MARKET: str = "US"
 
@@ -56,9 +56,6 @@ class AnalyticsFeature(str, Enum):
 _US_ONLY_FEATURES: dict[AnalyticsFeature, str] = {
     AnalyticsFeature.THEME_DISCOVERY: (
         "theme content sources are English-language biased; no non-US coverage"
-    ),
-    AnalyticsFeature.BREADTH_SNAPSHOT: (
-        "breadth indicators are computed from the US universe only"
     ),
 }
 

--- a/backend/app/schemas/breadth.py
+++ b/backend/app/schemas/breadth.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Dict, Any
 class BreadthResponse(BaseModel):
     """Response model for market breadth data"""
 
+    market: str = Field("US", description="Market code for this breadth snapshot")
     date: Date = Field(..., description="Trading date for this breadth snapshot")
 
     # Daily movers (4%+ threshold)
@@ -52,6 +53,7 @@ class TrendResponse(BaseModel):
     """Response model for indicator trend data"""
 
     indicator: str = Field(..., description="Indicator name")
+    market: str = Field("US", description="Market code for this trend")
     data: List[TrendDataPoint] = Field(..., description="Time series data points")
     total_points: int = Field(..., description="Number of data points returned")
 
@@ -59,6 +61,7 @@ class TrendResponse(BaseModel):
 class CalculationRequest(BaseModel):
     """Request model for manual breadth calculation"""
 
+    market: str = Field("US", description="Market code: US, HK, IN, JP, or TW")
     calculation_date: Optional[str] = Field(
         None,
         description="Date to calculate for (YYYY-MM-DD), defaults to today"
@@ -78,6 +81,7 @@ class BackfillRequest(BaseModel):
 
     start_date: str = Field(..., description="Start date (YYYY-MM-DD)")
     end_date: str = Field(..., description="End date (YYYY-MM-DD)")
+    market: str = Field("US", description="Market code: US, HK, IN, JP, or TW")
 
 
 class BackfillResponse(BaseModel):
@@ -92,6 +96,7 @@ class BackfillResponse(BaseModel):
 class BreadthSummary(BaseModel):
     """Summary statistics for breadth data"""
 
+    market: str = Field("US", description="Market code for this summary")
     latest_date: Optional[Date] = Field(None, description="Most recent breadth date")
     total_records: int = Field(..., description="Total breadth records in database")
     date_range_start: Optional[Date] = Field(None, description="Earliest date with data")

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -782,7 +782,7 @@ class StaticSiteExportService:
         serialized_rows: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         if serialized_rows is None:
-            snapshot = self._ui_snapshot_service.publish_breadth_bootstrap().to_dict()
+            snapshot = self._ui_snapshot_service.publish_breadth_bootstrap(market=market).to_dict()
             payload = snapshot.get("payload", {})
             current_date = ((payload.get("current") or {}).get("date"))
             if current_date != expected_as_of_date.isoformat():

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -809,8 +809,8 @@ class StaticSiteExportService:
                 reason=f"No scan rows are available for market {market} on {expected_as_of_date.isoformat()}.",
             )
 
-        benchmark = self._get_market_benchmark_history(market, period="1y")
-        if benchmark is None or benchmark.empty:
+        benchmark_symbol, benchmark = self._get_market_benchmark_history(market, period="1y")
+        if benchmark.empty:
             raise StaticSiteSectionUnavailableError(
                 section="breadth",
                 reason=f"No cached benchmark price history is available for market {market}.",
@@ -841,8 +841,17 @@ class StaticSiteExportService:
             )
 
         ordered_dates = sorted(metrics_by_date.keys())
-        ordered_history = [metrics_by_date[item_date] for item_date in ordered_dates]
+        ordered_history = [
+            {**metrics_by_date[item_date], "market": market}
+            for item_date in ordered_dates
+        ]
         chart_data = ordered_history[-31:]
+        current = {**current, "market": market}
+        benchmark_overlay = self._serialize_history_bars(
+            benchmark,
+            period_days=31,
+            end_date=expected_as_of_date,
+        )
         return {
             "schema_version": STATIC_SITE_SCHEMA_VERSION,
             "generated_at": generated_at,
@@ -853,6 +862,7 @@ class StaticSiteExportService:
             "payload": {
                 "current": current,
                 "summary": {
+                    "market": market,
                     "latest_date": expected_as_of_date.isoformat(),
                     "total_records": len(ordered_history),
                     "date_range_start": ordered_dates[0].isoformat() if ordered_dates else None,
@@ -861,11 +871,9 @@ class StaticSiteExportService:
                 "history_90d": list(reversed(ordered_history[-STATIC_BREADTH_HISTORY_LOOKBACK_DAYS:])),
                 "chart_range": "1M",
                 "chart_data": list(reversed(chart_data)),
-                "spy_overlay": self._serialize_history_bars(
-                    benchmark,
-                    period_days=31,
-                    end_date=expected_as_of_date,
-                ),
+                "benchmark_symbol": benchmark_symbol,
+                "benchmark_overlay": benchmark_overlay,
+                "spy_overlay": benchmark_overlay,
             },
         }
 
@@ -1391,12 +1399,12 @@ class StaticSiteExportService:
             results.update(self._price_cache.get_many_cached_only(batch, period=period))
         return results
 
-    def _get_market_benchmark_history(self, market: str, *, period: str) -> pd.DataFrame | None:
+    def _get_market_benchmark_history(self, market: str, *, period: str) -> tuple[str, pd.DataFrame]:
         for candidate in self._benchmark_cache.get_benchmark_candidates(market):
             history = self._get_symbol_price_history(candidate, period=period)
             if history is not None and not history.empty:
-                return history
-        return None
+                return candidate, history
+        return self._benchmark_cache.get_benchmark_symbol(market), pd.DataFrame()
 
     def _get_symbol_price_history(self, symbol: str, *, period: str) -> pd.DataFrame | None:
         data = self._price_cache.get_cached_only(symbol.upper(), period=period)

--- a/backend/app/services/ui_snapshot_service.py
+++ b/backend/app/services/ui_snapshot_service.py
@@ -611,8 +611,11 @@ class UISnapshotService:
             # Local import: wiring.bootstrap imports this module, so a
             # top-level import would cycle.
             from ..wiring.bootstrap import get_benchmark_cache
-            benchmark_symbol = get_benchmark_cache().get_benchmark_symbol(normalized_market)
-            benchmark_overlay = self._get_cached_price_history(benchmark_symbol, "1mo")
+            benchmark_symbol, benchmark_overlay = self._get_cached_benchmark_overlay(
+                get_benchmark_cache(),
+                normalized_market,
+                "1mo",
+            )
             return {
                 "current": market_breadth_to_dict(current),
                 "summary": {
@@ -810,6 +813,17 @@ class UISnapshotService:
 
     def _themes_variant_key(self, pipeline: str, theme_view: str) -> str:
         return f"{pipeline}:{theme_view}"
+
+    def _get_cached_benchmark_overlay(self, benchmark_cache, market: str, period: str) -> tuple[str, list[dict[str, Any]]]:
+        candidates = list(benchmark_cache.get_benchmark_candidates(market))
+        if not candidates:
+            candidates = [benchmark_cache.get_benchmark_symbol(market)]
+        primary_symbol = candidates[0]
+        for symbol in candidates:
+            overlay = self._get_cached_price_history(symbol, period)
+            if overlay:
+                return symbol, overlay
+        return primary_symbol, []
 
     def _get_cached_price_history(self, symbol: str, period: str) -> list[dict[str, Any]]:
         import pandas as pd

--- a/backend/app/services/ui_snapshot_service.py
+++ b/backend/app/services/ui_snapshot_service.py
@@ -225,9 +225,14 @@ class UISnapshotService:
 
     def publish_all(self) -> dict[str, dict[str, Any] | None]:
         """Rebuild all bootstrap variants."""
+        breadth_snapshots = {
+            market: self.publish_breadth_bootstrap(market=market).to_dict()
+            for market in SUPPORTED_MARKETS
+        }
         published = {
             "scan_latest": self.publish_scan_bootstrap().to_dict(),
-            "breadth": self.publish_breadth_bootstrap().to_dict(),
+            "breadth": breadth_snapshots["US"],
+            **{f"breadth_{market.lower()}": snapshot for market, snapshot in breadth_snapshots.items()},
         }
         groups_snapshot = self.publish_groups_bootstrap()
         published["groups"] = groups_snapshot.to_dict() if groups_snapshot is not None else None

--- a/backend/app/services/ui_snapshot_service.py
+++ b/backend/app/services/ui_snapshot_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import settings
 from app.database import is_corruption_error
-from app.domain.analytics.scope import AnalyticsFeature, market_scope_tag, us_only_tag
+from app.domain.analytics.scope import market_scope_tag
 from app.domain.scanning.filter_spec import PageSpec, QuerySpec, SortOrder, SortSpec
 from app.infra.db.uow import SqlUnitOfWork
 from app.models.industry import IBDGroupRank
@@ -63,6 +63,7 @@ from app.services.theme_taxonomy_service import ThemeTaxonomyService
 from app.use_cases.scanning.get_filter_options import GetFilterOptionsQuery, GetFilterOptionsUseCase
 from app.use_cases.scanning.get_scan_results import GetScanResultsQuery, GetScanResultsUseCase
 from app.wiring.bootstrap import get_stock_universe_service
+from app.tasks.market_queues import SUPPORTED_MARKETS
 
 logger = logging.getLogger(__name__)
 
@@ -145,26 +146,37 @@ class UISnapshotService:
             )
         )
 
-    def get_breadth_bootstrap(self) -> SnapshotResult | None:
+    def _normalize_breadth_market(self, market: str | None) -> str:
+        normalized = str(market or "US").strip().upper()
+        if normalized not in SUPPORTED_MARKETS:
+            raise ValueError(f"Unsupported breadth market: {market}")
+        return normalized
+
+    def _breadth_variant_key(self, market: str | None) -> str:
+        return f"market:{self._normalize_breadth_market(market).lower()}"
+
+    def get_breadth_bootstrap(self, market: str | None = "US") -> SnapshotResult | None:
         self._ensure_schema()
+        normalized_market = self._normalize_breadth_market(market)
         return self._run_with_storage_recovery(
             lambda db: self._get_snapshot(
                 db=db,
                 view_key=BREADTH_VIEW_KEY,
-                variant_key="default",
-                source_revision=self._resolve_breadth_source_revision(db),
+                variant_key=self._breadth_variant_key(normalized_market),
+                source_revision=self._resolve_breadth_source_revision(db, normalized_market),
             )
         )
 
-    def publish_breadth_bootstrap(self) -> SnapshotResult:
+    def publish_breadth_bootstrap(self, market: str | None = "US") -> SnapshotResult:
         self._ensure_schema()
+        normalized_market = self._normalize_breadth_market(market)
         return self._run_with_storage_recovery(
             lambda db: self._publish(
                 db=db,
                 view_key=BREADTH_VIEW_KEY,
-                variant_key="default",
-                source_revision=self._resolve_breadth_source_revision(db),
-                payload=self._build_breadth_payload(),
+                variant_key=self._breadth_variant_key(normalized_market),
+                source_revision=self._resolve_breadth_source_revision(db, normalized_market),
+                payload=self._build_breadth_payload(normalized_market),
             )
         )
 
@@ -401,10 +413,10 @@ class UISnapshotService:
         )
         return latest[0] if latest else "none"
 
-    def _resolve_breadth_source_revision(self, db: Session) -> str:
-        # Bootstrap snapshots are US-scoped; non-US surfaces will get their own.
+    def _resolve_breadth_source_revision(self, db: Session, market: str = "US") -> str:
+        normalized_market = self._normalize_breadth_market(market)
         latest = db.query(func.max(MarketBreadth.date)).filter(
-            MarketBreadth.market == "US",
+            MarketBreadth.market == normalized_market,
         ).scalar()
         return latest.isoformat() if latest else "none"
 
@@ -568,40 +580,38 @@ class UISnapshotService:
             ).model_dump(mode="json")
             return payload
 
-    def _build_breadth_payload(self) -> dict[str, Any]:
+    def _build_breadth_payload(self, market: str = "US") -> dict[str, Any]:
+        normalized_market = self._normalize_breadth_market(market)
         with self._session_factory() as db:
-            # Breadth bootstrap is US-scoped — non-US partitions will get their
-            # own bootstrap surface.
-            us_only = MarketBreadth.market == "US"
-            current = db.query(MarketBreadth).filter(us_only).order_by(MarketBreadth.date.desc()).first()
-            total_records = db.query(func.count(MarketBreadth.id)).filter(us_only).scalar() or 0
-            min_date = db.query(func.min(MarketBreadth.date)).filter(us_only).scalar()
-            max_date = db.query(func.max(MarketBreadth.date)).filter(us_only).scalar()
+            market_filter = MarketBreadth.market == normalized_market
+            current = db.query(MarketBreadth).filter(market_filter).order_by(MarketBreadth.date.desc()).first()
+            total_records = db.query(func.count(MarketBreadth.id)).filter(market_filter).scalar() or 0
+            min_date = db.query(func.min(MarketBreadth.date)).filter(market_filter).scalar()
+            max_date = db.query(func.max(MarketBreadth.date)).filter(market_filter).scalar()
             end_date = datetime.utcnow().date()
             history_start = end_date - timedelta(days=90)
             chart_start = end_date - timedelta(days=31)
             history = (
                 db.query(MarketBreadth)
-                .filter(MarketBreadth.date >= history_start, MarketBreadth.date <= end_date, us_only)
+                .filter(MarketBreadth.date >= history_start, MarketBreadth.date <= end_date, market_filter)
                 .order_by(MarketBreadth.date.desc())
                 .all()
             )
             chart = (
                 db.query(MarketBreadth)
-                .filter(MarketBreadth.date >= chart_start, MarketBreadth.date <= end_date, us_only)
+                .filter(MarketBreadth.date >= chart_start, MarketBreadth.date <= end_date, market_filter)
                 .order_by(MarketBreadth.date.desc())
                 .all()
             )
-            # Breadth is US-scoped today (see app.domain.analytics.scope);
-            # resolve the overlay symbol through the benchmark registry so
-            # this layer doesn't hard-code "SPY".
             # Local import: wiring.bootstrap imports this module, so a
             # top-level import would cycle.
             from ..wiring.bootstrap import get_benchmark_cache
-            benchmark_symbol = get_benchmark_cache().get_benchmark_symbol("US")
+            benchmark_symbol = get_benchmark_cache().get_benchmark_symbol(normalized_market)
+            benchmark_overlay = self._get_cached_price_history(benchmark_symbol, "1mo")
             return {
                 "current": market_breadth_to_dict(current),
                 "summary": {
+                    "market": normalized_market,
                     "latest_date": max_date,
                     "total_records": total_records,
                     "date_range_start": min_date,
@@ -610,12 +620,11 @@ class UISnapshotService:
                 "history_90d": [market_breadth_to_dict(row) for row in history],
                 "chart_range": DEFAULT_BREADTH_RANGE,
                 "chart_data": [market_breadth_to_dict(row) for row in chart],
-                # Key retained as ``spy_overlay`` for frontend compatibility
-                # (BreadthPage.jsx, StaticBreadthPage.jsx). When breadth is
-                # generalised to multi-market, rename to ``benchmark_overlay``
-                # alongside the scope flip in mixed_market / analytics scope.
-                "spy_overlay": self._get_cached_price_history(benchmark_symbol, "1mo"),
-                **us_only_tag(AnalyticsFeature.BREADTH_SNAPSHOT),
+                "benchmark_symbol": benchmark_symbol,
+                "benchmark_overlay": benchmark_overlay,
+                # Legacy key retained for existing static/live frontend clients.
+                "spy_overlay": benchmark_overlay,
+                **market_scope_tag(normalized_market),
             }
 
     def _publish_groups_bootstrap_with_db(self, db: Session) -> SnapshotResult:
@@ -847,6 +856,7 @@ def market_breadth_to_dict(row: MarketBreadth | None) -> dict[str, Any] | None:
     if row is None:
         return None
     return {
+        "market": row.market,
         "date": row.date,
         "stocks_up_4pct": row.stocks_up_4pct,
         "stocks_down_4pct": row.stocks_down_4pct,
@@ -861,6 +871,7 @@ def market_breadth_to_dict(row: MarketBreadth | None) -> dict[str, Any] | None:
         "stocks_up_13pct_34days": row.stocks_up_13pct_34days,
         "stocks_down_13pct_34days": row.stocks_down_13pct_34days,
         "total_stocks_scanned": row.total_stocks_scanned,
+        "calculation_duration_seconds": row.calculation_duration_seconds,
     }
 
 
@@ -924,14 +935,16 @@ def safe_publish_scan_bootstrap(scan_id: str | None = None) -> dict[str, Any] | 
     )
 
 
-def safe_publish_breadth_bootstrap() -> dict[str, Any] | None:
+def safe_publish_breadth_bootstrap(market: str | None = "US") -> dict[str, Any] | None:
     from app.wiring.bootstrap import get_ui_snapshot_service
 
+    normalized_market = str(market or "US").strip().upper()
     return _safe_publish(
         "publish_breadth_bootstrap",
         view_key=BREADTH_VIEW_KEY,
-        variant_key="default",
-        fn=get_ui_snapshot_service().publish_breadth_bootstrap,
+        variant_key=f"market:{normalized_market.lower()}",
+        source_revision=normalized_market,
+        fn=lambda: get_ui_snapshot_service().publish_breadth_bootstrap(normalized_market),
     )
 
 

--- a/backend/app/tasks/breadth_tasks.py
+++ b/backend/app/tasks/breadth_tasks.py
@@ -316,7 +316,7 @@ def calculate_daily_breadth(
         try:
             from ..services.ui_snapshot_service import safe_publish_breadth_bootstrap
 
-            safe_publish_breadth_bootstrap()
+            safe_publish_breadth_bootstrap(effective_market)
         except Exception as snapshot_error:
             logger.warning("Breadth snapshot publish failed: %s", snapshot_error)
 
@@ -461,7 +461,7 @@ def backfill_breadth_data(self, start_date: str, end_date: str, market: str = "U
     try:
         from ..services.ui_snapshot_service import safe_publish_breadth_bootstrap
 
-        safe_publish_breadth_bootstrap()
+        safe_publish_breadth_bootstrap((market or "US").upper())
     except Exception as snapshot_error:
         logger.warning("Breadth snapshot publish failed after backfill: %s", snapshot_error)
 

--- a/backend/start_celery.sh
+++ b/backend/start_celery.sh
@@ -29,7 +29,7 @@ echo "Starting Celery workers..."
 POOL="${CELERY_POOL:-solo}"
 
 # Enabled markets (comma-separated). Override via env to skip markets locally.
-ENABLED_MARKETS="${ENABLED_MARKETS:-US,HK,JP,TW}"
+ENABLED_MARKETS="${ENABLED_MARKETS:-US,HK,IN,JP,TW}"
 
 echo "  Pool: $POOL"
 echo "  Enabled markets: $ENABLED_MARKETS"
@@ -47,7 +47,7 @@ echo "  Enabled markets: $ENABLED_MARKETS"
     --loglevel=info \
     --pool="$POOL" \
     --concurrency=1 \
-    -Q data_fetch_shared,data_fetch_us,data_fetch_hk,data_fetch_jp,data_fetch_tw \
+    -Q data_fetch_shared,data_fetch_us,data_fetch_hk,data_fetch_in,data_fetch_jp,data_fetch_tw \
     -n datafetch-global@%h &
 
 # Shared user-scans worker — same safety-net pattern for user-initiated scans.
@@ -64,7 +64,7 @@ for RAW_MARKET in "${MARKET_ARRAY[@]}"; do
     MARKET_LOWER="$(echo "$MARKET_UPPER" | tr '[:upper:]' '[:lower:]')"
 
     case "$MARKET_UPPER" in
-        US|HK|JP|TW) ;;
+        US|HK|IN|JP|TW) ;;
         *)
             echo "  Skipping unknown market: $MARKET_UPPER"
             continue

--- a/backend/tests/parity/test_market_parity_e6.py
+++ b/backend/tests/parity/test_market_parity_e6.py
@@ -60,8 +60,6 @@ EXPECTED_PRIMARY_BENCHMARK = {
 EXPECTED_SCOPE_REASON = {
     AnalyticsFeature.THEME_DISCOVERY:
         "theme content sources are English-language biased; no non-US coverage",
-    AnalyticsFeature.BREADTH_SNAPSHOT:
-        "breadth indicators are computed from the US universe only",
 }
 
 
@@ -127,7 +125,7 @@ class TestUSParityAnalyticsScope:
 
     @pytest.mark.parametrize(
         "feature",
-        [AnalyticsFeature.THEME_DISCOVERY, AnalyticsFeature.BREADTH_SNAPSHOT],
+        [AnalyticsFeature.THEME_DISCOVERY],
     )
     def test_us_tag_shape_is_stable(self, feature: AnalyticsFeature):
         tag = us_only_tag(feature)
@@ -147,6 +145,11 @@ class TestUSParityAnalyticsScope:
         tag = market_scope_tag("HK")
         assert tag == {"market_scope": "HK"}
         require_us_scope("HK", AnalyticsFeature.IBD_GROUP_RANK)
+
+    def test_breadth_scope_is_market_aware(self):
+        tag = market_scope_tag("HK")
+        assert tag == {"market_scope": "HK"}
+        require_us_scope("HK", AnalyticsFeature.BREADTH_SNAPSHOT)
 
 
 class TestUSParityScanner:
@@ -282,12 +285,16 @@ class TestNonUSAnalyticsScope:
     @pytest.mark.parametrize("market", ["HK", "JP", "TW", "hk", " JP ", "eu"])
     @pytest.mark.parametrize(
         "feature",
-        [AnalyticsFeature.THEME_DISCOVERY, AnalyticsFeature.BREADTH_SNAPSHOT],
+        [AnalyticsFeature.THEME_DISCOVERY],
     )
     def test_non_us_scope_is_rejected(self, market, feature):
         with pytest.raises(UnsupportedMarketError) as exc:
             require_us_scope(market, feature)
         assert feature.value in str(exc.value)
+
+    @pytest.mark.parametrize("market", ["HK", "JP", "TW", "hk", " JP ", "eu"])
+    def test_breadth_scope_is_not_rejected(self, market):
+        require_us_scope(market, AnalyticsFeature.BREADTH_SNAPSHOT)
 
     @pytest.mark.parametrize("market", ["HK", "JP", "TW", "hk", " JP ", "eu"])
     def test_group_rank_scope_is_not_rejected(self, market):
@@ -340,7 +347,7 @@ class TestPolicyVersions:
         assert MIXED_MARKET_POLICY_VERSION == "2026.04.13.1"
 
     def test_analytics_scope_policy_version(self):
-        assert ANALYTICS_POLICY_VERSION == "2026.04.20.1"
+        assert ANALYTICS_POLICY_VERSION == "2026.04.26.1"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_analytics_scope.py
+++ b/backend/tests/unit/test_analytics_scope.py
@@ -32,12 +32,13 @@ class TestUsOnlyTag:
         # rejected-field errors.
         assert "policy_version" not in tag
 
-    def test_each_us_only_feature_has_its_own_reason(self):
+    def test_breadth_snapshot_is_market_aware(self):
         themes = us_only_tag(AnalyticsFeature.THEME_DISCOVERY)
-        breadth = us_only_tag(AnalyticsFeature.BREADTH_SNAPSHOT)
+        breadth = market_scope_tag("HK")
 
-        # Reasons must differ — each feature has a distinct justification.
-        assert themes["scope_reason"] != breadth["scope_reason"]
+        assert themes["market_scope"] == "US"
+        assert "scope_reason" in themes
+        assert breadth == {"market_scope": "HK"}
 
 
 class TestRequireUsScope:
@@ -50,7 +51,6 @@ class TestRequireUsScope:
         "market,feature",
         [
             ("JP", AnalyticsFeature.THEME_DISCOVERY),
-            ("TW", AnalyticsFeature.BREADTH_SNAPSHOT),
             ("hk", AnalyticsFeature.THEME_DISCOVERY),  # case-folded
         ],
     )
@@ -73,6 +73,7 @@ class TestRequireUsScope:
     def test_market_aware_features_bypass_us_only_guard(self):
         require_us_scope("HK", AnalyticsFeature.IBD_GROUP_RANK)
         require_us_scope("TW", AnalyticsFeature.IBD_GROUP_RANK)
+        require_us_scope("TW", AnalyticsFeature.BREADTH_SNAPSHOT)
 
 
 class TestMarketScopeTag:
@@ -91,7 +92,8 @@ class TestDescribePolicy:
         snap = describe_policy()
         assert snap["policy_version"] == POLICY_VERSION
         us_only = snap["us_only_features"]
-        for feature in (AnalyticsFeature.THEME_DISCOVERY, AnalyticsFeature.BREADTH_SNAPSHOT):
+        for feature in (AnalyticsFeature.THEME_DISCOVERY,):
             assert feature.value in us_only
             assert isinstance(us_only[feature.value], str)
         assert AnalyticsFeature.IBD_GROUP_RANK.value not in us_only
+        assert AnalyticsFeature.BREADTH_SNAPSHOT.value not in us_only

--- a/backend/tests/unit/test_breadth_endpoints.py
+++ b/backend/tests/unit/test_breadth_endpoints.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base, get_db
+from app.main import app
+from app.models.market_breadth import MarketBreadth
+from app.services import server_auth
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch):
+    monkeypatch.setattr(server_auth.settings, "server_auth_enabled", False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(engine, tables=[MarketBreadth.__table__])
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(engine, tables=[MarketBreadth.__table__])
+        app.dependency_overrides.clear()
+
+
+def _override_db(session):
+    def _yield_db():
+        try:
+            yield session
+        finally:
+            pass
+
+    return _yield_db
+
+
+def _breadth_row(market: str, day: date, *, up: int, down: int) -> MarketBreadth:
+    return MarketBreadth(
+        market=market,
+        date=day,
+        stocks_up_4pct=up,
+        stocks_down_4pct=down,
+        ratio_5day=up / max(down, 1),
+        ratio_10day=(up + 1) / max(down, 1),
+        stocks_up_25pct_quarter=up + 10,
+        stocks_down_25pct_quarter=down + 10,
+        stocks_up_25pct_month=up + 5,
+        stocks_down_25pct_month=down + 5,
+        stocks_up_50pct_month=up + 2,
+        stocks_down_50pct_month=down + 2,
+        stocks_up_13pct_34days=up + 3,
+        stocks_down_13pct_34days=down + 3,
+        total_stocks_scanned=up + down,
+        calculation_duration_seconds=1.25,
+    )
+
+
+@pytest.mark.asyncio
+async def test_current_breadth_filters_by_market(client, session):
+    app.dependency_overrides[get_db] = _override_db(session)
+    session.add_all([
+        _breadth_row("US", date(2026, 4, 24), up=10, down=4),
+        _breadth_row("HK", date(2026, 4, 24), up=22, down=8),
+    ])
+    session.commit()
+
+    response = await client.get("/api/v1/breadth/current", params={"market": "HK"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["market"] == "HK"
+    assert payload["stocks_up_4pct"] == 22
+    assert payload["stocks_down_4pct"] == 8
+
+
+@pytest.mark.asyncio
+async def test_historical_trend_and_summary_filter_by_market(client, session):
+    app.dependency_overrides[get_db] = _override_db(session)
+    session.add_all([
+        _breadth_row("US", date(2026, 4, 23), up=10, down=4),
+        _breadth_row("HK", date(2026, 4, 23), up=20, down=10),
+        _breadth_row("HK", date(2026, 4, 24), up=30, down=5),
+    ])
+    session.commit()
+
+    historical = await client.get(
+        "/api/v1/breadth/historical",
+        params={
+            "start_date": "2026-04-23",
+            "end_date": "2026-04-24",
+            "market": "HK",
+        },
+    )
+    trend = await client.get(
+        "/api/v1/breadth/trend/ratio_5day",
+        params={"days": 10, "market": "HK"},
+    )
+    summary = await client.get("/api/v1/breadth/summary", params={"market": "HK"})
+
+    assert historical.status_code == 200
+    assert [row["market"] for row in historical.json()] == ["HK", "HK"]
+    assert [row["stocks_up_4pct"] for row in historical.json()] == [30, 20]
+
+    assert trend.status_code == 200
+    assert trend.json()["data"] == [
+        {"date": "2026-04-23", "value": 2.0},
+        {"date": "2026-04-24", "value": 6.0},
+    ]
+
+    assert summary.status_code == 200
+    assert summary.json() == {
+        "market": "HK",
+        "latest_date": "2026-04-24",
+        "total_records": 2,
+        "date_range_start": "2026-04-23",
+        "date_range_end": "2026-04-24",
+    }
+
+
+@pytest.mark.asyncio
+async def test_manual_calculation_and_backfill_pass_market_to_tasks(client, monkeypatch):
+    from app.api.v1 import breadth as breadth_module
+    from app.tasks import breadth_tasks
+
+    monkeypatch.setattr(breadth_module.settings, "feature_tasks", True)
+
+    calculation_calls = []
+
+    def fake_calculate(calculation_date=None, market="US"):
+        calculation_calls.append((calculation_date, market))
+
+    monkeypatch.setattr(breadth_tasks, "calculate_daily_breadth", fake_calculate)
+
+    backfill_delay = MagicMock(return_value=SimpleNamespace(id="backfill-hk"))
+    monkeypatch.setattr(breadth_tasks.backfill_breadth_data, "delay", backfill_delay)
+
+    calculate_response = await client.post(
+        "/api/v1/breadth/calculate",
+        json={"calculation_date": "2026-04-24", "market": "HK"},
+    )
+    backfill_response = await client.post(
+        "/api/v1/breadth/backfill",
+        json={"start_date": "2026-04-23", "end_date": "2026-04-24", "market": "HK"},
+    )
+
+    assert calculate_response.status_code == 200
+    assert calculation_calls == [("2026-04-24", "HK")]
+    assert backfill_response.status_code == 200
+    backfill_delay.assert_called_once_with("2026-04-23", "2026-04-24", market="HK")

--- a/backend/tests/unit/test_breadth_tasks.py
+++ b/backend/tests/unit/test_breadth_tasks.py
@@ -126,7 +126,8 @@ def test_manual_breadth_can_force_cache_only_for_static_exports(monkeypatch):
     monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
     _patch_serialized_lock(monkeypatch)
     _patch_calendar_service(monkeypatch, datetime(2026, 4, 3, 0, 30, 0))
-    monkeypatch.setattr(snapshot_module, "safe_publish_breadth_bootstrap", lambda: None)
+    publish_breadth = MagicMock()
+    monkeypatch.setattr(snapshot_module, "safe_publish_breadth_bootstrap", publish_breadth)
 
     fake_price_cache = MagicMock()
     fake_calculator = MagicMock()
@@ -160,6 +161,7 @@ def test_manual_breadth_can_force_cache_only_for_static_exports(monkeypatch):
         calculation_date=date(2026, 4, 2),
         cache_only=True,
     )
+    publish_breadth.assert_called_once_with("US")
 
 
 def test_daily_breadth_persists_non_us_record_in_market_partition(monkeypatch):
@@ -171,7 +173,8 @@ def test_daily_breadth_persists_non_us_record_in_market_partition(monkeypatch):
     monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
     _patch_serialized_lock(monkeypatch)
     _patch_calendar_service(monkeypatch, datetime(2026, 4, 3, 0, 30, 0))
-    monkeypatch.setattr(snapshot_module, "safe_publish_breadth_bootstrap", lambda: None)
+    publish_breadth = MagicMock()
+    monkeypatch.setattr(snapshot_module, "safe_publish_breadth_bootstrap", publish_breadth)
 
     fake_calculator = MagicMock()
     fake_calculator.price_cache = MagicMock()
@@ -208,6 +211,7 @@ def test_daily_breadth_persists_non_us_record_in_market_partition(monkeypatch):
     saved_record = fake_db.add.call_args.args[0]
     assert saved_record.market == "HK"
     fake_db.commit.assert_called_once()
+    publish_breadth.assert_called_once_with("HK")
 
 
 def test_backfill_breadth_uses_service_range_with_trading_dates(monkeypatch):

--- a/backend/tests/unit/test_market_worker_config.py
+++ b/backend/tests/unit/test_market_worker_config.py
@@ -1,0 +1,29 @@
+"""Deployment worker queue coverage for supported markets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.tasks.market_queues import SUPPORTED_MARKETS
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_docker_compose_consumes_every_supported_market_queue():
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+    for market in SUPPORTED_MARKETS:
+        suffix = market.lower()
+        assert f"data_fetch_{suffix}" in compose
+        assert f"market_jobs_{suffix}" in compose
+        assert f"user_scans_{suffix}" in compose
+
+
+def test_local_celery_script_consumes_every_supported_market_queue():
+    script = (ROOT / "backend" / "start_celery.sh").read_text(encoding="utf-8")
+    supported_csv = ",".join(SUPPORTED_MARKETS)
+    supported_case = "|".join(SUPPORTED_MARKETS)
+
+    assert f'ENABLED_MARKETS="${{ENABLED_MARKETS:-{supported_csv}}}"' in script
+    assert f"data_fetch_shared,{','.join(f'data_fetch_{market.lower()}' for market in SUPPORTED_MARKETS)}" in script
+    assert f"{supported_case}) ;;" in script

--- a/backend/tests/unit/test_scan_create_endpoint.py
+++ b/backend/tests/unit/test_scan_create_endpoint.py
@@ -687,6 +687,24 @@ async def test_refresh_scan_cache_rejects_invalid_market(client, monkeypatch):
     apply_async.assert_not_called()
 
 
+@pytest.mark.parametrize("market", ["", "  ", "SHARED", "shared"])
+@pytest.mark.asyncio
+async def test_refresh_scan_cache_rejects_non_explicit_market_scope(client, monkeypatch, market):
+    from app.api.v1 import cache as cache_module
+
+    apply_async = MagicMock()
+    monkeypatch.setattr(cache_module.smart_refresh_cache, "apply_async", apply_async)
+
+    response = await client.post(
+        "/api/v1/scans/refresh-cache",
+        json={"market": market, "mode": "full"},
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported market" in response.json()["detail"]
+    apply_async.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_refresh_scan_cache_only_blocks_same_market_active_refresh(client, monkeypatch):
     from app.api.v1 import cache as cache_module

--- a/backend/tests/unit/test_scan_create_endpoint.py
+++ b/backend/tests/unit/test_scan_create_endpoint.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import httpx
 import pytest
 import pytest_asyncio
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from app.main import app
 from app.services import server_auth
@@ -636,6 +637,83 @@ async def test_create_scan_returns_409_when_market_price_data_is_stale(client):
     assert payload["detail"]["stale_markets"][0]["market"] == "US"
     assert payload["detail"]["stale_markets"][0]["uncovered_symbols"] == 1
     assert payload["detail"]["stale_markets"][0]["oldest_last_cached_date"] == "2026-04-22"
+
+
+@pytest.mark.asyncio
+async def test_refresh_scan_cache_queues_market_specific_manual_refresh(client, monkeypatch):
+    from app.api.v1 import cache as cache_module
+
+    mock_lock = MagicMock()
+    mock_lock.get_current_task.return_value = None
+    monkeypatch.setattr(cache_module, "get_data_fetch_lock", lambda: mock_lock)
+
+    apply_async = MagicMock(return_value=SimpleNamespace(id="refresh-hk"))
+    monkeypatch.setattr(cache_module.smart_refresh_cache, "apply_async", apply_async)
+
+    response = await client.post(
+        "/api/v1/scans/refresh-cache",
+        json={"market": "hk", "mode": "full"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "status": "queued",
+        "task_id": "refresh-hk",
+        "message": "Smart refresh started for entire universe, force re-fetch (~2 hours)",
+    }
+    mock_lock.get_current_task.assert_called_once_with(market="HK")
+    apply_async.assert_called_once_with(
+        kwargs={"mode": "full", "market": "HK"},
+        headers={"origin": "manual"},
+        queue="data_fetch_hk",
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_scan_cache_rejects_invalid_market(client, monkeypatch):
+    from app.api.v1 import cache as cache_module
+
+    apply_async = MagicMock()
+    monkeypatch.setattr(cache_module.smart_refresh_cache, "apply_async", apply_async)
+
+    response = await client.post(
+        "/api/v1/scans/refresh-cache",
+        json={"market": "CN", "mode": "full"},
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported market" in response.json()["detail"]
+    apply_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_scan_cache_only_blocks_same_market_active_refresh(client, monkeypatch):
+    from app.api.v1 import cache as cache_module
+
+    mock_lock = MagicMock()
+    mock_lock.get_current_task.return_value = {
+        "task_id": "running-hk",
+        "task_name": "smart_refresh_cache",
+    }
+    monkeypatch.setattr(cache_module, "get_data_fetch_lock", lambda: mock_lock)
+
+    apply_async = MagicMock()
+    monkeypatch.setattr(cache_module.smart_refresh_cache, "apply_async", apply_async)
+
+    response = await client.post(
+        "/api/v1/scans/refresh-cache",
+        json={"market": "HK", "mode": "full"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "already_running",
+        "task_id": "running-hk",
+        "message": "Refresh already in progress (smart_refresh_cache)",
+    }
+    mock_lock.get_current_task.assert_called_once_with(market="HK")
+    apply_async.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -837,6 +837,52 @@ def test_build_breadth_payload_requires_target_date(service_and_session_factory,
         )
 
 
+def test_build_breadth_payload_serialized_rows_emit_market_benchmark_overlay(
+    service_and_session_factory,
+    monkeypatch,
+):
+    service, _session_factory = service_and_session_factory
+    idx = pd.date_range("2026-03-01", "2026-04-24", freq="D")
+
+    def history_frame(start_price: float) -> pd.DataFrame:
+        closes = [start_price + index for index in range(len(idx))]
+        return pd.DataFrame(
+            {
+                "Open": closes,
+                "High": [value + 1 for value in closes],
+                "Low": [value - 1 for value in closes],
+                "Close": closes,
+                "Volume": [1000] * len(idx),
+            },
+            index=idx,
+        )
+
+    monkeypatch.setattr(
+        service,
+        "_get_market_benchmark_history",
+        lambda market, *, period: ("^HSI", history_frame(18000.0)),
+    )
+    monkeypatch.setattr(
+        service,
+        "_get_cached_price_histories",
+        lambda symbols, *, period: {symbol: history_frame(100.0) for symbol in symbols},
+    )
+
+    payload = service._build_breadth_payload(  # noqa: SLF001 - intentional unit coverage
+        generated_at="2026-04-24T22:00:00Z",
+        expected_as_of_date=date(2026, 4, 24),
+        market="HK",
+        serialized_rows=[{"symbol": "0700.HK"}],
+    )
+
+    breadth_payload = payload["payload"]
+    assert breadth_payload["current"]["market"] == "HK"
+    assert breadth_payload["summary"]["market"] == "HK"
+    assert breadth_payload["benchmark_symbol"] == "^HSI"
+    assert breadth_payload["benchmark_overlay"] == breadth_payload["spy_overlay"]
+    assert breadth_payload["benchmark_overlay"][-1]["date"] == "2026-04-24"
+
+
 def test_export_rejects_legacy_unscoped_run_for_market_bundle(
     service_and_session_factory,
     tmp_path,

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -821,7 +821,7 @@ def test_build_breadth_payload_requires_target_date(service_and_session_factory,
     monkeypatch.setattr(
         service._ui_snapshot_service,
         "publish_breadth_bootstrap",
-        lambda: SimpleNamespace(
+        lambda market="US": SimpleNamespace(
             to_dict=lambda: {
                 "published_at": "2026-04-02T22:00:00Z",
                 "source_revision": "breadth:2026-04-02",

--- a/backend/tests/unit/test_ui_snapshot_service.py
+++ b/backend/tests/unit/test_ui_snapshot_service.py
@@ -237,7 +237,12 @@ def test_publish_all_skips_groups_when_rankings_are_missing(monkeypatch):
             return fake_snapshot
 
     monkeypatch.setattr(service, "publish_scan_bootstrap", lambda scan_id=None: _FakeSnapshot())
-    monkeypatch.setattr(service, "publish_breadth_bootstrap", lambda: _FakeSnapshot())
+    published_breadth_markets = []
+    monkeypatch.setattr(
+        service,
+        "publish_breadth_bootstrap",
+        lambda market="US": published_breadth_markets.append(market) or _FakeSnapshot(),
+    )
     monkeypatch.setattr(service, "publish_groups_bootstrap", lambda: None)
     monkeypatch.setattr(service, "publish_themes_bootstrap", lambda pipeline, theme_view: _FakeSnapshot())
     monkeypatch.setattr("app.services.ui_snapshot_service.settings.feature_themes", False)
@@ -246,6 +251,10 @@ def test_publish_all_skips_groups_when_rankings_are_missing(monkeypatch):
 
     assert published["scan_latest"] == fake_snapshot
     assert published["breadth"] == fake_snapshot
+    assert published["breadth_us"] == fake_snapshot
+    assert published["breadth_hk"] == fake_snapshot
+    assert published["breadth_in"] == fake_snapshot
+    assert published_breadth_markets == ["US", "HK", "IN", "JP", "TW"]
     assert published["groups"] is None
 
 

--- a/backend/tests/unit/test_ui_snapshot_service.py
+++ b/backend/tests/unit/test_ui_snapshot_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import sessionmaker
 from app.database import Base
 from app.infra.db.models.feature_store import FeatureRun
 from app.models.industry import IBDGroupRank
+from app.models.market_breadth import MarketBreadth
 from app.models.scan_result import Scan, ScanResult
 from app.models.stock_universe import StockUniverse
 from app.models.theme import ThemeAlert, ThemeCluster, ThemeMergeSuggestion, ThemeMetrics, ThemePipelineRun
@@ -256,6 +257,64 @@ def test_publish_all_skips_groups_when_rankings_are_missing(monkeypatch):
     assert published["breadth_in"] == fake_snapshot
     assert published_breadth_markets == ["US", "HK", "IN", "JP", "TW"]
     assert published["groups"] is None
+
+
+def test_breadth_payload_uses_benchmark_fallback_when_primary_cache_is_empty(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[MarketBreadth.__table__])
+    Session = sessionmaker(bind=engine)
+    service = UISnapshotService(Session)
+
+    with Session() as db:
+        db.add(
+            MarketBreadth(
+                market="HK",
+                date=date(2026, 4, 24),
+                stocks_up_4pct=22,
+                stocks_down_4pct=8,
+                ratio_5day=2.75,
+                ratio_10day=2.5,
+                stocks_up_25pct_quarter=30,
+                stocks_down_25pct_quarter=12,
+                stocks_up_25pct_month=24,
+                stocks_down_25pct_month=10,
+                stocks_up_50pct_month=6,
+                stocks_down_50pct_month=2,
+                stocks_up_13pct_34days=18,
+                stocks_down_13pct_34days=7,
+                total_stocks_scanned=30,
+                calculation_duration_seconds=1.25,
+            )
+        )
+        db.commit()
+
+    class _FakeBenchmarkCache:
+        def get_benchmark_candidates(self, market):
+            assert market == "HK"
+            return ["^HSI", "2800.HK"]
+
+        def get_benchmark_symbol(self, market):
+            assert market == "HK"
+            return "^HSI"
+
+    monkeypatch.setattr("app.wiring.bootstrap.get_benchmark_cache", lambda: _FakeBenchmarkCache())
+
+    history_calls = []
+
+    def fake_cached_price_history(symbol, period):
+        history_calls.append((symbol, period))
+        if symbol == "2800.HK":
+            return [{"date": "2026-04-24", "close": 18.4}]
+        return []
+
+    monkeypatch.setattr(service, "_get_cached_price_history", fake_cached_price_history)
+
+    payload = service._build_breadth_payload("HK")  # noqa: SLF001 - intentional unit coverage
+
+    assert payload["benchmark_symbol"] == "2800.HK"
+    assert payload["benchmark_overlay"] == [{"date": "2026-04-24", "close": 18.4}]
+    assert payload["spy_overlay"] == payload["benchmark_overlay"]
+    assert history_calls == [("^HSI", "1mo"), ("2800.HK", "1mo")]
 
 
 def test_publish_groups_bootstrap_serializes_rankings_when_available():

--- a/backend/tests/unit/test_ui_snapshot_service.py
+++ b/backend/tests/unit/test_ui_snapshot_service.py
@@ -145,13 +145,23 @@ def test_publish_scan_bootstrap_serializes_universe_stats_counts():
 
     snapshot = service.publish_scan_bootstrap()
 
-    assert snapshot.payload["universe_stats"] == {
+    universe_stats = snapshot.payload["universe_stats"]
+    core_universe_stats = {
+        key: universe_stats[key]
+        for key in ("total", "active", "by_exchange", "sp500", "by_status", "recent_deactivations")
+    }
+    assert core_universe_stats == {
         "total": 4,
         "active": 3,
         "by_exchange": {"NASDAQ": 2, "NYSE": 1},
         "sp500": 2,
         "by_status": {"active": 3, "inactive_manual": 1},
         "recent_deactivations": [],
+    }
+    assert universe_stats["by_market"]["US"]["counts"] == {
+        "total": 4,
+        "active": 3,
+        "inactive": 1,
     }
     assert json.loads(json.dumps(snapshot.payload)) == snapshot.payload
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
 
   celery-datafetch:
     <<: *worker-common
-    command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q data_fetch_shared,data_fetch_us,data_fetch_hk,data_fetch_jp,data_fetch_tw -n datafetch-global@%h
+    command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q data_fetch_shared,data_fetch_us,data_fetch_hk,data_fetch_in,data_fetch_jp,data_fetch_tw -n datafetch-global@%h
 
   celery-marketjobs-us:
     <<: *worker-common
@@ -173,6 +173,10 @@ services:
   celery-marketjobs-hk:
     <<: *worker-common
     command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q market_jobs_hk -n marketjobs-hk@%h
+
+  celery-marketjobs-in:
+    <<: *worker-common
+    command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q market_jobs_in -n marketjobs-in@%h
 
   celery-marketjobs-jp:
     <<: *worker-common
@@ -193,6 +197,10 @@ services:
   celery-userscans-hk:
     <<: *worker-common
     command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q user_scans_hk -n userscans-hk@%h
+
+  celery-userscans-in:
+    <<: *worker-common
+    command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q user_scans_in -n userscans-in@%h
 
   celery-userscans-jp:
     <<: *worker-common

--- a/frontend/src/api/breadth.js
+++ b/frontend/src/api/breadth.js
@@ -6,16 +6,20 @@ import apiClient from './client';
 /**
  * Get the most recent market breadth data.
  */
-export const getCurrentBreadth = async () => {
-  const response = await apiClient.get('/v1/breadth/current');
+export const getCurrentBreadth = async (market = 'US') => {
+  const response = await apiClient.get('/v1/breadth/current', {
+    params: { market }
+  });
   return response.data;
 };
 
 /**
  * Get the published breadth bootstrap snapshot for the default dashboard view.
  */
-export const getBreadthBootstrap = async () => {
-  const response = await apiClient.get('/v1/breadth/bootstrap');
+export const getBreadthBootstrap = async (market = 'US') => {
+  const response = await apiClient.get('/v1/breadth/bootstrap', {
+    params: { market }
+  });
   return response.data;
 };
 
@@ -26,9 +30,9 @@ export const getBreadthBootstrap = async () => {
  * @param {string} endDate - End date in YYYY-MM-DD format
  * @param {number} limit - Maximum number of records to return (default: 365)
  */
-export const getHistoricalBreadth = async (startDate, endDate, limit = 365) => {
+export const getHistoricalBreadth = async (startDate, endDate, limit = 365, market = 'US') => {
   const response = await apiClient.get('/v1/breadth/historical', {
-    params: { start_date: startDate, end_date: endDate, limit }
+    params: { start_date: startDate, end_date: endDate, limit, market }
   });
   return response.data;
 };
@@ -39,9 +43,9 @@ export const getHistoricalBreadth = async (startDate, endDate, limit = 365) => {
  * @param {string} indicator - The indicator name (e.g., 'stocks_up_4pct')
  * @param {number} days - Number of days to retrieve (default: 30)
  */
-export const getIndicatorTrend = async (indicator, days = 30) => {
+export const getIndicatorTrend = async (indicator, days = 30, market = 'US') => {
   const response = await apiClient.get(`/v1/breadth/trend/${indicator}`, {
-    params: { days }
+    params: { days, market }
   });
   return response.data;
 };
@@ -49,8 +53,10 @@ export const getIndicatorTrend = async (indicator, days = 30) => {
 /**
  * Get summary statistics for market breadth.
  */
-export const getBreadthSummary = async () => {
-  const response = await apiClient.get('/v1/breadth/summary');
+export const getBreadthSummary = async (market = 'US') => {
+  const response = await apiClient.get('/v1/breadth/summary', {
+    params: { market }
+  });
   return response.data;
 };
 
@@ -59,9 +65,10 @@ export const getBreadthSummary = async () => {
  *
  * @param {string|null} date - Date in YYYY-MM-DD format (null for today)
  */
-export const triggerCalculation = async (date = null) => {
+export const triggerCalculation = async (date = null, market = 'US') => {
   const response = await apiClient.post('/v1/breadth/calculate', {
-    calculation_date: date
+    calculation_date: date,
+    market
   });
   return response.data;
 };
@@ -72,10 +79,11 @@ export const triggerCalculation = async (date = null) => {
  * @param {string} startDate - Start date in YYYY-MM-DD format
  * @param {string} endDate - End date in YYYY-MM-DD format
  */
-export const triggerBackfill = async (startDate, endDate) => {
+export const triggerBackfill = async (startDate, endDate, market = 'US') => {
   const response = await apiClient.post('/v1/breadth/backfill', {
     start_date: startDate,
-    end_date: endDate
+    end_date: endDate,
+    market
   });
   return response.data;
 };

--- a/frontend/src/api/scans.js
+++ b/frontend/src/api/scans.js
@@ -39,6 +39,18 @@ export const createScan = async ({
 };
 
 /**
+ * Trigger a market-scoped price cache refresh from the scan workflow.
+ * @param {Object} params - Refresh parameters
+ * @param {string} params.market - Market code: US, HK, IN, JP, or TW
+ * @param {string} params.mode - Refresh mode: 'auto' or 'full'
+ * @returns {Promise<Object>} Refresh queue response with task_id
+ */
+export const refreshScanCache = async ({ market, mode = 'full' }) => {
+  const response = await apiClient.post('/v1/scans/refresh-cache', { market, mode });
+  return response.data;
+};
+
+/**
  * Get scan status and progress
  * @param {string} scanId - Scan ID
  * @returns {Promise<Object>} Scan status with progress information

--- a/frontend/src/components/Charts/BreadthChart.jsx
+++ b/frontend/src/components/Charts/BreadthChart.jsx
@@ -1,8 +1,8 @@
 /**
- * Market Breadth Chart with SPY Overlay
+ * Market Breadth Chart with optional benchmark overlay
  *
  * Displays daily breadth movers (stocks up/down 4%+)
- * with S&P 500 price overlay on secondary axis
+ * with benchmark price overlay on secondary axis when available
  */
 import { useMemo } from 'react';
 import {
@@ -31,7 +31,7 @@ import { format, parseISO } from 'date-fns';
 /**
  * Custom tooltip component for breadth chart
  */
-const CustomTooltip = ({ active, payload, label }) => {
+const CustomTooltip = ({ active, payload, label, benchmarkLabel = 'SPY' }) => {
   if (!active || !payload || !payload.length) return null;
 
   return (
@@ -51,7 +51,7 @@ const CustomTooltip = ({ active, payload, label }) => {
       {payload.map((entry, index) => (
         <Typography key={index} variant="body2" sx={{ color: entry.color }}>
           {entry.name}:{' '}
-          {entry.name === 'SPY' ? `$${entry.value?.toFixed(2)}` : entry.value}
+          {entry.name === benchmarkLabel ? `$${entry.value?.toFixed(2)}` : entry.value}
         </Typography>
       ))}
     </Box>
@@ -63,7 +63,7 @@ const CustomTooltip = ({ active, payload, label }) => {
  *
  * @param {Object} props
  * @param {Array} props.breadthData - Historical breadth data array
- * @param {Array} props.spyData - SPY historical price data array
+ * @param {Array} props.spyData - Benchmark historical price data array
  * @param {boolean} props.isLoading - Loading state
  * @param {Error} props.error - Error object if any
  * @param {string} props.timeRange - Selected time range (6M, 1Y, 2Y)
@@ -73,6 +73,7 @@ const CustomTooltip = ({ active, payload, label }) => {
 function BreadthChart({
   breadthData,
   spyData,
+  benchmarkLabel = 'SPY',
   isLoading,
   error,
   timeRange = '1Y',
@@ -81,28 +82,29 @@ function BreadthChart({
   height = 400,
   fillContainer = false,
 }) {
-  // Merge breadth and SPY data by date
+  // Merge breadth and benchmark data by date
   const chartData = useMemo(() => {
     if (!breadthData || breadthData.length === 0) return [];
 
-    // Create map of SPY prices by date
-    const spyByDate = {};
+    // Create map of benchmark prices by date
+    const benchmarkByDate = {};
     if (spyData && spyData.length > 0) {
       spyData.forEach((d) => {
-        spyByDate[d.date] = d.close;
+        benchmarkByDate[d.date] = d.close;
       });
     }
 
-    // Merge data (breadth data is primary, add SPY where available)
+    // Merge data (breadth data is primary, add benchmark where available)
     return breadthData
       .map((b) => ({
         date: b.date,
         stocksUp: b.stocks_up_4pct,
         stocksDown: b.stocks_down_4pct,
-        spy: spyByDate[b.date] || null,
+        benchmark: benchmarkByDate[b.date] || null,
       }))
       .sort((a, b) => new Date(a.date) - new Date(b.date));
   }, [breadthData, spyData]);
+  const hasBenchmarkOverlay = chartData.some((row) => row.benchmark != null);
 
   if (isLoading) {
     return (
@@ -152,7 +154,7 @@ function BreadthChart({
           }}
         >
           <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: fillContainer ? '14px' : '16px' }}>
-            Market Breadth (4%+ Movers) with SPY Overlay
+            Market Breadth (4%+ Movers){hasBenchmarkOverlay ? ` with ${benchmarkLabel} Overlay` : ''}
           </Typography>
           <ToggleButtonGroup
             value={timeRange}
@@ -201,22 +203,23 @@ function BreadthChart({
               }}
             />
 
-            {/* Right Y-axis: SPY price */}
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              tick={{ fontSize: 11 }}
-              tickFormatter={(value) => `$${value}`}
-              domain={['auto', 'auto']}
-              label={{
-                value: 'SPY Price',
-                angle: 90,
-                position: 'insideRight',
-                style: { fontSize: 12 },
-              }}
-            />
+            {hasBenchmarkOverlay && (
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tick={{ fontSize: 11 }}
+                tickFormatter={(value) => `$${value}`}
+                domain={['auto', 'auto']}
+                label={{
+                  value: `${benchmarkLabel} Price`,
+                  angle: 90,
+                  position: 'insideRight',
+                  style: { fontSize: 12 },
+                }}
+              />
+            )}
 
-            <Tooltip content={<CustomTooltip />} />
+            <Tooltip content={<CustomTooltip benchmarkLabel={benchmarkLabel} />} />
             <Legend />
 
             {/* Stocks Up 4%+ - Green Area */}
@@ -241,17 +244,18 @@ function BreadthChart({
               strokeWidth={1.5}
             />
 
-            {/* SPY Price - Blue Line */}
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="spy"
-              name="SPY"
-              stroke="#2196f3"
-              strokeWidth={2}
-              dot={false}
-              connectNulls
-            />
+            {hasBenchmarkOverlay && (
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="benchmark"
+                name={benchmarkLabel}
+                stroke="#2196f3"
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+              />
+            )}
           </ComposedChart>
         </ResponsiveContainer>
         </Box>
@@ -274,10 +278,12 @@ function BreadthChart({
             <span style={{ color: '#f44336', fontWeight: 600 }}>Red:</span>{' '}
             Stocks down 4%+ (daily count)
           </Typography>
-          <Typography variant="caption" color="text.secondary">
-            <span style={{ color: '#2196f3', fontWeight: 600 }}>Blue:</span>{' '}
-            S&P 500 (SPY) price
-          </Typography>
+          {hasBenchmarkOverlay && (
+            <Typography variant="caption" color="text.secondary">
+              <span style={{ color: '#2196f3', fontWeight: 600 }}>Blue:</span>{' '}
+              {benchmarkLabel} price
+            </Typography>
+          )}
         </Box>
       </CardContent>
     </Card>

--- a/frontend/src/features/scan/components/ScanControlBar.jsx
+++ b/frontend/src/features/scan/components/ScanControlBar.jsx
@@ -99,9 +99,13 @@ export default function ScanControlBar({
   const cancelScanErrorMessage = typeof cancelScanError === 'string'
     ? cancelScanError
     : cancelScanError?.message;
+  const refreshStaleDataErrorDetail = refreshStaleDataError?.response?.data?.detail;
   const refreshStaleDataErrorMessage = typeof refreshStaleDataError === 'string'
     ? refreshStaleDataError
-    : refreshStaleDataError?.response?.data?.detail || refreshStaleDataError?.message;
+    : (typeof refreshStaleDataErrorDetail === 'string'
+        ? refreshStaleDataErrorDetail
+        : refreshStaleDataErrorDetail?.message)
+      || refreshStaleDataError?.message;
   const staleMarket = staleRefreshMarket(createScanError, universeMarket);
 
   return (

--- a/frontend/src/features/scan/components/ScanControlBar.jsx
+++ b/frontend/src/features/scan/components/ScanControlBar.jsx
@@ -17,6 +17,7 @@ import {
   Tooltip,
 } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import StopIcon from '@mui/icons-material/Stop';
 import ScanProgress from '../../../components/Scan/ScanProgress';
 import { formatScanDropdownLabel } from '../../../utils/scanLabel';
@@ -42,6 +43,15 @@ function stockCountLabel(universeMarket, universeScope, universeStats, statsLoad
 
 function toOptionalNumber(rawValue) {
   return rawValue === '' ? undefined : Number(rawValue);
+}
+
+function staleRefreshMarket(createScanError, fallbackMarket) {
+  const detail = createScanError?.detail;
+  if (detail?.code !== 'market_data_stale') {
+    return null;
+  }
+  const market = detail.stale_markets?.[0]?.market || detail.market || fallbackMarket;
+  return market ? String(market).toUpperCase() : null;
 }
 
 export default function ScanControlBar({
@@ -71,6 +81,9 @@ export default function ScanControlBar({
   createScanError,
   cancelScanError,
   refreshConflict = null,
+  onRefreshStaleData,
+  refreshStaleDataPending = false,
+  refreshStaleDataError = null,
 }) {
   const controlsDisabled = createScanPending || scanStatus === 'running';
   const scopeOptions = universeMarket ? UNIVERSE_SCOPES_BY_MARKET[universeMarket] ?? [] : [];
@@ -86,6 +99,10 @@ export default function ScanControlBar({
   const cancelScanErrorMessage = typeof cancelScanError === 'string'
     ? cancelScanError
     : cancelScanError?.message;
+  const refreshStaleDataErrorMessage = typeof refreshStaleDataError === 'string'
+    ? refreshStaleDataError
+    : refreshStaleDataError?.response?.data?.detail || refreshStaleDataError?.message;
+  const staleMarket = staleRefreshMarket(createScanError, universeMarket);
 
   return (
     <Paper elevation={1} sx={{ p: 1.5, mb: 2 }}>
@@ -337,8 +354,27 @@ export default function ScanControlBar({
       </Collapse>
 
       {createScanErrorMessage && (
-        <Alert severity="error" sx={{ mt: 1 }}>
+        <Alert
+          severity="error"
+          sx={{ mt: 1 }}
+          action={staleMarket && onRefreshStaleData ? (
+            <Button
+              color="inherit"
+              size="small"
+              startIcon={refreshStaleDataPending ? <CircularProgress size={14} /> : <RefreshIcon />}
+              disabled={refreshStaleDataPending}
+              onClick={() => onRefreshStaleData(staleMarket)}
+            >
+              Refresh {staleMarket} data
+            </Button>
+          ) : null}
+        >
           Error: {createScanErrorMessage}
+        </Alert>
+      )}
+      {refreshStaleDataErrorMessage && (
+        <Alert severity="error" sx={{ mt: 1 }}>
+          Error: {refreshStaleDataErrorMessage}
         </Alert>
       )}
       {cancelScanErrorMessage && (

--- a/frontend/src/features/scan/pages/ScanPageContainer.jsx
+++ b/frontend/src/features/scan/pages/ScanPageContainer.jsx
@@ -11,6 +11,7 @@ import {
   getScans,
   getScanStatus,
   getUniverseStats,
+  refreshScanCache,
 } from '../../../api/scans';
 import FilterPanel from '../components/FilterPanelContainer';
 import ChartViewerModal from '../../../components/Scan/ChartViewerModal';
@@ -66,6 +67,11 @@ function getMutationErrorMessage(error) {
     || error?.response?.data?.message
     || error?.message
     || 'Failed to start scan.';
+}
+
+function getMutationErrorDetail(error) {
+  const detail = error?.response?.data?.detail;
+  return detail && typeof detail === 'object' ? detail : null;
 }
 
 function ScanPage() {
@@ -309,6 +315,13 @@ function ScanPage() {
     },
   });
 
+  const refreshScanCacheMutation = useMutation({
+    mutationFn: (params) => refreshScanCache(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['runtimeActivity'] });
+    },
+  });
+
   const { data: statusData } = useQuery({
     queryKey: ['scanStatus', currentScanId],
     queryFn: () => getScanStatus(currentScanId),
@@ -373,7 +386,8 @@ function ScanPage() {
   );
   const createScanError = useMemo(() => {
     const message = getMutationErrorMessage(createScanMutation.error);
-    return message ? { message } : null;
+    const detail = getMutationErrorDetail(createScanMutation.error);
+    return message ? { message, detail } : null;
   }, [createScanMutation.error]);
 
   const handleStartScan = () => {
@@ -395,6 +409,13 @@ function ScanPage() {
       criteria,
     });
   };
+
+  const handleRefreshStaleData = useCallback((market) => {
+    if (!market) {
+      return;
+    }
+    refreshScanCacheMutation.mutate({ market, mode: 'full' });
+  }, [refreshScanCacheMutation]);
 
   const handleUniverseMarketChange = useCallback((nextMarket) => {
     if (nextMarket === universeMarket) {
@@ -578,6 +599,9 @@ function ScanPage() {
         createScanError={createScanError}
         cancelScanError={cancelScanMutation.error}
         refreshConflict={refreshConflict}
+        onRefreshStaleData={handleRefreshStaleData}
+        refreshStaleDataPending={refreshScanCacheMutation.isPending}
+        refreshStaleDataError={refreshScanCacheMutation.error}
       />
 
       {(scanStatus === 'completed' || scanStatus === 'cancelled') && (

--- a/frontend/src/pages/BreadthPage.jsx
+++ b/frontend/src/pages/BreadthPage.jsx
@@ -267,6 +267,26 @@ function BreadthPage() {
     setSelectedTab(newValue);
   };
 
+  const marketSelector = (
+    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+      <FormControl size="small" sx={{ minWidth: 180 }}>
+        <InputLabel id="breadth-market-label">Market</InputLabel>
+        <Select
+          labelId="breadth-market-label"
+          value={selectedMarket}
+          label="Market"
+          onChange={(event) => setSelectedMarket(event.target.value)}
+        >
+          {marketOptions.map((market) => (
+            <MenuItem key={market} value={market}>
+              {MARKET_LABELS[market] || market}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+
   if (!runtimeReady) {
     return (
       <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
@@ -279,9 +299,10 @@ function BreadthPage() {
 
   if (errorCurrent) {
     return (
-      <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 2 }}>
+        {marketSelector}
         <Alert severity="error">
-          Error loading breadth data: {errorCurrent.message}
+          Error loading {selectedMarket} breadth data: {errorCurrent.message}
         </Alert>
       </Container>
     );
@@ -295,23 +316,7 @@ function BreadthPage() {
         </Box>
       ) : (
         <>
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
-            <FormControl size="small" sx={{ minWidth: 180 }}>
-              <InputLabel id="breadth-market-label">Market</InputLabel>
-              <Select
-                labelId="breadth-market-label"
-                value={selectedMarket}
-                label="Market"
-                onChange={(event) => setSelectedMarket(event.target.value)}
-              >
-                {marketOptions.map((market) => (
-                  <MenuItem key={market} value={market}>
-                    {MARKET_LABELS[market] || market}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Box>
+          {marketSelector}
 
           {/* Top Section - Side by Side Layout */}
           <Grid container spacing={2} sx={{ mb: 2 }}>

--- a/frontend/src/pages/BreadthPage.jsx
+++ b/frontend/src/pages/BreadthPage.jsx
@@ -147,6 +147,13 @@ function BreadthPage() {
         return fallbackMarket;
       }
       if (
+        !userSelectedMarketRef.current
+        && marketOptions.includes(normalizedPrimary)
+        && currentMarket !== normalizedPrimary
+      ) {
+        return normalizedPrimary;
+      }
+      if (
         primaryChanged
         && !userSelectedMarketRef.current
         && currentMarket !== fallbackMarket
@@ -205,10 +212,9 @@ function BreadthPage() {
         ['breadth', 'chart', selectedMarket, defaultChartDateRange.startDate, defaultChartDateRange.endDate],
         payload.chart_data ?? []
       );
-      const snapshotBenchmarkSymbol = payload.benchmark_symbol || benchmarkSymbol;
-      if (snapshotBenchmarkSymbol) {
+      if (benchmarkSymbol) {
         queryClient.setQueryData(
-          ['benchmark', 'history', selectedMarket, snapshotBenchmarkSymbol, '1mo'],
+          ['benchmark', 'history', selectedMarket, benchmarkSymbol, '1mo'],
           payload.benchmark_overlay ?? payload.spy_overlay ?? []
         );
       }

--- a/frontend/src/pages/BreadthPage.jsx
+++ b/frontend/src/pages/BreadthPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Container,
@@ -92,12 +92,12 @@ const MARKET_LABELS = {
   TW: 'Taiwan',
 };
 
-const MARKET_BENCHMARK_SYMBOLS = {
+const MARKET_LIVE_BENCHMARK_SYMBOLS = {
   US: 'SPY',
-  HK: '^HSI',
-  IN: '^NSEI',
-  JP: '^N225',
-  TW: '^TWII',
+  HK: '2800.HK',
+  IN: 'NIFTYBEES.NS',
+  JP: '1306.T',
+  TW: '0050.TW',
 };
 
 function normalizeMarket(market) {
@@ -118,6 +118,8 @@ function BreadthPage() {
   const [chartTimeRange, setChartTimeRange] = useState('1M');
   const [bootstrapSettled, setBootstrapSettled] = useState(false);
   const [selectedMarket, setSelectedMarket] = useState(() => normalizeMarket(primaryMarket));
+  const userSelectedMarketRef = useRef(false);
+  const previousPrimaryMarketRef = useRef(normalizeMarket(primaryMarket));
   const marketOptions = useMemo(() => {
     const enabled = (enabledMarkets || [])
       .map(normalizeMarket)
@@ -133,13 +135,28 @@ function BreadthPage() {
     if (marketOptions.length === 0) {
       return;
     }
-    if (!marketOptions.includes(selectedMarket)) {
-      const normalizedPrimary = normalizeMarket(primaryMarket);
-      setSelectedMarket(
-        marketOptions.includes(normalizedPrimary) ? normalizedPrimary : marketOptions[0]
-      );
-    }
-  }, [marketOptions, primaryMarket, selectedMarket]);
+    const normalizedPrimary = normalizeMarket(primaryMarket);
+    const fallbackMarket = marketOptions.includes(normalizedPrimary)
+      ? normalizedPrimary
+      : marketOptions[0];
+    const primaryChanged = previousPrimaryMarketRef.current !== normalizedPrimary;
+
+    setSelectedMarket((currentMarket) => {
+      if (!marketOptions.includes(currentMarket)) {
+        userSelectedMarketRef.current = false;
+        return fallbackMarket;
+      }
+      if (
+        primaryChanged
+        && !userSelectedMarketRef.current
+        && currentMarket !== fallbackMarket
+      ) {
+        return fallbackMarket;
+      }
+      return currentMarket;
+    });
+    previousPrimaryMarketRef.current = normalizedPrimary;
+  }, [marketOptions, primaryMarket]);
   useEffect(() => {
     setBootstrapSettled(false);
   }, [selectedMarket]);
@@ -153,7 +170,7 @@ function BreadthPage() {
   const startDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
   const spyPeriodMap = { '1M': '1mo', '3M': '3mo', '6M': '6mo', '1Y': '1y' };
   const spyPeriod = spyPeriodMap[chartTimeRange] || '1y';
-  const benchmarkSymbol = MARKET_BENCHMARK_SYMBOLS[selectedMarket] || null;
+  const benchmarkSymbol = MARKET_LIVE_BENCHMARK_SYMBOLS[selectedMarket] || null;
 
   const breadthBootstrapQuery = useQuery({
     queryKey: ['breadthBootstrap', selectedMarket],
@@ -188,13 +205,17 @@ function BreadthPage() {
         ['breadth', 'chart', selectedMarket, defaultChartDateRange.startDate, defaultChartDateRange.endDate],
         payload.chart_data ?? []
       );
-      queryClient.setQueryData(
-        ['benchmark', 'history', selectedMarket, '1mo'],
-        payload.benchmark_overlay ?? payload.spy_overlay ?? []
-      );
+      const snapshotBenchmarkSymbol = payload.benchmark_symbol || benchmarkSymbol;
+      if (snapshotBenchmarkSymbol) {
+        queryClient.setQueryData(
+          ['benchmark', 'history', selectedMarket, snapshotBenchmarkSymbol, '1mo'],
+          payload.benchmark_overlay ?? payload.spy_overlay ?? []
+        );
+      }
     }
     setBootstrapSettled(true);
   }, [
+    benchmarkSymbol,
     breadthBootstrapQuery.data,
     breadthBootstrapQuery.isError,
     breadthBootstrapQuery.isSuccess,
@@ -250,13 +271,11 @@ function BreadthPage() {
     staleTime: 60_000,
   });
 
-  // Fetch SPY historical data for overlay
+  // Fetch optional benchmark history for the overlay
   const {
     data: benchmarkData,
-    isLoading: isLoadingSpy,
-    error: errorSpy,
   } = useQuery({
-    queryKey: ['benchmark', 'history', selectedMarket, spyPeriod],
+    queryKey: ['benchmark', 'history', selectedMarket, benchmarkSymbol, spyPeriod],
     queryFn: () => getPriceHistory(benchmarkSymbol, spyPeriod),
     enabled: liveQueriesEnabled && Boolean(benchmarkSymbol),
     staleTime: 60_000,
@@ -274,7 +293,10 @@ function BreadthPage() {
           labelId="breadth-market-label"
           value={selectedMarket}
           label="Market"
-          onChange={(event) => setSelectedMarket(event.target.value)}
+          onChange={(event) => {
+            userSelectedMarketRef.current = true;
+            setSelectedMarket(event.target.value);
+          }}
         >
           {marketOptions.map((market) => (
             <MenuItem key={market} value={market}>
@@ -325,8 +347,8 @@ function BreadthPage() {
                 breadthData={chartBreadthData}
                 spyData={benchmarkData || []}
                 benchmarkLabel={benchmarkSymbol || 'Benchmark'}
-                isLoading={isLoadingChartBreadth || (Boolean(benchmarkSymbol) && isLoadingSpy)}
-                error={errorChartBreadth || errorSpy}
+                isLoading={isLoadingChartBreadth}
+                error={errorChartBreadth}
                 timeRange={chartTimeRange}
                 onTimeRangeChange={setChartTimeRange}
                 fillContainer

--- a/frontend/src/pages/BreadthPage.jsx
+++ b/frontend/src/pages/BreadthPage.jsx
@@ -154,7 +154,6 @@ function BreadthPage() {
   const spyPeriodMap = { '1M': '1mo', '3M': '3mo', '6M': '6mo', '1Y': '1y' };
   const spyPeriod = spyPeriodMap[chartTimeRange] || '1y';
   const benchmarkSymbol = MARKET_BENCHMARK_SYMBOLS[selectedMarket] || null;
-  const liveBenchmarkSymbol = benchmarkSymbol && !benchmarkSymbol.startsWith('^') ? benchmarkSymbol : null;
 
   const breadthBootstrapQuery = useQuery({
     queryKey: ['breadthBootstrap', selectedMarket],
@@ -258,8 +257,8 @@ function BreadthPage() {
     error: errorSpy,
   } = useQuery({
     queryKey: ['benchmark', 'history', selectedMarket, spyPeriod],
-    queryFn: () => getPriceHistory(liveBenchmarkSymbol, spyPeriod),
-    enabled: liveQueriesEnabled && Boolean(liveBenchmarkSymbol),
+    queryFn: () => getPriceHistory(benchmarkSymbol, spyPeriod),
+    enabled: liveQueriesEnabled && Boolean(benchmarkSymbol),
     staleTime: 60_000,
   });
 
@@ -326,7 +325,7 @@ function BreadthPage() {
                 breadthData={chartBreadthData}
                 spyData={benchmarkData || []}
                 benchmarkLabel={benchmarkSymbol || 'Benchmark'}
-                isLoading={isLoadingChartBreadth || (Boolean(liveBenchmarkSymbol) && isLoadingSpy)}
+                isLoading={isLoadingChartBreadth || (Boolean(benchmarkSymbol) && isLoadingSpy)}
                 error={errorChartBreadth || errorSpy}
                 timeRange={chartTimeRange}
                 onTimeRangeChange={setChartTimeRange}

--- a/frontend/src/pages/BreadthPage.jsx
+++ b/frontend/src/pages/BreadthPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Container,
@@ -9,8 +9,12 @@ import {
   Paper,
   Grid,
   Chip,
+  FormControl,
   Tab,
   Tabs,
+  InputLabel,
+  MenuItem,
+  Select,
   Table,
   TableBody,
   TableCell,
@@ -80,12 +84,65 @@ const sentimentBg = {
   neutral: { row: 'transparent', cell: 'transparent' },
 };
 
+const MARKET_LABELS = {
+  US: 'United States',
+  HK: 'Hong Kong',
+  IN: 'India',
+  JP: 'Japan',
+  TW: 'Taiwan',
+};
+
+const MARKET_BENCHMARK_SYMBOLS = {
+  US: 'SPY',
+  HK: '^HSI',
+  IN: '^NSEI',
+  JP: '^N225',
+  TW: '^TWII',
+};
+
+function normalizeMarket(market) {
+  const normalized = String(market || 'US').trim().toUpperCase();
+  return MARKET_LABELS[normalized] ? normalized : 'US';
+}
+
 function BreadthPage() {
-  const { runtimeReady, uiSnapshots } = useRuntime();
+  const {
+    runtimeReady,
+    uiSnapshots,
+    primaryMarket = 'US',
+    enabledMarkets = ['US'],
+    supportedMarkets = ['US', 'HK', 'IN', 'JP', 'TW'],
+  } = useRuntime();
   const queryClient = useQueryClient();
   const [selectedTab, setSelectedTab] = useState(0);
   const [chartTimeRange, setChartTimeRange] = useState('1M');
   const [bootstrapSettled, setBootstrapSettled] = useState(false);
+  const [selectedMarket, setSelectedMarket] = useState(() => normalizeMarket(primaryMarket));
+  const marketOptions = useMemo(() => {
+    const enabled = (enabledMarkets || [])
+      .map(normalizeMarket)
+      .filter((market, index, markets) => markets.indexOf(market) === index);
+    if (enabled.length > 0) {
+      return enabled;
+    }
+    return (supportedMarkets || ['US'])
+      .map(normalizeMarket)
+      .filter((market, index, markets) => markets.indexOf(market) === index);
+  }, [enabledMarkets, supportedMarkets]);
+  useEffect(() => {
+    if (marketOptions.length === 0) {
+      return;
+    }
+    if (!marketOptions.includes(selectedMarket)) {
+      const normalizedPrimary = normalizeMarket(primaryMarket);
+      setSelectedMarket(
+        marketOptions.includes(normalizedPrimary) ? normalizedPrimary : marketOptions[0]
+      );
+    }
+  }, [marketOptions, primaryMarket, selectedMarket]);
+  useEffect(() => {
+    setBootstrapSettled(false);
+  }, [selectedMarket]);
   const snapshotEnabled = runtimeReady && Boolean(uiSnapshots?.breadth);
   const liveQueriesEnabled = runtimeReady && (!snapshotEnabled || bootstrapSettled);
 
@@ -96,10 +153,12 @@ function BreadthPage() {
   const startDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
   const spyPeriodMap = { '1M': '1mo', '3M': '3mo', '6M': '6mo', '1Y': '1y' };
   const spyPeriod = spyPeriodMap[chartTimeRange] || '1y';
+  const benchmarkSymbol = MARKET_BENCHMARK_SYMBOLS[selectedMarket] || null;
+  const liveBenchmarkSymbol = benchmarkSymbol && !benchmarkSymbol.startsWith('^') ? benchmarkSymbol : null;
 
   const breadthBootstrapQuery = useQuery({
-    queryKey: ['breadthBootstrap'],
-    queryFn: getBreadthBootstrap,
+    queryKey: ['breadthBootstrap', selectedMarket],
+    queryFn: () => getBreadthBootstrap(selectedMarket),
     enabled: snapshotEnabled && !bootstrapSettled,
     retry: false,
     staleTime: 60_000,
@@ -122,15 +181,18 @@ function BreadthPage() {
     }
 
     const payload = breadthBootstrapQuery.data?.payload ?? {};
-    queryClient.setQueryData(['breadth', 'current'], payload.current ?? null);
-    queryClient.setQueryData(['breadth', 'historical', startDate, endDate], payload.history_90d ?? []);
-    queryClient.setQueryData(['breadth', 'summary'], payload.summary ?? {});
+    queryClient.setQueryData(['breadth', 'current', selectedMarket], payload.current ?? null);
+    queryClient.setQueryData(['breadth', 'historical', selectedMarket, startDate, endDate], payload.history_90d ?? []);
+    queryClient.setQueryData(['breadth', 'summary', selectedMarket], payload.summary ?? {});
     if (payload.chart_range === '1M') {
       queryClient.setQueryData(
-        ['breadth', 'chart', defaultChartDateRange.startDate, defaultChartDateRange.endDate],
+        ['breadth', 'chart', selectedMarket, defaultChartDateRange.startDate, defaultChartDateRange.endDate],
         payload.chart_data ?? []
       );
-      queryClient.setQueryData(['spy', 'history', '1mo'], payload.spy_overlay ?? []);
+      queryClient.setQueryData(
+        ['benchmark', 'history', selectedMarket, '1mo'],
+        payload.benchmark_overlay ?? payload.spy_overlay ?? []
+      );
     }
     setBootstrapSettled(true);
   }, [
@@ -141,6 +203,7 @@ function BreadthPage() {
     defaultChartDateRange.startDate,
     endDate,
     queryClient,
+    selectedMarket,
     snapshotEnabled,
     startDate,
   ]);
@@ -151,8 +214,8 @@ function BreadthPage() {
     isLoading: isLoadingCurrent,
     error: errorCurrent,
   } = useQuery({
-    queryKey: ['breadth', 'current'],
-    queryFn: getCurrentBreadth,
+    queryKey: ['breadth', 'current', selectedMarket],
+    queryFn: () => getCurrentBreadth(selectedMarket),
     enabled: liveQueriesEnabled,
     refetchInterval: 60000, // Refetch every minute
     staleTime: 60_000,
@@ -162,16 +225,16 @@ function BreadthPage() {
   const {
     data: historicalBreadth,
   } = useQuery({
-    queryKey: ['breadth', 'historical', startDate, endDate],
-    queryFn: () => getHistoricalBreadth(startDate, endDate),
+    queryKey: ['breadth', 'historical', selectedMarket, startDate, endDate],
+    queryFn: () => getHistoricalBreadth(startDate, endDate, 365, selectedMarket),
     enabled: liveQueriesEnabled,
     staleTime: 60_000,
   });
 
   // Fetch summary statistics
   useQuery({
-    queryKey: ['breadth', 'summary'],
-    queryFn: getBreadthSummary,
+    queryKey: ['breadth', 'summary', selectedMarket],
+    queryFn: () => getBreadthSummary(selectedMarket),
     enabled: liveQueriesEnabled,
     staleTime: 60_000,
   });
@@ -182,21 +245,21 @@ function BreadthPage() {
     isLoading: isLoadingChartBreadth,
     error: errorChartBreadth,
   } = useQuery({
-    queryKey: ['breadth', 'chart', chartDateRange.startDate, chartDateRange.endDate],
-    queryFn: () => getHistoricalBreadth(chartDateRange.startDate, chartDateRange.endDate, 730),
+    queryKey: ['breadth', 'chart', selectedMarket, chartDateRange.startDate, chartDateRange.endDate],
+    queryFn: () => getHistoricalBreadth(chartDateRange.startDate, chartDateRange.endDate, 730, selectedMarket),
     enabled: liveQueriesEnabled,
     staleTime: 60_000,
   });
 
   // Fetch SPY historical data for overlay
   const {
-    data: spyData,
+    data: benchmarkData,
     isLoading: isLoadingSpy,
     error: errorSpy,
   } = useQuery({
-    queryKey: ['spy', 'history', spyPeriod],
-    queryFn: () => getPriceHistory('SPY', spyPeriod),
-    enabled: liveQueriesEnabled,
+    queryKey: ['benchmark', 'history', selectedMarket, spyPeriod],
+    queryFn: () => getPriceHistory(liveBenchmarkSymbol, spyPeriod),
+    enabled: liveQueriesEnabled && Boolean(liveBenchmarkSymbol),
     staleTime: 60_000,
   });
 
@@ -232,14 +295,33 @@ function BreadthPage() {
         </Box>
       ) : (
         <>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+            <FormControl size="small" sx={{ minWidth: 180 }}>
+              <InputLabel id="breadth-market-label">Market</InputLabel>
+              <Select
+                labelId="breadth-market-label"
+                value={selectedMarket}
+                label="Market"
+                onChange={(event) => setSelectedMarket(event.target.value)}
+              >
+                {marketOptions.map((market) => (
+                  <MenuItem key={market} value={market}>
+                    {MARKET_LABELS[market] || market}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+
           {/* Top Section - Side by Side Layout */}
           <Grid container spacing={2} sx={{ mb: 2 }}>
             {/* Left: Chart (60%) */}
             <Grid item xs={12} lg={7} sx={{ height: 450 }}>
               <BreadthChart
                 breadthData={chartBreadthData}
-                spyData={spyData}
-                isLoading={isLoadingChartBreadth || isLoadingSpy}
+                spyData={benchmarkData || []}
+                benchmarkLabel={benchmarkSymbol || 'Benchmark'}
+                isLoading={isLoadingChartBreadth || (Boolean(liveBenchmarkSymbol) && isLoadingSpy)}
                 error={errorChartBreadth || errorSpy}
                 timeRange={chartTimeRange}
                 onTimeRangeChange={setChartTimeRange}

--- a/frontend/src/pages/BreadthPage.test.jsx
+++ b/frontend/src/pages/BreadthPage.test.jsx
@@ -113,4 +113,28 @@ describe('BreadthPage', () => {
       );
     });
   });
+
+  it('keeps the market selector available when the selected market has no breadth rows', async () => {
+    const user = userEvent.setup();
+    breadthApi.getCurrentBreadth.mockImplementation((market = 'US') => (
+      market === 'HK'
+        ? Promise.reject(new Error('No breadth data available for market HK.'))
+        : Promise.resolve(breadthRow(market))
+    ));
+
+    renderWithProviders(<BreadthPage />);
+
+    expect(
+      await screen.findByText('Error loading HK breadth data: No breadth data available for market HK.')
+    ).toBeInTheDocument();
+
+    const marketSelect = screen.getByRole('combobox', { name: /market/i });
+    fireEvent.mouseDown(marketSelect);
+    await user.click(await screen.findByRole('option', { name: /United States/i }));
+
+    await waitFor(() => {
+      expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('US');
+    });
+    expect(await screen.findByText('Latest Breadth Data')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/BreadthPage.test.jsx
+++ b/frontend/src/pages/BreadthPage.test.jsx
@@ -20,8 +20,8 @@ vi.mock('../contexts/RuntimeContext', () => ({
 }));
 
 vi.mock('../components/Charts/BreadthChart', () => ({
-  default: ({ breadthData, benchmarkLabel }) => (
-    <div data-testid="breadth-chart">
+  default: ({ breadthData, benchmarkLabel, error }) => (
+    <div data-testid="breadth-chart" data-error={error?.message || ''}>
       {benchmarkLabel}:{breadthData?.length ?? 0}
     </div>
   ),
@@ -91,8 +91,39 @@ describe('BreadthPage', () => {
     await waitFor(() => {
       expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('HK');
       expect(breadthApi.getBreadthSummary).toHaveBeenCalledWith('HK');
-      expect(stocksApi.getPriceHistory).toHaveBeenCalledWith('^HSI', '1mo');
+      expect(stocksApi.getPriceHistory).toHaveBeenCalledWith('2800.HK', '1mo');
     });
+  });
+
+  it('resyncs the default market when runtime primary market data loads late', async () => {
+    runtimeState.primaryMarket = 'US';
+    runtimeState.enabledMarkets = ['US'];
+
+    const { rerender } = renderWithProviders(<BreadthPage />);
+
+    expect(await screen.findByText('Latest Breadth Data')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('US');
+    });
+
+    runtimeState.primaryMarket = 'HK';
+    runtimeState.enabledMarkets = ['US', 'HK'];
+    rerender(<BreadthPage />);
+
+    await waitFor(() => {
+      expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('HK');
+      expect(stocksApi.getPriceHistory).toHaveBeenCalledWith('2800.HK', '1mo');
+    });
+  });
+
+  it('renders breadth data when the optional benchmark overlay request fails', async () => {
+    stocksApi.getPriceHistory.mockRejectedValue(new Error('benchmark unavailable'));
+
+    renderWithProviders(<BreadthPage />);
+
+    const chart = await screen.findByTestId('breadth-chart');
+    expect(chart).toHaveTextContent('2800.HK:1');
+    expect(chart).toHaveAttribute('data-error', '');
   });
 
   it('refetches breadth data when the selected market changes', async () => {

--- a/frontend/src/pages/BreadthPage.test.jsx
+++ b/frontend/src/pages/BreadthPage.test.jsx
@@ -91,6 +91,7 @@ describe('BreadthPage', () => {
     await waitFor(() => {
       expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('HK');
       expect(breadthApi.getBreadthSummary).toHaveBeenCalledWith('HK');
+      expect(stocksApi.getPriceHistory).toHaveBeenCalledWith('^HSI', '1mo');
     });
   });
 
@@ -111,6 +112,7 @@ describe('BreadthPage', () => {
         730,
         'US',
       );
+      expect(stocksApi.getPriceHistory).toHaveBeenCalledWith('SPY', '1mo');
     });
   });
 

--- a/frontend/src/pages/BreadthPage.test.jsx
+++ b/frontend/src/pages/BreadthPage.test.jsx
@@ -20,9 +20,9 @@ vi.mock('../contexts/RuntimeContext', () => ({
 }));
 
 vi.mock('../components/Charts/BreadthChart', () => ({
-  default: ({ breadthData, benchmarkLabel, error }) => (
+  default: ({ breadthData, benchmarkLabel, spyData, error }) => (
     <div data-testid="breadth-chart" data-error={error?.message || ''}>
-      {benchmarkLabel}:{breadthData?.length ?? 0}
+      {benchmarkLabel}:{breadthData?.length ?? 0}:{spyData?.length ?? 0}
     </div>
   ),
 }));
@@ -114,6 +114,50 @@ describe('BreadthPage', () => {
       expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('HK');
       expect(stocksApi.getPriceHistory).toHaveBeenCalledWith('2800.HK', '1mo');
     });
+  });
+
+  it('resyncs to the runtime primary market when market options load late', async () => {
+    runtimeState.primaryMarket = 'HK';
+    runtimeState.enabledMarkets = ['US'];
+
+    const { rerender } = renderWithProviders(<BreadthPage />);
+
+    expect(await screen.findByText('Latest Breadth Data')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('US');
+    });
+
+    runtimeState.enabledMarkets = ['US', 'HK'];
+    rerender(<BreadthPage />);
+
+    await waitFor(() => {
+      expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('HK');
+      expect(stocksApi.getPriceHistory).toHaveBeenCalledWith('2800.HK', '1mo');
+    });
+  });
+
+  it('seeds bootstrap benchmark overlay under the live benchmark query key', async () => {
+    runtimeState.uiSnapshots = { breadth: true };
+    breadthApi.getBreadthBootstrap.mockResolvedValue({
+      is_stale: false,
+      payload: {
+        current: breadthRow('HK'),
+        history_90d: [breadthRow('HK')],
+        summary: { market: 'HK', total_records: 1 },
+        chart_range: '1M',
+        chart_data: [breadthRow('HK')],
+        benchmark_symbol: '^HSI',
+        benchmark_overlay: [{ date: '2026-04-24', close: 18400 }],
+      },
+    });
+
+    renderWithProviders(<BreadthPage />);
+
+    const chart = await screen.findByTestId('breadth-chart');
+    await waitFor(() => {
+      expect(chart).toHaveTextContent('2800.HK:1:1');
+    });
+    expect(stocksApi.getPriceHistory).not.toHaveBeenCalledWith('^HSI', '1mo');
   });
 
   it('renders breadth data when the optional benchmark overlay request fails', async () => {

--- a/frontend/src/pages/BreadthPage.test.jsx
+++ b/frontend/src/pages/BreadthPage.test.jsx
@@ -1,0 +1,116 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+
+import BreadthPage from './BreadthPage';
+import * as breadthApi from '../api/breadth';
+import * as stocksApi from '../api/stocks';
+import { renderWithProviders } from '../test/renderWithProviders';
+
+const runtimeState = {
+  runtimeReady: true,
+  uiSnapshots: { breadth: false },
+  primaryMarket: 'HK',
+  enabledMarkets: ['US', 'HK'],
+  supportedMarkets: ['US', 'HK', 'IN', 'JP', 'TW'],
+};
+
+vi.mock('../contexts/RuntimeContext', () => ({
+  useRuntime: () => runtimeState,
+}));
+
+vi.mock('../components/Charts/BreadthChart', () => ({
+  default: ({ breadthData, benchmarkLabel }) => (
+    <div data-testid="breadth-chart">
+      {benchmarkLabel}:{breadthData?.length ?? 0}
+    </div>
+  ),
+}));
+
+vi.mock('../api/breadth', () => ({
+  getBreadthBootstrap: vi.fn(),
+  getCurrentBreadth: vi.fn(),
+  getHistoricalBreadth: vi.fn(),
+  getBreadthSummary: vi.fn(),
+}));
+
+vi.mock('../api/stocks', () => ({
+  getPriceHistory: vi.fn(),
+}));
+
+function breadthRow(market = 'HK') {
+  return {
+    market,
+    date: '2026-04-24',
+    stocks_up_4pct: market === 'HK' ? 22 : 10,
+    stocks_down_4pct: market === 'HK' ? 8 : 4,
+    ratio_5day: 2.75,
+    ratio_10day: 2.5,
+    stocks_up_25pct_quarter: 30,
+    stocks_down_25pct_quarter: 12,
+    stocks_up_25pct_month: 24,
+    stocks_down_25pct_month: 10,
+    stocks_up_50pct_month: 6,
+    stocks_down_50pct_month: 2,
+    stocks_up_13pct_34days: 18,
+    stocks_down_13pct_34days: 7,
+    total_stocks_scanned: 30,
+    calculation_duration_seconds: 1.25,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runtimeState.runtimeReady = true;
+  runtimeState.uiSnapshots = { breadth: false };
+  runtimeState.primaryMarket = 'HK';
+  runtimeState.enabledMarkets = ['US', 'HK'];
+  runtimeState.supportedMarkets = ['US', 'HK', 'IN', 'JP', 'TW'];
+
+  breadthApi.getCurrentBreadth.mockImplementation((market = 'US') => Promise.resolve(breadthRow(market)));
+  breadthApi.getHistoricalBreadth.mockImplementation((startDate, endDate, limit, market = 'US') => (
+    Promise.resolve([breadthRow(market)])
+  ));
+  breadthApi.getBreadthSummary.mockImplementation((market = 'US') => Promise.resolve({
+    market,
+    latest_date: '2026-04-24',
+    total_records: 1,
+    date_range_start: '2026-04-24',
+    date_range_end: '2026-04-24',
+  }));
+  breadthApi.getBreadthBootstrap.mockRejectedValue(new Error('no snapshot'));
+  stocksApi.getPriceHistory.mockResolvedValue([]);
+});
+
+describe('BreadthPage', () => {
+  it('defaults breadth requests to the runtime primary market', async () => {
+    renderWithProviders(<BreadthPage />);
+
+    expect(await screen.findByText('Latest Breadth Data')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('HK');
+      expect(breadthApi.getBreadthSummary).toHaveBeenCalledWith('HK');
+    });
+  });
+
+  it('refetches breadth data when the selected market changes', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<BreadthPage />);
+
+    const marketSelect = await screen.findByRole('combobox', { name: /market/i });
+    fireEvent.mouseDown(marketSelect);
+    await user.click(await screen.findByRole('option', { name: /United States/i }));
+
+    await waitFor(() => {
+      expect(breadthApi.getCurrentBreadth).toHaveBeenCalledWith('US');
+      expect(breadthApi.getHistoricalBreadth).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        730,
+        'US',
+      );
+    });
+  });
+});

--- a/frontend/src/pages/ScanPage.test.jsx
+++ b/frontend/src/pages/ScanPage.test.jsx
@@ -434,4 +434,47 @@ describe('ScanPage', () => {
       expect(scanApi.refreshScanCache).toHaveBeenCalledWith({ market: 'HK', mode: 'full' });
     });
   });
+
+  it('renders structured refresh failure details without crashing', async () => {
+    runtimeState.runtimeReady = true;
+    runtimeState.scanDefaults = {
+      ...DEFAULT_SCAN_DEFAULTS,
+      universe: 'market:hk',
+    };
+    scanApi.createScan.mockRejectedValueOnce({
+      response: {
+        status: 409,
+        data: {
+          detail: {
+            code: 'market_data_stale',
+            message: 'Price data is stale for HK.',
+            stale_markets: [{ market: 'HK' }],
+          },
+        },
+      },
+      message: 'Request failed with status code 409',
+    });
+    scanApi.refreshScanCache.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: {
+          detail: {
+            code: 'refresh_rejected',
+            message: 'Refresh blocked for HK.',
+          },
+        },
+      },
+      message: 'Request failed with status code 400',
+    });
+
+    renderWithProviders(<ScanPage />);
+
+    const scanButton = await screen.findByRole('button', { name: 'Scan' });
+    fireEvent.click(scanButton);
+
+    const refreshButton = await screen.findByRole('button', { name: /refresh hk data/i });
+    fireEvent.click(refreshButton);
+
+    expect(await screen.findByText('Error: Refresh blocked for HK.')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ScanPage.test.jsx
+++ b/frontend/src/pages/ScanPage.test.jsx
@@ -60,6 +60,7 @@ vi.mock('../api/scans', () => ({
   getScans: vi.fn().mockResolvedValue({ scans: [] }),
   cancelScan: vi.fn(),
   getFilterOptions: vi.fn(),
+  refreshScanCache: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -385,5 +386,52 @@ describe('ScanPage', () => {
     expect(
       await screen.findByText('Error: US fundamentals refresh is running. Wait for it to finish before starting a scan.')
     ).toBeInTheDocument();
+  });
+
+  it('lets the user refresh stale market data from a scan failure', async () => {
+    runtimeState.runtimeReady = true;
+    runtimeState.scanDefaults = {
+      ...DEFAULT_SCAN_DEFAULTS,
+      universe: 'market:hk',
+    };
+    scanApi.createScan.mockRejectedValueOnce({
+      response: {
+        status: 409,
+        data: {
+          detail: {
+            code: 'market_data_stale',
+            message: 'Price data is stale for HK.',
+            stale_markets: [
+              {
+                market: 'HK',
+                total_symbols: 10,
+                covered_symbols: 9,
+                uncovered_symbols: 1,
+                oldest_last_cached_date: '2026-04-22',
+                expected_date: '2026-04-24',
+              },
+            ],
+          },
+        },
+      },
+      message: 'Request failed with status code 409',
+    });
+    scanApi.refreshScanCache.mockResolvedValueOnce({
+      status: 'queued',
+      task_id: 'refresh-hk',
+      message: 'Smart refresh started',
+    });
+
+    renderWithProviders(<ScanPage />);
+
+    const scanButton = await screen.findByRole('button', { name: 'Scan' });
+    fireEvent.click(scanButton);
+
+    const refreshButton = await screen.findByRole('button', { name: /refresh hk data/i });
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(scanApi.refreshScanCache).toHaveBeenCalledWith({ market: 'HK', mode: 'full' });
+    });
   });
 });

--- a/frontend/src/static/pages/StaticBreadthPage.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.jsx
@@ -55,9 +55,10 @@ function StaticBreadthPage() {
     return allData.slice(-(RANGE_DAYS[timeRange] || 31));
   }, [payload.chart_data, payload.history_90d, timeRange]);
   const filteredSpyData = useMemo(() => {
-    const allSpy = payload.spy_overlay || [];
+    const allSpy = payload.benchmark_overlay ?? payload.spy_overlay ?? [];
     return allSpy.slice(-(RANGE_DAYS[timeRange] || 31));
-  }, [payload.spy_overlay, timeRange]);
+  }, [payload.benchmark_overlay, payload.spy_overlay, timeRange]);
+  const benchmarkLabel = payload.benchmark_symbol || (marketEntry.market === 'US' ? 'SPY' : 'Benchmark');
 
   if (manifestQuery.isLoading || breadthQuery.isLoading) {
     return (
@@ -105,6 +106,7 @@ function StaticBreadthPage() {
       <BreadthChart
         breadthData={filteredChartData}
         spyData={filteredSpyData}
+        benchmarkLabel={benchmarkLabel}
         isLoading={false}
         error={null}
         timeRange={timeRange}

--- a/frontend/src/static/pages/StaticBreadthPage.test.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.test.jsx
@@ -2,14 +2,20 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router-dom';
 
 import StaticBreadthPage from './StaticBreadthPage';
+import { StaticMarketProvider } from '../StaticMarketContext';
 
 vi.mock('../../components/Charts/BreadthChart', () => ({
-  default: () => <div data-testid="breadth-chart" />,
+  default: ({ benchmarkLabel, spyData = [] }) => (
+    <div data-testid="breadth-chart">
+      {benchmarkLabel}:{spyData.length}
+    </div>
+  ),
 }));
 
-const renderPage = () => {
+const renderPage = (initialEntry = '/breadth') => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -21,7 +27,11 @@ const renderPage = () => {
   return render(
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={createTheme()}>
-        <StaticBreadthPage />
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <StaticMarketProvider supportedMarkets={['US', 'HK']} defaultMarket="US">
+            <StaticBreadthPage />
+          </StaticMarketProvider>
+        </MemoryRouter>
       </ThemeProvider>
     </QueryClientProvider>
   );
@@ -80,5 +90,68 @@ describe('StaticBreadthPage', () => {
       await screen.findByText('No breadth snapshot is available for static-site export date 2026-04-02.')
     ).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Market Breadth' })).not.toBeInTheDocument();
+  });
+
+  it('passes non-US benchmark labels and overlays to the chart', async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      const path = String(url).split('/static-data/')[1];
+
+      if (path === 'manifest.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            default_market: 'US',
+            supported_markets: ['US', 'HK'],
+            markets: {
+              HK: {
+                display_name: 'Hong Kong',
+                pages: {
+                  breadth: {
+                    path: 'markets/hk/breadth.json',
+                  },
+                },
+              },
+            },
+            pages: {},
+          }),
+        };
+      }
+
+      if (path === 'markets/hk/breadth.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            available: true,
+            generated_at: '2026-04-24T22:00:00Z',
+            payload: {
+              benchmark_symbol: '^HSI',
+              benchmark_overlay: [{ date: '2026-04-24', close: 18400 }],
+              current: {
+                market: 'HK',
+                date: '2026-04-24',
+                stocks_up_4pct: 22,
+                stocks_down_4pct: 8,
+                ratio_10day: 2.4,
+              },
+              chart_data: [{ market: 'HK', date: '2026-04-24', stocks_up_4pct: 22, stocks_down_4pct: 8 }],
+              history_90d: [],
+            },
+          }),
+        };
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      };
+    });
+
+    renderPage('/breadth?market=HK');
+
+    expect(await screen.findByRole('heading', { name: 'Hong Kong Breadth' })).toBeInTheDocument();
+    expect(screen.getByTestId('breadth-chart')).toHaveTextContent('^HSI:1');
   });
 });


### PR DESCRIPTION
## Summary
- add scan-facing `POST /api/v1/scans/refresh-cache` and stale-data UI recovery action
- queue manual smart refreshes on market-specific data-fetch queues and only block same-market active refreshes
- market-scope breadth endpoints, bootstrap snapshots, frontend queries, and analytics scope

## Verification
- `cd backend && source venv/bin/activate && pytest tests/unit/test_scan_create_endpoint.py tests/unit/test_cache_refresh_unification.py tests/unit/test_breadth_tasks.py tests/unit/test_analytics_scope.py tests/unit/test_breadth_endpoints.py tests/unit/test_ui_snapshot_service.py tests/unit/test_static_site_export_service.py tests/parity/test_market_parity_e6.py`
- `cd frontend && npm run test:run -- BreadthPage ScanPage`
- `cd frontend && npm run lint` (0 errors; 2 pre-existing warnings in unrelated files)
- `git diff --check`

## Notes
- `cd backend && source venv/bin/activate && pytest` is still blocked by existing localhost collection scripts when no server is running.
- Full frontend `npm run test:run` still has an unrelated `AssistantWatchlistDialog.test.jsx` timeout in the watchlist preview path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market selection support for breadth data across endpoints, enabling queries for specific markets beyond US.
  * Introduced manual cache refresh endpoint for market-specific data synchronization.
  * Implemented dynamic benchmark overlay selection based on market context, replacing fixed overlays.
  * Added market-aware stale data detection in scan creation with inline refresh action.

* **UI/UX Improvements**
  * Market dropdown selector in breadth page for multi-market analysis.
  * Inline refresh button for stale market data directly in scan control bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->