### PR TITLE
ci: introduce develop integration branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -92,7 +92,7 @@ jobs:
   publish-images:
     name: Publish Docker Images
     needs: [backend, frontend, assistant-compose-smoke]
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,13 +43,25 @@ fix(chatbot): handle empty response from LLM provider
 refactor(api): consolidate stock data fetching logic
 ```
 
+## Branching Model
+
+The repo uses a two-branch flow:
+
+- **`develop`** — long-lived integration branch. Feature branches branch off `develop`, get merged back into `develop` via PR after CI passes.
+- **`main`** — production source of truth. Only `develop` (or hotfix branches) get merged into `main`. Production-grade workflows fire off `main` only: GHCR `latest` images, semver `v*` release tags, the static site (GitHub Pages), and the weekly reference data refresh.
+
+PRs into either `develop` or `main` run the full CI quality gate suite. Image publishing is gated to direct pushes on `main` and `v*` tags only — it never fires from develop or from PRs.
+
+GitHub branch protection should require PRs (no direct pushes) and passing CI on both `main` and `develop`.
+
 ## Pull Requests
 
-1. Create a feature branch from `main`
+1. Create a feature branch from `develop`
 2. Make your changes with clear, conventional commit messages
 3. Ensure all quality gates pass locally (`make all`)
-4. Open a PR against `main` with a description of what changed and why
+4. Open a PR against `develop` with a description of what changed and why
 5. CI runs automatically on all PRs
+6. Once accumulated work in `develop` is validated, open a `develop` → `main` PR to ship a release-ready slice
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Adds `develop` as a long-lived integration branch alongside `main`. New feature branches branch off `develop`, get merged back into `develop` via PR (CI gates run), accumulate there for testing/validation, then `develop` → `main` once ready to ship a release-grade slice.

## What changes

- **`.github/workflows/ci.yml`** (3 small edits):
  - Add `develop` to `push.branches` and `pull_request.branches` so CI fires on PRs into develop and on direct pushes to develop.
  - Tighten the `publish-images` job guard from `if: github.event_name != 'pull_request'` to `if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))`. Belt-and-suspenders policy: image publishing fires only on direct pushes to `main` or `v*` tags, never from develop or PRs. The existing `enable={{is_default_branch}}` Handlebars at line 127 already pinned `latest` to main; this makes the policy explicit at the job level too.
- **`CONTRIBUTING.md`**: new "Branching Model" section explaining the two-branch flow; updated PR steps to point at `develop`.

## What does NOT change

- `static-site.yml` and `weekly-reference-data.yml` — these already use `github.event.repository.default_branch` so they automatically continue running off `main` (which stays the default branch). No edits needed.
- The release flow (`v*` tag → GHCR semver images + GitHub Release from `release-notes.md`) is unchanged.

## After this merges

I'll create the `develop` branch from main HEAD and push it (`git checkout main && git checkout -b develop && git push -u origin develop`).

**Manual follow-up for you**: in repo Settings → Branches, add branch protection rules requiring PR + passing CI on both `main` and `develop`. Without protection on develop, the integration-gate purpose is undermined since contributors could push directly.

## Test plan

- [ ] CI on this PR runs all 5 quality gates + smoke
- [ ] Confirm `Publish Docker Images` is skipped (it's a PR, so the `!= 'pull_request'` guard catches it)
- [ ] After merge to main: confirm publish runs and pushes `:latest` images
- [ ] After develop branch creation: open a trivial test PR into develop and confirm gates run but publish is skipped (the new `refs/heads/main` guard catches it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration testing to run across additional branches for improved coverage
  * Refined release image publishing to execute only on main branch and semantic version tags

* **Documentation**
  * Updated contribution guidelines with defined branching model and pull request workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->