### PR TITLE
Fix market bootstrap reliability and scan performance

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        market: [US, HK, IN, JP, TW]
+        market: [US, HK, IN, JP, KR, TW]
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        market: [US, HK, IN, JP, TW]
+        market: [US, HK, IN, JP, KR, TW]
     services:
       postgres:
         image: postgres:16-alpine

--- a/backend/app/analysis/patterns/aggregator.py
+++ b/backend/app/analysis/patterns/aggregator.py
@@ -6,6 +6,7 @@ TODO(SE-B7): Emit typed SetupEngineReport-compatible aggregation output.
 from __future__ import annotations
 
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -105,31 +106,19 @@ class SetupEngineAggregator:
         key_levels: dict[str, float | None] = {}
         detector_traces: list[DetectorExecutionTrace] = []
 
-        for idx, detector in enumerate(self._detectors):
-            t0 = time.perf_counter()
-            result = detector.detect_safe(detector_input, parameters)
-            elapsed_ms = (time.perf_counter() - t0) * 1000.0
-            detector_traces.append(
-                DetectorExecutionTrace(
-                    execution_index=idx,
-                    detector_name=detector.name,
-                    outcome=result.outcome.value,
-                    candidate_count=len(result.candidates),
-                    passed_checks=tuple(result.passed_checks),
-                    failed_checks=tuple(result.failed_checks),
-                    warnings=tuple(result.warnings),
-                    error_detail=result.error_detail,
-                    elapsed_ms=elapsed_ms,
-                )
-            )
-
+        for idx, _detector, result, trace in _run_detectors_ordered(
+            self._detectors,
+            detector_input,
+            parameters,
+        ):
+            detector_traces.append(trace)
             if result.outcome == DetectorOutcome.ERROR:
                 failed_checks.append(
-                    f"{detector.name}:{DetectorOutcome.ERROR.value}"
+                    f"{trace.detector_name}:{DetectorOutcome.ERROR.value}"
                 )
                 if result.error_detail:
                     diagnostics.append(
-                        f"{detector.name}:{result.error_detail}"
+                        f"{trace.detector_name}:{result.error_detail}"
                     )
                 continue
 
@@ -186,6 +175,59 @@ class SetupEngineAggregator:
             diagnostics=tuple(diagnostics),
             detector_traces=tuple(detector_traces),
         )
