### PR TITLE
Add feature-store-first compile path for custom-only scans

### DIFF
--- a/backend/app/domain/feature_store/ports.py
+++ b/backend/app/domain/feature_store/ports.py
@@ -130,6 +130,28 @@ class FeatureRunRepository(abc.ABC):
         ...
 
     @abc.abstractmethod
+    def find_latest_published_covering(
+        self,
+        *,
+        symbols: Sequence[str],
+        market: str | None = None,
+    ) -> FeatureRunDomain | None:
+        """Return the newest published run whose universe covers all *symbols*.
+
+        Used by the feature-store-first custom scan path: when the criteria
+        compile cleanly into queryable fields we don't need an exact
+        signature match — we just need a published run that already covers
+        every symbol the scan would otherwise process.
+
+        If *market* is provided the implementation tries the
+        ``latest_published_market:{market}`` pointer first (matching the
+        per-market publish convention) and falls back to the global
+        ``latest_published`` pointer. Returns ``None`` when no covering run
+        exists.
+        """
+        ...
+
+    @abc.abstractmethod
     def get_run(self, run_id: int) -> FeatureRunDomain:
         """Return a run by PK.
 
@@ -350,6 +372,35 @@ class FeatureStoreRepository(abc.ABC):
         symbol: str,
     ) -> dict | None:
         """Return setup-engine explain payload for a symbol in a feature run."""
+        ...
+
+    @abc.abstractmethod
+    def query_run_details(
+        self,
+        run_id: int,
+        filters: FilterSpec | None = None,
+        *,
+        symbols: Sequence[str] | None = None,
+    ) -> list[tuple[str, dict]]:
+        """Return ``(symbol, details_json)`` pairs from a feature run.
+
+        Used by the feature-store-first custom scan path: the use case
+        compiles user criteria into a ``FilterSpec`` and asks for the raw
+        per-symbol details so it can persist them as scan results without
+        recomputing scores. ``details_json`` matches the orchestrator's
+        output shape, so the result is directly usable by
+        ``ScanResultRepository.persist_orchestrator_results``.
+
+        Args:
+            run_id: Feature run ID (caller validates existence).
+            filters: Optional feature-store filter spec to apply (range,
+                categorical, boolean filters on indexed columns or JSON
+                paths).
+            symbols: Optional symbol allow-list to intersect with the run's
+                rows. Useful when the scan's universe is narrower than the
+                run's published universe (e.g., index/custom scoped scans
+                served from an all-market run).
+        """
         ...
 
 

--- a/backend/app/domain/scanning/custom_criteria_compiler.py
+++ b/backend/app/domain/scanning/custom_criteria_compiler.py
@@ -195,11 +195,18 @@ def compile_custom_criteria(
         spec.add_range("sales_growth_qq", min_value=sales_min)
         representable.append("sales_growth_min")
 
-    # MA alignment -> JSON ma_alignment (boolean)
-    ma_aligned = flat.get("ma_alignment")
-    if ma_aligned is True:
-        spec.add_boolean("ma_alignment", True)
-        representable.append("ma_alignment")
+    # MA alignment cannot be safely served from the stored snapshot.
+    # ``stock_feature_daily.details_json["ma_alignment"]`` is populated by
+    # ``MinerviniScanner`` from ``ma_analysis["meets_all_criteria"]``, which
+    # requires perfect alignment AND a rising 200-day MA AND the
+    # Minervini-specific ``ma_50_pos`` predicate
+    # (``app/scanners/criteria/moving_averages.py``::comprehensive_ma_analysis).
+    # ``CustomScanner._check_ma_alignment`` only requires
+    # ``price > MA50 > MA150 > MA200``, so the stored field is strictly
+    # stricter and would silently produce false negatives. The only
+    # correct behaviour is to defer to async.
+    if flat.get("ma_alignment") is True:
+        unrepresentable.append("ma_alignment")
     # ma_alignment == False is the no-op default; nothing to do.
 
     # 52-week high proximity -> JSON week_52_high_distance (% from high)
@@ -208,15 +215,27 @@ def compile_custom_criteria(
         spec.add_range("week_52_high_distance", max_value=near_high)
         representable.append("near_52w_high")
 
-    # Sector inclusion -> JSON gics_sector
-    sectors = flat.get("sectors")
-    if sectors:
-        spec.add_categorical(
-            "gics_sector", tuple(sectors), mode=FilterMode.INCLUDE
-        )
-        representable.append("sectors")
+    # Sector inclusion -> JSON gics_sector. ``CustomScanner`` treats
+    # ``sectors`` as enabled whenever the key is present (``is not None``);
+    # an explicit empty list causes every symbol to fail the filter. We
+    # can't express "match nothing" in the filter spec without contorting
+    # the query, so an empty list defers to async — otherwise the compile
+    # path would silently drop the constraint and return matches the
+    # async path would reject.
+    if "sectors" in flat and flat["sectors"] is not None:
+        sectors = flat["sectors"]
+        if sectors:
+            spec.add_categorical(
+                "gics_sector", tuple(sectors), mode=FilterMode.INCLUDE
+            )
+            representable.append("sectors")
+        else:
+            unrepresentable.append("sectors")
 
-    # Industry exclusion -> JSON gics_industry
+    # Industry exclusion -> JSON gics_industry. An empty exclude list is a
+    # no-op in async (every symbol passes), and dropping it here produces
+    # the same pass set, so silent drop is safe — only non-empty lists add
+    # a NOT IN filter.
     excluded = flat.get("exclude_industries")
     if excluded:
         spec.add_categorical(

--- a/backend/app/domain/scanning/custom_criteria_compiler.py
+++ b/backend/app/domain/scanning/custom_criteria_compiler.py
@@ -28,13 +28,18 @@ from dataclasses import dataclass
 from app.domain.common.query import FilterMode, FilterSpec
 
 
-# Markets where the feature store's USD-normalised columns (adv_usd,
-# market_cap_usd) match the unit a user is most likely to type into the
-# custom volume/market-cap filters. For other single-market universes
-# (e.g. HK with HKD-denominated thresholds) the units would mismatch, so
-# we treat those filters as unrepresentable and fall back to async — where
-# CustomScanner applies the correct mixed-market policy per symbol.
-_USD_COMPATIBLE_SINGLE_MARKETS: frozenset[str] = frozenset({"US"})
+# Markets where the feature store's USD-normalised ``market_cap_usd``
+# column matches the unit a user is most likely to type into the custom
+# market-cap filter. ``CustomScanner._check_market_cap`` reads native
+# market_cap in single-market mode and ``market_cap_usd`` in mixed-market
+# mode (see ``app.domain.scanning.mixed_market_policy.resolve_cap_for_filter``);
+# for US the native column already holds USD so the values agree, but
+# every other single-market universe (HK, JP, TW…) holds native currency
+# and would silently disagree with our USD column. Volume has no
+# analogous mapping — single-market mode evaluates ``volume_min`` against
+# share count, which has no column in ``stock_feature_daily``, so volume
+# is *only* representable in mixed-market mode regardless of currency.
+_USD_MARKET_CAP_COMPATIBLE_SINGLE_MARKETS: frozenset[str] = frozenset({"US"})
 
 
 @dataclass(frozen=True)
@@ -77,16 +82,28 @@ def _flatten_filters(criteria: dict | None) -> dict:
     return base
 
 
-def _is_usd_unit_compatible(universe_market: str | None) -> bool:
-    """Whether the universe's market matches the feature store's USD columns.
+def _is_mixed_market(universe_market: str | None) -> bool:
+    """Whether the universe runs in mixed-market mode (no single-market pin).
 
-    ``None`` (mixed-market) and explicit USD markets compile; other single
-    markets (HK, JP, TW…) do not, because the user's threshold is most
-    likely in native currency while the column is USD-normalised.
+    ``CustomScanner`` derives mixed-vs-single from the resolved StockData
+    flag, but at scan-creation time we only have the universe metadata;
+    ``universe_type ∈ {ALL, MARKET}`` (gated upstream) plus
+    ``universe_market is None`` is the unambiguous mixed-market signal.
     """
-    if universe_market is None:
+    return universe_market is None
+
+
+def _is_market_cap_usd_compatible(universe_market: str | None) -> bool:
+    """Whether the user's market-cap threshold can be evaluated against
+    ``market_cap_usd`` without a unit mismatch — true for mixed-market and
+    explicit USD markets only.
+    """
+    if _is_mixed_market(universe_market):
         return True
