### PR TITLE
Add multi-market support for group rank history backfill

### DIFF
--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -23,10 +23,11 @@ from app.services.ibd_industry_service import IBDIndustryService
 from app.services.static_site_export_service import StaticSiteExportService
 from app.tasks.data_fetch_lock import disable_serialized_data_fetch_lock
 from app.tasks.workload_coordination import disable_serialized_market_workload
-from app.utils.market_hours import get_last_market_close, is_trading_day
+from app.utils.market_hours import get_last_market_close
 from app.utils.symbol_support import split_supported_price_symbols
 from app.wiring.bootstrap import (
     get_group_rank_service,
+    get_market_calendar_service,
     get_price_cache,
     get_provider_snapshot_service,
 )
@@ -197,21 +198,32 @@ def _refresh_static_daily_prices(*, as_of_date: date, market: str | None = None)
     }
 
 
-def _generate_trading_dates(start_date: date, end_date: date) -> list[date]:
+def _generate_trading_dates(
+    start_date: date,
+    end_date: date,
+    *,
+    market: str = STATIC_DEFAULT_MARKET,
+) -> list[date]:
+    normalized_market = (market or STATIC_DEFAULT_MARKET).upper()
+    calendar_service = get_market_calendar_service()
     trading_dates: list[date] = []
     current = start_date
     while current <= end_date:
-        if is_trading_day(current):
+        if calendar_service.is_trading_day(normalized_market, current):
             trading_dates.append(current)
         current += timedelta(days=1)
     return trading_dates
 
 
 def _ensure_group_rank_history(*, as_of_date: date, market: str = "US") -> dict[str, Any]:
-    """Backfill recent group-rank history so 1W/1M/3M/6M deltas can be rendered."""
+    """Backfill recent group-rank history so 1W/1M/3M deltas can be rendered."""
     normalized_market = (market or "US").upper()
     start_date = as_of_date - timedelta(days=STATIC_GROUP_HISTORY_LOOKBACK_DAYS)
-    desired_dates = _generate_trading_dates(start_date, as_of_date)
+    desired_dates = _generate_trading_dates(
+        start_date,
+        as_of_date,
+        market=normalized_market,
+    )
 
     with SessionLocal() as db:
         if not hasattr(db, "query"):

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -207,19 +207,31 @@ def _generate_trading_dates(start_date: date, end_date: date) -> list[date]:
     return trading_dates
 
 
-def _ensure_group_rank_history(*, as_of_date: date) -> dict[str, Any]:
-    """Backfill recent group-rank history so 1W/1M/3M deltas can be rendered."""
+def _ensure_group_rank_history(*, as_of_date: date, market: str = "US") -> dict[str, Any]:
+    """Backfill recent group-rank history so 1W/1M/3M/6M deltas can be rendered."""
+    normalized_market = (market or "US").upper()
     start_date = as_of_date - timedelta(days=STATIC_GROUP_HISTORY_LOOKBACK_DAYS)
     desired_dates = _generate_trading_dates(start_date, as_of_date)
 
     with SessionLocal() as db:
+        if not hasattr(db, "query"):
+            return {
+                "status": "skipped",
+                "market": normalized_market,
+                "as_of_date": as_of_date.isoformat(),
+                "lookback_start_date": start_date.isoformat(),
+                "missing_dates": 0,
+                "processed": 0,
+                "errors": 0,
+                "reason": "session_factory_stub",
+            }
         existing_dates = {
             record_date
             for record_date, in db.query(IBDGroupRank.date)
             .filter(
                 IBDGroupRank.date >= start_date,
                 IBDGroupRank.date <= as_of_date,
-                IBDGroupRank.market == "US",
+                IBDGroupRank.market == normalized_market,
             )
             .distinct()
             .all()
@@ -227,12 +239,13 @@ def _ensure_group_rank_history(*, as_of_date: date) -> dict[str, Any]:
         missing_dates = [calc_date for calc_date in desired_dates if calc_date not in existing_dates]
         if not missing_dates:
             print(
-                f"[static-groups] Existing rankings already cover {len(desired_dates):,} trading dates "
-                f"through {as_of_date}.",
+                f"[static-groups:{normalized_market}] Existing rankings already cover "
+                f"{len(desired_dates):,} trading dates through {as_of_date}.",
                 flush=True,
             )
             return {
                 "status": "skipped",
+                "market": normalized_market,
                 "as_of_date": as_of_date.isoformat(),
                 "lookback_start_date": start_date.isoformat(),
                 "missing_dates": 0,
@@ -241,14 +254,33 @@ def _ensure_group_rank_history(*, as_of_date: date) -> dict[str, Any]:
             }
 
         print(
-            f"[static-groups] Backfilling {len(missing_dates):,} missing trading dates "
+            f"[static-groups:{normalized_market}] Backfilling {len(missing_dates):,} missing trading dates "
             f"from {missing_dates[0]} to {missing_dates[-1]} before publishing {as_of_date}.",
             flush=True,
         )
-        stats = get_group_rank_service().fill_gaps_optimized(db, missing_dates)
+        try:
+            stats = get_group_rank_service().fill_gaps_optimized(
+                db, missing_dates, market=normalized_market,
+            )
+        except Exception as exc:
+            print(
+                f"[static-groups:{normalized_market}] Group-rank backfill failed: {exc}",
+                flush=True,
+            )
+            return {
+                "status": "errored",
+                "market": normalized_market,
+                "as_of_date": as_of_date.isoformat(),
+                "lookback_start_date": start_date.isoformat(),
+                "missing_dates": len(missing_dates),
+                "processed": 0,
+                "errors": len(missing_dates),
+                "error": str(exc),
+            }
         stats.update(
             {
                 "status": "completed",
+                "market": normalized_market,
                 "as_of_date": as_of_date.isoformat(),
                 "lookback_start_date": start_date.isoformat(),
                 "missing_dates": len(missing_dates),
@@ -395,6 +427,23 @@ def _run_daily_refresh(
             feature_snapshots[selected_market] = market_result
 
         results["feature_snapshots"] = feature_snapshots
+
+        group_rank_history: dict[str, Any] = {}
+        for selected_market in selected_markets:
+            snapshot = feature_snapshots.get(selected_market, {})
+            if not _snapshot_ready(snapshot):
+                group_rank_history[selected_market] = {
+                    "status": "skipped",
+                    "market": selected_market,
+                    "reason": "snapshot_not_ready",
+                }
+                continue
+            group_rank_history[selected_market] = _ensure_group_rank_history(
+                as_of_date=as_of_date,
+                market=selected_market,
+            )
+        results["group_rank_history_backfill"] = group_rank_history
+
         for snapshot_market, snapshot in feature_snapshots.items():
             if snapshot_market == STATIC_DEFAULT_MARKET:
                 continue

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -548,6 +548,24 @@ class IBDGroupRankService:
             .all()
         )
 
+    def get_historical_ranks_batch(
+        self,
+        db: Session,
+        group_names: List[str],
+        current_date: date,
+        period_days: Dict[str, int],
+        *,
+        market: str = "US",
+    ) -> Dict[tuple, int]:
+        """Public alias of :meth:`_get_historical_ranks_batch`."""
+        return self._get_historical_ranks_batch(
+            db,
+            group_names,
+            current_date,
+            period_days,
+            market=market,
+        )
+
     def _get_historical_ranks_batch(
         self,
         db: Session,

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -973,6 +973,12 @@ class StaticSiteExportService:
             for run in history_runs
         }
         self._apply_group_rank_changes(rankings, market_runs, historical_rankings)
+        self._apply_group_rank_changes_from_table(
+            db,
+            rankings,
+            market=market,
+            calculation_date=expected_as_of_date,
+        )
         group_details = self._build_group_details(
             rankings=rankings,
             serialized_rows=serialized_rows,
@@ -1285,6 +1291,56 @@ class StaticSiteExportService:
                     if historical is not None
                     else None
                 )
+
+    def _apply_group_rank_changes_from_table(
+        self,
+        db: Session,
+        rankings: list[dict[str, Any]],
+        *,
+        market: str,
+        calculation_date: date,
+    ) -> None:
+        """Backfill rank-change deltas from the ``IBDGroupRank`` history table.
+
+        Runs after the FeatureRun-based path so it only fills periods that the
+        historical-FeatureRun lookup couldn't supply (typical in CI, where
+        Postgres is ephemeral and only one FeatureRun per market exists).
+        Existing non-null deltas are preserved.
+        """
+        if not rankings:
+            return
+        period_days = {
+            period: offset for period, offset in STATIC_GROUP_CHANGE_OFFSETS.items()
+        }
+        group_names = [ranking["industry_group"] for ranking in rankings]
+        normalized_market = (market or STATIC_DEFAULT_MARKET).upper()
+        try:
+            historical = get_group_rank_service().get_historical_ranks_batch(
+                db,
+                group_names,
+                calculation_date,
+                period_days,
+                market=normalized_market,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to load IBDGroupRank history for market %s on %s",
+                normalized_market,
+                calculation_date,
+                exc_info=True,
+            )
+            return
+        if not historical:
+            return
+        for ranking in rankings:
+            for period in period_days:
+                key = f"rank_change_{period}"
+                if ranking.get(key) is not None:
+                    continue
+                historical_rank = historical.get((ranking["industry_group"], period))
+                if historical_rank is None:
+                    continue
+                ranking[key] = historical_rank - ranking["rank"]
 
     def _build_group_details(
         self,

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -70,6 +70,10 @@ STATIC_GROUP_CHANGE_OFFSETS = {
     "3m": 63,
     "6m": 126,
 }
+STATIC_GROUP_TABLE_FALLBACK_OFFSETS = {
+    period: STATIC_GROUP_CHANGE_OFFSETS[period]
+    for period in ("1w", "1m", "3m")
+}
 _DEFAULT_KEY_MARKETS = {
     "US": (
         {"symbol": "SPY", "display_name": "S&P 500 ETF", "currency": "USD"},
@@ -1309,9 +1313,7 @@ class StaticSiteExportService:
         """
         if not rankings:
             return
-        period_days = {
-            period: offset for period, offset in STATIC_GROUP_CHANGE_OFFSETS.items()
-        }
+        period_days = dict(STATIC_GROUP_TABLE_FALLBACK_OFFSETS)
         group_names = [ranking["industry_group"] for ranking in rankings]
         normalized_market = (market or STATIC_DEFAULT_MARKET).upper()
         try:

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 from pathlib import Path
 from types import SimpleNamespace
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import create_engine
@@ -23,6 +24,70 @@ from app.models.stock_universe import StockUniverse
 
 def test_static_export_markets_include_india():
     assert export_script.STATIC_EXPORT_MARKETS == ("US", "HK", "IN", "JP", "TW")
+
+
+def test_ensure_group_rank_history_uses_market_calendar_for_non_us_market(monkeypatch):
+    query = MagicMock()
+    query.filter.return_value = query
+    query.distinct.return_value = query
+    query.all.return_value = []
+
+    db = MagicMock()
+    db.query.return_value = query
+
+    @contextmanager
+    def fake_session():
+        yield db
+
+    calendar_calls: list[tuple[str, date]] = []
+    hk_trading_dates = {date(2026, 4, 3), date(2026, 4, 7)}
+
+    def is_trading_day(market: str, day: date) -> bool:
+        calendar_calls.append((market, day))
+        return day in hk_trading_dates
+
+    fill_calls: list[dict] = []
+
+    def fill_gaps_optimized(db_arg, missing_dates, *, market):
+        fill_calls.append(
+            {
+                "db": db_arg,
+                "missing_dates": list(missing_dates),
+                "market": market,
+            }
+        )
+        return {"processed": len(missing_dates), "errors": 0}
+
+    monkeypatch.setattr(export_script, "SessionLocal", fake_session)
+    monkeypatch.setattr(
+        export_script,
+        "get_market_calendar_service",
+        lambda: SimpleNamespace(is_trading_day=is_trading_day),
+    )
+    monkeypatch.setattr(
+        export_script,
+        "get_group_rank_service",
+        lambda: SimpleNamespace(fill_gaps_optimized=fill_gaps_optimized),
+    )
+
+    result = export_script._ensure_group_rank_history(  # noqa: SLF001 - intentional unit test coverage
+        as_of_date=date(2026, 4, 7),
+        market="hk",
+    )
+
+    assert {market for market, _day in calendar_calls} == {"HK"}
+    assert calendar_calls[0] == ("HK", date(2025, 12, 28))
+    assert calendar_calls[-1] == ("HK", date(2026, 4, 7))
+    assert fill_calls == [
+        {
+            "db": db,
+            "missing_dates": [date(2026, 4, 3), date(2026, 4, 7)],
+            "market": "HK",
+        }
+    ]
+    assert result["status"] == "completed"
+    assert result["market"] == "HK"
+    assert result["missing_dates"] == 2
 
 
 def test_run_daily_refresh_bootstraps_universe_before_other_tasks(monkeypatch):

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1544,3 +1544,102 @@ def test_build_key_markets_includes_india_defaults(service_and_session_factory, 
 
     assert [item["symbol"] for item in markets] == ["^NSEI", "NIFTYBEES.NS", "RELIANCE.NS", "TCS.NS", "HDFCBANK.NS"]
     assert all(item["currency"] == "INR" for item in markets)
+
+
+def test_apply_group_rank_changes_from_table_fills_missing_periods(
+    service_and_session_factory, monkeypatch
+):
+    service, session_factory = service_and_session_factory
+
+    rankings = [
+        {
+            "industry_group": "Semiconductors",
+            "rank": 3,
+            "rank_change_1w": 5,
+            "rank_change_1m": None,
+            "rank_change_3m": None,
+            "rank_change_6m": None,
+        },
+        {
+            "industry_group": "Software",
+            "rank": 7,
+            "rank_change_1w": None,
+            "rank_change_1m": None,
+            "rank_change_3m": None,
+            "rank_change_6m": None,
+        },
+    ]
+
+    captured: dict[str, object] = {}
+
+    def fake_batch(db, group_names, current_date, period_days, *, market):
+        captured["group_names"] = list(group_names)
+        captured["current_date"] = current_date
+        captured["market"] = market
+        captured["period_days"] = dict(period_days)
+        return {
+            ("Semiconductors", "1w"): 99,
+            ("Semiconductors", "1m"): 6,
+            ("Semiconductors", "3m"): 12,
+            ("Software", "1w"): 10,
+            ("Software", "3m"): 4,
+        }
+
+    fake_service = SimpleNamespace(get_historical_ranks_batch=fake_batch)
+    monkeypatch.setattr(export_module, "get_group_rank_service", lambda: fake_service)
+
+    with session_factory() as db:
+        service._apply_group_rank_changes_from_table(  # noqa: SLF001 - intentional unit coverage
+            db,
+            rankings,
+            market="hk",
+            calculation_date=date(2026, 4, 28),
+        )
+
+    assert captured["market"] == "HK"
+    assert captured["current_date"] == date(2026, 4, 28)
+    assert captured["group_names"] == ["Semiconductors", "Software"]
+    assert captured["period_days"] == {"1w": 5, "1m": 21, "3m": 63, "6m": 126}
+
+    semis, software = rankings
+    assert semis["rank_change_1w"] == 5
+    assert semis["rank_change_1m"] == 6 - 3
+    assert semis["rank_change_3m"] == 12 - 3
+    assert semis["rank_change_6m"] is None
+    assert software["rank_change_1w"] == 10 - 7
+    assert software["rank_change_1m"] is None
+    assert software["rank_change_3m"] == 4 - 7
+    assert software["rank_change_6m"] is None
+
+
+def test_apply_group_rank_changes_from_table_swallows_lookup_errors(
+    service_and_session_factory, monkeypatch
+):
+    service, session_factory = service_and_session_factory
+
+    rankings = [
+        {
+            "industry_group": "Semiconductors",
+            "rank": 1,
+            "rank_change_1w": None,
+            "rank_change_1m": None,
+            "rank_change_3m": None,
+            "rank_change_6m": None,
+        }
+    ]
+
+    def fake_batch(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    fake_service = SimpleNamespace(get_historical_ranks_batch=fake_batch)
+    monkeypatch.setattr(export_module, "get_group_rank_service", lambda: fake_service)
+
+    with session_factory() as db:
+        service._apply_group_rank_changes_from_table(  # noqa: SLF001 - intentional unit coverage
+            db,
+            rankings,
+            market="US",
+            calculation_date=date(2026, 4, 28),
+        )
+
+    assert all(rankings[0][f"rank_change_{period}"] is None for period in ("1w", "1m", "3m", "6m"))

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1599,7 +1599,7 @@ def test_apply_group_rank_changes_from_table_fills_missing_periods(
     assert captured["market"] == "HK"
     assert captured["current_date"] == date(2026, 4, 28)
     assert captured["group_names"] == ["Semiconductors", "Software"]
-    assert captured["period_days"] == {"1w": 5, "1m": 21, "3m": 63, "6m": 126}
+    assert captured["period_days"] == {"1w": 5, "1m": 21, "3m": 63}
 
     semis, software = rankings
     assert semis["rank_change_1w"] == 5


### PR DESCRIPTION
## Summary
This PR extends the group rank history backfill functionality to support multiple markets (not just US), and adds a fallback mechanism to fill missing rank-change deltas from the IBDGroupRank history table when FeatureRun-based lookups are unavailable.

## Key Changes

- **Multi-market group rank backfill**: Modified `_ensure_group_rank_history()` to accept a `market` parameter and process group rank history for any market, not just US. Added market-specific logging and error handling.

- **Fallback rank-change delta calculation**: Implemented `_apply_group_rank_changes_from_table()` in `StaticSiteExportService` to backfill missing rank-change deltas from the `IBDGroupRank` history table. This runs after the FeatureRun-based path and only fills periods that couldn't be supplied by historical FeatureRun lookups.

- **Public API for historical rank batch lookup**: Added `get_historical_ranks_batch()` as a public alias to `_get_historical_ranks_batch()` in `IBDGroupRankService` to support the new fallback mechanism.

- **Enhanced export script**: Updated the static site export script to backfill group rank history for all selected markets and track results per market in the export report.

- **Comprehensive test coverage**: Added two new unit tests covering the fallback rank-change calculation with both successful and error scenarios.

## Notable Implementation Details

- The fallback mechanism preserves existing non-null deltas from the FeatureRun-based path, only filling gaps where data is missing.
- Errors during historical rank lookups are logged as warnings but don't fail the export process.
- Market names are normalized to uppercase for consistency with the database schema.
- The export script includes a session factory stub check to gracefully handle test environments.

https://claude.ai/code/session_01F4YVzvtwyn4A3D3RWL7YKg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/stock-screener/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-market group-rank backfill so histories and rank-change calculations respect each market’s trading calendar.
  * Rank-change values now get filled from historical data when missing.
  * Daily refresh reports per-market backfill status and skips markets whose snapshots aren’t ready.

* **Bug Fixes**
  * Improved guards and error handling to prevent backfill failures from crashing refresh flows.

* **Tests**
  * Added unit tests covering backfill behavior and error suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->