+
+
+def _run_detectors_ordered(
+    detectors: Sequence[PatternDetector],
+    detector_input: PatternDetectorInput,
+    parameters: SetupEngineParameters,
+):
+    if len(detectors) <= 1:
+        return [
+            _run_detector(idx, detector, detector_input, parameters)
+            for idx, detector in enumerate(detectors)
+        ]
+
+    results = []
+    with ThreadPoolExecutor(max_workers=len(detectors)) as executor:
+        futures = {
+            executor.submit(
+                _run_detector,
+                idx,
+                detector,
+                detector_input,
+                parameters,
+            ): idx
+            for idx, detector in enumerate(detectors)
+        }
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    results.sort(key=lambda item: item[0])
+    return results
+
+
+def _run_detector(
+    idx: int,
+    detector: PatternDetector,
+    detector_input: PatternDetectorInput,
+    parameters: SetupEngineParameters,
+):
+    t0 = time.perf_counter()
+    result = detector.detect_safe(detector_input, parameters)
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+    trace = DetectorExecutionTrace(
+        execution_index=idx,
+        detector_name=detector.name,
+        outcome=result.outcome.value,
+        candidate_count=len(result.candidates),
+        passed_checks=tuple(result.passed_checks),
+        failed_checks=tuple(result.failed_checks),
+        warnings=tuple(result.warnings),
+        error_detail=result.error_detail,
+        elapsed_ms=elapsed_ms,
+    )
+    return idx, detector, result, trace
 
 
 def _select_primary_candidate(

--- a/backend/app/analysis/patterns/aggregator.py
+++ b/backend/app/analysis/patterns/aggregator.py
@@ -83,10 +83,18 @@ _STRUCTURAL_TIE_EPSILON = 0.015
 class SetupEngineAggregator:
     """Run detectors and normalize candidates for setup_engine payload use."""
 
-    def __init__(self, detectors: Sequence[PatternDetector] | None = None):
+    def __init__(
+        self,
+        detectors: Sequence[PatternDetector] | None = None,
+        *,
+        detector_workers: int = 1,
+    ):
+        if detector_workers < 1:
+            raise ValueError("detector_workers must be >= 1")
         self._detectors: tuple[PatternDetector, ...] = tuple(
             detectors if detectors is not None else default_pattern_detectors()
         )
+        self._detector_workers = detector_workers
 
     def aggregate(
         self,
@@ -110,6 +118,7 @@ class SetupEngineAggregator:
             self._detectors,
             detector_input,
             parameters,
+            detector_workers=self._detector_workers,
         ):
             detector_traces.append(trace)
             if result.outcome == DetectorOutcome.ERROR:
@@ -181,15 +190,21 @@ def _run_detectors_ordered(
     detectors: Sequence[PatternDetector],
     detector_input: PatternDetectorInput,
     parameters: SetupEngineParameters,
+    *,
+    detector_workers: int = 1,
 ):
-    if len(detectors) <= 1:
+    if detector_workers < 1:
+        raise ValueError("detector_workers must be >= 1")
+    if len(detectors) <= 1 or detector_workers <= 1:
         return [
             _run_detector(idx, detector, detector_input, parameters)
             for idx, detector in enumerate(detectors)
         ]
 
     results = []
-    with ThreadPoolExecutor(max_workers=len(detectors)) as executor:
+    with ThreadPoolExecutor(
+        max_workers=min(detector_workers, len(detectors))
+    ) as executor:
         futures = {
             executor.submit(
                 _run_detector,

--- a/backend/app/analysis/patterns/aggregator.py
+++ b/backend/app/analysis/patterns/aggregator.py
@@ -205,6 +205,8 @@ def _run_detectors_ordered(
     with ThreadPoolExecutor(
         max_workers=min(detector_workers, len(detectors))
     ) as executor:
+        # PatternDetectorInput is frozen and detector implementations treat
+        # feature frames as read-only. Sharing avoids copying large OHLCV data.
         futures = {
             executor.submit(
                 _run_detector,

--- a/backend/app/analysis/patterns/high_tight_flag.py
+++ b/backend/app/analysis/patterns/high_tight_flag.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import numpy as np
 import pandas as pd
 
 from app.analysis.patterns.config import SetupEngineParameters
@@ -273,31 +274,53 @@ def _find_pole_windows(frame: pd.DataFrame) -> list[_PoleCandidateWindow]:
     last_idx = n - 1
     closes = close.to_numpy(dtype=float)
 
-    for end_idx in range(_POLE_MIN_BARS - 1, n):
-        for window_bars in range(_POLE_MIN_BARS, _POLE_MAX_BARS + 1):
-            start_idx = end_idx - window_bars + 1
-            if start_idx < 0:
-                continue
+    for window_bars in range(_POLE_MIN_BARS, _POLE_MAX_BARS + 1):
+        end_indices = np.arange(window_bars - 1, n)
+        start_indices = end_indices - window_bars + 1
+        start_closes = closes[start_indices]
+        end_closes = closes[end_indices]
 
-            start_close = closes[start_idx]
-            end_close = closes[end_idx]
-            if start_close <= 0.0:
-                continue
+        valid_start = start_closes > 0.0
+        if not np.any(valid_start):
+            continue
 
-            pole_return = (end_close / start_close) - 1.0
-            if pole_return < _MIN_POLE_RETURN:
-                continue
+        pole_returns = np.full_like(end_closes, np.nan, dtype=float)
+        np.divide(
+            end_closes,
+            start_closes,
+            out=pole_returns,
+            where=valid_start,
+        )
+        pole_returns -= 1.0
+        valid = valid_start & (pole_returns >= _MIN_POLE_RETURN)
+        if not np.any(valid):
+            continue
 
-            recency_bars = last_idx - end_idx
-            weighted_score = pole_return * (1.0 + _recency_weight(recency_bars))
+        valid_start_indices = start_indices[valid]
+        valid_end_indices = end_indices[valid]
+        valid_returns = pole_returns[valid]
+        recencies = last_idx - valid_end_indices
+        recency_weights = np.array(
+            [_recency_weight(int(value)) for value in recencies],
+            dtype=float,
+        )
+        weighted_scores = valid_returns * (1.0 + recency_weights)
+
+        for start_idx, end_idx, pole_return, recency_bars, weighted_score in zip(
+            valid_start_indices,
+            valid_end_indices,
+            valid_returns,
+            recencies,
+            weighted_scores,
+        ):
             candidates.append(
                 _PoleCandidateWindow(
-                    start_idx=start_idx,
-                    end_idx=end_idx,
+                    start_idx=int(start_idx),
+                    end_idx=int(end_idx),
                     window_bars=window_bars,
-                    pole_return=pole_return,
-                    recency_bars=recency_bars,
-                    weighted_score=weighted_score,
+                    pole_return=float(pole_return),
+                    recency_bars=int(recency_bars),
+                    weighted_score=float(weighted_score),
                 )
             )
 
@@ -342,107 +365,137 @@ def _find_best_flag_candidate(
     if start_idx >= len(frame):
         return None, ("flag_missing_structure",)
 
-    highs = frame["High"]
-    lows = frame["Low"]
-    volumes = frame["Volume"]
+    highs = frame["High"].to_numpy(dtype=float)
+    lows = frame["Low"].to_numpy(dtype=float)
+    volumes = frame["Volume"].to_numpy(dtype=float)
 
-    pole_high = float(highs.iloc[pole_candidate.start_idx : pole_candidate.end_idx + 1].max())
-    pole_low = float(lows.iloc[pole_candidate.start_idx : pole_candidate.end_idx + 1].min())
+    pole_slice = slice(pole_candidate.start_idx, pole_candidate.end_idx + 1)
+    pole_high = float(np.nanmax(highs[pole_slice]))
+    pole_low = float(np.nanmin(lows[pole_slice]))
     pole_range = max(pole_high - pole_low, 1e-9)
     upper_half_floor = pole_low + (pole_range * 0.5)
-    pole_volume_mean = float(
-        volumes.iloc[pole_candidate.start_idx : pole_candidate.end_idx + 1].mean()
-    )
+    pole_volume_mean = float(np.nanmean(volumes[pole_slice]))
     if pole_volume_mean <= 0.0 or pd.isna(pole_volume_mean):
         return None, ("flag_volume_baseline_invalid",)
 
-    rejected: list[str] = []
-    valid_candidates: list[_FlagCandidate] = []
     n = len(frame)
+    max_duration = min(_FLAG_MAX_BARS, n - start_idx)
+    if max_duration < _FLAG_MIN_BARS:
+        return None, ("flag_missing_structure",)
 
-    for duration_bars in range(_FLAG_MIN_BARS, _FLAG_MAX_BARS + 1):
-        end_idx = start_idx + duration_bars - 1
-        if end_idx >= n:
-            break
+    duration_bars = np.arange(_FLAG_MIN_BARS, max_duration + 1)
+    duration_offsets = duration_bars - 1
+    high_segment = highs[start_idx : start_idx + max_duration]
+    low_segment = lows[start_idx : start_idx + max_duration]
+    volume_segment = volumes[start_idx : start_idx + max_duration]
 
-        segment = frame.iloc[start_idx : end_idx + 1]
-        segment_high = segment["High"].to_numpy(dtype=float)
-        segment_low = segment["Low"].to_numpy(dtype=float)
-        segment_volume = segment["Volume"].to_numpy(dtype=float)
+    cumulative_high = np.fmax.accumulate(high_segment)
+    cumulative_low = np.fmin.accumulate(low_segment)
+    volume_valid = ~np.isnan(volume_segment)
+    cumulative_volume = np.cumsum(np.where(volume_valid, volume_segment, 0.0))
+    cumulative_volume_count = np.cumsum(volume_valid)
 
-        flag_high = float(segment_high.max())
-        flag_low = float(segment_low.min())
-        if flag_high <= 0.0:
-            rejected.append("flag_missing_structure")
-            continue
+    flag_highs = cumulative_high[duration_offsets]
+    flag_lows = cumulative_low[duration_offsets]
+    volume_counts = cumulative_volume_count[duration_offsets]
+    flag_volume_means = np.full_like(flag_highs, np.nan, dtype=float)
+    np.divide(
+        cumulative_volume[duration_offsets],
+        volume_counts,
+        out=flag_volume_means,
+        where=volume_counts > 0,
+    )
 
-        flag_depth_pct = ((flag_high - flag_low) / flag_high) * 100.0
-        upper_half_margin_pct = ((flag_low - upper_half_floor) / pole_range) * 100.0
-        flag_volume_mean = float(segment_volume.mean())
-        if flag_volume_mean <= 0.0 or pd.isna(flag_volume_mean):
-            rejected.append("flag_volume_rejected")
-            continue
-        volume_ratio = flag_volume_mean / pole_volume_mean
+    structure_ok = flag_highs > 0.0
+    flag_depth_pct = ((flag_highs - flag_lows) / flag_highs) * 100.0
+    upper_half_margin_pct = ((flag_lows - upper_half_floor) / pole_range) * 100.0
+    volume_mean_ok = (flag_volume_means > 0.0) & ~np.isnan(flag_volume_means)
+    volume_ratios = np.full_like(flag_volume_means, np.nan, dtype=float)
+    np.divide(
+        flag_volume_means,
+        pole_volume_mean,
+        out=volume_ratios,
+        where=volume_mean_ok,
+    )
 
-        depth_ok = flag_depth_pct <= _FLAG_MAX_DEPTH_PCT
-        upper_half_ok = flag_low >= upper_half_floor
-        volume_ok = volume_ratio <= _FLAG_MAX_VOLUME_RATIO
+    depth_ok = flag_depth_pct <= _FLAG_MAX_DEPTH_PCT
+    upper_half_ok = flag_lows >= upper_half_floor
+    volume_ok = volume_ratios <= _FLAG_MAX_VOLUME_RATIO
+    valid = structure_ok & volume_mean_ok & depth_ok & upper_half_ok & volume_ok
 
-        if not depth_ok:
-            rejected.append("flag_depth_rejected")
-        if not upper_half_ok:
-            rejected.append("flag_upper_half_rejected")
-        if not volume_ok:
-            rejected.append("flag_volume_rejected")
-        if not (depth_ok and upper_half_ok and volume_ok):
-            continue
+    rejected: list[str] = []
+    if np.any(~structure_ok):
+        rejected.append("flag_missing_structure")
+    if np.any(structure_ok & ~depth_ok):
+        rejected.append("flag_depth_rejected")
+    if np.any(structure_ok & ~upper_half_ok):
+        rejected.append("flag_upper_half_rejected")
+    if np.any(structure_ok & (~volume_mean_ok | ~volume_ok)):
+        rejected.append("flag_volume_rejected")
 
-        pivot_offset = int(segment_high.argmax())
-        pivot_idx = start_idx + pivot_offset
-        recency_bars = (n - 1) - end_idx
-        depth_component = max(0.0, 1.0 - (flag_depth_pct / _FLAG_MAX_DEPTH_PCT))
-        volume_component = max(0.0, 1.0 - max(0.0, volume_ratio - 1.0))
-        score = (
-            depth_component * 0.50
-            + min(max(upper_half_margin_pct, 0.0), 12.0) / 12.0 * 0.25
-            + volume_component * 0.15
-            + _recency_weight(recency_bars) * 0.10
-        )
-
-        valid_candidates.append(
-            _FlagCandidate(
-                pole=pole_candidate,
-                start_idx=start_idx,
-                end_idx=end_idx,
-                duration_bars=duration_bars,
-                flag_high=flag_high,
-                flag_low=flag_low,
-                pivot_idx=pivot_idx,
-                flag_depth_pct=flag_depth_pct,
-                upper_half_floor=upper_half_floor,
-                upper_half_margin_pct=upper_half_margin_pct,
-                volume_ratio=volume_ratio,
-                score=score,
-                recency_bars=recency_bars,
-            )
-        )
-
-    if not valid_candidates:
+    valid_positions = np.flatnonzero(valid)
+    if len(valid_positions) == 0:
         fallback = ("flag_missing_structure",) if not rejected else tuple(
             _stable_unique(rejected)
         )
         return None, fallback
 
-    valid_candidates.sort(
-        key=lambda candidate: (
-            -candidate.score,
-            candidate.flag_depth_pct,
-            candidate.duration_bars,
-            candidate.recency_bars,
-            -candidate.pivot_idx,
-        )
+    depth_components = np.maximum(
+        0.0,
+        1.0 - (flag_depth_pct / _FLAG_MAX_DEPTH_PCT),
     )
-    return valid_candidates[0], tuple(_stable_unique(rejected))
+    volume_components = np.maximum(
+        0.0,
+        1.0 - np.maximum(0.0, volume_ratios - 1.0),
+    )
+    recency_bars_values = (n - 1) - (start_idx + duration_bars - 1)
+    scores = (
+        depth_components * 0.50
+        + np.minimum(np.maximum(upper_half_margin_pct, 0.0), 12.0) / 12.0 * 0.25
+        + volume_components * 0.15
+        + np.array(
+            [_recency_weight(int(value)) for value in recency_bars_values],
+            dtype=float,
+        )
+        * 0.10
+    )
+
+    def _candidate_sort_key(position: int) -> tuple[float, float, int, int, int]:
+        pivot_offset = int(np.nanargmax(high_segment[: duration_bars[position]]))
+        return (
+            -float(scores[position]),
+            float(flag_depth_pct[position]),
+            int(duration_bars[position]),
+            int(recency_bars_values[position]),
+            -(start_idx + pivot_offset),
+        )
+
+    best_position = min(
+        (int(position) for position in valid_positions),
+        key=_candidate_sort_key,
+    )
+    best_duration = int(duration_bars[best_position])
+    pivot_idx = start_idx + int(np.nanargmax(high_segment[:best_duration]))
+    end_idx = start_idx + best_duration - 1
+
+    return (
+        _FlagCandidate(
+            pole=pole_candidate,
+            start_idx=start_idx,
+            end_idx=end_idx,
+            duration_bars=best_duration,
+            flag_high=float(flag_highs[best_position]),
+            flag_low=float(flag_lows[best_position]),
+            pivot_idx=pivot_idx,
+            flag_depth_pct=float(flag_depth_pct[best_position]),
+            upper_half_floor=upper_half_floor,
+            upper_half_margin_pct=float(upper_half_margin_pct[best_position]),
+            volume_ratio=float(volume_ratios[best_position]),
+            score=float(scores[best_position]),
+            recency_bars=int(recency_bars_values[best_position]),
+        ),
+        tuple(_stable_unique(rejected)),
+    )
 
 
 def _stable_unique(values: list[str]) -> list[str]:

--- a/backend/app/analysis/patterns/high_tight_flag.py
+++ b/backend/app/analysis/patterns/high_tight_flag.py
@@ -312,6 +312,7 @@ def _find_pole_windows(frame: pd.DataFrame) -> list[_PoleCandidateWindow]:
             valid_returns,
             recencies,
             weighted_scores,
+            strict=True,
         ):
             candidates.append(
                 _PoleCandidateWindow(

--- a/backend/app/domain/scanning/defaults.py
+++ b/backend/app/domain/scanning/defaults.py
@@ -16,6 +16,10 @@ DEFAULT_SCAN_SCREENERS = [
     "volume_breakthrough",
     "setup_engine",
 ]
+DEFAULT_BOOTSTRAP_SCAN_SCREENERS = [
+    screener for screener in DEFAULT_SCAN_SCREENERS
+    if screener != "setup_engine"
+]
 DEFAULT_SCAN_COMPOSITE_METHOD = "weighted_average"
 DEFAULT_SCAN_CUSTOM_FILTERS = {
     "price_min": 20,
@@ -59,4 +63,16 @@ def get_default_scan_profile(market: str | None = None) -> dict[str, Any]:
     profile["universe"] = f"market:{normalized_market}"
     profile["benchmark_symbol"] = benchmark_symbol
     profile["criteria"]["benchmark_symbol"] = benchmark_symbol
+    return profile
+
+
+def get_bootstrap_scan_profile(market: str | None = None) -> dict[str, Any]:
+    """Return the lightweight initial-bootstrap scan profile.
+
+    Bootstrap snapshots run across whole market universes while the app is
+    coming online, so they avoid Setup Engine's expensive pattern detectors.
+    Manual and daily scan defaults keep using the full profile.
+    """
+    profile = get_default_scan_profile(market)
+    profile["screeners"] = list(DEFAULT_BOOTSTRAP_SCAN_SCREENERS)
     return profile

--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -754,9 +754,17 @@ def build_daily_snapshot(
         if as_of_date_str
         else MarketCalendarService().last_completed_trading_day(effective_market)
     )
-    from app.domain.scanning.defaults import get_default_scan_profile
+    bootstrap_gate_requested = bool(bootstrap_cache_only_if_covered)
+    from app.domain.scanning.defaults import (
+        get_bootstrap_scan_profile,
+        get_default_scan_profile,
+    )
 
-    defaults = get_default_scan_profile(effective_market)
+    defaults = (
+        get_bootstrap_scan_profile(effective_market)
+        if bootstrap_gate_requested and screener_names is None
+        else get_default_scan_profile(effective_market)
+    )
     screeners = defaults["screeners"] if screener_names is None else screener_names
     universe_name = defaults["universe"] if universe_name is None else universe_name
     criteria = defaults["criteria"] if criteria is None else criteria
@@ -768,7 +776,6 @@ def build_daily_snapshot(
     publish_pointer_key = publish_pointer_key or f"latest_published_market:{effective_market}"
     correlation_id = self.request.id
     activity_lifecycle = activity_lifecycle or "daily_refresh"
-    bootstrap_gate_requested = bool(bootstrap_cache_only_if_covered)
     static_worker_config_requested = static_daily_mode or bootstrap_gate_requested
     effective_bootstrap_coverage_report = bootstrap_coverage_report
 

--- a/backend/app/scanners/setup_engine_screener.py
+++ b/backend/app/scanners/setup_engine_screener.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 from app.analysis.patterns.aggregator import (
     AggregatedPatternOutput,
+    DetectorExecutionTrace,
     SetupEngineAggregator,
 )
 from app.analysis.patterns.config import (
@@ -46,6 +47,10 @@ from app.scanners.criteria.stage_analysis import quick_stage_check
 from app.scanners.setup_engine_scanner import build_setup_engine_payload
 
 logger = logging.getLogger(__name__)
+
+_SLOW_DETECTOR_PHASE_THRESHOLD_MS = 500.0
+_SLOW_DETECTOR_TRACE_FLOOR_MS = 50.0
+_SLOW_DETECTOR_TRACE_LIMIT = 3
 
 
 @register_screener
@@ -196,6 +201,11 @@ class SetupEngineScanner(BaseStockScreener):
                 trace.detector_name, trace.outcome, trace.candidate_count,
                 trace.elapsed_ms, symbol,
             )
+        _log_slow_detector_summary(
+            symbol,
+            agg_output.detector_traces,
+            detectors_ms=detectors_ms,
+        )
 
         # ── Phase B½: context analysis (stage, MA alignment, RS rating) ──
         context = self._compute_context(
@@ -464,3 +474,40 @@ def _count_current_week_sessions(price_data: pd.DataFrame) -> int:
     last_date = price_data.index[-1]
     week_start = (last_date - pd.Timedelta(days=last_date.weekday())).normalize()
     return int((price_data.index >= week_start).sum())
+
+
+def _log_slow_detector_summary(
+    symbol: str,
+    traces: tuple[DetectorExecutionTrace, ...],
+    *,
+    detectors_ms: float,
+    threshold_ms: float = _SLOW_DETECTOR_PHASE_THRESHOLD_MS,
+) -> None:
+    """Log top detector timings when the setup-engine detector phase is slow."""
+    if detectors_ms < threshold_ms or not traces:
+        return
+
+    slow_floor_ms = min(threshold_ms, _SLOW_DETECTOR_TRACE_FLOOR_MS)
+    slow_traces = [
+        trace for trace in traces
+        if trace.elapsed_ms >= slow_floor_ms
+    ]
+    if not slow_traces:
+        return
+
+    top_traces = sorted(
+        slow_traces,
+        key=lambda trace: trace.elapsed_ms,
+        reverse=True,
+    )[:_SLOW_DETECTOR_TRACE_LIMIT]
+    trace_summary = ", ".join(
+        f"{trace.detector_name}={trace.elapsed_ms:.1f}ms/"
+        f"{trace.candidate_count}/{trace.outcome}"
+        for trace in top_traces
+    )
+    logger.info(
+        "SE slow detectors %s: total=%.1fms top=%s",
+        symbol,
+        detectors_ms,
+        trace_summary,
+    )

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -435,12 +435,16 @@ class CnMarketDataService:
         end_token = _as_yyyymmdd(end or date.today())
         if self._should_try_akshare_ohlcv():
             try:
-                frame = self._akshare.stock_zh_a_hist(
-                    symbol=code,
-                    period="daily",
-                    start_date=start_token,
-                    end_date=end_token,
-                    adjust="",
+                frame = _call_with_timeout(
+                    lambda: self._akshare.stock_zh_a_hist(
+                        symbol=code,
+                        period="daily",
+                        start_date=start_token,
+                        end_date=end_token,
+                        adjust="",
+                    ),
+                    timeout_seconds=self._timeout_seconds,
+                    operation_name=f"CN OHLCV fetch for {code}",
                 )
                 rows = self._daily_rows_from_akshare_frame(frame)
                 if rows:

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -6,10 +6,14 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 import importlib
 import logging
+import signal
+import threading
 from typing import Any
 
 import pandas as pd
+import requests
 
+from ..config import settings
 from .cn_universe_ingestion_adapter import infer_cn_sector
 
 logger = logging.getLogger(__name__)
@@ -116,6 +120,28 @@ def _suffix_for_exchange(exchange: str) -> str:
     return ".SS"
 
 
+def _call_with_timeout(fetcher, *, timeout_seconds: int, operation_name: str):
+    if timeout_seconds <= 0 or threading.current_thread() is not threading.main_thread():
+        return fetcher()
+    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "setitimer"):
+        return fetcher()
+
+    def _raise_timeout(signum, frame):
+        del signum, frame
+        raise TimeoutError(f"{operation_name} timed out after {timeout_seconds}s")
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    try:
+        signal.signal(signal.SIGALRM, _raise_timeout)
+        signal.setitimer(signal.ITIMER_REAL, float(timeout_seconds))
+        return fetcher()
+    except TimeoutError as exc:
+        raise requests.exceptions.Timeout(str(exc)) from exc
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
 @dataclass(frozen=True)
 class CnDailyPriceRow:
     date: str
@@ -135,9 +161,13 @@ class CnMarketDataService:
         *,
         akshare_module: Any | None = None,
         baostock_module: Any | None = None,
+        timeout_seconds: int | None = None,
     ) -> None:
         self._akshare_module = akshare_module
         self._baostock_module = baostock_module
+        self._timeout_seconds = int(
+            timeout_seconds or settings.universe_source_timeout_seconds
+        )
         self._listing_rows_cache: list[dict[str, Any]] | None = None
 
     @property
@@ -164,7 +194,11 @@ class CnMarketDataService:
         if self._listing_rows_cache is not None:
             return [dict(row) for row in self._listing_rows_cache]
 
-        frame = self._akshare.stock_zh_a_spot_em()
+        frame = _call_with_timeout(
+            self._akshare.stock_zh_a_spot_em,
+            timeout_seconds=self._timeout_seconds,
+            operation_name="CN A-share listing fetch",
+        )
         if frame is None or frame.empty:
             return []
 

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -19,6 +19,9 @@ from .cn_universe_ingestion_adapter import infer_cn_sector
 
 logger = logging.getLogger(__name__)
 
+_AKSHARE_OHLCV_FAILURE_THRESHOLD = 2
+_AKSHARE_OHLCV_COOLDOWN_SECONDS = 300.0
+
 
 class CnDependencyError(RuntimeError):
     """Raised when a CN market dependency is unavailable."""
@@ -181,6 +184,8 @@ class CnMarketDataService:
             timeout_seconds or settings.universe_source_timeout_seconds
         )
         self._listing_rows_cache: list[dict[str, Any]] | None = None
+        self._akshare_ohlcv_consecutive_failures = 0
+        self._akshare_ohlcv_disabled_until = 0.0
 
     @property
     def _akshare(self):
@@ -428,23 +433,43 @@ class CnMarketDataService:
         code = _normalize_code(local_code)
         start_token = _as_yyyymmdd(start)
         end_token = _as_yyyymmdd(end or date.today())
-        try:
-            frame = self._akshare.stock_zh_a_hist(
-                symbol=code,
-                period="daily",
-                start_date=start_token,
-                end_date=end_token,
-                adjust="",
-            )
-            rows = self._daily_rows_from_akshare_frame(frame)
-            if rows:
-                return rows
-        except CnDependencyError:
-            raise
-        except Exception as exc:  # pragma: no cover - network variability
-            logger.warning("AKShare CN OHLCV fetch failed for %s: %s", code, exc)
+        if self._should_try_akshare_ohlcv():
+            try:
+                frame = self._akshare.stock_zh_a_hist(
+                    symbol=code,
+                    period="daily",
+                    start_date=start_token,
+                    end_date=end_token,
+                    adjust="",
+                )
+                rows = self._daily_rows_from_akshare_frame(frame)
+                if rows:
+                    self._record_akshare_ohlcv_success()
+                    return rows
+            except CnDependencyError:
+                raise
+            except Exception as exc:  # pragma: no cover - network variability
+                self._record_akshare_ohlcv_failure()
+                logger.warning("AKShare CN OHLCV fetch failed for %s: %s", code, exc)
 
         return self._daily_ohlcv_from_baostock(code, start=start_token, end=end_token)
+
+    def _should_try_akshare_ohlcv(self) -> bool:
+        return time.monotonic() >= self._akshare_ohlcv_disabled_until
+
+    def _record_akshare_ohlcv_success(self) -> None:
+        self._akshare_ohlcv_consecutive_failures = 0
+        self._akshare_ohlcv_disabled_until = 0.0
+
+    def _record_akshare_ohlcv_failure(self) -> None:
+        self._akshare_ohlcv_consecutive_failures += 1
+        if self._akshare_ohlcv_consecutive_failures < _AKSHARE_OHLCV_FAILURE_THRESHOLD:
+            return
+        self._akshare_ohlcv_disabled_until = time.monotonic() + _AKSHARE_OHLCV_COOLDOWN_SECONDS
+        logger.warning(
+            "Temporarily disabling AKShare CN OHLCV after %d consecutive failures; using BaoStock fallback",
+            self._akshare_ohlcv_consecutive_failures,
+        )
 
     @staticmethod
     def _daily_rows_from_akshare_frame(frame: pd.DataFrame | None) -> list[CnDailyPriceRow]:

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -189,19 +189,62 @@ class CnMarketDataService:
         return self._baostock_module
 
     def listing_rows(self, *, as_of: date | str | None = None) -> list[dict[str, Any]]:
-        """Return A-share listing/quote rows from AKShare's Eastmoney bulk surface."""
-        del as_of  # AKShare spot returns the current source snapshot.
+        """Return A-share listing rows from AKShare-backed no-key sources."""
+        del as_of  # CN listing sources return the current source snapshot.
         if self._listing_rows_cache is not None:
             return [dict(row) for row in self._listing_rows_cache]
 
+        frame = self._listing_frame()
+        if frame is None or frame.empty:
+            return []
+
+        rows = self._rows_from_listing_frame(frame)
+        self._listing_rows_cache = rows
+        return [dict(row) for row in rows]
+
+    def _listing_frame(self) -> pd.DataFrame | None:
+        spot_error: Exception | None = None
+        try:
+            frame = self._akshare_spot_frame()
+            if frame is not None and not frame.empty:
+                return frame
+        except CnDependencyError:
+            raise
+        except Exception as exc:
+            spot_error = exc
+            logger.warning("AKShare CN spot listing fetch failed: %s", exc)
+
+        fallback_fetcher = getattr(self._akshare, "stock_info_a_code_name", None)
+        if callable(fallback_fetcher):
+            try:
+                frame = _call_with_timeout(
+                    fallback_fetcher,
+                    timeout_seconds=self._timeout_seconds,
+                    operation_name="CN A-share code-name fetch",
+                )
+                if frame is not None and not frame.empty:
+                    logger.info("Using AKShare CN code-name listing fallback")
+                    return frame
+            except Exception as exc:
+                logger.warning("AKShare CN code-name listing fallback failed: %s", exc)
+                if spot_error is None:
+                    raise
+
+        if spot_error is not None:
+            raise spot_error
+        return None
+
+    def _akshare_spot_frame(self) -> pd.DataFrame | None:
         frame = _call_with_timeout(
             self._akshare.stock_zh_a_spot_em,
             timeout_seconds=self._timeout_seconds,
             operation_name="CN A-share listing fetch",
         )
         if frame is None or frame.empty:
-            return []
+            logger.warning("AKShare CN spot listing fetch returned no rows")
+        return frame
 
+    def _rows_from_listing_frame(self, frame: pd.DataFrame) -> list[dict[str, Any]]:
         rows: list[dict[str, Any]] = []
         for raw in frame.to_dict("records"):
             local_code = _normalize_code(raw.get("代码") or raw.get("code") or raw.get("symbol"))
@@ -237,8 +280,7 @@ class CnMarketDataService:
                     "source_board": _board_for_code(local_code, exchange),
                 }
             )
-        self._listing_rows_cache = rows
-        return [dict(row) for row in rows]
+        return rows
 
     def core_fundamentals(
         self,

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -8,6 +8,7 @@ import importlib
 import logging
 import signal
 import threading
+import time
 from typing import Any
 
 import pandas as pd
@@ -131,6 +132,8 @@ def _call_with_timeout(fetcher, *, timeout_seconds: int, operation_name: str):
         raise TimeoutError(f"{operation_name} timed out after {timeout_seconds}s")
 
     previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
+    started_at = time.monotonic()
     try:
         signal.signal(signal.SIGALRM, _raise_timeout)
         signal.setitimer(signal.ITIMER_REAL, float(timeout_seconds))
@@ -140,6 +143,15 @@ def _call_with_timeout(fetcher, *, timeout_seconds: int, operation_name: str):
     finally:
         signal.setitimer(signal.ITIMER_REAL, 0)
         signal.signal(signal.SIGALRM, previous_handler)
+        previous_delay, previous_interval = previous_timer
+        if previous_delay > 0 or previous_interval > 0:
+            elapsed = time.monotonic() - started_at
+            restored_delay = max(previous_delay - elapsed, 0.001)
+            signal.setitimer(
+                signal.ITIMER_REAL,
+                restored_delay,
+                previous_interval,
+            )
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/fx_service.py
+++ b/backend/app/services/fx_service.py
@@ -42,6 +42,7 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple
 
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 
 from ..models.fx_rate import FXRate
@@ -430,11 +431,29 @@ class FXService:
             db.close()
 
     def _persist_database(self, quote: FXQuote) -> None:
-        # Try insert; if the UNIQUE constraint trips (another worker wrote
-        # the same tuple), roll back and UPDATE the rate. This avoids the
-        # check-then-insert race window.
         db = self._session_factory()
         try:
+            bind = db.get_bind()
+            if bind is not None and bind.dialect.name == "postgresql":
+                stmt = pg_insert(FXRate).values(
+                    from_currency=quote.from_currency,
+                    to_currency=quote.to_currency,
+                    as_of_date=quote.as_of_date,
+                    rate=quote.rate,
+                    source=quote.source,
+                )
+                db.execute(
+                    stmt.on_conflict_do_update(
+                        constraint="uq_fx_rates_currency_date_source",
+                        set_={"rate": stmt.excluded.rate},
+                    )
+                )
+                db.commit()
+                return
+
+            # Non-Postgres fallback for tests/local tooling. Production uses
+            # the atomic ON CONFLICT path above so duplicate writes do not emit
+            # Postgres ERROR log entries.
             db.add(FXRate(
                 from_currency=quote.from_currency,
                 to_currency=quote.to_currency,

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -34,8 +34,12 @@ class IncompleteGroupRankingCacheError(RuntimeError):
 
     def __init__(self, stats: Dict[str, int | bool]):
         self.stats = stats
-        reason = "SPY benchmark data is missing from cache"
-        if stats.get("spy_cached"):
+        benchmark_cached = stats.get("benchmark_cached", stats.get("spy_cached"))
+        benchmark_symbol = str(stats.get("benchmark_symbol") or "SPY")
+        market = str(stats.get("market") or "").strip().upper()
+        market_suffix = f" for {market}" if market else ""
+        reason = f"{benchmark_symbol} benchmark data is missing from cache{market_suffix}"
+        if benchmark_cached:
             reason = (
                 f"{stats.get('cache_miss_symbols', 0)} symbols are missing cached price data"
             )
@@ -981,6 +985,9 @@ class IBDGroupRankService:
                     "symbols_with_prices": 0,
                     "cache_miss_symbols": 0,
                     "spy_cached": False,
+                    "benchmark_cached": False,
+                    "benchmark_symbol": benchmark_symbol,
+                    "market": normalized_market,
                 },
                 symbols_by_group={},
             )

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -32,7 +32,7 @@ CACHE_MISS_TOLERANCE_RATIO = 0.05  # Allow up to 5% cache misses in cache-only g
 class IncompleteGroupRankingCacheError(RuntimeError):
     """Raised when a cache-only same-day group ranking run lacks required inputs."""
 
-    def __init__(self, stats: Dict[str, int | bool]):
+    def __init__(self, stats: Dict[str, Any]):
         self.stats = stats
         benchmark_cached = stats.get("benchmark_cached", stats.get("spy_cached"))
         benchmark_symbol = str(stats.get("benchmark_symbol") or "SPY")
@@ -964,8 +964,13 @@ class IBDGroupRankService:
         )
 
         # 1. Get benchmark data once (SPY for US, HSI/N225/TAIEX/NIFTY for Asia)
+        benchmark_role = "primary"
         if cache_only:
-            spy_data = self.price_cache.get_cached_only_fresh(benchmark_symbol, period="2y")
+            spy_data, benchmark_symbol, benchmark_role = self._get_cached_only_benchmark_data(
+                normalized_market,
+                benchmark_symbol,
+                period="2y",
+            )
         else:
             spy_data = self.benchmark_cache.get_benchmark_data(
                 market=normalized_market, period="2y",
@@ -1050,6 +1055,9 @@ class IBDGroupRankService:
             "spy_cached": True,
             "skipped_unsupported_symbols": len(skipped_unsupported_symbols),
         }
+        if benchmark_role != "primary":
+            stats["benchmark_symbol"] = benchmark_symbol
+            stats["benchmark_role"] = benchmark_role
 
         return GroupRankPrefetchData(
             benchmark_prices=spy_data,
@@ -1059,6 +1067,37 @@ class IBDGroupRankService:
             stats=stats,
             symbols_by_group=symbols_by_group,
         )
+
+    def _get_cached_only_benchmark_data(
+        self,
+        market: str,
+        primary_symbol: str,
+        *,
+        period: str,
+    ) -> tuple[Optional[pd.DataFrame], str, str]:
+        candidates = [primary_symbol]
+        candidate_fn = getattr(self.benchmark_cache, "get_benchmark_candidates", None)
+        if callable(candidate_fn):
+            try:
+                resolved = [str(symbol) for symbol in candidate_fn(market) if symbol]
+                if resolved:
+                    candidates = resolved
+            except Exception:
+                logger.debug("Could not resolve benchmark candidates for market=%s", market, exc_info=True)
+
+        for idx, candidate in enumerate(candidates):
+            role = "primary" if idx == 0 else "fallback"
+            data = self.price_cache.get_cached_only_fresh(candidate, period=period)
+            if data is not None and not data.empty:
+                if role != "primary":
+                    logger.info(
+                        "Using cached fallback benchmark %s for market %s",
+                        candidate,
+                        market,
+                    )
+                return data, candidate, role
+
+        return None, primary_symbol, "primary"
 
     def _delete_rankings_for_range(
         self,

--- a/backend/app/services/kr_market_data_service.py
+++ b/backend/app/services/kr_market_data_service.py
@@ -139,7 +139,14 @@ class KrxMarketDataService:
                 )
                 tickers = []
             if not tickers:
-                rows.extend(self._current_listing_rows(normalized_board))
+                if as_of is None or _as_date(as_of) == date.today():
+                    rows.extend(self._current_listing_rows(normalized_board))
+                else:
+                    logger.warning(
+                        "Skipping current-listing fallback for historical KR as_of=%s board=%s",
+                        as_of_token,
+                        normalized_board,
+                    )
                 continue
 
             market_cap_frame = self._market_cap_frame(as_of_token, normalized_board)

--- a/backend/app/services/kr_market_data_service.py
+++ b/backend/app/services/kr_market_data_service.py
@@ -15,6 +15,15 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+_KR_BOARD_TO_MARKET_CODE = {
+    "KOSPI": "STK",
+    "KOSDAQ": "KSQ",
+}
+_KR_BOARD_TO_SUFFIX = {
+    "KOSPI": ".KS",
+    "KOSDAQ": ".KQ",
+}
+
 
 class KrxDependencyError(RuntimeError):
     """Raised when pykrx is not installed but KR market data is requested."""
@@ -87,8 +96,14 @@ class KrxDailyPriceRow:
 class KrxMarketDataService:
     """Fetch KOSPI/KOSDAQ listings, prices, and core valuation fields."""
 
-    def __init__(self, *, stock_module: Any | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        stock_module: Any | None = None,
+        listing_source: Any | None = None,
+    ) -> None:
         self._stock_module = stock_module
+        self._listing_source = listing_source
         self._market_cap_frames: dict[tuple[str, str], pd.DataFrame | None] = {}
         self._market_fundamental_frames: dict[tuple[str, str], pd.DataFrame | None] = {}
 
@@ -113,7 +128,20 @@ class KrxMarketDataService:
             normalized_board = str(board or "").strip().upper()
             if normalized_board not in {"KOSPI", "KOSDAQ"}:
                 continue
-            tickers = stock.get_market_ticker_list(as_of_token, market=normalized_board)
+            try:
+                tickers = stock.get_market_ticker_list(as_of_token, market=normalized_board)
+            except Exception as exc:  # pragma: no cover - pykrx/network variability
+                logger.warning(
+                    "KRX daily ticker fetch failed for %s on %s: %s",
+                    normalized_board,
+                    as_of_token,
+                    exc,
+                )
+                tickers = []
+            if not tickers:
+                rows.extend(self._current_listing_rows(normalized_board))
+                continue
+
             market_cap_frame = self._market_cap_frame(as_of_token, normalized_board)
             fundamental_frame = self._market_fundamental_frame(as_of_token, normalized_board)
 
@@ -157,6 +185,52 @@ class KrxMarketDataService:
                 rows.append(row)
 
         return rows
+
+    def _current_listing_rows(self, board: str) -> list[dict[str, Any]]:
+        market_code = _KR_BOARD_TO_MARKET_CODE[board]
+        frame = self._listing_frame(market_code)
+        if frame is None or getattr(frame, "empty", True):
+            return []
+
+        rows: list[dict[str, Any]] = []
+        for _, item in frame.iterrows():
+            row_market_code = str(item.get("marketCode") or "").strip().upper()
+            if row_market_code and row_market_code != market_code:
+                continue
+            ticker = str(item.get("short_code") or "").strip().zfill(6)
+            name = str(item.get("codeName") or "").strip()
+            if not ticker or not ticker.isdigit() or not name:
+                continue
+            row: dict[str, Any] = {
+                "symbol": f"{ticker}{_KR_BOARD_TO_SUFFIX[board]}",
+                "local_code": ticker,
+                "name": name,
+                "exchange": board,
+                "sector": "",
+                "industry": "",
+                "market_cap": None,
+                "source_board": board,
+            }
+            isin = str(item.get("full_code") or "").strip()
+            if isin:
+                row["isin"] = isin
+            rows.append(row)
+        return rows
+
+    def _listing_frame(self, market_code: str) -> pd.DataFrame | None:
+        try:
+            source = self._listing_source
+            if source is None:
+                from pykrx.website.krx.market.core import 상장종목검색  # type: ignore
+
+                source = 상장종목검색()
+            frame = source.fetch(market_code)
+        except Exception as exc:  # pragma: no cover - pykrx/network variability
+            logger.warning("KRX listing finder fetch failed for %s: %s", market_code, exc)
+            return None
+        if frame is None or getattr(frame, "empty", True):
+            return None
+        return frame
 
     def daily_ohlcv(
         self,

--- a/backend/app/services/kr_market_data_service.py
+++ b/backend/app/services/kr_market_data_service.py
@@ -197,9 +197,12 @@ class KrxMarketDataService:
             row_market_code = str(item.get("marketCode") or "").strip().upper()
             if row_market_code and row_market_code != market_code:
                 continue
-            ticker = str(item.get("short_code") or "").strip().zfill(6)
+            raw_ticker = str(item.get("short_code") or "").strip()
+            if not raw_ticker or not raw_ticker.isdigit():
+                continue
+            ticker = raw_ticker.zfill(6)
             name = str(item.get("codeName") or "").strip()
-            if not ticker or not ticker.isdigit() or not name:
+            if not name:
                 continue
             row: dict[str, Any] = {
                 "symbol": f"{ticker}{_KR_BOARD_TO_SUFFIX[board]}",

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -45,6 +45,7 @@ DEFAULT_LIFECYCLE_BY_STAGE = {
 }
 
 ACTIVE_STATUSES = {"queued", "running"}
+_OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
 
 
 def _utcnow_iso() -> str:
@@ -98,6 +99,24 @@ def _should_preserve_existing_failed_message(
     )
 
 
+def _should_supersede_failed_activity(
+    existing_payload: dict[str, Any],
+    payload: dict[str, Any],
+) -> bool:
+    """Allow a real scan stage to replace stale optional-stage failures."""
+    if existing_payload.get("stage_key") not in _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES:
+        return False
+    if payload.get("status") not in {"running", "completed"}:
+        return False
+    if payload.get("stage_key") != "scan":
+        return False
+    if existing_payload.get("lifecycle") != payload.get("lifecycle"):
+        return False
+    if payload.get("lifecycle") != "bootstrap":
+        return False
+    return _stage_index(payload.get("stage_key")) > _stage_index(existing_payload.get("stage_key"))
+
+
 def _save_market_activity(
     db: Session,
     market: str,
@@ -136,13 +155,19 @@ def _save_market_activity(
                     if not incoming_new_cycle:
                         return existing_payload
             elif existing_status == "failed":
+                supersedes_failed_activity = _should_supersede_failed_activity(
+                    existing_payload,
+                    payload,
+                )
                 incoming_new_cycle = payload_status in {"queued", "running"} and not same_owner
                 if incoming_new_cycle:
                     existing_stage_index = _stage_index(existing_payload.get("stage_key"))
                     payload_stage_index = _stage_index(payload.get("stage_key"))
                     lifecycle_changed = existing_payload.get("lifecycle") != payload.get("lifecycle")
                     incoming_new_cycle = lifecycle_changed or payload_stage_index <= existing_stage_index
-                if payload_status == "failed" and same_owner:
+                if supersedes_failed_activity:
+                    pass
+                elif payload_status == "failed" and same_owner:
                     if _should_preserve_existing_failed_message(existing_payload, payload):
                         return existing_payload
                 elif not incoming_new_cycle:

--- a/backend/app/services/official_market_universe_source_service.py
+++ b/backend/app/services/official_market_universe_source_service.py
@@ -372,7 +372,7 @@ class OfficialMarketUniverseSourceService:
         if self._cn_provider is None:
             from .cn_market_data_service import CnMarketDataService
 
-            self._cn_provider = CnMarketDataService()
+            self._cn_provider = CnMarketDataService(timeout_seconds=self._timeout_seconds)
         return self._cn_provider
 
     @staticmethod

--- a/backend/app/tasks/scan_tasks.py
+++ b/backend/app/tasks/scan_tasks.py
@@ -240,7 +240,7 @@ def _run_bulk_scan_via_use_case(task_instance, scan_id, symbol_list, criteria):
             chunk_size=settings.scan_usecase_chunk_size,
             correlation_id=task_instance.request.id,
             cache_only=cache_only,
-            parallel_workers=bounded_symbol_workers(4) if cache_only else 1,
+            parallel_workers=bounded_symbol_workers(4),
         )
         result = use_case.execute(uow, cmd, progress, cancel)
     except Exception:

--- a/backend/app/tasks/universe_tasks.py
+++ b/backend/app/tasks/universe_tasks.py
@@ -9,6 +9,8 @@ import logging
 from datetime import datetime
 from typing import Any, Optional
 
+import requests
+
 from ..celery_app import celery_app
 from ..database import SessionLocal, safe_rollback
 from ..services.market_activity_service import (
@@ -26,6 +28,10 @@ _GITHUB_SYNC_SUCCESS_STATUSES = frozenset({"success", "up_to_date"})
 _OFFICIAL_UNIVERSE_LOCK_RETRY_BASE_SECONDS = 300
 _OFFICIAL_UNIVERSE_LOCK_RETRY_MAX_SECONDS = 1800
 _OFFICIAL_UNIVERSE_LOCK_MAX_RETRIES = 12
+_OFFICIAL_UNIVERSE_TRANSIENT_EXCEPTIONS = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+)
 
 
 def _mark_market_activity_failed_safely(db, **kwargs) -> None:
@@ -470,6 +476,46 @@ def refresh_official_market_universe(
             **stats,
             'timestamp': datetime.now().isoformat(),
         }
+    except _OFFICIAL_UNIVERSE_TRANSIENT_EXCEPTIONS as exc:
+        retry_count = int(getattr(self.request, "retries", 0) or 0)
+        if retry_count < _OFFICIAL_UNIVERSE_LOCK_MAX_RETRIES:
+            delay_seconds = _official_lock_retry_delay(retry_count)
+            logger.warning(
+                "Transient official universe refresh failure for %s; retrying in %ss: %s",
+                _market,
+                delay_seconds,
+                exc,
+                extra=_log_extra,
+            )
+            raise self.retry(
+                countdown=delay_seconds,
+                max_retries=_OFFICIAL_UNIVERSE_LOCK_MAX_RETRIES,
+                exc=exc,
+            )
+
+        activity_db = None
+        try:
+            activity_db = SessionLocal()
+            _mark_market_activity_failed_safely(
+                activity_db,
+                market=_market,
+                stage_key="universe",
+                lifecycle=activity_lifecycle,
+                task_name=getattr(self, "name", task_name),
+                task_id=task_id,
+                message=str(exc),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to open activity session for official universe refresh",
+                extra={"market": _market, "task_id": task_id},
+                exc_info=True,
+            )
+        finally:
+            if activity_db is not None:
+                activity_db.close()
+        logger.exception("Error refreshing official universe for %s", _market)
+        raise
     except Exception as exc:
         activity_db = None
         try:

--- a/backend/app/tasks/universe_tasks.py
+++ b/backend/app/tasks/universe_tasks.py
@@ -29,6 +29,8 @@ _GITHUB_SYNC_SUCCESS_STATUSES = frozenset({"success", "up_to_date"})
 _OFFICIAL_UNIVERSE_LOCK_RETRY_BASE_SECONDS = 300
 _OFFICIAL_UNIVERSE_LOCK_RETRY_MAX_SECONDS = 1800
 _OFFICIAL_UNIVERSE_LOCK_MAX_RETRIES = 12
+_OFFICIAL_UNIVERSE_SOFT_TIME_LIMIT_SECONDS = 1800
+_OFFICIAL_UNIVERSE_HARD_TIME_LIMIT_SECONDS = 2100
 _OFFICIAL_UNIVERSE_TRANSIENT_EXCEPTIONS = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
@@ -344,7 +346,12 @@ def refresh_stock_universe(
         db.close()
 
 
-@celery_app.task(bind=True, name='app.tasks.universe_tasks.refresh_official_market_universe')
+@celery_app.task(
+    bind=True,
+    name='app.tasks.universe_tasks.refresh_official_market_universe',
+    soft_time_limit=_OFFICIAL_UNIVERSE_SOFT_TIME_LIMIT_SECONDS,
+    time_limit=_OFFICIAL_UNIVERSE_HARD_TIME_LIMIT_SECONDS,
+)
 def refresh_official_market_universe(
     self,
     market: str,

--- a/backend/app/tasks/universe_tasks.py
+++ b/backend/app/tasks/universe_tasks.py
@@ -16,6 +16,7 @@ from ..database import SessionLocal, safe_rollback
 from ..services.market_activity_service import (
     mark_market_activity_completed,
     mark_market_activity_failed,
+    mark_market_activity_progress,
     mark_market_activity_started,
 )
 from ..wiring.bootstrap import get_provider_snapshot_service, get_stock_universe_service
@@ -47,6 +48,26 @@ def _mark_market_activity_failed_safely(db, **kwargs) -> None:
             },
             exc_info=True,
         )
+
+
+def _mark_market_activity_progress_safely(**kwargs) -> None:
+    db = None
+    try:
+        db = SessionLocal()
+        mark_market_activity_progress(db, **kwargs)
+    except Exception:
+        logger.warning(
+            "Failed to publish market activity progress for universe task",
+            extra={
+                "market": kwargs.get("market"),
+                "stage_key": kwargs.get("stage_key"),
+                "task_id": kwargs.get("task_id"),
+            },
+            exc_info=True,
+        )
+    finally:
+        if db is not None:
+            db.close()
 
 
 def _count_active_universe(market: Optional[str]) -> Optional[int]:
@@ -397,6 +418,14 @@ def refresh_official_market_universe(
         finally:
             activity_db.close()
         prior_size = _count_active_universe(_market)
+        _mark_market_activity_progress_safely(
+            market=_market,
+            stage_key="universe",
+            lifecycle=activity_lifecycle,
+            task_name=getattr(self, "name", task_name),
+            task_id=task_id,
+            message="Checking weekly reference bundle",
+        )
         sync_db = SessionLocal()
         try:
             github_sync = get_provider_snapshot_service().sync_weekly_reference_from_github(
@@ -438,7 +467,27 @@ def refresh_official_market_universe(
                 "timestamp": datetime.now().isoformat(),
             }
 
+        _mark_market_activity_progress_safely(
+            market=_market,
+            stage_key="universe",
+            lifecycle=activity_lifecycle,
+            task_name=getattr(self, "name", task_name),
+            task_id=task_id,
+            message=(
+                "Fetching live CN A-share listings"
+                if _market == "CN"
+                else "Fetching live official market universe"
+            ),
+        )
         snapshot = OfficialMarketUniverseSourceService().fetch_market_snapshot(_market)
+        _mark_market_activity_progress_safely(
+            market=_market,
+            stage_key="universe",
+            lifecycle=activity_lifecycle,
+            task_name=getattr(self, "name", task_name),
+            task_id=task_id,
+            message="Ingesting official market universe",
+        )
         stats = _ingest_official_snapshot(snapshot)
         _emit_universe_drift(_market, prior_size)
 

--- a/backend/app/use_cases/scanning/run_bulk_scan.py
+++ b/backend/app/use_cases/scanning/run_bulk_scan.py
@@ -294,7 +294,14 @@ class RunBulkScanUseCase:
             outcomes: list[tuple[str, dict | None, bool, bool] | None] = [
                 None for _ in chunk
             ]
-            effective_workers = cmd.parallel_workers if cmd.cache_only else 1
+            prefetch_covers_chunk = bool(pre_fetched_data) and all(
+                symbol.upper() in pre_fetched_data for symbol in chunk
+            )
+            effective_workers = (
+                cmd.parallel_workers
+                if cmd.cache_only or prefetch_covers_chunk
+                else 1
+            )
             if effective_workers > 1 and len(chunk) > 1:
                 workers = min(effective_workers, len(chunk))
                 with ThreadPoolExecutor(max_workers=workers) as executor:

--- a/backend/requirements-runtime.txt
+++ b/backend/requirements-runtime.txt
@@ -7,6 +7,8 @@ pydantic==2.5.3
 pydantic-settings==2.1.0
 python-dotenv==1.0.0
 yfinance==0.2.66
+# pykrx imports pkg_resources at module import time; setuptools>=81 removes it.
+setuptools<81
 pykrx>=1.0.51
 akshare>=1.18.59
 baostock>=0.8.9

--- a/backend/requirements-server.txt
+++ b/backend/requirements-server.txt
@@ -7,6 +7,8 @@ pydantic==2.5.3
 pydantic-settings==2.1.0
 python-dotenv==1.0.0
 yfinance==0.2.66
+# pykrx imports pkg_resources at module import time; setuptools>=81 removes it.
+setuptools<81
 pykrx>=1.0.51
 akshare>=1.18.59
 baostock>=0.8.9

--- a/backend/tests/performance/test_setup_engine_performance.py
+++ b/backend/tests/performance/test_setup_engine_performance.py
@@ -209,11 +209,12 @@ class TestAggregatorBudget:
     def test_trace_timing_sums_are_consistent(
         self, synthetic_detector_input: PatternDetectorInput
     ):
-        """Sum of detector traces must be positive and less than total elapsed.
+        """Sum of detector traces must be positive and comparable to elapsed.
 
         Lower bound: ensures instrumentation is actually recording time.
-        Upper bound: confirms calibration/selection work happens outside
-        detector traces (i.e., there's non-detector overhead in aggregate()).
+        Upper bound: keeps detector timing instrumentation sane even when
+        detectors execute concurrently and summed detector time can exceed
+        wall-clock aggregation time.
         """
         aggregator = SetupEngineAggregator()
 
@@ -228,10 +229,9 @@ class TestAggregatorBudget:
         assert trace_sum_ms > 0, (
             "Detector trace elapsed_ms sum is zero — instrumentation broken?"
         )
-        assert trace_sum_ms < total_elapsed_ms, (
-            f"Detector trace sum ({trace_sum_ms:.1f}ms) >= total aggregator "
-            f"elapsed ({total_elapsed_ms:.1f}ms) — calibration/selection "
-            f"overhead should make total strictly larger"
+        assert trace_sum_ms < total_elapsed_ms * len(default_pattern_detectors()) * 2, (
+            f"Detector trace sum ({trace_sum_ms:.1f}ms) is implausible relative "
+            f"to total aggregator elapsed ({total_elapsed_ms:.1f}ms)"
         )
 
 

--- a/backend/tests/performance/test_setup_engine_performance.py
+++ b/backend/tests/performance/test_setup_engine_performance.py
@@ -206,15 +206,13 @@ class TestAggregatorBudget:
             f"Aggregator took {elapsed_ms:.1f}ms (budget: {AGGREGATOR_BUDGET_MS}ms)"
         )
 
-    def test_trace_timing_sums_are_consistent(
+    def test_serial_trace_timing_sum_tracks_wall_clock(
         self, synthetic_detector_input: PatternDetectorInput
     ):
-        """Sum of detector traces must be positive and comparable to elapsed.
+        """Serial detector trace timing should stay close to wall-clock elapsed.
 
         Lower bound: ensures instrumentation is actually recording time.
-        Upper bound: keeps detector timing instrumentation sane even when
-        detectors execute concurrently and summed detector time can exceed
-        wall-clock aggregation time.
+        Upper bound: keeps serial detector timing instrumentation sane.
         """
         aggregator = SetupEngineAggregator()
 
@@ -229,9 +227,33 @@ class TestAggregatorBudget:
         assert trace_sum_ms > 0, (
             "Detector trace elapsed_ms sum is zero — instrumentation broken?"
         )
+        assert trace_sum_ms < total_elapsed_ms * 1.2, (
+            f"Detector trace sum ({trace_sum_ms:.1f}ms) is implausible relative "
+            f"to serial aggregator elapsed ({total_elapsed_ms:.1f}ms)"
+        )
+
+    def test_concurrent_trace_timing_sum_allows_worker_overlap(
+        self, synthetic_detector_input: PatternDetectorInput
+    ):
+        """Concurrent detector traces may sum above wall-clock elapsed."""
+        aggregator = SetupEngineAggregator(
+            detector_workers=len(default_pattern_detectors())
+        )
+
+        t0 = time.perf_counter()
+        output = aggregator.aggregate(
+            synthetic_detector_input, parameters=DEFAULT_SETUP_ENGINE_PARAMETERS
+        )
+        total_elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        trace_sum_ms = sum(t.elapsed_ms for t in output.detector_traces)
+
+        assert trace_sum_ms > 0, (
+            "Detector trace elapsed_ms sum is zero — instrumentation broken?"
+        )
         assert trace_sum_ms < total_elapsed_ms * len(default_pattern_detectors()) * 2, (
             f"Detector trace sum ({trace_sum_ms:.1f}ms) is implausible relative "
-            f"to total aggregator elapsed ({total_elapsed_ms:.1f}ms)"
+            f"to concurrent aggregator elapsed ({total_elapsed_ms:.1f}ms)"
         )
 
 

--- a/backend/tests/unit/test_aggregator_execution_pipeline.py
+++ b/backend/tests/unit/test_aggregator_execution_pipeline.py
@@ -1,6 +1,7 @@
 """Tests for deterministic detector orchestration in the aggregator."""
 
 import threading
+from unittest.mock import patch
 
 from app.analysis.patterns.aggregator import SetupEngineAggregator, _pick_primary_candidate
 from app.analysis.patterns.config import DEFAULT_SETUP_ENGINE_PARAMETERS
@@ -71,6 +72,40 @@ def test_aggregator_execution_trace_preserves_detector_order():
     assert "detector_pipeline_executed" in first.passed_checks
 
 
+def test_aggregator_runs_detectors_serially_by_default():
+    execution_order: list[str] = []
+
+    class _FirstDetector(PatternDetector):
+        name = "first"
+
+        def detect(self, detector_input, parameters):
+            del detector_input, parameters
+            execution_order.append(self.name)
+            return PatternDetectorResult.no_detection(self.name)
+
+    class _SecondDetector(PatternDetector):
+        name = "second"
+
+        def detect(self, detector_input, parameters):
+            del detector_input, parameters
+            execution_order.append(self.name)
+            return PatternDetectorResult.no_detection(self.name)
+
+    agg = SetupEngineAggregator(detectors=[_FirstDetector(), _SecondDetector()])
+
+    with patch(
+        "app.analysis.patterns.aggregator.ThreadPoolExecutor",
+        side_effect=AssertionError("default detector execution must not spawn a pool"),
+    ):
+        result = agg.aggregate(_detector_input(), parameters=DEFAULT_SETUP_ENGINE_PARAMETERS)
+
+    assert execution_order == ["first", "second"]
+    assert [trace.detector_name for trace in result.detector_traces] == [
+        "first",
+        "second",
+    ]
+
+
 def test_aggregator_runs_detectors_concurrently_while_preserving_trace_order():
     barrier = threading.Barrier(2)
     overlapped: list[str] = []
@@ -94,7 +129,8 @@ def test_aggregator_runs_detectors_concurrently_while_preserving_trace_order():
             return PatternDetectorResult.no_detection(self.name)
 
     agg = SetupEngineAggregator(
-        detectors=[_FirstDetector(), _SecondDetector()]
+        detectors=[_FirstDetector(), _SecondDetector()],
+        detector_workers=2,
     )
 
     result = agg.aggregate(_detector_input(), parameters=DEFAULT_SETUP_ENGINE_PARAMETERS)

--- a/backend/tests/unit/test_aggregator_execution_pipeline.py
+++ b/backend/tests/unit/test_aggregator_execution_pipeline.py
@@ -1,5 +1,7 @@
 """Tests for deterministic detector orchestration in the aggregator."""
 
+import threading
+
 from app.analysis.patterns.aggregator import SetupEngineAggregator, _pick_primary_candidate
 from app.analysis.patterns.config import DEFAULT_SETUP_ENGINE_PARAMETERS
 from app.analysis.patterns.detectors.base import (
@@ -67,6 +69,42 @@ def test_aggregator_execution_trace_preserves_detector_order():
     assert first.detector_traces[1].outcome == "not_detected"
     assert first.pattern_primary == "vcp"
     assert "detector_pipeline_executed" in first.passed_checks
+
+
+def test_aggregator_runs_detectors_concurrently_while_preserving_trace_order():
+    barrier = threading.Barrier(2)
+    overlapped: list[str] = []
+
+    class _FirstDetector(PatternDetector):
+        name = "first"
+
+        def detect(self, detector_input, parameters):
+            del detector_input, parameters
+            barrier.wait(timeout=1.0)
+            overlapped.append(self.name)
+            return PatternDetectorResult.no_detection(self.name)
+
+    class _SecondDetector(PatternDetector):
+        name = "second"
+
+        def detect(self, detector_input, parameters):
+            del detector_input, parameters
+            barrier.wait(timeout=1.0)
+            overlapped.append(self.name)
+            return PatternDetectorResult.no_detection(self.name)
+
+    agg = SetupEngineAggregator(
+        detectors=[_FirstDetector(), _SecondDetector()]
+    )
+
+    result = agg.aggregate(_detector_input(), parameters=DEFAULT_SETUP_ENGINE_PARAMETERS)
+
+    assert sorted(overlapped) == ["first", "second"]
+    assert [trace.detector_name for trace in result.detector_traces] == [
+        "first",
+        "second",
+    ]
+    assert [trace.execution_index for trace in result.detector_traces] == [0, 1]
 
 
 def test_aggregator_trace_includes_detector_errors():

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
+import signal
 import time
 
 import pandas as pd
@@ -137,6 +138,61 @@ def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_is_empty(
 
     assert rows[0]["symbol"] == "688001.SS"
     assert rows[0]["board"] == "SSE_STAR"
+
+
+def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_times_out():
+    class FallbackAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            time.sleep(5)
+            return pd.DataFrame([{"代码": "600519", "名称": "贵州茅台"}])
+
+        @staticmethod
+        def stock_info_a_code_name():
+            return pd.DataFrame([{"code": "000001", "name": "平安银行"}])
+
+    service = CnMarketDataService(akshare_module=FallbackAkshare(), timeout_seconds=1)
+    started_at = time.monotonic()
+
+    rows = service.listing_rows(as_of=date(2026, 4, 30))
+
+    assert time.monotonic() - started_at < 3
+    assert rows[0]["symbol"] == "000001.SZ"
+    assert rows[0]["name"] == "平安银行"
+
+
+def test_cn_timeout_helper_restores_existing_signal_timer():
+    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "setitimer"):
+        pytest.skip("SIGALRM timers are unavailable on this platform")
+
+    import app.services.cn_market_data_service as module
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
+
+    def temporary_handler(signum, frame):
+        del signum, frame
+
+    try:
+        signal.signal(signal.SIGALRM, temporary_handler)
+        signal.setitimer(signal.ITIMER_REAL, 10.0)
+
+        result = module._call_with_timeout(
+            lambda: "ok",
+            timeout_seconds=1,
+            operation_name="test fetch",
+        )
+
+        restored_delay, restored_interval = signal.getitimer(signal.ITIMER_REAL)
+        assert result == "ok"
+        assert restored_delay > 8.0
+        assert restored_interval == 0.0
+        assert signal.getsignal(signal.SIGALRM) is temporary_handler
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer[0] > 0 or previous_timer[1] > 0:
+            signal.setitimer(signal.ITIMER_REAL, *previous_timer)
 
 
 def test_cn_market_data_service_times_out_listing_fetch():

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -250,6 +250,62 @@ def test_cn_market_data_service_maps_akshare_ohlcv_to_yfinance_shape():
     assert result.iloc[-1]["Close"] == 105.0
 
 
+def test_cn_market_data_service_skips_akshare_after_repeated_ohlcv_transport_failures():
+    class FakeAkshare:
+        calls = 0
+
+        @classmethod
+        def stock_zh_a_hist(cls, **kwargs):
+            cls.calls += 1
+            raise ConnectionError("remote disconnected")
+
+    class FakeLogin:
+        error_code = "0"
+
+    class FakeQuery:
+        error_code = "0"
+        fields = ["date", "open", "high", "low", "close", "volume", "amount"]
+
+        def __init__(self):
+            self._remaining = [
+                ["2026-04-29", "10", "11", "9", "10.5", "1000", "10500"],
+            ]
+
+        def next(self):
+            return bool(self._remaining)
+
+        def get_row_data(self):
+            return self._remaining.pop(0)
+
+    class FakeBaoStock:
+        queries = 0
+
+        @staticmethod
+        def login():
+            return FakeLogin()
+
+        @classmethod
+        def query_history_k_data_plus(cls, *args, **kwargs):
+            cls.queries += 1
+            return FakeQuery()
+
+        @staticmethod
+        def logout():
+            return None
+
+    service = CnMarketDataService(
+        akshare_module=FakeAkshare(),
+        baostock_module=FakeBaoStock(),
+    )
+
+    for _ in range(3):
+        rows = service.daily_ohlcv("002153", start="20260401", end="20260430")
+        assert rows[0].close == 10.5
+
+    assert FakeAkshare.calls == 2
+    assert FakeBaoStock.queries == 3
+
+
 def test_cn_market_data_service_raises_dependency_error_when_akshare_missing(monkeypatch):
     import app.services.cn_market_data_service as module
 

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -8,10 +8,14 @@ import pandas as pd
 import pytest
 import requests
 
+import app.services.cn_market_data_service as cn_market_data_module
 from app.services.cn_market_data_service import (
     CnDependencyError,
     CnMarketDataService,
 )
+
+
+_SIGALRM_AVAILABLE = hasattr(signal, "SIGALRM") and hasattr(signal, "setitimer")
 
 
 def test_cn_market_data_service_maps_akshare_spot_rows_to_listing_rows():
@@ -140,6 +144,7 @@ def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_is_empty(
     assert rows[0]["board"] == "SSE_STAR"
 
 
+@pytest.mark.skipif(not _SIGALRM_AVAILABLE, reason="SIGALRM timers are unavailable on this platform")
 def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_times_out():
     class FallbackAkshare:
         @staticmethod
@@ -162,7 +167,7 @@ def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_times_out
 
 
 def test_cn_timeout_helper_restores_existing_signal_timer():
-    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "setitimer"):
+    if not _SIGALRM_AVAILABLE:
         pytest.skip("SIGALRM timers are unavailable on this platform")
 
     import app.services.cn_market_data_service as module
@@ -195,6 +200,7 @@ def test_cn_timeout_helper_restores_existing_signal_timer():
             signal.setitimer(signal.ITIMER_REAL, *previous_timer)
 
 
+@pytest.mark.skipif(not _SIGALRM_AVAILABLE, reason="SIGALRM timers are unavailable on this platform")
 def test_cn_market_data_service_times_out_listing_fetch():
     class SlowAkshare:
         @staticmethod
@@ -247,6 +253,41 @@ def test_cn_market_data_service_maps_akshare_ohlcv_to_yfinance_shape():
     assert result.index[0].date().isoformat() == "2026-04-28"
     assert result.iloc[0]["Open"] == 0
     assert result.iloc[0]["Volume"] == 0
+    assert result.iloc[-1]["Close"] == 105.0
+
+
+def test_cn_market_data_service_wraps_akshare_ohlcv_fetch_in_timeout_helper(monkeypatch):
+    frame = pd.DataFrame(
+        [
+            {
+                "日期": "2026-04-29",
+                "开盘": 104.0,
+                "最高": 106.0,
+                "最低": 103.0,
+                "收盘": 105.0,
+                "成交量": 234567,
+            },
+        ]
+    )
+    helper_calls = []
+
+    class FakeAkshare:
+        @staticmethod
+        def stock_zh_a_hist(**kwargs):  # pragma: no cover - should be called only by helper
+            raise AssertionError("AKShare OHLCV must be invoked via timeout helper")
+
+    def fake_call_with_timeout(fetcher, *, timeout_seconds: int, operation_name: str):
+        del fetcher
+        helper_calls.append((timeout_seconds, operation_name))
+        return frame
+
+    monkeypatch.setattr(cn_market_data_module, "_call_with_timeout", fake_call_with_timeout)
+    service = CnMarketDataService(akshare_module=FakeAkshare(), timeout_seconds=7)
+
+    result = service.daily_ohlcv_dataframe("600519", period="1mo", end=date(2026, 4, 30))
+
+    assert helper_calls == [(7, "CN OHLCV fetch for 600519")]
+    assert result is not None
     assert result.iloc[-1]["Close"] == 105.0
 
 

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from datetime import date
+import time
 
 import pandas as pd
 import pytest
+import requests
 
 from app.services.cn_market_data_service import (
     CnDependencyError,
@@ -90,6 +92,22 @@ def test_cn_market_data_service_preserves_zero_listing_numeric_fields():
     assert row["pe_ratio"] == 0
     assert row["price_to_book"] == 0
     assert row["dividend_yield"] == 0
+
+
+def test_cn_market_data_service_times_out_listing_fetch():
+    class SlowAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            time.sleep(5)
+            return pd.DataFrame([{"代码": "600519", "名称": "贵州茅台"}])
+
+    service = CnMarketDataService(akshare_module=SlowAkshare(), timeout_seconds=1)
+    started_at = time.monotonic()
+
+    with pytest.raises(requests.exceptions.Timeout, match="CN A-share listing fetch timed out"):
+        service.listing_rows(as_of=date(2026, 4, 30))
+
+    assert time.monotonic() - started_at < 3
 
 
 def test_cn_market_data_service_skips_baostock_ohlcv_for_beijing_codes():

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -94,6 +94,51 @@ def test_cn_market_data_service_preserves_zero_listing_numeric_fields():
     assert row["dividend_yield"] == 0
 
 
+def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_fails():
+    class FallbackAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            raise requests.exceptions.ConnectionError("eastmoney disconnected")
+
+        @staticmethod
+        def stock_info_a_code_name():
+            return pd.DataFrame(
+                [
+                    {"code": "600519", "name": "贵州茅台"},
+                    {"code": "000001", "name": "平安银行"},
+                    {"code": "920118", "name": "太湖雪"},
+                ]
+            )
+
+    service = CnMarketDataService(akshare_module=FallbackAkshare(), timeout_seconds=1)
+
+    rows = service.listing_rows(as_of=date(2026, 4, 30))
+
+    assert [row["symbol"] for row in rows] == ["600519.SS", "000001.SZ", "920118.BJ"]
+    assert rows[0]["name"] == "贵州茅台"
+    assert rows[0]["market_cap"] is None
+    assert rows[1]["exchange"] == "SZSE"
+    assert rows[2]["exchange"] == "BJSE"
+
+
+def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_is_empty():
+    class FallbackAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            return pd.DataFrame()
+
+        @staticmethod
+        def stock_info_a_code_name():
+            return pd.DataFrame([{"code": 688001, "name": "华兴源创"}])
+
+    service = CnMarketDataService(akshare_module=FallbackAkshare(), timeout_seconds=1)
+
+    rows = service.listing_rows(as_of=date(2026, 4, 30))
+
+    assert rows[0]["symbol"] == "688001.SS"
+    assert rows[0]["board"] == "SSE_STAR"
+
+
 def test_cn_market_data_service_times_out_listing_fetch():
     class SlowAkshare:
         @staticmethod

--- a/backend/tests/unit/test_feature_store_tasks.py
+++ b/backend/tests/unit/test_feature_store_tasks.py
@@ -27,7 +27,10 @@ from app.interfaces.tasks.feature_store_tasks import (
     _upsert_feature_run_pointer,
     build_daily_snapshot,
 )
-from app.domain.scanning.defaults import get_default_scan_profile
+from app.domain.scanning.defaults import (
+    get_bootstrap_scan_profile,
+    get_default_scan_profile,
+)
 from app.schemas.universe import UniverseType
 from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer, StockFeatureDaily
 from app.models.scan_result import Scan
@@ -191,6 +194,45 @@ def test_build_daily_snapshot_uses_default_scan_profile_when_not_provided():
     assert fake_use_case.received_cmd.screener_names == defaults["screeners"]
     assert fake_use_case.received_cmd.criteria == defaults["criteria"]
     assert fake_use_case.received_cmd.composite_method == defaults["composite_method"]
+
+
+def test_build_daily_snapshot_bootstrap_uses_lightweight_scan_profile():
+    fake_use_case = _FakeUseCase()
+    bootstrap_defaults = get_bootstrap_scan_profile("US")
+
+    with patch(
+        "app.use_cases.feature_store.build_daily_snapshot._is_us_trading_day",
+        return_value=True,
+    ), patch(
+        "app.wiring.bootstrap.get_build_daily_snapshot_use_case",
+        return_value=fake_use_case,
+    ), patch(
+        "app.database.SessionLocal"
+    ), patch(
+        "app.infra.db.uow.SqlUnitOfWork",
+        side_effect=lambda *_args, **_kwargs: _NonSkippingUoW(),
+    ), patch(
+        "app.infra.tasks.progress_sink.CeleryProgressSink",
+        return_value=object(),
+    ), patch(
+        "app.domain.scanning.ports.NeverCancelledToken",
+        return_value=object(),
+    ), patch(
+        "app.interfaces.tasks.feature_store_tasks._create_auto_scan_for_published_run",
+        return_value="auto-scan-001",
+    ):
+        _TASK_BODY(
+            _FakeTask(),
+            as_of_date_str="2026-03-16",
+            activity_lifecycle="bootstrap",
+            bootstrap_cache_only_if_covered=True,
+            bootstrap_coverage_report={"eligible": True},
+        )
+
+    assert fake_use_case.received_cmd.screener_names == bootstrap_defaults["screeners"]
+    assert "setup_engine" not in fake_use_case.received_cmd.screener_names
+    assert fake_use_case.received_cmd.criteria == bootstrap_defaults["criteria"]
+    assert fake_use_case.received_cmd.composite_method == bootstrap_defaults["composite_method"]
 
 
 def test_build_daily_snapshot_defaults_to_market_profile_and_pointer():

--- a/backend/tests/unit/test_feature_store_tasks.py
+++ b/backend/tests/unit/test_feature_store_tasks.py
@@ -235,6 +235,78 @@ def test_build_daily_snapshot_bootstrap_uses_lightweight_scan_profile():
     assert fake_use_case.received_cmd.composite_method == bootstrap_defaults["composite_method"]
 
 
+def test_build_daily_snapshot_bootstrap_lifecycle_without_cache_gate_uses_full_profile():
+    fake_use_case = _FakeUseCase()
+    defaults = get_default_scan_profile("US")
+
+    with patch(
+        "app.use_cases.feature_store.build_daily_snapshot._is_us_trading_day",
+        return_value=True,
+    ), patch(
+        "app.wiring.bootstrap.get_build_daily_snapshot_use_case",
+        return_value=fake_use_case,
+    ), patch(
+        "app.database.SessionLocal"
+    ), patch(
+        "app.infra.db.uow.SqlUnitOfWork",
+        side_effect=lambda *_args, **_kwargs: _NonSkippingUoW(),
+    ), patch(
+        "app.infra.tasks.progress_sink.CeleryProgressSink",
+        return_value=object(),
+    ), patch(
+        "app.domain.scanning.ports.NeverCancelledToken",
+        return_value=object(),
+    ), patch(
+        "app.interfaces.tasks.feature_store_tasks._create_auto_scan_for_published_run",
+        return_value="auto-scan-001",
+    ):
+        _TASK_BODY(
+            _FakeTask(),
+            as_of_date_str="2026-03-16",
+            activity_lifecycle="bootstrap",
+        )
+
+    assert fake_use_case.received_cmd.screener_names == defaults["screeners"]
+    assert "setup_engine" in fake_use_case.received_cmd.screener_names
+
+
+def test_build_daily_snapshot_bootstrap_preserves_explicit_screener_names():
+    fake_use_case = _FakeUseCase()
+    explicit_screeners = ["setup_engine"]
+
+    with patch(
+        "app.use_cases.feature_store.build_daily_snapshot._is_us_trading_day",
+        return_value=True,
+    ), patch(
+        "app.wiring.bootstrap.get_build_daily_snapshot_use_case",
+        return_value=fake_use_case,
+    ), patch(
+        "app.database.SessionLocal"
+    ), patch(
+        "app.infra.db.uow.SqlUnitOfWork",
+        side_effect=lambda *_args, **_kwargs: _NonSkippingUoW(),
+    ), patch(
+        "app.infra.tasks.progress_sink.CeleryProgressSink",
+        return_value=object(),
+    ), patch(
+        "app.domain.scanning.ports.NeverCancelledToken",
+        return_value=object(),
+    ), patch(
+        "app.interfaces.tasks.feature_store_tasks._create_auto_scan_for_published_run",
+        return_value="auto-scan-001",
+    ):
+        _TASK_BODY(
+            _FakeTask(),
+            as_of_date_str="2026-03-16",
+            activity_lifecycle="bootstrap",
+            bootstrap_cache_only_if_covered=True,
+            bootstrap_coverage_report={"eligible": True},
+            screener_names=explicit_screeners,
+        )
+
+    assert fake_use_case.received_cmd.screener_names == explicit_screeners
+
+
 def test_build_daily_snapshot_defaults_to_market_profile_and_pointer():
     fake_use_case = _FakeUseCase()
 

--- a/backend/tests/unit/test_fx_service.py
+++ b/backend/tests/unit/test_fx_service.py
@@ -10,6 +10,7 @@ from datetime import date, timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
 from app.services.fx_service import (
     FXQuote,
@@ -226,6 +227,37 @@ class TestLookupChain:
         assert quote is not None
         assert quote.rate == 0.127
         fetcher.assert_not_called()
+
+
+class TestPersistence:
+    def test_postgres_persist_uses_atomic_upsert(self):
+        fake_db = MagicMock()
+        fake_bind = MagicMock()
+        fake_bind.dialect.name = "postgresql"
+        fake_db.get_bind.return_value = fake_bind
+        svc = FXService(
+            rate_fetcher=lambda c: None,
+            session_factory=lambda: fake_db,
+            redis_client=None,
+        )
+        quote = FXQuote(
+            from_currency="JPY",
+            to_currency="USD",
+            rate=0.0062,
+            as_of_date=date(2026, 4, 30),
+            source="yfinance",
+        )
+
+        svc._persist_database(quote)
+
+        fake_db.add.assert_not_called()
+        fake_db.execute.assert_called_once()
+        statement = fake_db.execute.call_args.args[0]
+        compiled = str(statement.compile(dialect=postgresql.dialect()))
+        assert "ON CONFLICT ON CONSTRAINT uq_fx_rates_currency_date_source" in compiled
+        assert "DO UPDATE SET rate = excluded.rate" in compiled
+        fake_db.commit.assert_called_once()
+        fake_db.close.assert_called_once()
 
 
 class TestConvertToUSD:

--- a/backend/tests/unit/test_group_rank_service.py
+++ b/backend/tests/unit/test_group_rank_service.py
@@ -264,6 +264,37 @@ def test_prefetch_all_data_uses_cached_only_prices_for_same_day(db_session, monk
     price_cache.get_many_cached_only_fresh.assert_called_once_with(["AAPL"], period="2y")
 
 
+def test_cache_only_missing_market_benchmark_names_market_symbol(db_session, monkeypatch):
+    service = _make_group_rank_service()
+
+    price_cache = Mock()
+    price_cache.get_cached_only_fresh.return_value = None
+    price_cache.get_many_cached_only_fresh.return_value = {}
+    service.price_cache = price_cache
+
+    benchmark_cache = Mock()
+    benchmark_cache.get_benchmark_symbol.return_value = "^N225"
+    service.benchmark_cache = benchmark_cache
+
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_all_groups",
+        lambda db, **kw: ["JP_Software"],
+    )
+
+    with pytest.raises(IncompleteGroupRankingCacheError) as excinfo:
+        service.calculate_group_rankings(
+            db_session,
+            date(2026, 5, 1),
+            market="JP",
+            cache_only=True,
+            require_complete_cache=True,
+        )
+
+    assert str(excinfo.value) == "^N225 benchmark data is missing from cache for JP"
+    assert excinfo.value.stats["benchmark_symbol"] == "^N225"
+    assert excinfo.value.stats["market"] == "JP"
+
+
 def test_prefetch_all_data_treats_stale_same_day_cache_as_missing(db_session, monkeypatch):
     service = _make_group_rank_service()
     spy_data = _price_frame()

--- a/backend/tests/unit/test_group_rank_service.py
+++ b/backend/tests/unit/test_group_rank_service.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from uuid import uuid4
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pandas as pd
 import pytest
@@ -293,6 +293,56 @@ def test_cache_only_missing_market_benchmark_names_market_symbol(db_session, mon
     assert str(excinfo.value) == "^N225 benchmark data is missing from cache for JP"
     assert excinfo.value.stats["benchmark_symbol"] == "^N225"
     assert excinfo.value.stats["market"] == "JP"
+
+
+def test_cache_only_prefetch_uses_cached_market_benchmark_fallback(db_session, monkeypatch):
+    service = _make_group_rank_service()
+    fallback_data = _price_frame()
+    sony_data = _price_frame()
+
+    price_cache = Mock()
+    price_cache.get_cached_only_fresh.side_effect = [None, fallback_data]
+    price_cache.get_many_cached_only_fresh.return_value = {"6758.T": sony_data}
+    service.price_cache = price_cache
+
+    benchmark_cache = Mock()
+    benchmark_cache.get_benchmark_symbol.return_value = "^N225"
+    benchmark_cache.get_benchmark_candidates.return_value = ["^N225", "1306.T"]
+    service.benchmark_cache = benchmark_cache
+
+    stock_universe_service = Mock()
+    stock_universe_service.get_active_symbols.return_value = ["6758.T"]
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_stock_universe_service",
+        lambda: stock_universe_service,
+    )
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_all_groups",
+        lambda db, **kw: ["JP_Technology"],
+    )
+    monkeypatch.setattr(
+        "app.services.ibd_group_rank_service.IBDIndustryService.get_group_symbols",
+        lambda db, group, **kw: ["6758.T"],
+    )
+    monkeypatch.setattr(
+        service,
+        "_get_market_caps_for_symbols",
+        lambda db, symbols: {"6758.T": 1_000_000_000},
+    )
+
+    prefetch = service._prefetch_all_data(
+        db_session,
+        market="JP",
+        cache_only=True,
+    )
+
+    assert prefetch.benchmark_prices is fallback_data
+    assert prefetch.stats["benchmark_symbol"] == "1306.T"
+    assert prefetch.stats["benchmark_role"] == "fallback"
+    assert price_cache.get_cached_only_fresh.call_args_list == [
+        call("^N225", period="2y"),
+        call("1306.T", period="2y"),
+    ]
 
 
 def test_prefetch_all_data_treats_stale_same_day_cache_as_missing(db_session, monkeypatch):

--- a/backend/tests/unit/test_kr_market_data_service.py
+++ b/backend/tests/unit/test_kr_market_data_service.py
@@ -196,6 +196,12 @@ def test_krx_listing_rows_falls_back_to_current_listing_finder_when_daily_ticker
                         "codeName": "Wrong Board",
                         "marketCode": "KNX",
                     },
+                    {
+                        "full_code": "KR7000000000",
+                        "short_code": "",
+                        "codeName": "Blank Code",
+                        "marketCode": "STK",
+                    },
                 ]
             )
 

--- a/backend/tests/unit/test_kr_market_data_service.py
+++ b/backend/tests/unit/test_kr_market_data_service.py
@@ -154,3 +154,87 @@ def test_krx_core_fundamentals_caches_whole_market_frames() -> None:
     assert celltrion["pe_ratio"] == 28.0
     assert stock_module.market_cap_calls == [("20260429", "ALL")]
     assert stock_module.fundamental_calls == [("20260429", "ALL")]
+
+
+def test_krx_listing_rows_falls_back_to_current_listing_finder_when_daily_tickers_empty() -> None:
+    class _FakeStockModule:
+        def __init__(self) -> None:
+            self.ticker_calls: list[tuple[str, str]] = []
+            self.name_calls: list[str] = []
+
+        def get_market_ticker_list(self, as_of: str, *, market: str):
+            self.ticker_calls.append((as_of, market))
+            return []
+
+        def get_market_ticker_name(self, ticker: str):
+            self.name_calls.append(ticker)
+            return f"daily {ticker}"
+
+    class _FakeListingSource:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def fetch(self, market_code: str):
+            self.calls.append(market_code)
+            return pd.DataFrame(
+                [
+                    {
+                        "full_code": "KR7005930003",
+                        "short_code": "005930",
+                        "codeName": "Samsung Electronics",
+                        "marketCode": "STK",
+                    },
+                    {
+                        "full_code": "KR7091990002",
+                        "short_code": "091990",
+                        "codeName": "Celltrion Healthcare",
+                        "marketCode": "KSQ",
+                    },
+                    {
+                        "full_code": "KR7066660001",
+                        "short_code": "066660",
+                        "codeName": "Wrong Board",
+                        "marketCode": "KNX",
+                    },
+                ]
+            )
+
+    stock_module = _FakeStockModule()
+    listing_source = _FakeListingSource()
+    service = KrxMarketDataService(
+        stock_module=stock_module,
+        listing_source=listing_source,
+    )
+
+    rows = service.listing_rows(boards=("KOSPI", "KOSDAQ"), as_of=date(2026, 4, 30))
+
+    assert stock_module.ticker_calls == [
+        ("20260430", "KOSPI"),
+        ("20260430", "KOSDAQ"),
+    ]
+    assert stock_module.name_calls == []
+    assert listing_source.calls == ["STK", "KSQ"]
+    assert rows == [
+        {
+            "symbol": "005930.KS",
+            "local_code": "005930",
+            "name": "Samsung Electronics",
+            "exchange": "KOSPI",
+            "sector": "",
+            "industry": "",
+            "market_cap": None,
+            "source_board": "KOSPI",
+            "isin": "KR7005930003",
+        },
+        {
+            "symbol": "091990.KQ",
+            "local_code": "091990",
+            "name": "Celltrion Healthcare",
+            "exchange": "KOSDAQ",
+            "sector": "",
+            "industry": "",
+            "market_cap": None,
+            "source_board": "KOSDAQ",
+            "isin": "KR7091990002",
+        },
+    ]

--- a/backend/tests/unit/test_kr_market_data_service.py
+++ b/backend/tests/unit/test_kr_market_data_service.py
@@ -212,11 +212,12 @@ def test_krx_listing_rows_falls_back_to_current_listing_finder_when_daily_ticker
         listing_source=listing_source,
     )
 
-    rows = service.listing_rows(boards=("KOSPI", "KOSDAQ"), as_of=date(2026, 4, 30))
+    rows = service.listing_rows(boards=("KOSPI", "KOSDAQ"), as_of=None)
 
+    today_token = date.today().strftime("%Y%m%d")
     assert stock_module.ticker_calls == [
-        ("20260430", "KOSPI"),
-        ("20260430", "KOSDAQ"),
+        (today_token, "KOSPI"),
+        (today_token, "KOSDAQ"),
     ]
     assert stock_module.name_calls == []
     assert listing_source.calls == ["STK", "KSQ"]
@@ -244,3 +245,43 @@ def test_krx_listing_rows_falls_back_to_current_listing_finder_when_daily_ticker
             "isin": "KR7091990002",
         },
     ]
+
+
+def test_krx_listing_rows_does_not_use_current_listing_finder_for_historical_empty_tickers() -> None:
+    class _FakeStockModule:
+        def __init__(self) -> None:
+            self.ticker_calls: list[tuple[str, str]] = []
+
+        def get_market_ticker_list(self, as_of: str, *, market: str):
+            self.ticker_calls.append((as_of, market))
+            return []
+
+    class _FakeListingSource:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def fetch(self, market_code: str):
+            self.calls.append(market_code)
+            return pd.DataFrame(
+                [
+                    {
+                        "full_code": "KR7005930003",
+                        "short_code": "005930",
+                        "codeName": "Samsung Electronics",
+                        "marketCode": "STK",
+                    },
+                ]
+            )
+
+    stock_module = _FakeStockModule()
+    listing_source = _FakeListingSource()
+    service = KrxMarketDataService(
+        stock_module=stock_module,
+        listing_source=listing_source,
+    )
+
+    rows = service.listing_rows(boards=("KOSPI",), as_of=date(2026, 4, 1))
+
+    assert stock_module.ticker_calls == [("20260401", "KOSPI")]
+    assert listing_source.calls == []
+    assert rows == []

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -575,6 +575,89 @@ def test_failed_activity_is_sticky_against_later_stage_updates(db_session, monke
     assert hk_market["message"] == "Price refresh failed"
 
 
+def test_failed_group_activity_is_replaced_when_bootstrap_scan_starts(db_session, monkeypatch):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_failed(
+        db_session,
+        market="HK",
+        stage_key="groups",
+        lifecycle="bootstrap",
+        task_name="calculate_daily_group_rankings_with_gapfill",
+        task_id="groups-task",
+        message="Daily group ranking failed: Cache warmup not complete",
+    )
+    module.mark_market_activity_started(
+        db_session,
+        market="HK",
+        stage_key="scan",
+        lifecycle="bootstrap",
+        task_name="build_daily_snapshot",
+        task_id="scan-task",
+        current=12,
+        total=100,
+        message="Running market scan",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=True, enabled=["HK"], primary="HK", state="running"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    hk_market = next(item for item in payload["markets"] if item["market"] == "HK")
+    assert hk_market["status"] == "running"
+    assert hk_market["stage_key"] == "scan"
+    assert hk_market["stage_label"] == "Scan"
+    assert hk_market["message"] == "Running market scan"
+    assert hk_market["percent"] == 12.0
+
+
+@pytest.mark.parametrize("stage_key", ["universe", "prices"])
+def test_failed_hard_activity_is_not_replaced_when_bootstrap_scan_starts(
+    db_session,
+    monkeypatch,
+    stage_key,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_failed(
+        db_session,
+        market="HK",
+        stage_key=stage_key,
+        lifecycle="bootstrap",
+        task_name=f"{stage_key}_task",
+        task_id=f"{stage_key}-task",
+        message=f"{stage_key.title()} failed",
+    )
+    module.mark_market_activity_started(
+        db_session,
+        market="HK",
+        stage_key="scan",
+        lifecycle="bootstrap",
+        task_name="build_daily_snapshot",
+        task_id="scan-task",
+        current=12,
+        total=100,
+        message="Running market scan",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=True, enabled=["HK"], primary="HK", state="failed"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    hk_market = next(item for item in payload["markets"] if item["market"] == "HK")
+    assert hk_market["status"] == "failed"
+    assert hk_market["stage_key"] == stage_key
+    assert hk_market["message"] == f"{stage_key.title()} failed"
+
+
 def test_failed_activity_can_replace_completed_record(db_session, monkeypatch):
     from app.services import market_activity_service as module
 

--- a/backend/tests/unit/test_run_bulk_scan_wrapper.py
+++ b/backend/tests/unit/test_run_bulk_scan_wrapper.py
@@ -293,8 +293,8 @@ class TestRunBulkScanViaUseCase:
 
         assert captured_cmd is not None
         assert captured_cmd.cache_only is False
-        assert captured_cmd.parallel_workers == 1
-        mock_bounded.assert_not_called()
+        assert captured_cmd.parallel_workers == 2
+        mock_bounded.assert_called_once_with(4)
 
     @patch(f"{_WRAPPER_PATH}._run_post_scan_pipeline")
     @patch(f"{_WRAPPER_PATH}.settings")

--- a/backend/tests/unit/test_scan_defaults.py
+++ b/backend/tests/unit/test_scan_defaults.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from app.domain.scanning.defaults import get_default_scan_profile
+from app.domain.scanning.defaults import (
+    get_bootstrap_scan_profile,
+    get_default_scan_profile,
+)
 
 
 def test_default_scan_profile_remains_backward_compatible() -> None:
@@ -22,3 +25,14 @@ def test_market_default_scan_profiles_scope_universe_and_benchmark() -> None:
         assert profile["universe"] == f"market:{market}"
         assert profile["benchmark_symbol"] == benchmark_symbol
         assert profile["criteria"]["benchmark_symbol"] == benchmark_symbol
+
+
+def test_bootstrap_scan_profile_keeps_market_scope_but_skips_setup_engine() -> None:
+    default_profile = get_default_scan_profile("US")
+    bootstrap_profile = get_bootstrap_scan_profile("US")
+
+    assert "setup_engine" in default_profile["screeners"]
+    assert "setup_engine" not in bootstrap_profile["screeners"]
+    assert bootstrap_profile["universe"] == default_profile["universe"]
+    assert bootstrap_profile["benchmark_symbol"] == default_profile["benchmark_symbol"]
+    assert bootstrap_profile["criteria"] == default_profile["criteria"]

--- a/backend/tests/unit/test_setup_engine_screener.py
+++ b/backend/tests/unit/test_setup_engine_screener.py
@@ -319,6 +319,48 @@ class TestTimingObservability:
             assert "elapsed=" in line.message
             assert "outcome=" in line.message
 
+    def test_slow_detector_summary_logs_at_info(self, caplog):
+        """Slow detector phases should expose top detector timings at INFO."""
+        from app.scanners.setup_engine_screener import _log_slow_detector_summary
+
+        traces = (
+            DetectorExecutionTrace(
+                execution_index=0,
+                detector_name="fast",
+                outcome="success",
+                candidate_count=0,
+                passed_checks=(),
+                failed_checks=(),
+                warnings=(),
+                error_detail=None,
+                elapsed_ms=12.3,
+            ),
+            DetectorExecutionTrace(
+                execution_index=1,
+                detector_name="slow",
+                outcome="success",
+                candidate_count=2,
+                passed_checks=(),
+                failed_checks=(),
+                warnings=(),
+                error_detail=None,
+                elapsed_ms=812.4,
+            ),
+        )
+
+        with caplog.at_level(logging.INFO, logger="app.scanners.setup_engine_screener"):
+            _log_slow_detector_summary(
+                "SLOW",
+                traces,
+                detectors_ms=930.0,
+                threshold_ms=500.0,
+            )
+
+        messages = [r.message for r in caplog.records]
+        assert any("SE slow detectors SLOW" in msg for msg in messages)
+        assert any("slow=812.4ms/2/success" in msg for msg in messages)
+        assert all("fast=12.3ms" not in msg for msg in messages)
+
 
 class TestOperationalFlagsIntegration:
     """SE-E7: Operational invalidation flags wired through full pipeline."""

--- a/backend/tests/unit/test_static_workflow_markets.py
+++ b/backend/tests/unit/test_static_workflow_markets.py
@@ -1,0 +1,23 @@
+"""Static-site workflow market matrix coverage."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _workflow_matrix_markets(path: str) -> list[str]:
+    content = (_PROJECT_ROOT / path).read_text(encoding="utf-8")
+    match = re.search(r"market:\s*\[([^\]]+)\]", content)
+    assert match is not None, f"{path} does not declare a market matrix"
+    return [market.strip() for market in match.group(1).split(",")]
+
+
+def test_static_and_weekly_reference_workflows_include_korea_market():
+    expected = ["US", "HK", "IN", "JP", "KR", "TW"]
+
+    assert _workflow_matrix_markets(".github/workflows/static-site.yml") == expected
+    assert _workflow_matrix_markets(".github/workflows/weekly-reference-data.yml") == expected

--- a/backend/tests/unit/test_universe_tasks.py
+++ b/backend/tests/unit/test_universe_tasks.py
@@ -45,6 +45,7 @@ def test_refresh_stock_universe_returns_original_error_when_activity_publish_fai
     monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
     monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_mark_market_activity_progress_safely", lambda **kwargs: None)
     monkeypatch.setattr(
         module,
         "mark_market_activity_failed",
@@ -77,6 +78,7 @@ def test_refresh_official_market_universe_preserves_original_error_when_activity
     monkeypatch.setattr(module, "SessionLocal", lambda: activity_sessions.pop(0))
     monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_mark_market_activity_progress_safely", lambda **kwargs: None)
     monkeypatch.setattr(
         module,
         "mark_market_activity_failed",
@@ -105,6 +107,7 @@ def test_refresh_stock_universe_prefers_github_weekly_bundle(monkeypatch):
     monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
     monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_mark_market_activity_progress_safely", lambda **kwargs: None)
     monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         module,
@@ -145,6 +148,7 @@ def test_refresh_official_market_universe_falls_back_when_github_sync_is_unsuppo
     monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
     monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_mark_market_activity_progress_safely", lambda **kwargs: None)
     monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         module,
@@ -196,6 +200,7 @@ def test_refresh_official_market_universe_retries_transient_provider_failure(mon
     monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
     monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_mark_market_activity_progress_safely", lambda **kwargs: None)
     failed = MagicMock()
     monkeypatch.setattr(module, "mark_market_activity_failed", failed)
     monkeypatch.setattr(

--- a/backend/tests/unit/test_universe_tasks.py
+++ b/backend/tests/unit/test_universe_tasks.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from celery.exceptions import Retry
 import pytest
+import requests
 
 
 def _patch_data_fetch_lock(monkeypatch):
@@ -183,3 +185,48 @@ def test_refresh_official_market_universe_falls_back_when_github_sync_is_unsuppo
     assert result["status"] == "success"
     assert result["market"] == "IN"
     fake_lock.release.assert_called_once_with("task-123", market="IN")
+
+
+def test_refresh_official_market_universe_retries_transient_provider_failure(monkeypatch):
+    import app.tasks.universe_tasks as module
+
+    fake_lock = _patch_data_fetch_lock(monkeypatch)
+    activity_sessions = [MagicMock(), MagicMock()]
+    monkeypatch.setattr(module, "SessionLocal", lambda: activity_sessions.pop(0))
+    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
+    monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
+    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    failed = MagicMock()
+    monkeypatch.setattr(module, "mark_market_activity_failed", failed)
+    monkeypatch.setattr(
+        module,
+        "get_provider_snapshot_service",
+        lambda: SimpleNamespace(
+            sync_weekly_reference_from_github=lambda db, market, hydrate_cache, hydrate_mode: {
+                "status": "missing",
+                "market": market,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.official_market_universe_source_service.OfficialMarketUniverseSourceService.fetch_market_snapshot",
+        MagicMock(side_effect=requests.exceptions.ConnectionError("remote disconnected")),
+    )
+
+    retry_calls = []
+
+    def fake_retry(*args, **kwargs):
+        retry_calls.append(kwargs)
+        raise Retry("retry")
+
+    monkeypatch.setattr(module.refresh_official_market_universe, "retry", fake_retry)
+    module.refresh_official_market_universe.request.id = "task-123"
+    module.refresh_official_market_universe.request.retries = 0
+
+    with pytest.raises(Retry):
+        module.refresh_official_market_universe.run(market="CN")
+
+    assert retry_calls[0]["countdown"] == 300
+    assert retry_calls[0]["max_retries"] == 12
+    failed.assert_not_called()
+    fake_lock.release.assert_called_once_with("task-123", market="CN")

--- a/backend/tests/unit/use_cases/test_run_bulk_scan.py
+++ b/backend/tests/unit/use_cases/test_run_bulk_scan.py
@@ -605,7 +605,7 @@ class TestRunBulkScanHappyPath:
         )
 
         assert observed_workers == [2]
-        assert scanner.calls == ["AAPL", "MSFT"]
+        assert sorted(scanner.calls) == ["AAPL", "MSFT"]
 
     def test_parallel_workers_ignored_for_partial_prefetch_cache_populating_scans(
         self, monkeypatch

--- a/backend/tests/unit/use_cases/test_run_bulk_scan.py
+++ b/backend/tests/unit/use_cases/test_run_bulk_scan.py
@@ -559,7 +559,9 @@ class TestRunBulkScanHappyPath:
 
         assert observed_workers == [2]
 
-    def test_parallel_workers_ignored_when_cache_only_false(self, monkeypatch):
+    def test_parallel_workers_used_for_prefetched_cache_populating_scans(
+        self, monkeypatch
+    ):
         scan_repo = FakeScanRepository()
         scan_repo.scans["s1"] = _make_scan("s1")
         observed_workers: list[int] = []
@@ -585,8 +587,64 @@ class TestRunBulkScanHappyPath:
             raising=False,
         )
 
-        scanner = FakeScanner()
-        _make_use_case(scanner).execute(
+        scanner = _BulkAwareFakeScanner()
+        RunBulkScanUseCase(
+            scanner=scanner,
+            data_provider=FakeStockDataProvider(),
+        ).execute(
+            FakeUnitOfWork(scans=scan_repo),
+            RunBulkScanCommand(
+                scan_id="s1",
+                symbols=["AAPL", "MSFT"],
+                chunk_size=2,
+                cache_only=False,
+                parallel_workers=4,
+            ),
+            FakeProgressSink(),
+            FakeCancellationToken(),
+        )
+
+        assert observed_workers == [2]
+        assert scanner.calls == ["AAPL", "MSFT"]
+
+    def test_parallel_workers_ignored_for_partial_prefetch_cache_populating_scans(
+        self, monkeypatch
+    ):
+        scan_repo = FakeScanRepository()
+        scan_repo.scans["s1"] = _make_scan("s1")
+        observed_workers: list[int] = []
+
+        class CapturingExecutor:
+            def __init__(self, max_workers):
+                observed_workers.append(max_workers)
+                self._executor = RealThreadPoolExecutor(max_workers=max_workers)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self._executor.shutdown(wait=True)
+                return False
+
+            def submit(self, *args, **kwargs):
+                return self._executor.submit(*args, **kwargs)
+
+        class PartialPrefetchProvider(FakeStockDataProvider):
+            def prepare_data_bulk(self, symbols, requirements, **kwargs):
+                del requirements, kwargs
+                return {symbols[0]: self.prepare_data(symbols[0], object())}
+
+        monkeypatch.setattr(
+            "app.use_cases.scanning.run_bulk_scan.ThreadPoolExecutor",
+            CapturingExecutor,
+            raising=False,
+        )
+
+        scanner = _BulkAwareFakeScanner()
+        RunBulkScanUseCase(
+            scanner=scanner,
+            data_provider=PartialPrefetchProvider(),
+        ).execute(
             FakeUnitOfWork(scans=scan_repo),
             RunBulkScanCommand(
                 scan_id="s1",


### PR DESCRIPTION
## Summary

Fixes several market bootstrap blockers and speeds up the initial bootstrap scan path.

## Changes

- Add runtime fixes for KR/CN universe refresh failures, including pykrx import support, KR listing fallback behavior, bounded CN universe fetch duration, and CN listing fallback handling.
- Improve bootstrap status handling so optional/partial failures do not incorrectly block unrelated market work.
- Reduce initial bootstrap scan cost by excluding `setup_engine` from cache-gated bootstrap defaults while preserving full manual/daily scan defaults.
- Avoid nested setup-engine detector thread pools by making detector execution serial by default, with explicit detector concurrency still available for diagnostics.
- Add INFO-level slow setup-engine detector summaries for future scan performance diagnosis.
- Add tests covering bootstrap profile boundaries and setup-engine detector execution behavior.

## Validation

- `backend/venv/bin/pytest backend/tests/unit/test_aggregator_execution_pipeline.py backend/tests/unit/test_scan_defaults.py backend/tests/unit/test_feature_store_tasks.py backend/tests/unit/test_setup_engine_screener.py -q`: `74 passed`
- `backend/venv/bin/pytest backend/tests/unit/test_cn_market_data_service.py backend/tests/unit/test_universe_tasks.py backend/tests/unit/test_official_market_universe_source_service.py -q`: `39 passed`
- `backend/venv/bin/pytest backend/tests/unit/test_cn_market_data_service.py backend/tests/unit/test_provider_circuit_breaker.py backend/tests/unit/test_celery_config.py -q`: previously passed during this branch work
- `git diff --check`
- `python -m compileall` for changed app files

## Notes

- `bd` is not installed in this local shell, so bead sync commands could not run.
- Local working tree still has unrelated `.beads`, `.plans`, and telemetry files that were not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel detector execution and bounded parallel scanning for faster pattern scans
  * Lightweight bootstrap scan profile that omits heavy screening
  * Progress updates and enforced time limits for market-universe refreshes
  * INFO-level slow-detector timing summaries in logs
  * CI workflows expanded to include Korea (KR) market

* **Bug Fixes**
  * Timeout protection and deterministic fallback for market-data fetching (CN/KR)
  * AKShare retry/cooldown and fallback to alternate sources for OHLCV
  * Safer persistence path for FX rates with atomic upsert on supported DBs

* **Tests**
  * Expanded unit and performance tests covering parallel detectors, timeouts, fallbacks, and bootstrap profiles

* **Chores**
  * Runtime dependency pin added to preserve compatibility (setuptools<81)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->