-    return str(universe_market).strip().upper() in _USD_COMPATIBLE_SINGLE_MARKETS
+    return (
+        str(universe_market).strip().upper()
+        in _USD_MARKET_CAP_COMPATIBLE_SINGLE_MARKETS
+    )
 
 
 def compile_custom_criteria(
@@ -117,7 +134,8 @@ def compile_custom_criteria(
     representable: list[str] = []
     unrepresentable: list[str] = []
 
-    usd_compatible = _is_usd_unit_compatible(universe_market)
+    mixed_market = _is_mixed_market(universe_market)
+    market_cap_compatible = _is_market_cap_usd_compatible(universe_market)
 
     # Price range -> JSON current_price
     p_min = flat.get("price_min")
@@ -129,20 +147,25 @@ def compile_custom_criteria(
         if p_max is not None:
             representable.append("price_max")
 
-    # Volume -> StockFundamental.adv_usd (USD-normalised)
+    # Volume -> StockFundamental.adv_usd (USD notional). Only correct in
+    # mixed-market mode; single-market mode evaluates ``volume_min`` as a
+    # *share* threshold against price-data volume which has no column in
+    # ``stock_feature_daily``.
     v_min = flat.get("volume_min")
     if v_min is not None and v_min > 0:
-        if usd_compatible:
+        if mixed_market:
             spec.add_range("adv_usd", min_value=v_min)
             representable.append("volume_min")
         else:
             unrepresentable.append("volume_min")
 
-    # Market cap -> StockFundamental.market_cap_usd (USD-normalised)
+    # Market cap -> StockFundamental.market_cap_usd. Mixed-market and US
+    # single-market resolve to USD; other single-markets hold native
+    # currency and would silently disagree with the column.
     mc_min = flat.get("market_cap_min")
     mc_max = flat.get("market_cap_max")
     if mc_min is not None or mc_max is not None:
-        if usd_compatible:
+        if market_cap_compatible:
             spec.add_range("market_cap_usd", min_value=mc_min, max_value=mc_max)
             if mc_min is not None:
                 representable.append("market_cap_min")

--- a/backend/app/domain/scanning/custom_criteria_compiler.py
+++ b/backend/app/domain/scanning/custom_criteria_compiler.py
@@ -1,0 +1,256 @@
+"""Compile a custom-screener criteria dict into a feature-store FilterSpec.
+
+A "custom" scan is essentially a parameterised query: price ranges, volume
+thresholds, sector lists, MA alignment flags, etc. Almost every one of these
+criteria corresponds directly to a field already pre-computed by the daily
+feature snapshot (see ``app.use_cases.feature_store.build_daily_snapshot``
+and the JSON field map in ``app.infra.query.feature_store_query``). When
+that's the case the scan can be served by a single SQL query against an
+already-published feature run, without recomputing per-symbol scores.
+
+This module is the translation layer:
+
+    custom_filters dict --(compile)--> CompiledCustomCriteria
+                                            ├── filter_spec: FilterSpec
+                                            ├── score_field: str | None
+                                            ├── min_score: float | None
+                                            └── unrepresentable_keys
+
+The use case decides what to do based on ``unrepresentable_keys``:
+  * empty       → fully feature-store-answerable, instant scan
+  * non-empty   → fall back to async chunked compute
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.domain.common.query import FilterMode, FilterSpec
+
+
+# Markets where the feature store's USD-normalised columns (adv_usd,
+# market_cap_usd) match the unit a user is most likely to type into the
+# custom volume/market-cap filters. For other single-market universes
+# (e.g. HK with HKD-denominated thresholds) the units would mismatch, so
+# we treat those filters as unrepresentable and fall back to async — where
+# CustomScanner applies the correct mixed-market policy per symbol.
+_USD_COMPATIBLE_SINGLE_MARKETS: frozenset[str] = frozenset({"US"})
+
+
+@dataclass(frozen=True)
+class CompiledCustomCriteria:
+    """Result of compiling a custom-criteria dict against the feature store."""
+
+    filter_spec: FilterSpec
+    score_field: str | None
+    min_score: float | None
+    unrepresentable_keys: tuple[str, ...]
+    representable_keys: tuple[str, ...]
+
+    @property
+    def is_fully_representable(self) -> bool:
+        return not self.unrepresentable_keys
+
+    @property
+    def has_constraints(self) -> bool:
+        spec = self.filter_spec
+        return bool(
+            spec.range_filters
+            or spec.categorical_filters
+            or spec.boolean_filters
+            or spec.text_searches
+        ) or self.min_score is not None
+
+
+def _flatten_filters(criteria: dict | None) -> dict:
+    """Mirror ``CustomScanner._get_filters_config``: support nested + top-level.
+
+    Top-level keys are the legacy form; the modern form nests under
+    ``custom_filters``. Nested wins on conflict.
+    """
+    if not criteria:
+        return {}
+    base = dict(criteria)
+    nested = base.pop("custom_filters", None) or {}
+    base.pop("min_score", None)
+    base.update(nested)
+    return base
+
+
+def _is_usd_unit_compatible(universe_market: str | None) -> bool:
+    """Whether the universe's market matches the feature store's USD columns.
+
+    ``None`` (mixed-market) and explicit USD markets compile; other single
+    markets (HK, JP, TW…) do not, because the user's threshold is most
+    likely in native currency while the column is USD-normalised.
+    """
+    if universe_market is None:
+        return True
+    return str(universe_market).strip().upper() in _USD_COMPATIBLE_SINGLE_MARKETS
+
+
+def compile_custom_criteria(
+    criteria: dict | None,
+    *,
+    screeners: list[str] | None = None,
+    universe_market: str | None = None,
+) -> CompiledCustomCriteria:
+    """Translate a custom-criteria dict into a feature-store ``FilterSpec``.
+
+    Args:
+        criteria: The scan request's ``criteria`` dict. May contain nested
+            ``custom_filters`` and a ``min_score`` gate, plus legacy
+            top-level filter keys (``CustomScanner`` accepts both forms).
+        screeners: Screener list from the scan request. The score gate is
+            only set for single-screener custom scans (``["custom"]``);
+            multi-screener composites need extra logic to decide which
+            score field gates passing.
+        universe_market: Single-market universe code, or ``None`` for
+            mixed-market. Determines whether USD-normalised columns are
+            unit-compatible with the user's volume/market-cap thresholds.
+
+    Returns:
+        A ``CompiledCustomCriteria`` summarising what's representable.
+    """
+    flat = _flatten_filters(criteria)
+    spec = FilterSpec()
+    representable: list[str] = []
+    unrepresentable: list[str] = []
+
+    usd_compatible = _is_usd_unit_compatible(universe_market)
+
+    # Price range -> JSON current_price
+    p_min = flat.get("price_min")
+    p_max = flat.get("price_max")
+    if p_min is not None or p_max is not None:
+        spec.add_range("current_price", min_value=p_min, max_value=p_max)
+        if p_min is not None:
+            representable.append("price_min")
+        if p_max is not None:
+            representable.append("price_max")
+
+    # Volume -> StockFundamental.adv_usd (USD-normalised)
+    v_min = flat.get("volume_min")
+    if v_min is not None and v_min > 0:
+        if usd_compatible:
+            spec.add_range("adv_usd", min_value=v_min)
+            representable.append("volume_min")
+        else:
+            unrepresentable.append("volume_min")
+
+    # Market cap -> StockFundamental.market_cap_usd (USD-normalised)
+    mc_min = flat.get("market_cap_min")
+    mc_max = flat.get("market_cap_max")
+    if mc_min is not None or mc_max is not None:
+        if usd_compatible:
+            spec.add_range("market_cap_usd", min_value=mc_min, max_value=mc_max)
+            if mc_min is not None:
+                representable.append("market_cap_min")
+            if mc_max is not None:
+                representable.append("market_cap_max")
+        else:
+            if mc_min is not None:
+                unrepresentable.append("market_cap_min")
+            if mc_max is not None:
+                unrepresentable.append("market_cap_max")
+
+    # RS rating -> JSON rs_rating
+    rs_min = flat.get("rs_rating_min")
+    if rs_min is not None:
+        spec.add_range("rs_rating", min_value=rs_min)
+        representable.append("rs_rating_min")
+
+    # Quarterly EPS growth -> JSON eps_growth_qq
+    eps_min = flat.get("eps_growth_min")
+    if eps_min is not None:
+        spec.add_range("eps_growth_qq", min_value=eps_min)
+        representable.append("eps_growth_min")
+
+    # Quarterly sales growth -> JSON sales_growth_qq
+    sales_min = flat.get("sales_growth_min")
+    if sales_min is not None:
+        spec.add_range("sales_growth_qq", min_value=sales_min)
+        representable.append("sales_growth_min")
+
+    # MA alignment -> JSON ma_alignment (boolean)
+    ma_aligned = flat.get("ma_alignment")
+    if ma_aligned is True:
+        spec.add_boolean("ma_alignment", True)
+        representable.append("ma_alignment")
+    # ma_alignment == False is the no-op default; nothing to do.
+
+    # 52-week high proximity -> JSON week_52_high_distance (% from high)
+    near_high = flat.get("near_52w_high")
+    if near_high is not None:
+        spec.add_range("week_52_high_distance", max_value=near_high)
+        representable.append("near_52w_high")
+
+    # Sector inclusion -> JSON gics_sector
+    sectors = flat.get("sectors")
+    if sectors:
+        spec.add_categorical(
+            "gics_sector", tuple(sectors), mode=FilterMode.INCLUDE
+        )
+        representable.append("sectors")
+
+    # Industry exclusion -> JSON gics_industry
+    excluded = flat.get("exclude_industries")
+    if excluded:
+        spec.add_categorical(
+            "gics_industry", tuple(excluded), mode=FilterMode.EXCLUDE
+        )
+        representable.append("exclude_industries")
+
+    # Filters that have no feature-store representation today.
+    if flat.get("debt_to_equity_max") is not None:
+        unrepresentable.append("debt_to_equity_max")
+
+    # Anything we don't recognise is unrepresentable so user intent is never
+    # silently dropped.
+    handled = {
+        "price_min", "price_max", "volume_min",
+        "market_cap_min", "market_cap_max",
+        "rs_rating_min", "eps_growth_min", "sales_growth_min",
+        "ma_alignment", "near_52w_high",
+        "sectors", "exclude_industries",
+        "debt_to_equity_max",
+    }
+    for key, val in flat.items():
+        if key in handled or val is None:
+            continue
+        unrepresentable.append(key)
+
+    # Score gate. Only applicable for single-screener custom scans, where
+    # composite_score == custom_score by construction; we filter on the
+    # JSON field directly to avoid depending on composite-method invariants.
+    score_field: str | None = None
+    normalized_screeners = sorted({
+        str(s).strip().lower() for s in (screeners or []) if str(s).strip()
+    })
+    if normalized_screeners == ["custom"]:
+        score_field = "custom_score"
+
+    raw_min_score = (criteria or {}).get("min_score")
+    if isinstance(raw_min_score, (int, float)) and not isinstance(
+        raw_min_score, bool
+    ):
+        min_score_val: float | None = float(raw_min_score)
+    elif raw_min_score is None:
+        # CustomScanner default — applies whenever a score gate is in play.
+        min_score_val = 70.0 if score_field is not None else None
+    else:
+        min_score_val = None
+
+    return CompiledCustomCriteria(
+        filter_spec=spec,
+        score_field=score_field,
+        min_score=min_score_val,
+        unrepresentable_keys=tuple(unrepresentable),
+        representable_keys=tuple(representable),
+    )
+
+
+__all__ = [
+    "CompiledCustomCriteria",
+    "compile_custom_criteria",
+]

--- a/backend/app/domain/scanning/custom_criteria_compiler.py
+++ b/backend/app/domain/scanning/custom_criteria_compiler.py
@@ -51,6 +51,7 @@ class CompiledCustomCriteria:
     min_score: float | None
     unrepresentable_keys: tuple[str, ...]
     representable_keys: tuple[str, ...]
+    hard_gate_equivalent: bool = False
 
     @property
     def is_fully_representable(self) -> bool:
@@ -133,6 +134,8 @@ def compile_custom_criteria(
     spec = FilterSpec()
     representable: list[str] = []
     unrepresentable: list[str] = []
+    hard_gate_filters: list[str] = []
+    has_partial_score_filter = False
 
     mixed_market = _is_mixed_market(universe_market)
     market_cap_compatible = _is_market_cap_usd_compatible(universe_market)
@@ -142,6 +145,7 @@ def compile_custom_criteria(
     p_max = flat.get("price_max")
     if p_min is not None or p_max is not None:
         spec.add_range("current_price", min_value=p_min, max_value=p_max)
+        hard_gate_filters.append("price_range")
         if p_min is not None:
             representable.append("price_min")
         if p_max is not None:
@@ -156,6 +160,7 @@ def compile_custom_criteria(
         if mixed_market:
             spec.add_range("adv_usd", min_value=v_min)
             representable.append("volume_min")
+            has_partial_score_filter = True
         else:
             unrepresentable.append("volume_min")
 
@@ -167,6 +172,7 @@ def compile_custom_criteria(
     if mc_min is not None or mc_max is not None:
         if market_cap_compatible:
             spec.add_range("market_cap_usd", min_value=mc_min, max_value=mc_max)
+            hard_gate_filters.append("market_cap")
             if mc_min is not None:
                 representable.append("market_cap_min")
             if mc_max is not None:
@@ -182,18 +188,21 @@ def compile_custom_criteria(
     if rs_min is not None:
         spec.add_range("rs_rating", min_value=rs_min)
         representable.append("rs_rating_min")
+        has_partial_score_filter = True
 
     # Quarterly EPS growth -> JSON eps_growth_qq
     eps_min = flat.get("eps_growth_min")
     if eps_min is not None:
         spec.add_range("eps_growth_qq", min_value=eps_min)
         representable.append("eps_growth_min")
+        has_partial_score_filter = True
 
     # Quarterly sales growth -> JSON sales_growth_qq
     sales_min = flat.get("sales_growth_min")
     if sales_min is not None:
         spec.add_range("sales_growth_qq", min_value=sales_min)
         representable.append("sales_growth_min")
+        has_partial_score_filter = True
 
     # MA alignment cannot be safely served from the stored snapshot.
     # ``stock_feature_daily.details_json["ma_alignment"]`` is populated by
@@ -214,6 +223,7 @@ def compile_custom_criteria(
     if near_high is not None:
         spec.add_range("week_52_high_distance", max_value=near_high)
         representable.append("near_52w_high")
+        has_partial_score_filter = True
 
     # Sector inclusion -> JSON gics_sector. ``CustomScanner`` treats
     # ``sectors`` as enabled whenever the key is present (``is not None``);
@@ -228,6 +238,7 @@ def compile_custom_criteria(
             spec.add_categorical(
                 "gics_sector", tuple(sectors), mode=FilterMode.INCLUDE
             )
+            hard_gate_filters.append("sectors")
             representable.append("sectors")
         else:
             unrepresentable.append("sectors")
@@ -241,6 +252,7 @@ def compile_custom_criteria(
         spec.add_categorical(
             "gics_industry", tuple(excluded), mode=FilterMode.EXCLUDE
         )
+        hard_gate_filters.append("exclude_industries")
         representable.append("exclude_industries")
 
     # Filters that have no feature-store representation today.
@@ -283,12 +295,21 @@ def compile_custom_criteria(
     else:
         min_score_val = None
 
+    hard_gate_equivalent = (
+        not unrepresentable
+        and not has_partial_score_filter
+        and len(hard_gate_filters) == 1
+        and min_score_val is not None
+        and 0.0 < min_score_val <= 100.0
+    )
+
     return CompiledCustomCriteria(
         filter_spec=spec,
         score_field=score_field,
         min_score=min_score_val,
         unrepresentable_keys=tuple(unrepresentable),
         representable_keys=tuple(representable),
+        hard_gate_equivalent=hard_gate_equivalent,
     )
 
 

--- a/backend/app/domain/scanning/custom_criteria_compiler.py
+++ b/backend/app/domain/scanning/custom_criteria_compiler.py
@@ -263,10 +263,13 @@ def compile_custom_criteria(
         else:
             unrepresentable.append("sectors")
 
-    # Industry exclusion -> JSON gics_industry. An empty exclude list adds no
-    # SQL predicate, but CustomScanner still enables the filter and awards full
-    # points. That extra scoring weight can let rows pass async despite failing
-    # another hard gate, so it is not hard-gate equivalent.
+    # Industry exclusion -> JSON gics_industry. EXCLUDE SQL must keep NULL
+    # industries to match ``CustomScanner._check_industry_exclusion`` when
+    # fundamentals exist but omit an industry. However, when fundamentals are
+    # absent entirely, CustomScanner skips this filter and an exclude-only scan
+    # has no active filters. The snapshot field cannot distinguish those cases,
+    # so this filter is expressible but cannot be hard-gate equivalent for the
+    # instant custom-scan path.
     if "exclude_industries" in flat and flat["exclude_industries"] is not None:
         excluded = flat["exclude_industries"]
         if _is_non_empty_str_sequence(excluded):
@@ -275,6 +278,7 @@ def compile_custom_criteria(
             )
             hard_gate_filters.append("exclude_industries")
             representable.append("exclude_industries")
+            has_non_hard_gate_score_filter = True
         elif _is_empty_sequence(excluded):
             has_non_hard_gate_score_filter = True
         else:

--- a/backend/app/domain/scanning/custom_criteria_compiler.py
+++ b/backend/app/domain/scanning/custom_criteria_compiler.py
@@ -107,6 +107,18 @@ def _is_market_cap_usd_compatible(universe_market: str | None) -> bool:
     )
 
 
+def _is_non_empty_str_sequence(value: object) -> bool:
+    return (
+        isinstance(value, (list, tuple))
+        and bool(value)
+        and all(isinstance(item, str) for item in value)
+    )
+
+
+def _is_empty_sequence(value: object) -> bool:
+    return isinstance(value, (list, tuple)) and len(value) == 0
+
+
 def compile_custom_criteria(
     criteria: dict | None,
     *,
@@ -242,7 +254,7 @@ def compile_custom_criteria(
     # async path would reject.
     if "sectors" in flat and flat["sectors"] is not None:
         sectors = flat["sectors"]
-        if sectors:
+        if _is_non_empty_str_sequence(sectors):
             spec.add_categorical(
                 "gics_sector", tuple(sectors), mode=FilterMode.INCLUDE
             )
@@ -257,14 +269,16 @@ def compile_custom_criteria(
     # another hard gate, so it is not hard-gate equivalent.
     if "exclude_industries" in flat and flat["exclude_industries"] is not None:
         excluded = flat["exclude_industries"]
-        if excluded:
+        if _is_non_empty_str_sequence(excluded):
             spec.add_categorical(
                 "gics_industry", tuple(excluded), mode=FilterMode.EXCLUDE
             )
             hard_gate_filters.append("exclude_industries")
             representable.append("exclude_industries")
-        else:
+        elif _is_empty_sequence(excluded):
             has_non_hard_gate_score_filter = True
+        else:
+            unrepresentable.append("exclude_industries")
 
     # Filters that have no feature-store representation today.
     if flat.get("debt_to_equity_max") is not None:

--- a/backend/app/domain/scanning/custom_criteria_compiler.py
+++ b/backend/app/domain/scanning/custom_criteria_compiler.py
@@ -245,13 +245,12 @@ def compile_custom_criteria(
         representable.append("near_52w_high")
         has_non_hard_gate_score_filter = True
 
-    # Sector inclusion -> JSON gics_sector. ``CustomScanner`` treats
-    # ``sectors`` as enabled whenever the key is present (``is not None``);
-    # an explicit empty list causes every symbol to fail the filter. We
-    # can't express "match nothing" in the filter spec without contorting
-    # the query, so an empty list defers to async — otherwise the compile
-    # path would silently drop the constraint and return matches the
-    # async path would reject.
+    # Sector inclusion -> JSON gics_sector. This field is expressible as an
+    # INCLUDE predicate, but it cannot be hard-gate equivalent for instant
+    # custom scans: CustomScanner evaluates sectors only when fundamentals are
+    # present, while snapshots can carry taxonomy-derived gics_sector even when
+    # fundamentals are missing. An explicit empty list causes every symbol to
+    # fail in CustomScanner and cannot be expressed directly, so it defers.
     if "sectors" in flat and flat["sectors"] is not None:
         sectors = flat["sectors"]
         if _is_non_empty_str_sequence(sectors):
@@ -260,6 +259,7 @@ def compile_custom_criteria(
             )
             hard_gate_filters.append("sectors")
             representable.append("sectors")
+            has_non_hard_gate_score_filter = True
         else:
             unrepresentable.append("sectors")
 

--- a/backend/app/domain/scanning/custom_criteria_compiler.py
+++ b/backend/app/domain/scanning/custom_criteria_compiler.py
@@ -135,7 +135,9 @@ def compile_custom_criteria(
     representable: list[str] = []
     unrepresentable: list[str] = []
     hard_gate_filters: list[str] = []
-    has_partial_score_filter = False
+    # Any enabled CustomScanner filter whose scoring cannot be reduced to a
+    # single SQL hard gate makes compile-path pass semantics unsafe.
+    has_non_hard_gate_score_filter = False
 
     mixed_market = _is_mixed_market(universe_market)
     market_cap_compatible = _is_market_cap_usd_compatible(universe_market)
@@ -156,13 +158,19 @@ def compile_custom_criteria(
     # *share* threshold against price-data volume which has no column in
     # ``stock_feature_daily``.
     v_min = flat.get("volume_min")
-    if v_min is not None and v_min > 0:
-        if mixed_market:
-            spec.add_range("adv_usd", min_value=v_min)
-            representable.append("volume_min")
-            has_partial_score_filter = True
+    if v_min is not None:
+        if v_min > 0:
+            if mixed_market:
+                spec.add_range("adv_usd", min_value=v_min)
+                representable.append("volume_min")
+                has_non_hard_gate_score_filter = True
+            else:
+                unrepresentable.append("volume_min")
         else:
-            unrepresentable.append("volume_min")
+            # CustomScanner still enables the filter and awards full points.
+            # That adds scoring weight without a SQL predicate, so strict hard
+            # gates are not equivalent at lower min_score values.
+            has_non_hard_gate_score_filter = True
 
     # Market cap -> StockFundamental.market_cap_usd. Mixed-market and US
     # single-market resolve to USD; other single-markets hold native
@@ -188,21 +196,21 @@ def compile_custom_criteria(
     if rs_min is not None:
         spec.add_range("rs_rating", min_value=rs_min)
         representable.append("rs_rating_min")
-        has_partial_score_filter = True
+        has_non_hard_gate_score_filter = True
 
     # Quarterly EPS growth -> JSON eps_growth_qq
     eps_min = flat.get("eps_growth_min")
     if eps_min is not None:
         spec.add_range("eps_growth_qq", min_value=eps_min)
         representable.append("eps_growth_min")
-        has_partial_score_filter = True
+        has_non_hard_gate_score_filter = True
 
     # Quarterly sales growth -> JSON sales_growth_qq
     sales_min = flat.get("sales_growth_min")
     if sales_min is not None:
         spec.add_range("sales_growth_qq", min_value=sales_min)
         representable.append("sales_growth_min")
-        has_partial_score_filter = True
+        has_non_hard_gate_score_filter = True
 
     # MA alignment cannot be safely served from the stored snapshot.
     # ``stock_feature_daily.details_json["ma_alignment"]`` is populated by
@@ -223,7 +231,7 @@ def compile_custom_criteria(
     if near_high is not None:
         spec.add_range("week_52_high_distance", max_value=near_high)
         representable.append("near_52w_high")
-        has_partial_score_filter = True
+        has_non_hard_gate_score_filter = True
 
     # Sector inclusion -> JSON gics_sector. ``CustomScanner`` treats
     # ``sectors`` as enabled whenever the key is present (``is not None``);
@@ -243,17 +251,20 @@ def compile_custom_criteria(
         else:
             unrepresentable.append("sectors")
 
-    # Industry exclusion -> JSON gics_industry. An empty exclude list is a
-    # no-op in async (every symbol passes), and dropping it here produces
-    # the same pass set, so silent drop is safe — only non-empty lists add
-    # a NOT IN filter.
-    excluded = flat.get("exclude_industries")
-    if excluded:
-        spec.add_categorical(
-            "gics_industry", tuple(excluded), mode=FilterMode.EXCLUDE
-        )
-        hard_gate_filters.append("exclude_industries")
-        representable.append("exclude_industries")
+    # Industry exclusion -> JSON gics_industry. An empty exclude list adds no
+    # SQL predicate, but CustomScanner still enables the filter and awards full
+    # points. That extra scoring weight can let rows pass async despite failing
+    # another hard gate, so it is not hard-gate equivalent.
+    if "exclude_industries" in flat and flat["exclude_industries"] is not None:
+        excluded = flat["exclude_industries"]
+        if excluded:
+            spec.add_categorical(
+                "gics_industry", tuple(excluded), mode=FilterMode.EXCLUDE
+            )
+            hard_gate_filters.append("exclude_industries")
+            representable.append("exclude_industries")
+        else:
+            has_non_hard_gate_score_filter = True
 
     # Filters that have no feature-store representation today.
     if flat.get("debt_to_equity_max") is not None:
@@ -297,7 +308,7 @@ def compile_custom_criteria(
 
     hard_gate_equivalent = (
         not unrepresentable
-        and not has_partial_score_filter
+        and not has_non_hard_gate_score_filter
         and len(hard_gate_filters) == 1
         and min_score_val is not None
         and 0.0 < min_score_val <= 100.0

--- a/backend/app/infra/db/repositories/feature_run_repo.py
+++ b/backend/app/infra/db/repositories/feature_run_repo.py
@@ -20,7 +20,6 @@ from app.domain.feature_store.ports import FeatureRunRepository
 from app.infra.db.models.feature_store import (
     FeatureRun,
     FeatureRunPointer,
-    FeatureRunUniverseSymbol,
     StockFeatureDaily,
 )
 from app.domain.feature_store.quality import DQResult
@@ -220,20 +219,33 @@ class SqlFeatureRunRepository(FeatureRunRepository):
             row = self._session.get(FeatureRun, pointer.run_id)
             if row is None or row.status != RunStatus.PUBLISHED.value:
                 continue
-            if self._run_universe_covers(pointer.run_id, normalized):
+            if self._run_has_feature_rows_for(pointer.run_id, normalized):
                 return self._to_domain(row)
 
         return None
 
-    def _run_universe_covers(self, run_id: int, symbols: list[str]) -> bool:
-        """Return True iff every symbol is in the run's universe."""
+    def _run_has_feature_rows_for(self, run_id: int, symbols: list[str]) -> bool:
+        """Return True iff every symbol has a row in ``stock_feature_daily``.
+
+        Counting ``feature_run_universe_symbols`` would not be enough:
+        ``BuildDailyFeatureSnapshotUseCase`` saves the universe symbols
+        before scanning, and the default DQ thresholds permit publishing
+        a run with up to 10% of universe symbols missing rows
+        (``DQThresholds.row_count_threshold = 0.9`` /
+        ``symbol_coverage_threshold = 0.9``). A coverage test based on
+        the universe table would happily pick such a partial run, after
+        which ``query_run_details`` would silently omit the
+        symbols-without-rows from the scan output. Counting actual rows
+        ensures the compile path either serves every requested symbol
+        from the snapshot or defers to async.
+        """
         if not symbols:
             return True
         present = (
-            self._session.query(func.count(FeatureRunUniverseSymbol.symbol))
+            self._session.query(func.count(StockFeatureDaily.symbol))
             .filter(
-                FeatureRunUniverseSymbol.run_id == run_id,
-                FeatureRunUniverseSymbol.symbol.in_(symbols),
+                StockFeatureDaily.run_id == run_id,
+                StockFeatureDaily.symbol.in_(symbols),
             )
             .scalar()
             or 0

--- a/backend/app/infra/db/repositories/feature_run_repo.py
+++ b/backend/app/infra/db/repositories/feature_run_repo.py
@@ -17,9 +17,13 @@ from app.domain.feature_store.models import (
     validate_transition,
 )
 from app.domain.feature_store.ports import FeatureRunRepository
-from app.infra.db.models.feature_store import StockFeatureDaily
+from app.infra.db.models.feature_store import (
+    FeatureRun,
+    FeatureRunPointer,
+    FeatureRunUniverseSymbol,
+    StockFeatureDaily,
+)
 from app.domain.feature_store.quality import DQResult
-from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer
 from app.infra.serialization import convert_numpy_types
 
 
@@ -182,6 +186,59 @@ class SqlFeatureRunRepository(FeatureRunRepository):
         if row is None:
             return None
         return self._to_domain(row)
+
+    def find_latest_published_covering(
+        self,
+        *,
+        symbols,
+        market: str | None = None,
+    ) -> FeatureRunDomain | None:
+        normalized = sorted({
+            str(symbol).strip().upper()
+            for symbol in symbols
+            if str(symbol).strip()
+        })
+        if not normalized:
+            return None
+
+        # Try market-specific pointer first, then fall back to the global
+        # one — matches the convention in
+        # ``api.v1.stocks._get_latest_feature_run_for_symbol``.
+        candidate_keys: list[str] = []
+        if market:
+            candidate_keys.append(f"latest_published_market:{market.strip().upper()}")
+        candidate_keys.append("latest_published")
+
+        for key in candidate_keys:
+            pointer = (
+                self._session.query(FeatureRunPointer)
+                .filter(FeatureRunPointer.key == key)
+                .first()
+            )
+            if pointer is None:
+                continue
+            row = self._session.get(FeatureRun, pointer.run_id)
+            if row is None or row.status != RunStatus.PUBLISHED.value:
+                continue
+            if self._run_universe_covers(pointer.run_id, normalized):
+                return self._to_domain(row)
+
+        return None
+
+    def _run_universe_covers(self, run_id: int, symbols: list[str]) -> bool:
+        """Return True iff every symbol is in the run's universe."""
+        if not symbols:
+            return True
+        present = (
+            self._session.query(func.count(FeatureRunUniverseSymbol.symbol))
+            .filter(
+                FeatureRunUniverseSymbol.run_id == run_id,
+                FeatureRunUniverseSymbol.symbol.in_(symbols),
+            )
+            .scalar()
+            or 0
+        )
+        return int(present) == len(symbols)
 
     def get_run(self, run_id) -> FeatureRunDomain:
         row = self._get_or_raise(run_id)

--- a/backend/app/infra/db/repositories/feature_store_repo.py
+++ b/backend/app/infra/db/repositories/feature_store_repo.py
@@ -595,6 +595,48 @@ class SqlFeatureStoreRepository(FeatureStoreRepository):
         symbols = tuple(symbol for (symbol,) in rows)
         return symbols, total
 
+    def query_run_details(
+        self,
+        run_id: int,
+        filters: FilterSpec | None = None,
+        *,
+        symbols: Sequence[str] | None = None,
+    ) -> list[tuple[str, dict]]:
+        run = self._session.get(FeatureRun, run_id)
+        if run is None:
+            raise EntityNotFoundError("FeatureRun", run_id)
+
+        # We only need symbol + details_json. The StockUniverse +
+        # StockFundamental joins must still be present so any filter or
+        # sort field that lives on those tables (market_cap_usd, adv_usd…)
+        # resolves at SQL time — same convention as the bridge methods.
+        q = (
+            self._session.query(
+                StockFeatureDaily.symbol,
+                StockFeatureDaily.details_json,
+            )
+            .outerjoin(StockUniverse, StockFeatureDaily.symbol == StockUniverse.symbol)
+            .outerjoin(StockFundamental, StockFeatureDaily.symbol == StockFundamental.symbol)
+            .filter(StockFeatureDaily.run_id == run_id)
+        )
+
+        if symbols is not None:
+            normalized = sorted({
+                str(s).strip().upper() for s in symbols if str(s).strip()
+            })
+            if not normalized:
+                return []
+            q = q.filter(StockFeatureDaily.symbol.in_(normalized))
+
+        if filters is not None:
+            q = apply_filters(q, filters)
+
+        rows = q.all()
+        return [
+            (symbol, details if isinstance(details, dict) else {})
+            for symbol, details in rows
+        ]
+
     def get_setup_payload_for_run(self, run_id: int, symbol: str) -> dict | None:
         run = self._session.get(FeatureRun, run_id)
         if run is None:

--- a/backend/app/infra/query/feature_store_query.py
+++ b/backend/app/infra/query/feature_store_query.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import and_, asc, desc, func
+from sqlalchemy import and_, asc, desc, func, or_
 from sqlalchemy.orm import Query
 
 from app.domain.common.query import (
@@ -270,14 +270,14 @@ def _apply_categorical_filter(query: Query, cf: CategoricalFilter) -> Query:
     col = _COLUMN_MAP.get(cf.field)
     if col is not None:
         if cf.mode == FilterMode.EXCLUDE:
-            query = query.filter(~col.in_(cf.values))
+            query = query.filter(or_(col.is_(None), ~col.in_(cf.values)))
         else:
             query = query.filter(col.in_(cf.values))
     elif cf.field in _JSON_FIELD_MAP:
         json_path = _JSON_FIELD_MAP[cf.field]
         json_val = json_text(StockFeatureDaily.details_json, json_path, bind_or_session=query)
         if cf.mode == FilterMode.EXCLUDE:
-            query = query.filter(~json_val.in_(cf.values))
+            query = query.filter(or_(json_val.is_(None), ~json_val.in_(cf.values)))
         else:
             query = query.filter(json_val.in_(cf.values))
     return query

--- a/backend/app/infra/query/scan_result_query.py
+++ b/backend/app/infra/query/scan_result_query.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import and_, asc, desc, func
+from sqlalchemy import and_, asc, desc, func, or_
 from sqlalchemy.orm import Query
 
 from app.domain.scanning.filter_spec import (
@@ -280,14 +280,14 @@ def _apply_categorical_filter(query: Query, cf: CategoricalFilter) -> Query:
     col = _COLUMN_MAP.get(cf.field)
     if col is not None:
         if cf.mode == FilterMode.EXCLUDE:
-            query = query.filter(~col.in_(cf.values))
+            query = query.filter(or_(col.is_(None), ~col.in_(cf.values)))
         else:
             query = query.filter(col.in_(cf.values))
     elif cf.field in _JSON_FIELD_MAP:
         json_path = _JSON_FIELD_MAP[cf.field]
         json_val = json_text(ScanResult.details, json_path, bind_or_session=query)
         if cf.mode == FilterMode.EXCLUDE:
-            query = query.filter(~json_val.in_(cf.values))
+            query = query.filter(or_(json_val.is_(None), ~json_val.in_(cf.values)))
         else:
             query = query.filter(json_val.in_(cf.values))
     return query

--- a/backend/app/use_cases/scanning/create_scan.py
+++ b/backend/app/use_cases/scanning/create_scan.py
@@ -50,7 +50,11 @@ _COMPILE_PATH_DROP_KEYS: tuple[str, ...] = (
 )
 
 
-def _normalize_compile_details(details: dict) -> dict:
+def _normalize_compile_details(
+    details: dict,
+    *,
+    composite_method: str = "weighted_average",
+) -> dict:
     """Strip stale-criteria score fields from a compile-path row's details.
 
     Called per row before passing through ``persist_orchestrator_results``.
@@ -87,7 +91,7 @@ def _normalize_compile_details(details: dict) -> dict:
         "screeners_run": ["custom"],
         "screeners_passed": 1,
         "screeners_total": 1,
-        "composite_method": "weighted_average",
+        "composite_method": composite_method,
     })
     return normalized
 
@@ -469,7 +473,13 @@ class CreateScanUseCase:
                 # / rating would mislead users sorting by them. See
                 # ``_normalize_compile_details`` for the rationale.
                 normalized_results = [
-                    (symbol, _normalize_compile_details(details))
+                    (
+                        symbol,
+                        _normalize_compile_details(
+                            details,
+                            composite_method=cmd.composite_method,
+                        ),
+                    )
                     for symbol, details in results
                 ]
                 if normalized_results:

--- a/backend/app/use_cases/scanning/create_scan.py
+++ b/backend/app/use_cases/scanning/create_scan.py
@@ -38,6 +38,56 @@ FreshnessChecker = Callable[[Iterable[str]], Optional[dict]]
 logger = logging.getLogger(__name__)
 
 
+# Score / pass fields that the daily snapshot computed under whatever
+# criteria the snapshot itself used. By the time we reach the compile path
+# the exact-signature lookup has missed, so those values reflect *some
+# other* criteria set — sorting and ranking by them would mislead users.
+# We replace them with values that describe what the compile path actually
+# guarantees: every persisted row passed every user-specified per-field
+# filter at the SQL gate (so the row is a "perfect match" for the user's
+# enabled filter set, not for whatever the snapshot was scoring).
+_COMPILE_PATH_OVERRIDES: dict[str, object] = {
+    "custom_score": 100.0,
+    "composite_score": 100.0,
+    "rating": "Strong Buy",
+    "passes_template": True,
+    "screeners_run": ["custom"],
+    "screeners_passed": 1,
+    "screeners_total": 1,
+    "composite_method": "weighted_average",
+}
+
+# Per-screener scores belonging to screeners the user didn't request.
+# The covering snapshot may have computed them, but they have no meaning
+# in this scan's context and would clutter result columns / sort options.
+_COMPILE_PATH_DROP_KEYS: tuple[str, ...] = (
+    "minervini_score",
+    "canslim_score",
+    "ipo_score",
+    "volume_breakthrough_score",
+    "composite_reason",
+)
+
+
+def _normalize_compile_details(details: dict) -> dict:
+    """Strip stale-criteria score fields from a compile-path row's details.
+
+    Called per row before passing through ``persist_orchestrator_results``.
+    Per-symbol *facts* (price, RS rating, MA alignment, sector, growth,
+    sparklines, setup-engine outputs) are left untouched — they're inputs
+    to the user's filter, not derived from custom criteria — so users keep
+    seeing the snapshot's factual columns; only the score / rating /
+    pass-template metadata gets normalised.
+    """
+    if not isinstance(details, dict):
+        return dict(_COMPILE_PATH_OVERRIDES)
+    normalized = dict(details)
+    for key in _COMPILE_PATH_DROP_KEYS:
+        normalized.pop(key, None)
+    normalized.update(_COMPILE_PATH_OVERRIDES)
+    return normalized
+
+
 # ── Command (input) ──────────────────────────────────────────────────────
 
 
@@ -413,13 +463,24 @@ class CreateScanUseCase:
 
             if compile_outcome is not None:
                 source_run, results = compile_outcome
-                if results:
-                    uow.scan_results.persist_orchestrator_results(scan_id, results)
+                # Normalise stale-criteria score / rating / pass fields
+                # before persisting — the covering run was produced under
+                # different criteria, so its custom_score / composite_score
+                # / rating would mislead users sorting by them. See
+                # ``_normalize_compile_details`` for the rationale.
+                normalized_results = [
+                    (symbol, _normalize_compile_details(details))
+                    for symbol, details in results
+                ]
+                if normalized_results:
+                    uow.scan_results.persist_orchestrator_results(
+                        scan_id, normalized_results
+                    )
                 uow.scans.update_status(
                     scan_id,
                     "completed",
                     total_stocks=len(symbols),
-                    passed_stocks=len(results),
+                    passed_stocks=len(normalized_results),
                 )
                 uow.commit()
                 logger.info(

--- a/backend/app/use_cases/scanning/create_scan.py
+++ b/backend/app/use_cases/scanning/create_scan.py
@@ -45,6 +45,7 @@ _COMPILE_PATH_DROP_KEYS: tuple[str, ...] = (
     "minervini_score",
     "canslim_score",
     "ipo_score",
+    "ipo_bonus",
     "volume_breakthrough_score",
     "composite_reason",
 )

--- a/backend/app/use_cases/scanning/create_scan.py
+++ b/backend/app/use_cases/scanning/create_scan.py
@@ -20,6 +20,10 @@ from typing import Callable, Iterable, Optional
 
 from app.domain.common.errors import ValidationError
 from app.domain.common.uow import UnitOfWork
+from app.domain.scanning.custom_criteria_compiler import (
+    CompiledCustomCriteria,
+    compile_custom_criteria,
+)
 from app.domain.scanning.errors import SingleActiveScanViolation
 from app.domain.scanning.signature import (
     build_scan_signature_payload,
@@ -152,6 +156,97 @@ class CreateScanUseCase:
         self._dispatcher = dispatcher
         self._freshness_checker = freshness_checker
 
+    def _attempt_compile_path(
+        self,
+        uow: UnitOfWork,
+        cmd: CreateScanCommand,
+        symbols: list[str],
+    ) -> tuple[object, list[tuple[str, dict]]] | None:
+        """Try to serve the scan from a published feature run via compiled criteria.
+
+        Returns ``(run, results)`` on success — caller persists *results*
+        as scan_results and marks the scan completed. Returns ``None`` to
+        signal "fall back to async chunked compute" for any reason
+        (criteria not fully representable, no covering run, infra error).
+
+        Failures are logged but never raised so a misconfigured feature
+        store can never block scan creation.
+        """
+        try:
+            compiled: CompiledCustomCriteria = compile_custom_criteria(
+                cmd.criteria,
+                screeners=cmd.screeners,
+                universe_market=cmd.universe_market,
+            )
+        except Exception:
+            logger.warning(
+                "Criteria compile raised — falling back to async path",
+                exc_info=True,
+            )
+            return None
+
+        if not compiled.is_fully_representable:
+            logger.debug(
+                "Compile path skipped: %d unrepresentable criteria keys",
+                len(compiled.unrepresentable_keys),
+            )
+            return None
+        if compiled.score_field is None or compiled.min_score is None:
+            # Compile path is currently scoped to single-screener custom
+            # scans, where ``custom_score`` is the unambiguous pass field.
+            # Multi-screener composites would need extra logic to pick the
+            # right gate; defer those to the async path.
+            return None
+        if not compiled.has_constraints:
+            # No filters and no score gate: the result would be the entire
+            # run universe with no semantic guarantee. Defer to async so
+            # the scanner produces real per-symbol scores.
+            return None
+
+        try:
+            run = uow.feature_runs.find_latest_published_covering(
+                symbols=symbols,
+                market=cmd.universe_market,
+            )
+        except Exception:
+            logger.warning(
+                "Covering feature run lookup failed — falling back to async path",
+                exc_info=True,
+            )
+            return None
+
+        if run is None:
+            logger.debug(
+                "Compile path skipped: no covering published feature run for market=%s",
+                cmd.universe_market,
+            )
+            return None
+
+        # Apply the score gate (e.g. custom_score >= min_score) at the SQL
+        # layer so we only persist passing rows. This keeps the scan focused
+        # on matches and lets ``passed_stocks`` equal the persisted count.
+        filter_spec = compiled.filter_spec
+        if compiled.score_field is not None and compiled.min_score is not None:
+            filter_spec.add_range(
+                compiled.score_field, min_value=compiled.min_score
+            )
+
+        try:
+            results = uow.feature_store.query_run_details(
+                run.id,
+                filter_spec,
+                symbols=symbols,
+            )
+        except Exception:
+            logger.warning(
+                "Feature-store details query failed for run %s — falling back to async path",
+                run.id,
+                exc_info=True,
+            )
+            return None
+
+        return run, results
+
     @staticmethod
     def _raise_active_scan_conflict(active_scan: object) -> None:
         raise ActiveScanConflictError(
@@ -207,6 +302,7 @@ class CreateScanUseCase:
 
             feature_run_id = None
             instant_match = None
+            compile_outcome: tuple[object, list[tuple[str, dict]]] | None = None
             should_attempt_instant = cmd.universe_type in {
                 UniverseType.ALL.value,
                 UniverseType.MARKET.value,
@@ -233,12 +329,19 @@ class CreateScanUseCase:
                             instant_match.id,
                         )
                     else:
-                        logger.info("No exact published feature run match — scan uses async path")
+                        logger.info("No exact published feature run match — checking compile path")
                 except Exception:
                     logger.warning(
-                        "Exact feature run lookup failed — proceeding with async scan",
+                        "Exact feature run lookup failed — proceeding to compile path",
                         exc_info=True,
                     )
+
+            # Feature-store-first compile path: when no exact match exists
+            # but the criteria compile cleanly into queryable fields, serve
+            # the scan from a published feature run as a single SQL query
+            # instead of dispatching async chunked compute.
+            if instant_match is None:
+                compile_outcome = self._attempt_compile_path(uow, cmd, symbols)
 
             # ── Create scan record ───────────────────────────────────
             scan_id = str(uuid.uuid4())
@@ -286,6 +389,32 @@ class CreateScanUseCase:
                     total_stocks=len(symbols),
                     is_duplicate=False,
                     feature_run_id=feature_run_id,
+                )
+
+            if compile_outcome is not None:
+                source_run, results = compile_outcome
+                if results:
+                    uow.scan_results.persist_orchestrator_results(scan_id, results)
+                uow.scans.update_status(
+                    scan_id,
+                    "completed",
+                    total_stocks=len(symbols),
+                    passed_stocks=len(results),
+                )
+                uow.commit()
+                logger.info(
+                    "Scan %s completed instantly via compile path (run=%s, %d/%d passing)",
+                    scan_id,
+                    getattr(source_run, "id", None),
+                    len(results),
+                    len(symbols),
+                )
+                return CreateScanResult(
+                    scan_id=scan_id,
+                    status="completed",
+                    total_stocks=len(symbols),
+                    is_duplicate=False,
+                    feature_run_id=None,
                 )
 
             # Commit so the scan row is visible to the Celery worker.

--- a/backend/app/use_cases/scanning/create_scan.py
+++ b/backend/app/use_cases/scanning/create_scan.py
@@ -231,18 +231,9 @@ class CreateScanUseCase:
         produced under different custom-screener criteria. ``custom_score``
         in the stored details was computed against *that* run's filters,
         not the user's, so reusing it as a pass gate would yield results
-        that disagree with async (a different filter set produces a
-        different normalised score). We therefore don't apply
-        ``custom_score >= min_score`` here. The per-field thresholds the
-        user supplied (price, volume, RS, MA alignment, …) compile into
-        ``filter_spec`` and serve as the pass test: a row survives iff it
-        meets every user-specified threshold.
-
-        That makes the compile path strictly stricter than async (which
-        accepts partial-credit scoring against ``min_score``); a stock
-        scoring 75 with a missing filter would pass async at
-        ``min_score=70`` but is excluded here. We accept that strictness
-        as the price of avoiding a stale-criteria score.
+        that disagree with async. We therefore only use the compile path
+        when the compiler can prove the SQL hard gate is equivalent to
+        CustomScanner's weighted ``min_score`` pass semantics.
         """
         try:
             compiled: CompiledCustomCriteria = compile_custom_criteria(
@@ -267,6 +258,11 @@ class CreateScanUseCase:
             # ``score_field`` is set only for ``screeners == ["custom"]``.
             # Multi-screener composites would need extra logic to derive
             # a consistent pass test; defer those to the async path.
+            return None
+        if not compiled.hard_gate_equivalent:
+            logger.debug(
+                "Compile path skipped: criteria are not hard-gate equivalent",
+            )
             return None
         if not compiled.filter_spec.range_filters \
                 and not compiled.filter_spec.categorical_filters \

--- a/backend/app/use_cases/scanning/create_scan.py
+++ b/backend/app/use_cases/scanning/create_scan.py
@@ -38,25 +38,6 @@ FreshnessChecker = Callable[[Iterable[str]], Optional[dict]]
 logger = logging.getLogger(__name__)
 
 
-# Score / pass fields that the daily snapshot computed under whatever
-# criteria the snapshot itself used. By the time we reach the compile path
-# the exact-signature lookup has missed, so those values reflect *some
-# other* criteria set — sorting and ranking by them would mislead users.
-# We replace them with values that describe what the compile path actually
-# guarantees: every persisted row passed every user-specified per-field
-# filter at the SQL gate (so the row is a "perfect match" for the user's
-# enabled filter set, not for whatever the snapshot was scoring).
-_COMPILE_PATH_OVERRIDES: dict[str, object] = {
-    "custom_score": 100.0,
-    "composite_score": 100.0,
-    "rating": "Strong Buy",
-    "passes_template": True,
-    "screeners_run": ["custom"],
-    "screeners_passed": 1,
-    "screeners_total": 1,
-    "composite_method": "weighted_average",
-}
-
 # Per-screener scores belonging to screeners the user didn't request.
 # The covering snapshot may have computed them, but they have no meaning
 # in this scan's context and would clutter result columns / sort options.
@@ -73,18 +54,41 @@ def _normalize_compile_details(details: dict) -> dict:
     """Strip stale-criteria score fields from a compile-path row's details.
 
     Called per row before passing through ``persist_orchestrator_results``.
+    The compile path is reached only when the exact-signature lookup
+    missed, so ``custom_score`` / ``composite_score`` / ``rating`` /
+    ``passes_template`` from the covering snapshot reflect *some other*
+    criteria set; persisting them as-is would misrank matches in the UI.
+    Replace those fields with values that describe what the compile path
+    actually guarantees: every persisted row passed every user-specified
+    per-field filter at the SQL gate.
+
     Per-symbol *facts* (price, RS rating, MA alignment, sector, growth,
     sparklines, setup-engine outputs) are left untouched — they're inputs
     to the user's filter, not derived from custom criteria — so users keep
     seeing the snapshot's factual columns; only the score / rating /
     pass-template metadata gets normalised.
+
+    The override dict is constructed fresh inside this function so that
+    mutable values (notably ``screeners_run``'s list) are not shared by
+    reference across rows.
     """
-    if not isinstance(details, dict):
-        return dict(_COMPILE_PATH_OVERRIDES)
-    normalized = dict(details)
+    if isinstance(details, dict):
+        normalized = dict(details)
+    else:
+        normalized = {}
     for key in _COMPILE_PATH_DROP_KEYS:
         normalized.pop(key, None)
-    normalized.update(_COMPILE_PATH_OVERRIDES)
+    normalized.update({
+        "custom_score": 100.0,
+        "composite_score": 100.0,
+        "rating": "Strong Buy",
+        "passes_template": True,
+        # Fresh list per call — never shared between rows or invocations.
+        "screeners_run": ["custom"],
+        "screeners_passed": 1,
+        "screeners_total": 1,
+        "composite_method": "weighted_average",
+    })
     return normalized
 
 

--- a/backend/app/use_cases/scanning/create_scan.py
+++ b/backend/app/use_cases/scanning/create_scan.py
@@ -171,6 +171,24 @@ class CreateScanUseCase:
 
         Failures are logged but never raised so a misconfigured feature
         store can never block scan creation.
+
+        Correctness note — score gate. By definition this path runs only
+        when the exact-signature lookup missed, so the covering run was
+        produced under different custom-screener criteria. ``custom_score``
+        in the stored details was computed against *that* run's filters,
+        not the user's, so reusing it as a pass gate would yield results
+        that disagree with async (a different filter set produces a
+        different normalised score). We therefore don't apply
+        ``custom_score >= min_score`` here. The per-field thresholds the
+        user supplied (price, volume, RS, MA alignment, …) compile into
+        ``filter_spec`` and serve as the pass test: a row survives iff it
+        meets every user-specified threshold.
+
+        That makes the compile path strictly stricter than async (which
+        accepts partial-credit scoring against ``min_score``); a stock
+        scoring 75 with a missing filter would pass async at
+        ``min_score=70`` but is excluded here. We accept that strictness
+        as the price of avoiding a stale-criteria score.
         """
         try:
             compiled: CompiledCustomCriteria = compile_custom_criteria(
@@ -191,16 +209,17 @@ class CreateScanUseCase:
                 len(compiled.unrepresentable_keys),
             )
             return None
-        if compiled.score_field is None or compiled.min_score is None:
-            # Compile path is currently scoped to single-screener custom
-            # scans, where ``custom_score`` is the unambiguous pass field.
-            # Multi-screener composites would need extra logic to pick the
-            # right gate; defer those to the async path.
+        if compiled.score_field is None:
+            # ``score_field`` is set only for ``screeners == ["custom"]``.
+            # Multi-screener composites would need extra logic to derive
+            # a consistent pass test; defer those to the async path.
             return None
-        if not compiled.has_constraints:
-            # No filters and no score gate: the result would be the entire
-            # run universe with no semantic guarantee. Defer to async so
-            # the scanner produces real per-symbol scores.
+        if not compiled.filter_spec.range_filters \
+                and not compiled.filter_spec.categorical_filters \
+                and not compiled.filter_spec.boolean_filters:
+            # Without per-field thresholds the compile path would return
+            # the entire covering universe — meaningless as a "scan".
+            # Defer to async so the scanner produces real scores.
             return None
 
         try:
@@ -222,19 +241,10 @@ class CreateScanUseCase:
             )
             return None
 
-        # Apply the score gate (e.g. custom_score >= min_score) at the SQL
-        # layer so we only persist passing rows. This keeps the scan focused
-        # on matches and lets ``passed_stocks`` equal the persisted count.
-        filter_spec = compiled.filter_spec
-        if compiled.score_field is not None and compiled.min_score is not None:
-            filter_spec.add_range(
-                compiled.score_field, min_value=compiled.min_score
-            )
-
         try:
             results = uow.feature_store.query_run_details(
                 run.id,
-                filter_spec,
+                compiled.filter_spec,
                 symbols=symbols,
             )
         except Exception:
@@ -340,7 +350,17 @@ class CreateScanUseCase:
             # but the criteria compile cleanly into queryable fields, serve
             # the scan from a published feature run as a single SQL query
             # instead of dispatching async chunked compute.
-            if instant_match is None:
+            #
+            # Restricted to ALL / MARKET universes so the mixed-market vs
+            # single-market policy that drives volume/market-cap unit
+            # semantics is unambiguous: ALL is mixed-market, MARKET pins a
+            # single market explicitly. INDEX / CUSTOM / TEST universes
+            # have ``universe_market = None`` even when their resolved
+            # symbols all live in one market, so the compiler would treat
+            # them as mixed-market (USD columns) while async derives the
+            # mode from resolved symbols and may use native units. Defer
+            # those to async to avoid silent unit mismatches.
+            if instant_match is None and should_attempt_instant:
                 compile_outcome = self._attempt_compile_path(uow, cmd, symbols)
 
             # ── Create scan record ───────────────────────────────────

--- a/backend/tests/integration/test_setup_engine_query_integration.py
+++ b/backend/tests/integration/test_setup_engine_query_integration.py
@@ -26,6 +26,7 @@ from app.database import Base
 from app.domain.common.query import (
     BooleanFilter,
     CategoricalFilter,
+    FilterMode,
     FilterSpec,
     QuerySpec,
     RangeFilter,
@@ -38,7 +39,7 @@ from app.infra.db.repositories.scan_result_repo import (
     SqlScanResultRepository,
     _map_orchestrator_result,
 )
-from app.models.scan_result import Scan
+from app.models.scan_result import Scan, ScanResult
 from app.models.stock_universe import StockUniverse
 from app.scanners.base_screener import ScreenerResult, StockData
 from app.scanners.scan_orchestrator import ScanOrchestrator
@@ -464,6 +465,41 @@ class TestScanResultSEQueryIntegration:
         symbols = {item.symbol for item in page.items}
         assert symbols == {"AAPL", "NVDA"}
 
+    def test_exclude_filter_gics_industry_keeps_nulls(self, seeded_scan_session):
+        """EXCLUDE filters should keep NULLs like the feature-store path."""
+        industries = {
+            "AAPL": "Software",
+            "MSFT": "Tobacco",
+            "GOOGL": None,
+            "TSLA": None,
+            "NVDA": "Semiconductors",
+        }
+        for symbol, industry in industries.items():
+            row = (
+                seeded_scan_session.query(ScanResult)
+                .filter(ScanResult.scan_id == SCAN_ID, ScanResult.symbol == symbol)
+                .one()
+            )
+            row.gics_industry = industry
+        seeded_scan_session.commit()
+
+        repo = SqlScanResultRepository(seeded_scan_session)
+        spec = QuerySpec(
+            filters=FilterSpec(
+                categorical_filters=[
+                    CategoricalFilter(
+                        field="gics_industry",
+                        values=("Tobacco",),
+                        mode=FilterMode.EXCLUDE,
+                    )
+                ]
+            )
+        )
+
+        page = repo.query(SCAN_ID, spec)
+        symbols = {item.symbol for item in page.items}
+        assert symbols == {"AAPL", "GOOGL", "TSLA", "NVDA"}
+
     # -- Sort tests ---------------------------------------------------------
 
     def test_sort_se_setup_score_desc(self, seeded_scan_session):
@@ -597,6 +633,46 @@ class TestFeatureStoreSEQueryIntegration:
         page = repo.query_run_as_scan_results(1, spec)
         symbols = {item.symbol for item in page.items}
         assert symbols == {"AAPL", "NVDA"}
+
+    def test_exclude_filter_gics_industry_keeps_nulls(self, seeded_feature_session):
+        """Feature-store EXCLUDE filters keep NULL industry metadata."""
+        industries = {
+            "AAPL": "Software",
+            "MSFT": "Tobacco",
+            "GOOGL": None,
+            "TSLA": None,
+            "NVDA": "Semiconductors",
+        }
+        for symbol, industry in industries.items():
+            row = (
+                seeded_feature_session.query(StockFeatureDaily)
+                .filter(StockFeatureDaily.run_id == 1, StockFeatureDaily.symbol == symbol)
+                .one()
+            )
+            details = dict(row.details_json or {})
+            if industry is None:
+                details.pop("gics_industry", None)
+            else:
+                details["gics_industry"] = industry
+            row.details_json = details
+        seeded_feature_session.commit()
+
+        repo = SqlFeatureStoreRepository(seeded_feature_session)
+        spec = QuerySpec(
+            filters=FilterSpec(
+                categorical_filters=[
+                    CategoricalFilter(
+                        field="gics_industry",
+                        values=("Tobacco",),
+                        mode=FilterMode.EXCLUDE,
+                    )
+                ]
+            )
+        )
+
+        page = repo.query_run_as_scan_results(1, spec)
+        symbols = {item.symbol for item in page.items}
+        assert symbols == {"AAPL", "GOOGL", "TSLA", "NVDA"}
 
     # -- Sort tests ---------------------------------------------------------
 

--- a/backend/tests/unit/domain/test_custom_criteria_compiler.py
+++ b/backend/tests/unit/domain/test_custom_criteria_compiler.py
@@ -228,7 +228,7 @@ class TestBooleanAndCategorical:
         assert cf is not None
         assert cf.values == ("Technology", "Healthcare")
         assert cf.mode == FilterMode.INCLUDE
-        assert result.hard_gate_equivalent is True
+        assert result.hard_gate_equivalent is False
 
     def test_string_sectors_marked_unrepresentable(self):
         """A plain string is iterable, but it is not a category list."""

--- a/backend/tests/unit/domain/test_custom_criteria_compiler.py
+++ b/backend/tests/unit/domain/test_custom_criteria_compiler.py
@@ -1,0 +1,298 @@
+"""Unit tests for the custom-criteria → feature-store FilterSpec compiler."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.domain.common.query import FilterMode
+from app.domain.scanning.custom_criteria_compiler import (
+    CompiledCustomCriteria,
+    compile_custom_criteria,
+)
+
+
+def _range(spec, field):
+    return next((r for r in spec.range_filters if r.field == field), None)
+
+
+def _categorical(spec, field):
+    return next(
+        (c for c in spec.categorical_filters if c.field == field), None
+    )
+
+
+def _boolean(spec, field):
+    return next((b for b in spec.boolean_filters if b.field == field), None)
+
+
+class TestEmptyCriteria:
+    def test_none_returns_no_constraints(self):
+        result = compile_custom_criteria(None, screeners=["custom"])
+
+        assert result.is_fully_representable
+        # Custom-only with no explicit min_score still applies the
+        # CustomScanner default (70). That alone means has_constraints==True.
+        assert result.score_field == "custom_score"
+        assert result.min_score == 70.0
+        assert result.has_constraints
+        assert result.filter_spec.range_filters == []
+        assert result.unrepresentable_keys == ()
+
+    def test_empty_dict_treated_like_none(self):
+        result = compile_custom_criteria({}, screeners=["custom"])
+
+        assert result.is_fully_representable
+        assert result.filter_spec.range_filters == []
+
+    def test_no_screeners_yields_no_score_field(self):
+        result = compile_custom_criteria(None, screeners=[])
+
+        assert result.score_field is None
+        assert result.min_score is None
+        assert not result.has_constraints
+
+
+class TestRangeFilters:
+    def test_price_range_compiles_to_current_price(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"price_min": 20, "price_max": 500}},
+            screeners=["custom"],
+        )
+
+        rf = _range(result.filter_spec, "current_price")
+        assert rf is not None
+        assert rf.min_value == 20
+        assert rf.max_value == 500
+        assert "price_min" in result.representable_keys
+        assert "price_max" in result.representable_keys
+
+    def test_rs_rating_min_compiles_to_rs_rating(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"rs_rating_min": 80}},
+            screeners=["custom"],
+        )
+
+        rf = _range(result.filter_spec, "rs_rating")
+        assert rf is not None
+        assert rf.min_value == 80
+        assert rf.max_value is None
+
+    def test_eps_growth_compiles_to_eps_growth_qq(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"eps_growth_min": 25}},
+            screeners=["custom"],
+        )
+
+        rf = _range(result.filter_spec, "eps_growth_qq")
+        assert rf is not None
+        assert rf.min_value == 25
+
+    def test_near_52w_high_compiles_to_distance_max(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"near_52w_high": 15}},
+            screeners=["custom"],
+        )
+
+        rf = _range(result.filter_spec, "week_52_high_distance")
+        assert rf is not None
+        assert rf.max_value == 15
+        assert rf.min_value is None
+
+
+class TestUsdUnitCompatibility:
+    def test_volume_min_compiles_for_mixed_market(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"volume_min": 1_000_000}},
+            screeners=["custom"],
+            universe_market=None,
+        )
+
+        rf = _range(result.filter_spec, "adv_usd")
+        assert rf is not None
+        assert rf.min_value == 1_000_000
+        assert "volume_min" in result.representable_keys
+        assert "volume_min" not in result.unrepresentable_keys
+
+    def test_volume_min_compiles_for_us_market(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"volume_min": 1_000_000}},
+            screeners=["custom"],
+            universe_market="US",
+        )
+
+        rf = _range(result.filter_spec, "adv_usd")
+        assert rf is not None
+
+    def test_volume_min_unrepresentable_for_hk_market(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"volume_min": 1_000_000}},
+            screeners=["custom"],
+            universe_market="HK",
+        )
+
+        assert _range(result.filter_spec, "adv_usd") is None
+        assert "volume_min" in result.unrepresentable_keys
+        assert not result.is_fully_representable
+
+    def test_volume_min_zero_is_noop(self):
+        """CustomScanner treats volume_min<=0 as a disabled filter."""
+        result = compile_custom_criteria(
+            {"custom_filters": {"volume_min": 0}},
+            screeners=["custom"],
+            universe_market="HK",  # would otherwise be unrepresentable
+        )
+
+        assert "volume_min" not in result.unrepresentable_keys
+        assert _range(result.filter_spec, "adv_usd") is None
+
+    def test_market_cap_unrepresentable_for_non_usd_market(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"market_cap_min": 1e9, "market_cap_max": 5e10}},
+            screeners=["custom"],
+            universe_market="JP",
+        )
+
+        assert _range(result.filter_spec, "market_cap_usd") is None
+        assert "market_cap_min" in result.unrepresentable_keys
+        assert "market_cap_max" in result.unrepresentable_keys
+
+
+class TestBooleanAndCategorical:
+    def test_ma_alignment_true_adds_boolean_filter(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"ma_alignment": True}},
+            screeners=["custom"],
+        )
+
+        bf = _boolean(result.filter_spec, "ma_alignment")
+        assert bf is not None
+        assert bf.value is True
+
+    def test_ma_alignment_false_is_noop(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"ma_alignment": False}},
+            screeners=["custom"],
+        )
+
+        assert _boolean(result.filter_spec, "ma_alignment") is None
+        assert "ma_alignment" not in result.unrepresentable_keys
+
+    def test_sectors_compile_to_categorical_include(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"sectors": ["Technology", "Healthcare"]}},
+            screeners=["custom"],
+        )
+
+        cf = _categorical(result.filter_spec, "gics_sector")
+        assert cf is not None
+        assert cf.values == ("Technology", "Healthcare")
+        assert cf.mode == FilterMode.INCLUDE
+
+    def test_exclude_industries_compile_to_categorical_exclude(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"exclude_industries": ["Tobacco", "Gambling"]}},
+            screeners=["custom"],
+        )
+
+        cf = _categorical(result.filter_spec, "gics_industry")
+        assert cf is not None
+        assert cf.values == ("Tobacco", "Gambling")
+        assert cf.mode == FilterMode.EXCLUDE
+
+
+class TestUnrepresentable:
+    def test_debt_to_equity_marked_unrepresentable(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"debt_to_equity_max": 0.5}},
+            screeners=["custom"],
+        )
+
+        assert "debt_to_equity_max" in result.unrepresentable_keys
+        assert not result.is_fully_representable
+
+    def test_unknown_filter_marked_unrepresentable(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"some_made_up_filter": 42}},
+            screeners=["custom"],
+        )
+
+        assert "some_made_up_filter" in result.unrepresentable_keys
+
+    def test_fully_unrepresentable_with_known_and_unknown(self):
+        result = compile_custom_criteria(
+            {
+                "custom_filters": {
+                    "price_min": 10,  # representable
+                    "debt_to_equity_max": 0.5,  # not representable
+                },
+            },
+            screeners=["custom"],
+        )
+
+        assert "price_min" in result.representable_keys
+        assert "debt_to_equity_max" in result.unrepresentable_keys
+        assert not result.is_fully_representable
+
+
+class TestScoreGate:
+    def test_custom_only_default_min_score_70(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"price_min": 10}},
+            screeners=["custom"],
+        )
+
+        assert result.score_field == "custom_score"
+        assert result.min_score == 70.0
+
+    def test_explicit_min_score_overrides_default(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"price_min": 10}, "min_score": 85},
+            screeners=["custom"],
+        )
+
+        assert result.min_score == 85.0
+
+    def test_multi_screener_no_score_gate(self):
+        """Multi-screener composites need their own logic; we don't gate."""
+        result = compile_custom_criteria(
+            {"custom_filters": {"price_min": 10}},
+            screeners=["custom", "minervini"],
+        )
+
+        assert result.score_field is None
+        assert result.min_score is None
+
+    def test_minervini_only_no_score_gate(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"price_min": 10}},
+            screeners=["minervini"],
+        )
+
+        assert result.score_field is None
+
+
+class TestTopLevelLegacyForm:
+    """CustomScanner accepts both nested custom_filters and top-level keys."""
+
+    def test_top_level_keys_compile(self):
+        result = compile_custom_criteria(
+            {"price_min": 20, "rs_rating_min": 80, "min_score": 75},
+            screeners=["custom"],
+        )
+
+        assert _range(result.filter_spec, "current_price") is not None
+        assert _range(result.filter_spec, "rs_rating") is not None
+        assert result.min_score == 75.0
+
+    def test_nested_overrides_top_level(self):
+        """Mirrors CustomScanner._get_filters_config precedence."""
+        result = compile_custom_criteria(
+            {
+                "price_min": 5,
+                "custom_filters": {"price_min": 50},
+            },
+            screeners=["custom"],
+        )
+
+        rf = _range(result.filter_spec, "current_price")
+        assert rf.min_value == 50

--- a/backend/tests/unit/domain/test_custom_criteria_compiler.py
+++ b/backend/tests/unit/domain/test_custom_criteria_compiler.py
@@ -145,16 +145,25 @@ class TestUsdUnitCompatibility:
         assert "volume_min" in result.unrepresentable_keys
         assert not result.is_fully_representable
 
-    def test_volume_min_zero_is_noop(self):
-        """CustomScanner treats volume_min<=0 as a disabled filter."""
+    @pytest.mark.parametrize("volume_min", [0, -1])
+    def test_non_positive_volume_min_is_not_hard_gate_equivalent(self, volume_min):
+        """CustomScanner still enables ``volume_min<=0`` and awards full
+        points. It adds no SQL predicate, but it can change weighted scoring
+        when combined with a hard gate, so the compile path must defer.
+        """
         result = compile_custom_criteria(
-            {"custom_filters": {"volume_min": 0}},
+            {
+                "custom_filters": {"price_min": 20, "volume_min": volume_min},
+                "min_score": 50,
+            },
             screeners=["custom"],
             universe_market="HK",  # would otherwise be unrepresentable
         )
 
         assert "volume_min" not in result.unrepresentable_keys
         assert _range(result.filter_spec, "adv_usd") is None
+        assert _range(result.filter_spec, "current_price") is not None
+        assert result.hard_gate_equivalent is False
 
     def test_market_cap_compiles_for_us_single_market(self):
         """US native market_cap is already USD, so the column matches —
@@ -275,18 +284,27 @@ class TestBooleanAndCategorical:
         assert result.is_fully_representable
         assert result.hard_gate_equivalent is False
 
-    def test_empty_exclude_industries_silently_dropped(self):
-        """Empty exclude list is a no-op in async (every symbol passes the
-        exclusion); silent drop here produces the same pass set, so
-        deferring to async would be wasted work.
+    def test_empty_exclude_industries_not_hard_gate_equivalent(self):
+        """Empty exclude list adds no SQL predicate, but CustomScanner still
+        enables the filter and awards full points. With another hard gate and
+        a low min_score, async can pass rows that fail the hard gate, so the
+        compile path must defer.
         """
         result = compile_custom_criteria(
-            {"custom_filters": {"price_min": 10, "exclude_industries": []}},
+            {
+                "custom_filters": {
+                    "price_min": 20,
+                    "exclude_industries": [],
+                },
+                "min_score": 50,
+            },
             screeners=["custom"],
         )
 
         assert _categorical(result.filter_spec, "gics_industry") is None
         assert "exclude_industries" not in result.unrepresentable_keys
+        assert _range(result.filter_spec, "current_price") is not None
+        assert result.hard_gate_equivalent is False
 
 
 class TestUnrepresentable:

--- a/backend/tests/unit/domain/test_custom_criteria_compiler.py
+++ b/backend/tests/unit/domain/test_custom_criteria_compiler.py
@@ -35,6 +35,7 @@ class TestEmptyCriteria:
         assert result.score_field == "custom_score"
         assert result.min_score == 70.0
         assert result.has_constraints
+        assert result.hard_gate_equivalent is False
         assert result.filter_spec.range_filters == []
         assert result.unrepresentable_keys == ()
 
@@ -65,6 +66,7 @@ class TestRangeFilters:
         assert rf.max_value == 500
         assert "price_min" in result.representable_keys
         assert "price_max" in result.representable_keys
+        assert result.hard_gate_equivalent is True
 
     def test_rs_rating_min_compiles_to_rs_rating(self):
         result = compile_custom_criteria(
@@ -76,6 +78,7 @@ class TestRangeFilters:
         assert rf is not None
         assert rf.min_value == 80
         assert rf.max_value is None
+        assert result.hard_gate_equivalent is False
 
     def test_eps_growth_compiles_to_eps_growth_qq(self):
         result = compile_custom_criteria(
@@ -86,6 +89,7 @@ class TestRangeFilters:
         rf = _range(result.filter_spec, "eps_growth_qq")
         assert rf is not None
         assert rf.min_value == 25
+        assert result.hard_gate_equivalent is False
 
     def test_near_52w_high_compiles_to_distance_max(self):
         result = compile_custom_criteria(
@@ -97,6 +101,7 @@ class TestRangeFilters:
         assert rf is not None
         assert rf.max_value == 15
         assert rf.min_value is None
+        assert result.hard_gate_equivalent is False
 
 
 class TestUsdUnitCompatibility:
@@ -112,6 +117,7 @@ class TestUsdUnitCompatibility:
         assert rf.min_value == 1_000_000
         assert "volume_min" in result.representable_keys
         assert "volume_min" not in result.unrepresentable_keys
+        assert result.hard_gate_equivalent is False
 
     def test_volume_min_unrepresentable_for_us_single_market(self):
         """Single-market mode (any market) evaluates volume_min in *shares*,
@@ -213,6 +219,7 @@ class TestBooleanAndCategorical:
         assert cf is not None
         assert cf.values == ("Technology", "Healthcare")
         assert cf.mode == FilterMode.INCLUDE
+        assert result.hard_gate_equivalent is True
 
     def test_empty_sectors_marks_unrepresentable(self):
         """``CustomScanner`` treats ``sectors=[]`` as "filter enabled with no
@@ -249,6 +256,24 @@ class TestBooleanAndCategorical:
         assert cf is not None
         assert cf.values == ("Tobacco", "Gambling")
         assert cf.mode == FilterMode.EXCLUDE
+        assert result.hard_gate_equivalent is True
+
+    def test_multiple_binary_filters_are_not_hard_gate_equivalent(self):
+        result = compile_custom_criteria(
+            {
+                "custom_filters": {
+                    "price_min": 20,
+                    "market_cap_min": 1_000_000_000,
+                    "sectors": ["Technology"],
+                    "exclude_industries": ["Tobacco"],
+                },
+            },
+            screeners=["custom"],
+            universe_market=None,
+        )
+
+        assert result.is_fully_representable
+        assert result.hard_gate_equivalent is False
 
     def test_empty_exclude_industries_silently_dropped(self):
         """Empty exclude list is a no-op in async (every symbol passes the

--- a/backend/tests/unit/domain/test_custom_criteria_compiler.py
+++ b/backend/tests/unit/domain/test_custom_criteria_compiler.py
@@ -230,6 +230,27 @@ class TestBooleanAndCategorical:
         assert cf.mode == FilterMode.INCLUDE
         assert result.hard_gate_equivalent is True
 
+    def test_string_sectors_marked_unrepresentable(self):
+        """A plain string is iterable, but it is not a category list."""
+        result = compile_custom_criteria(
+            {"custom_filters": {"sectors": "Technology"}},
+            screeners=["custom"],
+        )
+
+        assert _categorical(result.filter_spec, "gics_sector") is None
+        assert "sectors" in result.unrepresentable_keys
+        assert not result.is_fully_representable
+
+    def test_non_string_sector_values_marked_unrepresentable(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"sectors": ["Technology", 123]}},
+            screeners=["custom"],
+        )
+
+        assert _categorical(result.filter_spec, "gics_sector") is None
+        assert "sectors" in result.unrepresentable_keys
+        assert not result.is_fully_representable
+
     def test_empty_sectors_marks_unrepresentable(self):
         """``CustomScanner`` treats ``sectors=[]`` as "filter enabled with no
         allowed sectors" — every symbol fails. We can't express that as a
@@ -266,6 +287,27 @@ class TestBooleanAndCategorical:
         assert cf.values == ("Tobacco", "Gambling")
         assert cf.mode == FilterMode.EXCLUDE
         assert result.hard_gate_equivalent is True
+
+    def test_string_exclude_industries_marked_unrepresentable(self):
+        """A plain string must not become per-character exclusion values."""
+        result = compile_custom_criteria(
+            {"custom_filters": {"exclude_industries": "Tobacco"}},
+            screeners=["custom"],
+        )
+
+        assert _categorical(result.filter_spec, "gics_industry") is None
+        assert "exclude_industries" in result.unrepresentable_keys
+        assert not result.is_fully_representable
+
+    def test_non_string_exclude_industries_marked_unrepresentable(self):
+        result = compile_custom_criteria(
+            {"custom_filters": {"exclude_industries": ["Tobacco", 123]}},
+            screeners=["custom"],
+        )
+
+        assert _categorical(result.filter_spec, "gics_industry") is None
+        assert "exclude_industries" in result.unrepresentable_keys
+        assert not result.is_fully_representable
 
     def test_multiple_binary_filters_are_not_hard_gate_equivalent(self):
         result = compile_custom_criteria(

--- a/backend/tests/unit/domain/test_custom_criteria_compiler.py
+++ b/backend/tests/unit/domain/test_custom_criteria_compiler.py
@@ -113,15 +113,20 @@ class TestUsdUnitCompatibility:
         assert "volume_min" in result.representable_keys
         assert "volume_min" not in result.unrepresentable_keys
 
-    def test_volume_min_compiles_for_us_market(self):
+    def test_volume_min_unrepresentable_for_us_single_market(self):
+        """Single-market mode (any market) evaluates volume_min in *shares*,
+        not USD; the feature store has no per-row share-volume column, so
+        the only safe behaviour is to defer to async.
+        """
         result = compile_custom_criteria(
             {"custom_filters": {"volume_min": 1_000_000}},
             screeners=["custom"],
             universe_market="US",
         )
 
-        rf = _range(result.filter_spec, "adv_usd")
-        assert rf is not None
+        assert _range(result.filter_spec, "adv_usd") is None
+        assert "volume_min" in result.unrepresentable_keys
+        assert not result.is_fully_representable
 
     def test_volume_min_unrepresentable_for_hk_market(self):
         result = compile_custom_criteria(
@@ -144,6 +149,21 @@ class TestUsdUnitCompatibility:
 
         assert "volume_min" not in result.unrepresentable_keys
         assert _range(result.filter_spec, "adv_usd") is None
+
+    def test_market_cap_compiles_for_us_single_market(self):
+        """US native market_cap is already USD, so the column matches —
+        unlike volume which always uses shares in single-market mode.
+        """
+        result = compile_custom_criteria(
+            {"custom_filters": {"market_cap_min": 1e9}},
+            screeners=["custom"],
+            universe_market="US",
+        )
+
+        rf = _range(result.filter_spec, "market_cap_usd")
+        assert rf is not None
+        assert rf.min_value == 1e9
+        assert "market_cap_min" in result.representable_keys
 
     def test_market_cap_unrepresentable_for_non_usd_market(self):
         result = compile_custom_criteria(

--- a/backend/tests/unit/domain/test_custom_criteria_compiler.py
+++ b/backend/tests/unit/domain/test_custom_criteria_compiler.py
@@ -286,7 +286,7 @@ class TestBooleanAndCategorical:
         assert cf is not None
         assert cf.values == ("Tobacco", "Gambling")
         assert cf.mode == FilterMode.EXCLUDE
-        assert result.hard_gate_equivalent is True
+        assert result.hard_gate_equivalent is False
 
     def test_string_exclude_industries_marked_unrepresentable(self):
         """A plain string must not become per-character exclusion values."""

--- a/backend/tests/unit/domain/test_custom_criteria_compiler.py
+++ b/backend/tests/unit/domain/test_custom_criteria_compiler.py
@@ -178,15 +178,21 @@ class TestUsdUnitCompatibility:
 
 
 class TestBooleanAndCategorical:
-    def test_ma_alignment_true_adds_boolean_filter(self):
+    def test_ma_alignment_true_marks_unrepresentable(self):
+        """Stored ``ma_alignment`` is set by Minervini's stricter
+        ``meets_all_criteria`` predicate (alignment + rising 200MA + ma_50
+        position), not CustomScanner's ``price > 50 > 150 > 200``. Filtering
+        on the JSON field would silently produce false negatives, so the
+        compiler must treat it as unrepresentable and defer to async.
+        """
         result = compile_custom_criteria(
             {"custom_filters": {"ma_alignment": True}},
             screeners=["custom"],
         )
 
-        bf = _boolean(result.filter_spec, "ma_alignment")
-        assert bf is not None
-        assert bf.value is True
+        assert _boolean(result.filter_spec, "ma_alignment") is None
+        assert "ma_alignment" in result.unrepresentable_keys
+        assert not result.is_fully_representable
 
     def test_ma_alignment_false_is_noop(self):
         result = compile_custom_criteria(
@@ -208,6 +214,31 @@ class TestBooleanAndCategorical:
         assert cf.values == ("Technology", "Healthcare")
         assert cf.mode == FilterMode.INCLUDE
 
+    def test_empty_sectors_marks_unrepresentable(self):
+        """``CustomScanner`` treats ``sectors=[]`` as "filter enabled with no
+        allowed sectors" — every symbol fails. We can't express that as a
+        SQL filter, so the compiler defers to async; otherwise the compile
+        path would silently drop the constraint and disagree with async.
+        """
+        result = compile_custom_criteria(
+            {"custom_filters": {"price_min": 10, "sectors": []}},
+            screeners=["custom"],
+        )
+
+        assert _categorical(result.filter_spec, "gics_sector") is None
+        assert "sectors" in result.unrepresentable_keys
+        assert not result.is_fully_representable
+
+    def test_explicit_sectors_none_is_noop(self):
+        """``sectors=None`` matches CustomScanner's "filter not enabled"."""
+        result = compile_custom_criteria(
+            {"custom_filters": {"price_min": 10, "sectors": None}},
+            screeners=["custom"],
+        )
+
+        assert _categorical(result.filter_spec, "gics_sector") is None
+        assert "sectors" not in result.unrepresentable_keys
+
     def test_exclude_industries_compile_to_categorical_exclude(self):
         result = compile_custom_criteria(
             {"custom_filters": {"exclude_industries": ["Tobacco", "Gambling"]}},
@@ -218,6 +249,19 @@ class TestBooleanAndCategorical:
         assert cf is not None
         assert cf.values == ("Tobacco", "Gambling")
         assert cf.mode == FilterMode.EXCLUDE
+
+    def test_empty_exclude_industries_silently_dropped(self):
+        """Empty exclude list is a no-op in async (every symbol passes the
+        exclusion); silent drop here produces the same pass set, so
+        deferring to async would be wasted work.
+        """
+        result = compile_custom_criteria(
+            {"custom_filters": {"price_min": 10, "exclude_industries": []}},
+            screeners=["custom"],
+        )
+
+        assert _categorical(result.filter_spec, "gics_industry") is None
+        assert "exclude_industries" not in result.unrepresentable_keys
 
 
 class TestUnrepresentable:

--- a/backend/tests/unit/repositories/test_feature_run_repo.py
+++ b/backend/tests/unit/repositories/test_feature_run_repo.py
@@ -391,11 +391,31 @@ class TestFindLatestPublishedCovering:
         symbols: list[str],
         as_of: date,
         pointer_key: str = "latest_published",
+        feature_row_symbols: list[str] | None = None,
     ) -> FeatureRunDomain:
+        """Publish a run.
+
+        ``symbols`` is the run's universe (rows in
+        ``feature_run_universe_symbols``). ``feature_row_symbols`` is the
+        subset that actually has rows in ``stock_feature_daily``; defaults
+        to ``symbols`` (full coverage). Pass a strict subset to model a
+        partial-publish run.
+        """
+        actual_rows = feature_row_symbols if feature_row_symbols is not None else symbols
         run = repo.start_run(as_of, RunType.DAILY_SNAPSHOT)
         repo.mark_completed(run.id, _make_stats())
         for symbol in symbols:
             session.add(FeatureRunUniverseSymbol(run_id=run.id, symbol=symbol))
+        for symbol in actual_rows:
+            session.add(StockFeatureDaily(
+                run_id=run.id,
+                symbol=symbol,
+                as_of_date=as_of,
+                composite_score=80.0,
+                overall_rating=3,
+                passes_count=1,
+                details_json={},
+            ))
         session.flush()
         repo.publish_atomically(run.id, pointer_key=pointer_key)
         return run
@@ -413,6 +433,25 @@ class TestFindLatestPublishedCovering:
 
         assert result is not None
         assert result.status == RunStatus.PUBLISHED
+
+    def test_returns_none_when_some_symbols_missing_feature_rows(
+        self, repo: SqlFeatureRunRepository, session: Session
+    ):
+        """Universe lists AAPL + MSFT, but only AAPL was scanned to a row.
+        Default DQ thresholds permit publishing such a partial run, so we
+        must check actual ``stock_feature_daily`` rows; otherwise the
+        compile path silently omits MSFT instead of falling back to async.
+        """
+        self._publish(
+            repo, session,
+            symbols=["AAPL", "MSFT"],
+            as_of=date(2026, 2, 17),
+            feature_row_symbols=["AAPL"],
+        )
+
+        result = repo.find_latest_published_covering(symbols=["AAPL", "MSFT"])
+
+        assert result is None
 
     def test_returns_none_when_universe_misses_a_symbol(
         self, repo: SqlFeatureRunRepository, session: Session

--- a/backend/tests/unit/repositories/test_feature_run_repo.py
+++ b/backend/tests/unit/repositories/test_feature_run_repo.py
@@ -382,6 +382,120 @@ class TestFindLatestPublishedExact:
         assert repo.find_latest_published_exact(input_hash="i1", universe_hash="x") is None
 
 
+class TestFindLatestPublishedCovering:
+    def _publish(
+        self,
+        repo: SqlFeatureRunRepository,
+        session: Session,
+        *,
+        symbols: list[str],
+        as_of: date,
+        pointer_key: str = "latest_published",
+    ) -> FeatureRunDomain:
+        run = repo.start_run(as_of, RunType.DAILY_SNAPSHOT)
+        repo.mark_completed(run.id, _make_stats())
+        for symbol in symbols:
+            session.add(FeatureRunUniverseSymbol(run_id=run.id, symbol=symbol))
+        session.flush()
+        repo.publish_atomically(run.id, pointer_key=pointer_key)
+        return run
+
+    def test_returns_run_when_universe_covers_symbols(
+        self, repo: SqlFeatureRunRepository, session: Session
+    ):
+        self._publish(
+            repo, session,
+            symbols=["AAPL", "MSFT", "GOOGL"],
+            as_of=date(2026, 2, 17),
+        )
+
+        result = repo.find_latest_published_covering(symbols=["AAPL", "MSFT"])
+
+        assert result is not None
+        assert result.status == RunStatus.PUBLISHED
+
+    def test_returns_none_when_universe_misses_a_symbol(
+        self, repo: SqlFeatureRunRepository, session: Session
+    ):
+        self._publish(
+            repo, session,
+            symbols=["AAPL", "MSFT"],
+            as_of=date(2026, 2, 17),
+        )
+
+        result = repo.find_latest_published_covering(
+            symbols=["AAPL", "GOOGL"],
+        )
+
+        assert result is None
+
+    def test_returns_none_when_no_pointer(
+        self, repo: SqlFeatureRunRepository
+    ):
+        result = repo.find_latest_published_covering(symbols=["AAPL"])
+        assert result is None
+
+    def test_normalizes_input_case_and_whitespace(
+        self, repo: SqlFeatureRunRepository, session: Session
+    ):
+        self._publish(
+            repo, session,
+            symbols=["AAPL"],
+            as_of=date(2026, 2, 17),
+        )
+
+        # Lower-case, whitespace, and dupes get normalised before lookup.
+        result = repo.find_latest_published_covering(
+            symbols=["  aapl ", "AAPL"],
+        )
+        assert result is not None
+
+    def test_market_pointer_takes_precedence(
+        self, repo: SqlFeatureRunRepository, session: Session
+    ):
+        # A market-specific run published under latest_published_market:US
+        market_run = self._publish(
+            repo, session,
+            symbols=["AAPL"],
+            as_of=date(2026, 2, 17),
+            pointer_key="latest_published_market:US",
+        )
+        # Plus a separate run under the global pointer
+        global_run = self._publish(
+            repo, session,
+            symbols=["AAPL"],
+            as_of=date(2026, 2, 16),
+            pointer_key="latest_published",
+        )
+
+        result = repo.find_latest_published_covering(
+            symbols=["AAPL"], market="US"
+        )
+
+        # Market pointer wins.
+        assert result is not None
+        assert result.id == market_run.id
+        assert global_run.id != market_run.id  # sanity
+
+    def test_falls_back_to_global_pointer_when_market_missing(
+        self, repo: SqlFeatureRunRepository, session: Session
+    ):
+        global_run = self._publish(
+            repo, session,
+            symbols=["AAPL"],
+            as_of=date(2026, 2, 17),
+            pointer_key="latest_published",
+        )
+
+        result = repo.find_latest_published_covering(
+            symbols=["AAPL"], market="HK"
+        )
+
+        # No market-specific pointer for HK → fall back to global.
+        assert result is not None
+        assert result.id == global_run.id
+
+
 class TestGetRun:
     def test_returns_domain_object(self, repo: SqlFeatureRunRepository):
         run = repo.start_run(date(2026, 2, 17), RunType.DAILY_SNAPSHOT)

--- a/backend/tests/unit/repositories/test_feature_store_repo.py
+++ b/backend/tests/unit/repositories/test_feature_store_repo.py
@@ -723,3 +723,102 @@ class TestUpsertSnapshotRowsExtended:
     def test_empty_rows_returns_zero(self, repo: SqlFeatureStoreRepository, session: Session):
         run_id = _create_run(session)
         assert repo.upsert_snapshot_rows(run_id, []) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestQueryRunDetails — backs the feature-store-first compile path.
+# ---------------------------------------------------------------------------
+
+
+class TestQueryRunDetails:
+    """``query_run_details`` returns ``(symbol, details_json)`` tuples that
+    flow straight into ``ScanResultRepository.persist_orchestrator_results``.
+    """
+
+    def _row(
+        self,
+        symbol: str,
+        score: float,
+        details: dict | None = None,
+    ) -> FeatureRowWrite:
+        return FeatureRowWrite(
+            symbol=symbol,
+            as_of_date=date(2026, 2, 17),
+            composite_score=score,
+            overall_rating=3,
+            passes_count=1,
+            details=details or {"custom_score": score, "current_price": 100.0},
+        )
+
+    def test_returns_all_rows_with_no_filters(
+        self, repo: SqlFeatureStoreRepository, session: Session
+    ):
+        run_id = _create_run(session)
+        repo.upsert_snapshot_rows(
+            run_id,
+            [self._row("AAPL", 85.0), self._row("MSFT", 90.0)],
+        )
+
+        result = repo.query_run_details(run_id)
+
+        assert sorted(symbol for symbol, _ in result) == ["AAPL", "MSFT"]
+        for _, details in result:
+            assert isinstance(details, dict)
+            assert "custom_score" in details
+
+    def test_applies_range_filter_on_json_field(
+        self, repo: SqlFeatureStoreRepository, session: Session
+    ):
+        run_id = _create_run(session)
+        repo.upsert_snapshot_rows(
+            run_id,
+            [
+                self._row("AAPL", 85.0),
+                self._row("MSFT", 65.0),  # below threshold
+                self._row("GOOGL", 95.0),
+            ],
+        )
+
+        spec = FilterSpec().add_range("custom_score", min_value=70.0)
+        result = repo.query_run_details(run_id, spec)
+
+        assert sorted(symbol for symbol, _ in result) == ["AAPL", "GOOGL"]
+
+    def test_intersects_with_symbol_allow_list(
+        self, repo: SqlFeatureStoreRepository, session: Session
+    ):
+        run_id = _create_run(session)
+        repo.upsert_snapshot_rows(
+            run_id,
+            [
+                self._row("AAPL", 85.0),
+                self._row("MSFT", 80.0),
+                self._row("GOOGL", 90.0),
+            ],
+        )
+
+        result = repo.query_run_details(run_id, symbols=["AAPL", "GOOGL"])
+
+        assert sorted(symbol for symbol, _ in result) == ["AAPL", "GOOGL"]
+
+    def test_normalizes_symbol_allow_list(
+        self, repo: SqlFeatureStoreRepository, session: Session
+    ):
+        run_id = _create_run(session)
+        repo.upsert_snapshot_rows(run_id, [self._row("AAPL", 85.0)])
+
+        result = repo.query_run_details(run_id, symbols=["  aapl ", "AAPL"])
+
+        assert [symbol for symbol, _ in result] == ["AAPL"]
+
+    def test_empty_allow_list_returns_no_rows(
+        self, repo: SqlFeatureStoreRepository, session: Session
+    ):
+        run_id = _create_run(session)
+        repo.upsert_snapshot_rows(run_id, [self._row("AAPL", 85.0)])
+
+        assert repo.query_run_details(run_id, symbols=[]) == []
+
+    def test_raises_for_unknown_run(self, repo: SqlFeatureStoreRepository):
+        with pytest.raises(EntityNotFoundError):
+            repo.query_run_details(99999)

--- a/backend/tests/unit/repositories/test_feature_store_repo.py
+++ b/backend/tests/unit/repositories/test_feature_store_repo.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 
 from app.domain.common.errors import EntityNotFoundError
 from app.domain.common.query import (
+    FilterMode,
     FilterSpec,
     PageSpec,
     QuerySpec,
@@ -818,6 +819,41 @@ class TestQueryRunDetails:
         repo.upsert_snapshot_rows(run_id, [self._row("AAPL", 85.0)])
 
         assert repo.query_run_details(run_id, symbols=[]) == []
+
+    def test_exclude_filter_keeps_null_json_values(
+        self, repo: SqlFeatureStoreRepository, session: Session
+    ):
+        """CustomScanner passes missing industry values for exclusions."""
+        run_id = _create_run(session)
+        repo.upsert_snapshot_rows(
+            run_id,
+            [
+                self._row(
+                    "AAPL",
+                    85.0,
+                    {"custom_score": 85.0, "gics_industry": None},
+                ),
+                self._row(
+                    "MSFT",
+                    90.0,
+                    {"custom_score": 90.0, "gics_industry": "Software"},
+                ),
+                self._row(
+                    "MO",
+                    75.0,
+                    {"custom_score": 75.0, "gics_industry": "Tobacco"},
+                ),
+            ],
+        )
+
+        spec = FilterSpec().add_categorical(
+            "gics_industry",
+            ("Tobacco",),
+            mode=FilterMode.EXCLUDE,
+        )
+        result = repo.query_run_details(run_id, spec)
+
+        assert sorted(symbol for symbol, _ in result) == ["AAPL", "MSFT"]
 
     def test_raises_for_unknown_run(self, repo: SqlFeatureStoreRepository):
         with pytest.raises(EntityNotFoundError):

--- a/backend/tests/unit/use_cases/conftest.py
+++ b/backend/tests/unit/use_cases/conftest.py
@@ -600,6 +600,55 @@ class FakeFeatureRunRepository(FeatureRunRepository):
         )
         return matches[0]
 
+    def set_run_universe(self, run_id: int, symbols: Sequence[str]) -> None:
+        """Test helper: register the universe a published run covers.
+
+        The real repo reads ``feature_run_universe_symbols``; this fake
+        keeps a parallel mapping so ``find_latest_published_covering``
+        can answer coverage questions without an actual DB.
+        """
+        if not hasattr(self, "_run_universes"):
+            self._run_universes: dict[int, set[str]] = {}
+        self._run_universes[run_id] = {
+            str(s).strip().upper() for s in symbols if str(s).strip()
+        }
+
+    def find_latest_published_covering(
+        self,
+        *,
+        symbols,
+        market: str | None = None,
+    ) -> FeatureRunDomain | None:
+        normalized = sorted({
+            str(s).strip().upper() for s in symbols if str(s).strip()
+        })
+        if not normalized:
+            return None
+
+        universes = getattr(self, "_run_universes", {})
+        published = [
+            run for run in self._runs.values()
+            if run.status == RunStatus.PUBLISHED
+        ]
+        if not published:
+            return None
+
+        # Newest published first — mirrors pointer-based selection in the
+        # real repo (the pointer always points at the most recent publish).
+        published.sort(
+            key=lambda run: (run.published_at or datetime.min, run.id or 0),
+            reverse=True,
+        )
+
+        for run in published:
+            covered = universes.get(run.id)
+            if covered is None:
+                continue
+            if all(symbol in covered for symbol in normalized):
+                return run
+
+        return None
+
     def get_run(self, run_id) -> FeatureRunDomain:
         return self._get_or_raise(run_id)
 
@@ -835,6 +884,95 @@ class FakeFeatureStoreRepository(FeatureStoreRepository):
         if page is not None:
             symbols = symbols[page.offset : page.offset + page.limit]
         return symbols, len(self._rows[run_id])
+
+    def query_run_details(
+        self,
+        run_id,
+        filters=None,
+        *,
+        symbols=None,
+    ):
+        """Bridge method: return ``(symbol, details_json)`` pairs from a run.
+
+        The real repo applies ``FilterSpec`` constraints in SQL; this fake
+        applies a small subset (range filters on either ``composite_score``
+        or JSON fields, plus categorical/boolean) in Python so use case
+        tests can exercise the compile path end-to-end without a DB.
+        """
+        if run_id not in self._rows:
+            raise EntityNotFoundError("FeatureRun", run_id)
+
+        rows = list(self._rows[run_id])
+
+        if symbols is not None:
+            allow = {
+                str(s).strip().upper() for s in symbols if str(s).strip()
+            }
+            rows = [r for r in rows if r.symbol.upper() in allow]
+
+        def _value(row, field: str):
+            if field == "composite_score":
+                return row.composite_score
+            if field == "overall_rating":
+                return row.overall_rating
+            if field == "passes_count":
+                return row.passes_count
+            if field == "symbol":
+                return row.symbol
+            details = row.details or {}
+            return details.get(field) if isinstance(details, dict) else None
+
+        if filters is not None:
+            from app.domain.common.query import FilterMode
+
+            filtered: list = []
+            for row in rows:
+                ok = True
+                for rf in filters.range_filters:
+                    val = _value(row, rf.field)
+                    if val is None:
+                        ok = False
+                        break
+                    try:
+                        numeric = float(val)
+                    except (TypeError, ValueError):
+                        ok = False
+                        break
+                    if rf.min_value is not None and numeric < float(rf.min_value):
+                        ok = False
+                        break
+                    if rf.max_value is not None and numeric > float(rf.max_value):
+                        ok = False
+                        break
+                if not ok:
+                    continue
+                for cf in filters.categorical_filters:
+                    val = _value(row, cf.field)
+                    in_values = val in cf.values
+                    if cf.mode == FilterMode.EXCLUDE:
+                        if in_values:
+                            ok = False
+                            break
+                    else:
+                        if not in_values:
+                            ok = False
+                            break
+                if not ok:
+                    continue
+                for bf in filters.boolean_filters:
+                    val = _value(row, bf.field)
+                    if val is None or bool(val) != bf.value:
+                        ok = False
+                        break
+                if not ok:
+                    continue
+                filtered.append(row)
+            rows = filtered
+
+        return [
+            (row.symbol, dict(row.details) if isinstance(row.details, dict) else {})
+            for row in rows
+        ]
 
     def get_setup_payload_for_run(self, run_id, symbol):
         self.last_get_setup_payload_for_run_args = {

--- a/backend/tests/unit/use_cases/conftest.py
+++ b/backend/tests/unit/use_cases/conftest.py
@@ -486,9 +486,17 @@ class FakeFeatureRunRepository(FeatureRunRepository):
     def __init__(self, *, row_counter=None) -> None:
         self._runs: dict[int, FeatureRunDomain] = {}
         self._next_id = 1
-        self._pointer_run_id: int | None = None
+        # Map of pointer_key -> run_id, mirroring ``feature_run_pointers``
+        # in the real repo. Populated by ``publish_atomically``; queried by
+        # ``get_latest_published`` and ``find_latest_published_covering``.
+        self._pointers: dict[str, int] = {}
         # Optional callback: (run_id) -> int for list_runs_with_counts
         self._row_counter = row_counter
+
+    @property
+    def _pointer_run_id(self) -> int | None:
+        """Backward-compat alias for tests reading the global pointer."""
+        return self._pointers.get("latest_published")
 
     def start_run(self, as_of_date, run_type, code_version=None,
                   universe_hash=None, input_hash=None,
@@ -557,7 +565,9 @@ class FakeFeatureRunRepository(FeatureRunRepository):
         self._runs[run_id] = updated
         return updated
 
-    def publish_atomically(self, run_id) -> FeatureRunDomain:
+    def publish_atomically(
+        self, run_id, pointer_key: str = "latest_published"
+    ) -> FeatureRunDomain:
         run = self._get_or_raise(run_id)
         validate_transition(run.status, RunStatus.PUBLISHED)
         updated = FeatureRunDomain(
@@ -570,13 +580,16 @@ class FakeFeatureRunRepository(FeatureRunRepository):
             stats=run.stats, warnings=run.warnings,
         )
         self._runs[run_id] = updated
-        self._pointer_run_id = run_id
+        self._pointers[pointer_key] = run_id
         return updated
 
-    def get_latest_published(self) -> FeatureRunDomain | None:
-        if self._pointer_run_id is None:
+    def get_latest_published(
+        self, pointer_key: str = "latest_published"
+    ) -> FeatureRunDomain | None:
+        run_id = self._pointers.get(pointer_key)
+        if run_id is None:
             return None
-        return self._runs.get(self._pointer_run_id)
+        return self._runs.get(run_id)
 
     def find_latest_published_exact(
         self,
@@ -626,22 +639,27 @@ class FakeFeatureRunRepository(FeatureRunRepository):
             return None
 
         universes = getattr(self, "_run_universes", {})
-        published = [
-            run for run in self._runs.values()
-            if run.status == RunStatus.PUBLISHED
-        ]
-        if not published:
-            return None
 
-        # Newest published first — mirrors pointer-based selection in the
-        # real repo (the pointer always points at the most recent publish).
-        published.sort(
-            key=lambda run: (run.published_at or datetime.min, run.id or 0),
-            reverse=True,
-        )
+        # Honour the same pointer ordering as the real repo: market-specific
+        # pointer first, then the global pointer. Without this the fake
+        # would silently pick any covering published run regardless of
+        # which market it was published for, and a regression that selects
+        # the wrong run for a market-scoped scan could pass tests.
+        candidate_keys: list[str] = []
+        if market:
+            candidate_keys.append(
+                f"latest_published_market:{str(market).strip().upper()}"
+            )
+        candidate_keys.append("latest_published")
 
-        for run in published:
-            covered = universes.get(run.id)
+        for key in candidate_keys:
+            run_id = self._pointers.get(key)
+            if run_id is None:
+                continue
+            run = self._runs.get(run_id)
+            if run is None or run.status != RunStatus.PUBLISHED:
+                continue
+            covered = universes.get(run_id)
             if covered is None:
                 continue
             if all(symbol in covered for symbol in normalized):

--- a/backend/tests/unit/use_cases/conftest.py
+++ b/backend/tests/unit/use_cases/conftest.py
@@ -613,12 +613,18 @@ class FakeFeatureRunRepository(FeatureRunRepository):
         )
         return matches[0]
 
-    def set_run_universe(self, run_id: int, symbols: Sequence[str]) -> None:
-        """Test helper: register the universe a published run covers.
+    def set_run_covered_symbols(self, run_id: int, symbols: Sequence[str]) -> None:
+        """Test helper: register the symbols that have a feature row in the run.
 
-        The real repo reads ``feature_run_universe_symbols``; this fake
+        The real repo counts rows in ``stock_feature_daily``; this fake
         keeps a parallel mapping so ``find_latest_published_covering``
         can answer coverage questions without an actual DB.
+
+        Note: matching production semantics, this is the set of symbols
+        with *persisted feature rows* — not the symbols listed in the
+        universe table. Default DQ thresholds permit publishing a run
+        with up to 10% of universe symbols missing rows, so the two sets
+        can legitimately differ.
         """
         if not hasattr(self, "_run_universes"):
             self._run_universes: dict[int, set[str]] = {}

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -498,6 +498,47 @@ class TestCompilePathHappyPath:
         assert result.status == "queued"
         assert len(dispatcher.dispatched) == 1
 
+    def test_exclude_only_with_missing_industry_dispatches_async(self):
+        """An exclude-only scan cannot be hard-gate equivalent.
+
+        The SQL exclude predicate keeps NULL industries, but CustomScanner only
+        runs the industry-exclusion filter when fundamentals are present. A row
+        with no fundamental industry metadata would therefore pass compile-path
+        SQL while async execution has no active filters and returns non-passing.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85, gics_industry=None)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {
+                        "exclude_industries": ["Tobacco"],
+                    },
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
 
 class TestCompilePathFallsBack:
     """Non-applicable scans must defer to the async path."""

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -419,6 +419,81 @@ class TestCompilePathHappyPath:
         assert result.status == "queued"
         assert len(dispatcher.dispatched) == 1
 
+    def test_non_positive_volume_min_with_hard_gate_dispatches_async(self):
+        """``volume_min<=0`` contributes full async points without adding a
+        SQL predicate. With ``min_score=50``, a row can fail price but pass via
+        the volume filter, so strict SQL price filtering would false-negative.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85, current_price=10)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {"price_min": 20, "volume_min": 0},
+                    "min_score": 50,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_empty_exclude_industries_with_hard_gate_dispatches_async(self):
+        """``exclude_industries=[]`` contributes full async points without a
+        SQL predicate. With ``min_score=50``, a row can fail price but pass via
+        the empty exclusion filter, so compile path must defer.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85, current_price=10)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {
+                        "price_min": 20,
+                        "exclude_industries": [],
+                    },
+                    "min_score": 50,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
 
 class TestCompilePathFallsBack:
     """Non-applicable scans must defer to the async path."""

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -242,6 +242,8 @@ class TestCompilePathHappyPath:
                 "screeners_run": ["custom", "minervini", "canslim"],
                 "screeners_passed": 2,
                 "screeners_total": 3,
+                "ipo_score": 62.0,
+                "ipo_bonus": 8.0,
                 "rs_rating": 91,
                 "gics_sector": "Technology",
             },
@@ -291,6 +293,8 @@ class TestCompilePathHappyPath:
         # scan was custom-only, so they have no meaning in this context.
         assert "minervini_score" not in persisted
         assert "canslim_score" not in persisted
+        assert "ipo_score" not in persisted
+        assert "ipo_bonus" not in persisted
 
         # Per-symbol facts (not derived from custom criteria) survive.
         assert persisted["current_price"] == 150.0

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -539,6 +539,46 @@ class TestCompilePathHappyPath:
         assert result.status == "queued"
         assert len(dispatcher.dispatched) == 1
 
+    def test_sector_only_with_snapshot_taxonomy_dispatches_async(self):
+        """A sector-only scan cannot be hard-gate equivalent.
+
+        Snapshot taxonomy can populate ``gics_sector`` even when async custom
+        scanning has no fundamentals. SQL would keep the row, while
+        CustomScanner would skip the sector filter and return non-passing.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85, gics_sector="Technology")],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {
+                        "sectors": ["Technology"],
+                    },
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
 
 class TestCompilePathFallsBack:
     """Non-applicable scans must defer to the async path."""

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -48,10 +48,11 @@ def _custom_command(
         composite_method="weighted_average",
         criteria=criteria or {
             # Use only filters the compiler can express today: price_min
-            # and rs_rating_min both map to indexed JSON fields. Avoid
+            # maps to an indexed JSON field and is hard-gate equivalent to
+            # CustomScanner when it is the only active filter. Avoid
             # ma_alignment in the default — the stored field has stricter
             # Minervini semantics so the compiler marks it unrepresentable.
-            "custom_filters": {"price_min": 20, "rs_rating_min": 70},
+            "custom_filters": {"price_min": 20},
             "min_score": 70,
         },
     )
@@ -132,11 +133,10 @@ class TestCompilePathHappyPath:
         feature_store = FakeFeatureStoreRepository()
         symbols = ["AAPL", "MSFT", "GOOGL"]
         rows = [
-            # Both per-field thresholds (price>=20, rs_rating>=70) pass.
-            _row("AAPL", custom_score=85, current_price=150, rs_rating=85),
-            _row("MSFT", custom_score=72, current_price=300, rs_rating=78),
-            # rs_rating below threshold — must be excluded.
-            _row("GOOGL", custom_score=85, current_price=120, rs_rating=40),
+            _row("AAPL", custom_score=85, current_price=150),
+            _row("MSFT", custom_score=72, current_price=300),
+            # price below threshold — must be excluded.
+            _row("GOOGL", custom_score=85, current_price=10),
         ]
         run_id = _publish_run(
             feature_runs, feature_store, symbols=symbols, rows=rows
@@ -155,7 +155,7 @@ class TestCompilePathHappyPath:
         assert result.status == "completed"
         assert result.total_stocks == 3
         # Per-field threshold pass test (no stale-criteria custom_score gate):
-        # GOOGL excluded because rs_rating=40 < 70; AAPL + MSFT persisted.
+        # GOOGL excluded because current_price=10 < 20; AAPL + MSFT persisted.
         assert len(dispatcher.dispatched) == 0
         persisted = uow.scan_results._persisted_results
         persisted_symbols = sorted(sym for _, sym, _ in persisted)
@@ -177,8 +177,8 @@ class TestCompilePathHappyPath:
         feature_store = FakeFeatureStoreRepository()
         symbols = ["AAPL"]
         # custom_score=10 was computed under different criteria; the user's
-        # actual per-field thresholds (price>=20, rs_rating>=70) all pass,
-        # so the row must be persisted regardless of the stored score.
+        # hard-gate-equivalent price threshold passes, so the row must be
+        # persisted regardless of the stored score.
         rows = [
             _row(
                 "AAPL", custom_score=10, current_price=150, rs_rating=85
@@ -200,7 +200,7 @@ class TestCompilePathHappyPath:
             uow,
             _custom_command(
                 criteria={
-                    "custom_filters": {"price_min": 20, "rs_rating_min": 70},
+                    "custom_filters": {"price_min": 20},
                     "min_score": 70,
                 },
             ),
@@ -264,7 +264,7 @@ class TestCompilePathHappyPath:
             uow,
             _custom_command(
                 criteria={
-                    "custom_filters": {"price_min": 20, "rs_rating_min": 70},
+                    "custom_filters": {"price_min": 20},
                     "min_score": 70,
                 },
             ),
@@ -325,6 +325,96 @@ class TestCompilePathHappyPath:
         assert result.status == "completed"
         persisted = sorted(sym for _, sym, _ in uow.scan_results._persisted_results)
         assert persisted == ["B"]
+
+    def test_multi_filter_partial_score_case_dispatches_async(self):
+        """Four binary filters are not equivalent to SQL hard gates.
+
+        CustomScanner would give this row 30/40 points because it passes
+        price, market cap, and sector, but fails industry exclusion. At the
+        default min_score=70, 75 points passes async. A SQL WHERE chain would
+        drop it, so the compile path must defer.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[
+                _row(
+                    "AAPL",
+                    custom_score=85,
+                    current_price=150,
+                    market_cap_usd=2_000_000_000,
+                    gics_sector="Technology",
+                    gics_industry="Tobacco",
+                )
+            ],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {
+                        "price_min": 20,
+                        "market_cap_min": 1_000_000_000,
+                        "sectors": ["Technology"],
+                        "exclude_industries": ["Tobacco"],
+                    },
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_scaled_score_filter_dispatches_async(self):
+        """RS rating threshold has partial score semantics in CustomScanner.
+
+        A row exactly at rs_rating_min satisfies the hard SQL gate, but gets
+        10/15 points in CustomScanner and fails the default min_score=70.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85, rs_rating=80)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {"rs_rating_min": 80},
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
 
 
 class TestCompilePathFallsBack:

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -200,6 +200,87 @@ class TestCompilePathHappyPath:
         )
         assert persisted == ["AAPL"]
 
+    def test_compile_path_normalises_stale_score_fields(self):
+        """Stored custom_score/composite_score/rating/passes_template come
+        from a different criteria set (otherwise the exact-match path would
+        have caught it). They must not leak into the persisted scan_result
+        row; sorting by score in the UI would otherwise misrank matches.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        # Stored row carries stale-criteria metadata that must not survive,
+        # plus factual snapshot fields that must.
+        stale_row = FeatureRowWrite(
+            symbol="AAPL",
+            as_of_date=date(2026, 4, 24),
+            composite_score=32.0,
+            overall_rating=2,
+            passes_count=0,
+            details={
+                "custom_score": 32.0,
+                "current_price": 150.0,
+                "ma_alignment": True,
+                "rating": "Watch",
+                "passes_template": False,
+                "minervini_score": 88.0,
+                "canslim_score": 70.0,
+                "screeners_run": ["custom", "minervini", "canslim"],
+                "screeners_passed": 2,
+                "screeners_total": 3,
+                "rs_rating": 91,
+                "gics_sector": "Technology",
+            },
+        )
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[stale_row],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "completed"
+        assert len(uow.scan_results._persisted_results) == 1
+        _, _, persisted = uow.scan_results._persisted_results[0]
+
+        # Stale score/rating/pass fields are normalised to compile-path
+        # semantics ("the row passed every user-specified filter").
+        assert persisted["custom_score"] == 100.0
+        assert persisted["composite_score"] == 100.0
+        assert persisted["rating"] == "Strong Buy"
+        assert persisted["passes_template"] is True
+        assert persisted["screeners_run"] == ["custom"]
+        assert persisted["screeners_passed"] == 1
+        assert persisted["screeners_total"] == 1
+
+        # Other-screener scores from the snapshot are dropped — the user's
+        # scan was custom-only, so they have no meaning in this context.
+        assert "minervini_score" not in persisted
+        assert "canslim_score" not in persisted
+
+        # Per-symbol facts (not derived from custom criteria) survive.
+        assert persisted["current_price"] == 150.0
+        assert persisted["rs_rating"] == 91
+        assert persisted["gics_sector"] == "Technology"
+
     def test_compile_path_applies_price_range(self):
         feature_runs = FakeFeatureRunRepository()
         feature_store = FakeFeatureStoreRepository()

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -1,0 +1,452 @@
+"""Unit tests for the feature-store-first compile path in CreateScanUseCase.
+
+These tests cover the new behavior where custom-only scans whose criteria
+compile cleanly into queryable feature-store fields are answered by a
+single SQL query against a published feature run, instead of being
+dispatched to the async chunked-compute path.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from app.domain.feature_store.models import (
+    FeatureRowWrite,
+    RunStats,
+    RunType,
+)
+from app.use_cases.scanning.create_scan import (
+    CreateScanCommand,
+    CreateScanUseCase,
+)
+
+from tests.unit.use_cases.conftest import (
+    FakeFeatureRunRepository,
+    FakeFeatureStoreRepository,
+    FakeTaskDispatcher,
+    FakeUnitOfWork,
+    FakeUniverseRepository,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _custom_command(
+    *,
+    universe_market: str | None = None,
+    criteria: dict | None = None,
+    screeners: list[str] | None = None,
+) -> CreateScanCommand:
+    return CreateScanCommand(
+        universe_def="all",
+        universe_label="All Stocks",
+        universe_key="all",
+        universe_type="all",
+        universe_market=universe_market,
+        screeners=screeners or ["custom"],
+        composite_method="weighted_average",
+        criteria=criteria or {
+            "custom_filters": {"price_min": 20, "ma_alignment": True},
+            "min_score": 70,
+        },
+    )
+
+
+def _publish_run(
+    feature_runs: FakeFeatureRunRepository,
+    feature_store: FakeFeatureStoreRepository,
+    *,
+    symbols: list[str],
+    rows: list[FeatureRowWrite],
+    as_of: date | None = None,
+) -> int:
+    """Create + populate + publish a feature run on the fake repos."""
+    run = feature_runs.start_run(
+        as_of_date=as_of or date(2026, 4, 24),
+        run_type=RunType.DAILY_SNAPSHOT,
+        universe_hash="universe-hash-irrelevant",
+        input_hash="input-hash-irrelevant",
+    )
+    feature_runs.set_run_universe(run.id, symbols)
+    feature_runs.mark_completed(
+        run.id,
+        stats=RunStats(
+            total_symbols=len(symbols),
+            processed_symbols=len(symbols),
+            failed_symbols=0,
+            duration_seconds=1.0,
+            passed_symbols=len([r for r in rows if r.composite_score and r.composite_score >= 70]),
+        ),
+    )
+    feature_runs.publish_atomically(run.id)
+    feature_store.save_run_universe_symbols(run.id, symbols)
+    feature_store.upsert_snapshot_rows(run.id, rows)
+    return run.id
+
+
+def _row(symbol: str, *, custom_score: float, **details) -> FeatureRowWrite:
+    """Build a FeatureRowWrite that mimics what the daily snapshot stores."""
+    payload = {
+        "custom_score": custom_score,
+        "current_price": details.pop("current_price", 100.0),
+        "ma_alignment": details.pop("ma_alignment", True),
+        "rs_rating": details.pop("rs_rating", 80),
+        "rating": "Buy" if custom_score >= 70 else "Watch",
+        "screeners_run": ["custom"],
+        "screeners_passed": 1 if custom_score >= 70 else 0,
+        "screeners_total": 1,
+        **details,
+    }
+    return FeatureRowWrite(
+        symbol=symbol,
+        as_of_date=date(2026, 4, 24),
+        composite_score=custom_score,
+        overall_rating=4 if custom_score >= 80 else (3 if custom_score >= 70 else 2),
+        passes_count=1 if custom_score >= 70 else 0,
+        details=payload,
+    )
+
+
+# ── Tests ────────────────────────────────────────────────────────────────
+
+
+class TestCompilePathHappyPath:
+    """Custom-only scans matching a covering published run complete instantly."""
+
+    def test_compile_path_skips_dispatch_and_persists_passing_rows(self):
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL", "MSFT", "GOOGL"]
+        rows = [
+            _row("AAPL", custom_score=85, current_price=150),
+            _row("MSFT", custom_score=72, current_price=300),
+            _row("GOOGL", custom_score=55, current_price=120),  # below min_score
+        ]
+        run_id = _publish_run(
+            feature_runs, feature_store, symbols=symbols, rows=rows
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(uow, _custom_command())
+
+        assert result.status == "completed"
+        assert result.total_stocks == 3
+        # GOOGL filtered out by min_score; AAPL + MSFT persisted.
+        assert len(dispatcher.dispatched) == 0
+        persisted = uow.scan_results._persisted_results
+        persisted_symbols = sorted(sym for _, sym, _ in persisted)
+        assert persisted_symbols == ["AAPL", "MSFT"]
+        scan = uow.scans.rows[0]
+        assert scan.status == "completed"
+        assert scan.passed_stocks == 2
+        # feature_run_id is intentionally None — read path uses scan_results.
+        assert scan.feature_run_id is None
+        assert run_id is not None
+
+    def test_compile_path_applies_price_range(self):
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["A", "B", "C"]
+        rows = [
+            _row("A", custom_score=85, current_price=10),  # below price_min
+            _row("B", custom_score=85, current_price=50),  # in range
+            _row("C", custom_score=85, current_price=600),  # above price_max
+        ]
+        _publish_run(feature_runs, feature_store, symbols=symbols, rows=rows)
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        uc = CreateScanUseCase(dispatcher=FakeTaskDispatcher())
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {"price_min": 20, "price_max": 500},
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "completed"
+        persisted = sorted(sym for _, sym, _ in uow.scan_results._persisted_results)
+        assert persisted == ["B"]
+
+
+class TestCompilePathFallsBack:
+    """Non-applicable scans must defer to the async path."""
+
+    def test_unrepresentable_criteria_dispatches_async(self):
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        # debt_to_equity_max is not in the feature store JSON map yet.
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {
+                        "price_min": 20,
+                        "debt_to_equity_max": 0.5,
+                    },
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+        assert uow.scans.rows[0].feature_run_id is None
+
+    def test_no_covering_run_dispatches_async(self):
+        """Run universe doesn't include all requested symbols."""
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        # Run only covers AAPL + MSFT; user asks for GOOGL too.
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=["AAPL", "MSFT"],
+            rows=[
+                _row("AAPL", custom_score=85),
+                _row("MSFT", custom_score=85),
+            ],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(["AAPL", "MSFT", "GOOGL"]),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(uow, _custom_command())
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_no_published_run_dispatches_async(self):
+        """No feature run has been published yet."""
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(["AAPL"]),
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(uow, _custom_command())
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_multi_screener_dispatches_async(self):
+        """Multi-screener composites are out of scope for the compile path."""
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(screeners=["custom", "minervini"]),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_non_us_single_market_with_volume_filter_dispatches_async(self):
+        """USD-normalised columns can't safely answer HK volume thresholds."""
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["0700.HK"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("0700.HK", custom_score=85)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            CreateScanCommand(
+                universe_def="market:HK",
+                universe_label="Hong Kong",
+                universe_key="market:HK",
+                universe_type="market",
+                universe_market="HK",
+                screeners=["custom"],
+                criteria={
+                    "custom_filters": {"volume_min": 1_000_000, "price_min": 20},
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+
+class TestCompilePathErrorHandling:
+    """Compile-path failures must never block the async fallback."""
+
+    def test_lookup_exception_falls_back_to_async(self):
+        class BrokenFeatureRunRepo(FakeFeatureRunRepository):
+            def find_latest_published_covering(self, *, symbols, market=None):
+                raise RuntimeError("feature_runs table unreachable")
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(["AAPL"]),
+            feature_runs=BrokenFeatureRunRepo(),
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(uow, _custom_command())
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_query_exception_falls_back_to_async(self):
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85)],
+        )
+
+        class BrokenFeatureStore(FakeFeatureStoreRepository):
+            def query_run_details(self, run_id, filters=None, *, symbols=None):
+                raise RuntimeError("query failed")
+
+        # Replace store but copy data over so coverage check passes.
+        broken = BrokenFeatureStore()
+        broken._rows = feature_store._rows
+        broken._universe = feature_store._universe
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=broken,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(uow, _custom_command())
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+
+class TestCompilePathCoexistsWithExactMatch:
+    """The exact-signature path should still take precedence when applicable."""
+
+    def test_exact_match_wins_over_compile_path(self):
+        from app.domain.scanning.signature import (
+            build_scan_signature_payload,
+            hash_scan_signature,
+            hash_universe_symbols,
+        )
+
+        symbols = ["AAPL"]
+        criteria = {
+            "custom_filters": {"price_min": 20, "ma_alignment": True},
+            "min_score": 70,
+        }
+        signature = build_scan_signature_payload(
+            universe_type="all",
+            screeners=["custom"],
+            composite_method="weighted_average",
+            criteria=criteria,
+        )
+
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        run = feature_runs.start_run(
+            as_of_date=date(2026, 4, 24),
+            run_type=RunType.DAILY_SNAPSHOT,
+            universe_hash=hash_universe_symbols(symbols),
+            input_hash=hash_scan_signature(signature),
+        )
+        feature_runs.set_run_universe(run.id, symbols)
+        feature_runs.mark_completed(
+            run.id,
+            stats=RunStats(
+                total_symbols=1, processed_symbols=1,
+                failed_symbols=0, duration_seconds=1.0, passed_symbols=1,
+            ),
+        )
+        feature_runs.publish_atomically(run.id)
+        feature_store.save_run_universe_symbols(run.id, symbols)
+        feature_store.upsert_snapshot_rows(
+            run.id, [_row("AAPL", custom_score=85)]
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(criteria=criteria),
+        )
+
+        # Exact match path sets feature_run_id (run IS the result).
+        assert result.status == "completed"
+        assert result.feature_run_id == run.id
+        # No compile-path persistence happened.
+        assert uow.scan_results._persisted_results == []
+        assert len(dispatcher.dispatched) == 0

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -37,6 +37,7 @@ def _custom_command(
     universe_market: str | None = None,
     criteria: dict | None = None,
     screeners: list[str] | None = None,
+    composite_method: str = "weighted_average",
 ) -> CreateScanCommand:
     return CreateScanCommand(
         universe_def="all",
@@ -45,7 +46,7 @@ def _custom_command(
         universe_type="all",
         universe_market=universe_market,
         screeners=screeners or ["custom"],
-        composite_method="weighted_average",
+        composite_method=composite_method,
         criteria=criteria or {
             # Use only filters the compiler can express today: price_min
             # maps to an indexed JSON field and is hard-gate equivalent to
@@ -263,6 +264,7 @@ class TestCompilePathHappyPath:
         result = uc.execute(
             uow,
             _custom_command(
+                composite_method="maximum",
                 criteria={
                     "custom_filters": {"price_min": 20},
                     "min_score": 70,
@@ -283,6 +285,7 @@ class TestCompilePathHappyPath:
         assert persisted["screeners_run"] == ["custom"]
         assert persisted["screeners_passed"] == 1
         assert persisted["screeners_total"] == 1
+        assert persisted["composite_method"] == "maximum"
 
         # Other-screener scores from the snapshot are dropped — the user's
         # scan was custom-only, so they have no meaning in this context.

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -66,20 +66,28 @@ def _publish_run(
     as_of: date | None = None,
     pointer_key: str = "latest_published",
 ) -> int:
-    """Create + populate + publish a feature run on the fake repos."""
+    """Create + populate + publish a feature run on the fake repos.
+
+    Coverage in the fake is keyed off the symbols actually persisted as
+    rows (``[r.symbol for r in rows]``), not the requested universe — this
+    matches the production coverage check, which counts
+    ``stock_feature_daily`` rows so partial-publish runs are correctly
+    rejected. Pass a ``rows`` list shorter than ``symbols`` to model a
+    partial run.
+    """
     run = feature_runs.start_run(
         as_of_date=as_of or date(2026, 4, 24),
         run_type=RunType.DAILY_SNAPSHOT,
         universe_hash="universe-hash-irrelevant",
         input_hash="input-hash-irrelevant",
     )
-    feature_runs.set_run_universe(run.id, symbols)
+    feature_runs.set_run_covered_symbols(run.id, [r.symbol for r in rows])
     feature_runs.mark_completed(
         run.id,
         stats=RunStats(
             total_symbols=len(symbols),
-            processed_symbols=len(symbols),
-            failed_symbols=0,
+            processed_symbols=len(rows),
+            failed_symbols=max(0, len(symbols) - len(rows)),
             duration_seconds=1.0,
             passed_symbols=len([r for r in rows if r.composite_score and r.composite_score >= 70]),
         ),
@@ -457,6 +465,35 @@ class TestCompilePathFallsBack:
         assert result.status == "queued"
         assert len(dispatcher.dispatched) == 1
 
+    def test_partial_publish_run_dispatches_async(self):
+        """Default DQ thresholds permit publishing a run with up to 10% of
+        universe symbols missing feature rows. The compile path must check
+        actual ``stock_feature_daily`` rows, not just universe membership,
+        otherwise it would silently omit those symbols from results.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        # Universe lists AAPL + MSFT, but only AAPL has a row (partial run).
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=["AAPL", "MSFT"],
+            rows=[_row("AAPL", custom_score=85)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(["AAPL", "MSFT"]),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(uow, _custom_command())
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
     def test_no_published_run_dispatches_async(self):
         """No feature run has been published yet."""
         uow = FakeUnitOfWork(
@@ -776,7 +813,7 @@ class TestCompilePathCoexistsWithExactMatch:
             universe_hash=hash_universe_symbols(symbols),
             input_hash=hash_scan_signature(signature),
         )
-        feature_runs.set_run_universe(run.id, symbols)
+        feature_runs.set_run_covered_symbols(run.id, symbols)
         feature_runs.mark_completed(
             run.id,
             stats=RunStats(

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -47,7 +47,11 @@ def _custom_command(
         screeners=screeners or ["custom"],
         composite_method="weighted_average",
         criteria=criteria or {
-            "custom_filters": {"price_min": 20, "ma_alignment": True},
+            # Use only filters the compiler can express today: price_min
+            # and rs_rating_min both map to indexed JSON fields. Avoid
+            # ma_alignment in the default — the stored field has stricter
+            # Minervini semantics so the compiler marks it unrepresentable.
+            "custom_filters": {"price_min": 20, "rs_rating_min": 70},
             "min_score": 70,
         },
     )
@@ -60,6 +64,7 @@ def _publish_run(
     symbols: list[str],
     rows: list[FeatureRowWrite],
     as_of: date | None = None,
+    pointer_key: str = "latest_published",
 ) -> int:
     """Create + populate + publish a feature run on the fake repos."""
     run = feature_runs.start_run(
@@ -79,7 +84,7 @@ def _publish_run(
             passed_symbols=len([r for r in rows if r.composite_score and r.composite_score >= 70]),
         ),
     )
-    feature_runs.publish_atomically(run.id)
+    feature_runs.publish_atomically(run.id, pointer_key=pointer_key)
     feature_store.save_run_universe_symbols(run.id, symbols)
     feature_store.upsert_snapshot_rows(run.id, rows)
     return run.id
@@ -119,11 +124,11 @@ class TestCompilePathHappyPath:
         feature_store = FakeFeatureStoreRepository()
         symbols = ["AAPL", "MSFT", "GOOGL"]
         rows = [
-            # Both per-field thresholds (price>=20, ma_alignment=True) pass.
-            _row("AAPL", custom_score=85, current_price=150, ma_alignment=True),
-            _row("MSFT", custom_score=72, current_price=300, ma_alignment=True),
-            # MA misaligned — must fail the boolean filter and be excluded.
-            _row("GOOGL", custom_score=85, current_price=120, ma_alignment=False),
+            # Both per-field thresholds (price>=20, rs_rating>=70) pass.
+            _row("AAPL", custom_score=85, current_price=150, rs_rating=85),
+            _row("MSFT", custom_score=72, current_price=300, rs_rating=78),
+            # rs_rating below threshold — must be excluded.
+            _row("GOOGL", custom_score=85, current_price=120, rs_rating=40),
         ]
         run_id = _publish_run(
             feature_runs, feature_store, symbols=symbols, rows=rows
@@ -142,7 +147,7 @@ class TestCompilePathHappyPath:
         assert result.status == "completed"
         assert result.total_stocks == 3
         # Per-field threshold pass test (no stale-criteria custom_score gate):
-        # GOOGL excluded because ma_alignment=False; AAPL + MSFT persisted.
+        # GOOGL excluded because rs_rating=40 < 70; AAPL + MSFT persisted.
         assert len(dispatcher.dispatched) == 0
         persisted = uow.scan_results._persisted_results
         persisted_symbols = sorted(sym for _, sym, _ in persisted)
@@ -164,11 +169,11 @@ class TestCompilePathHappyPath:
         feature_store = FakeFeatureStoreRepository()
         symbols = ["AAPL"]
         # custom_score=10 was computed under different criteria; the user's
-        # actual per-field thresholds (price>=20, ma_alignment=True) all
-        # pass, so the row must be persisted regardless of the stored score.
+        # actual per-field thresholds (price>=20, rs_rating>=70) all pass,
+        # so the row must be persisted regardless of the stored score.
         rows = [
             _row(
-                "AAPL", custom_score=10, current_price=150, ma_alignment=True
+                "AAPL", custom_score=10, current_price=150, rs_rating=85
             ),
         ]
         _publish_run(
@@ -187,7 +192,7 @@ class TestCompilePathHappyPath:
             uow,
             _custom_command(
                 criteria={
-                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "custom_filters": {"price_min": 20, "rs_rating_min": 70},
                     "min_score": 70,
                 },
             ),
@@ -251,7 +256,7 @@ class TestCompilePathHappyPath:
             uow,
             _custom_command(
                 criteria={
-                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "custom_filters": {"price_min": 20, "rs_rating_min": 70},
                     "min_score": 70,
                 },
             ),
@@ -316,6 +321,76 @@ class TestCompilePathHappyPath:
 
 class TestCompilePathFallsBack:
     """Non-applicable scans must defer to the async path."""
+
+    def test_ma_alignment_filter_dispatches_async(self):
+        """Stored ``ma_alignment`` has Minervini's stricter semantics, so
+        the compiler marks it unrepresentable and the scan goes async.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_empty_sectors_filter_dispatches_async(self):
+        """``sectors=[]`` makes every async stock fail; we can't express
+        "match nothing" cleanly in SQL, so defer to async.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[_row("AAPL", custom_score=85)],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {"price_min": 20, "sectors": []},
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
 
     def test_unrepresentable_criteria_dispatches_async(self):
         feature_runs = FakeFeatureRunRepository()
@@ -458,7 +533,7 @@ class TestCompilePathFallsBack:
                 universe_index="SP500",
                 screeners=["custom"],
                 criteria={
-                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "custom_filters": {"price_min": 20, "rs_rating_min": 70},
                     "min_score": 70,
                 },
             ),
@@ -500,7 +575,7 @@ class TestCompilePathFallsBack:
                 universe_symbols=symbols,
                 screeners=["custom"],
                 criteria={
-                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "custom_filters": {"price_min": 20, "rs_rating_min": 70},
                     "min_score": 70,
                 },
             ),
@@ -603,6 +678,74 @@ class TestCompilePathErrorHandling:
         assert len(dispatcher.dispatched) == 1
 
 
+class TestMarketAwareCoveringRunSelection:
+    """The fake mirrors the production market-pointer fallback so a
+    regression that picks the wrong run for a market-scoped scan would
+    still be caught here.
+    """
+
+    def test_market_pointer_takes_precedence_over_global(self):
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+
+        # Older global run + newer US-specific run; both cover the symbol.
+        global_run_id = _publish_run(
+            feature_runs, feature_store, symbols=symbols,
+            rows=[_row("AAPL", custom_score=85, current_price=100, rs_rating=80)],
+            as_of=date(2026, 4, 23),
+            pointer_key="latest_published",
+        )
+        us_run_id = _publish_run(
+            feature_runs, feature_store, symbols=symbols,
+            rows=[_row("AAPL", custom_score=85, current_price=200, rs_rating=80)],
+            as_of=date(2026, 4, 24),
+            pointer_key="latest_published_market:US",
+        )
+        assert us_run_id != global_run_id
+
+        run = feature_runs.find_latest_published_covering(
+            symbols=symbols, market="US"
+        )
+
+        assert run is not None
+        assert run.id == us_run_id
+
+    def test_falls_back_to_global_when_market_pointer_missing(self):
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        global_run_id = _publish_run(
+            feature_runs, feature_store, symbols=symbols,
+            rows=[_row("AAPL", custom_score=85)],
+            pointer_key="latest_published",
+        )
+
+        run = feature_runs.find_latest_published_covering(
+            symbols=symbols, market="HK"
+        )
+
+        assert run is not None
+        assert run.id == global_run_id
+
+    def test_returns_none_when_no_covering_pointer(self):
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        # Run published only under HK pointer, but query asks for US — and
+        # no global pointer exists either.
+        _publish_run(
+            feature_runs, feature_store, symbols=["0700.HK"],
+            rows=[_row("0700.HK", custom_score=85)],
+            pointer_key="latest_published_market:HK",
+        )
+
+        run = feature_runs.find_latest_published_covering(
+            symbols=["0700.HK"], market="US"
+        )
+
+        assert run is None
+
+
 class TestCompilePathCoexistsWithExactMatch:
     """The exact-signature path should still take precedence when applicable."""
 
@@ -615,7 +758,7 @@ class TestCompilePathCoexistsWithExactMatch:
 
         symbols = ["AAPL"]
         criteria = {
-            "custom_filters": {"price_min": 20, "ma_alignment": True},
+            "custom_filters": {"price_min": 20, "rs_rating_min": 70},
             "min_score": 70,
         }
         signature = build_scan_signature_payload(

--- a/backend/tests/unit/use_cases/test_create_scan_compile_path.py
+++ b/backend/tests/unit/use_cases/test_create_scan_compile_path.py
@@ -119,9 +119,11 @@ class TestCompilePathHappyPath:
         feature_store = FakeFeatureStoreRepository()
         symbols = ["AAPL", "MSFT", "GOOGL"]
         rows = [
-            _row("AAPL", custom_score=85, current_price=150),
-            _row("MSFT", custom_score=72, current_price=300),
-            _row("GOOGL", custom_score=55, current_price=120),  # below min_score
+            # Both per-field thresholds (price>=20, ma_alignment=True) pass.
+            _row("AAPL", custom_score=85, current_price=150, ma_alignment=True),
+            _row("MSFT", custom_score=72, current_price=300, ma_alignment=True),
+            # MA misaligned — must fail the boolean filter and be excluded.
+            _row("GOOGL", custom_score=85, current_price=120, ma_alignment=False),
         ]
         run_id = _publish_run(
             feature_runs, feature_store, symbols=symbols, rows=rows
@@ -139,7 +141,8 @@ class TestCompilePathHappyPath:
 
         assert result.status == "completed"
         assert result.total_stocks == 3
-        # GOOGL filtered out by min_score; AAPL + MSFT persisted.
+        # Per-field threshold pass test (no stale-criteria custom_score gate):
+        # GOOGL excluded because ma_alignment=False; AAPL + MSFT persisted.
         assert len(dispatcher.dispatched) == 0
         persisted = uow.scan_results._persisted_results
         persisted_symbols = sorted(sym for _, sym, _ in persisted)
@@ -150,6 +153,52 @@ class TestCompilePathHappyPath:
         # feature_run_id is intentionally None — read path uses scan_results.
         assert scan.feature_run_id is None
         assert run_id is not None
+
+    def test_compile_path_does_not_apply_stale_custom_score_gate(self):
+        """A covering run reached this path because its (input_hash) differs
+        from the request, so its stored custom_score was computed under a
+        different criteria set. The compile path must not use it as a pass
+        gate — only per-field thresholds gate passing.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL"]
+        # custom_score=10 was computed under different criteria; the user's
+        # actual per-field thresholds (price>=20, ma_alignment=True) all
+        # pass, so the row must be persisted regardless of the stored score.
+        rows = [
+            _row(
+                "AAPL", custom_score=10, current_price=150, ma_alignment=True
+            ),
+        ]
+        _publish_run(
+            feature_runs, feature_store, symbols=symbols, rows=rows
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            _custom_command(
+                criteria={
+                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "completed"
+        assert len(dispatcher.dispatched) == 0
+        persisted = sorted(
+            sym for _, sym, _ in uow.scan_results._persisted_results
+        )
+        assert persisted == ["AAPL"]
 
     def test_compile_path_applies_price_range(self):
         feature_runs = FakeFeatureRunRepository()
@@ -288,6 +337,92 @@ class TestCompilePathFallsBack:
         result = uc.execute(
             uow,
             _custom_command(screeners=["custom", "minervini"]),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_index_universe_dispatches_async(self):
+        """INDEX universes pass universe_market=None even when symbols are
+        single-market, which would mismatch async unit semantics. Defer.
+        """
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL", "MSFT"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[
+                _row("AAPL", custom_score=85),
+                _row("MSFT", custom_score=85),
+            ],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            CreateScanCommand(
+                universe_def="index:SP500",
+                universe_label="S&P 500",
+                universe_key="index:SP500",
+                universe_type="index",
+                universe_index="SP500",
+                screeners=["custom"],
+                criteria={
+                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "min_score": 70,
+                },
+            ),
+        )
+
+        assert result.status == "queued"
+        assert len(dispatcher.dispatched) == 1
+
+    def test_custom_universe_dispatches_async(self):
+        """Symbol-list (CUSTOM) universes also defer to async — same reason."""
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = FakeFeatureStoreRepository()
+        symbols = ["AAPL", "MSFT"]
+        _publish_run(
+            feature_runs,
+            feature_store,
+            symbols=symbols,
+            rows=[
+                _row("AAPL", custom_score=85),
+                _row("MSFT", custom_score=85),
+            ],
+        )
+
+        uow = FakeUnitOfWork(
+            universe=FakeUniverseRepository(symbols),
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        dispatcher = FakeTaskDispatcher()
+        uc = CreateScanUseCase(dispatcher=dispatcher)
+
+        result = uc.execute(
+            uow,
+            CreateScanCommand(
+                universe_def="custom",
+                universe_label="My Symbols",
+                universe_key="custom",
+                universe_type="custom",
+                universe_symbols=symbols,
+                screeners=["custom"],
+                criteria={
+                    "custom_filters": {"price_min": 20, "ma_alignment": True},
+                    "min_score": 70,
+                },
+            ),
         )
 
         assert result.status == "queued"


### PR DESCRIPTION
## Summary

Implement a new "compile path" for custom-only scans that can be answered directly from a published feature run via SQL, bypassing the async chunked-compute dispatcher. When scan criteria compile cleanly into queryable feature-store fields, the scan completes instantly with results persisted from the feature snapshot.

## Key Changes

- **Custom Criteria Compiler** (`app/domain/scanning/custom_criteria_compiler.py`): New module that translates custom filter criteria (price ranges, volume thresholds, sector lists, MA alignment, etc.) into `FilterSpec` objects queryable against the feature store. Tracks which criteria are representable vs. unrepresentable to determine if the compile path is viable.

- **Compile Path in CreateScanUseCase** (`app/use_cases/scanning/create_scan.py`): Added `_attempt_compile_path()` method that:
  - Compiles criteria and checks if fully representable
  - Verifies a published feature run covers all requested symbols
  - Applies score gates (e.g., `custom_score >= min_score`) at the SQL layer
  - Persists passing rows directly as scan results
  - Falls back gracefully to async path on any failure (unrepresentable criteria, no covering run, infra errors)

- **Feature Run Repository** (`app/infra/db/repositories/feature_run_repo.py`): Added `find_latest_published_covering()` method to locate the newest published run whose universe covers all requested symbols, with market-specific pointer precedence.

- **Feature Store Repository** (`app/infra/db/repositories/feature_store_repo.py`): Added `query_run_details()` method to retrieve `(symbol, details_json)` tuples from a run with optional `FilterSpec` constraints and symbol allow-list, enabling direct result materialization.

- **Repository Ports** (`app/domain/feature_store/ports.py`): Added abstract method signatures for the two new repository methods.

- **Comprehensive Test Coverage**:
  - `test_create_scan_compile_path.py`: 450+ lines covering happy path (instant completion, price/score filtering), fallback scenarios (unrepresentable criteria, missing runs, multi-screener, non-USD markets), error handling, and coexistence with exact-match path
  - `test_custom_criteria_compiler.py`: 300+ lines validating criteria translation (range filters, boolean/categorical, USD unit compatibility, unrepresentable keys)
  - Repository tests: Integration tests for `find_latest_published_covering()` and `query_run_details()`
  - Fake repository implementations in test conftest with full compile-path support

## Notable Implementation Details

- **Graceful Degradation**: All compile-path failures (lookup exceptions, query errors, unrepresentable criteria) are logged but never raised—a misconfigured feature store cannot block scan creation.

- **USD Unit Compatibility**: Volume and market-cap filters only compile for USD-compatible markets (US or mixed-market universes) to avoid unit mismatches with feature-store USD-normalised columns.

- **Score Gate Application**: The `min_score` threshold is applied at the SQL layer via `FilterSpec.add_range()` so only passing rows are persisted, keeping `passed_stocks` count accurate.

- **Scope Limitations**: Currently limited to single-screener custom scans (`screeners=["custom"]`); multi-screener composites defer to async path as they need extra logic to select the appropriate score field.

- **Market-Specific Pointers**: Respects per-market feature run pointers (`latest_published_market:{market}`) with fallback to global `latest_published` pointer, matching existing API conventions.

https://claude.ai/code/session_01RBWRHTu5eyVHBNVXFDT2dj
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom-only scans can complete synchronously when criteria are fully supported, returning immediate results.
  * Query per-run per-symbol feature details for targeted result retrieval.

* **Improvements**
  * Market-aware published-run lookup with market-first fallback to global improves data availability.
  * Stronger compilation and validation of custom filters; scan outputs normalized to avoid stale scoring metadata.

* **Bug Fixes**
  * EXCLUDE-style filters now retain missing/null values for more intuitive results.

* **Tests**
  * Expanded unit tests covering compilation, repo lookups, query behavior, and the compile-path execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->