### PR TITLE
fix: stabilize weekly KR and IN reference refresh

### DIFF
--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -22,6 +22,8 @@ from app.wiring.bootstrap import (
     get_stock_universe_service,
 )
 
+_WEEKLY_NON_US_YFINANCE_DELAY_PER_TICKER = 0.2
+
 
 def _default_output_dir() -> Path:
     return repo_root() / ".tmp" / "weekly-reference"
@@ -89,6 +91,27 @@ def _print_snapshot_publish_summary(snapshot_stats: dict[str, Any]) -> None:
         f"(max={thresholds.get('max_missing_ratio', 0.0):.2%}) "
         f"snapshot_rows={coverage.get('snapshot_symbols', 0)} "
         f"active_symbols={coverage.get('active_symbols', 0)}",
+        flush=True,
+    )
+
+
+def _configure_weekly_hybrid_service(market: str, hybrid_service: Any) -> None:
+    if market == "US" or not hasattr(hybrid_service, "yfinance_delay_per_ticker"):
+        return
+    hybrid_service.yfinance_delay_per_ticker = _WEEKLY_NON_US_YFINANCE_DELAY_PER_TICKER
+    print(
+        "Using weekly non-US yfinance per-ticker delay "
+        f"{_WEEKLY_NON_US_YFINANCE_DELAY_PER_TICKER:.2f}s for {market}",
+        flush=True,
+    )
+
+
+def _print_fundamentals_progress(market: str, completed: float, total: int) -> None:
+    total_count = max(int(total), 1)
+    completed_count = min(int(completed), total_count)
+    percent = (completed_count / total_count) * 100
+    print(
+        f"[fundamentals] {market} {completed_count}/{total_count} ({percent:.1f}%)",
         flush=True,
     )
 
@@ -303,6 +326,7 @@ def _build_asia_bundle(
     official_source_service = OfficialMarketUniverseSourceService()
     fundamentals_cache = get_fundamentals_cache()
     hybrid_service = get_hybrid_fundamentals_service()
+    _configure_weekly_hybrid_service(market, hybrid_service)
 
     print(f"Starting official universe refresh for {market}...", flush=True)
     official_snapshot = official_source_service.fetch_market_snapshot(market)
@@ -329,6 +353,11 @@ def _build_asia_bundle(
         symbols,
         include_technicals=True,
         include_finviz=False,
+        progress_callback=lambda completed, total: _print_fundamentals_progress(
+            market,
+            completed,
+            total,
+        ),
         market_by_symbol=market_by_symbol,
     )
     fundamentals_stats = hybrid_service.store_all_caches(

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -1029,7 +1029,15 @@ class BulkDataFetcher:
                     all_results[symbol] = {'has_error': True, 'error': str(e)}
 
             if progress_callback:
-                progress_callback(end_idx, len(symbols))
+                try:
+                    progress_callback(end_idx, len(symbols))
+                except Exception as exc:
+                    logger.warning(
+                        "Ignoring progress callback failure at batch %d/%d: %s",
+                        batch_num + 1,
+                        total_batches,
+                        exc,
+                    )
 
             # Batch-level backoff: if >50% of batch hit rate limits, back off
             batch_failure_rate = batch_rate_limit_failures / len(batch_symbols) if batch_symbols else 0

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -10,6 +10,7 @@ docs/learning_loop/adr_ll2_e1_canonical_price_contract_v1.md
 """
 import logging
 import math
+from collections.abc import Callable
 from typing import TYPE_CHECKING, List, Dict, Optional, Any
 from threading import RLock
 import yfinance as yf
@@ -898,6 +899,7 @@ class BulkDataFetcher:
         delay_per_ticker: float = 1.5,
         market_by_symbol: Optional[Dict[str, str]] = None,
         market: Optional[str] = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> Dict[str, Dict]:
         """
         Fetch fundamentals for multiple symbols efficiently.
@@ -913,6 +915,8 @@ class BulkDataFetcher:
             delay_per_ticker: Seconds to wait between individual ticker info fetches (default 0.2)
             market_by_symbol: Optional mapping ``{symbol: market}`` for
                 cadence-aware growth extraction.
+            progress_callback: Optional callback invoked after each yfinance batch
+                as ``(processed_symbols, total_symbols)``.
 
         Returns:
             Dict mapping symbols to their fundamental data
@@ -1023,6 +1027,9 @@ class BulkDataFetcher:
                 logger.error(f"Batch error: {e}")
                 for symbol in batch_symbols:
                     all_results[symbol] = {'has_error': True, 'error': str(e)}
+
+            if progress_callback:
+                progress_callback(end_idx, len(symbols))
 
             # Batch-level backoff: if >50% of batch hit rate limits, back off
             batch_failure_rate = batch_rate_limit_failures / len(batch_symbols) if batch_symbols else 0

--- a/backend/app/services/hybrid_fundamentals_service.py
+++ b/backend/app/services/hybrid_fundamentals_service.py
@@ -297,7 +297,8 @@ class HybridFundamentalsService:
         logger.info(f"Phase 1 complete: {yf_success}/{total} in {phase1_time:.1f}s")
 
         if progress_callback:
-            progress_callback(total * 0.3, total)  # 30% after phase 1
+            phase1_checkpoint = max(1, int(total * 0.3)) if total else 0
+            progress_callback(phase1_checkpoint, total)  # 30% after phase 1
 
         # ============================================================
         # Phase 2: Calculate technicals from price cache (~10 min)

--- a/backend/app/services/hybrid_fundamentals_service.py
+++ b/backend/app/services/hybrid_fundamentals_service.py
@@ -278,6 +278,14 @@ class HybridFundamentalsService:
                 delay_between_batches=self.yfinance_delay_between_batches,
                 delay_per_ticker=self.yfinance_delay_per_ticker,
                 market_by_symbol=market_by_symbol,
+                progress_callback=(
+                    lambda completed, yf_total: progress_callback(
+                        max(1, int(total * 0.3 * (completed / max(yf_total, 1)))),
+                        total,
+                    )
+                    if progress_callback
+                    else None
+                ),
             )
 
         for symbol in yfinance_symbols:
@@ -397,6 +405,8 @@ class HybridFundamentalsService:
             if progress_callback:
                 # Always emit completion even when finviz_eligible is empty.
                 progress_callback(total, total)
+        elif progress_callback:
+            progress_callback(total, total)
 
         # Add metadata to all results
         for symbol in symbols:

--- a/backend/app/services/official_market_universe_source_service.py
+++ b/backend/app/services/official_market_universe_source_service.py
@@ -190,11 +190,25 @@ class OfficialMarketUniverseSourceService:
 
     def fetch_kr_snapshot(self) -> OfficialMarketUniverseSnapshot:
         provider = self._get_kr_provider()
-        listing_as_of = self._kr_listing_as_of()
+        requested_listing_as_of = self._kr_listing_as_of()
         rows = list(
-            provider.listing_rows(boards=("KOSPI", "KOSDAQ"), as_of=listing_as_of)
+            provider.listing_rows(boards=("KOSPI", "KOSDAQ"), as_of=requested_listing_as_of)
         )
-        if not rows:
+        historical_listing_empty = False
+        krx_listing_mode = "last_completed_trading_day"
+        listing_as_of = requested_listing_as_of
+        if self._kr_kospi_kosdaq_row_count(rows) == 0:
+            historical_listing_empty = True
+            logger.warning(
+                "KR official universe fetch returned no rows for historical as_of=%s; "
+                "retrying current KRX listing finder.",
+                requested_listing_as_of.isoformat(),
+            )
+            rows = list(provider.listing_rows(boards=("KOSPI", "KOSDAQ"), as_of=None))
+            if self._kr_kospi_kosdaq_row_count(rows) > 0:
+                krx_listing_mode = "current_listing_fallback"
+                listing_as_of = self._seoul_today()
+        if self._kr_kospi_kosdaq_row_count(rows) == 0:
             raise ValueError("KR official universe fetch returned no KOSPI/KOSDAQ rows")
 
         rows = self._enrich_kr_rows_with_taxonomy(rows)
@@ -218,6 +232,9 @@ class OfficialMarketUniverseSourceService:
             "source_urls": [_KR_VALIDATED_BASELINE["source_url"]],
             "fetched_at": datetime.now(UTC).isoformat(),
             "listing_as_of": snapshot_as_of,
+            "requested_listing_as_of": requested_listing_as_of.isoformat(),
+            "krx_listing_mode": krx_listing_mode,
+            "historical_listing_empty": historical_listing_empty,
             "filters": {
                 "boards": ["KOSPI", "KOSDAQ"],
                 "excluded_products": ["ETF", "ETN", "ELW", "funds", "REITs"],
@@ -381,6 +398,14 @@ class OfficialMarketUniverseSourceService:
         return (
             math.ceil(expected * (1.0 - tolerance)),
             math.floor(expected * (1.0 + tolerance)),
+        )
+
+    @staticmethod
+    def _kr_kospi_kosdaq_row_count(rows: Iterable[dict[str, Any]]) -> int:
+        return sum(
+            1
+            for row in rows
+            if str(row.get("exchange") or "").strip().upper() in {"KOSPI", "KOSDAQ"}
         )
 
     @classmethod

--- a/backend/app/services/official_market_universe_source_service.py
+++ b/backend/app/services/official_market_universe_source_service.py
@@ -211,6 +211,7 @@ class OfficialMarketUniverseSourceService:
         if self._kr_kospi_kosdaq_row_count(rows) == 0:
             raise ValueError("KR official universe fetch returned no KOSPI/KOSDAQ rows")
 
+        rows = self._kr_supported_board_rows(rows)
         rows = self._enrich_kr_rows_with_taxonomy(rows)
         row_counts = {
             "kospi": sum(1 for row in rows if str(row.get("exchange") or "").upper() == "KOSPI"),
@@ -405,8 +406,20 @@ class OfficialMarketUniverseSourceService:
         return sum(
             1
             for row in rows
-            if str(row.get("exchange") or "").strip().upper() in {"KOSPI", "KOSDAQ"}
+            if OfficialMarketUniverseSourceService._is_kr_supported_board(row)
         )
+
+    @staticmethod
+    def _kr_supported_board_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [
+            row
+            for row in rows
+            if OfficialMarketUniverseSourceService._is_kr_supported_board(row)
+        ]
+
+    @staticmethod
+    def _is_kr_supported_board(row: dict[str, Any]) -> bool:
+        return str(row.get("exchange") or "").strip().upper() in {"KOSPI", "KOSDAQ"}
 
     @classmethod
     def _kr_baseline_count_breaches(cls, row_counts: dict[str, int]) -> list[dict[str, Any]]:

--- a/backend/app/services/official_market_universe_source_service.py
+++ b/backend/app/services/official_market_universe_source_service.py
@@ -207,7 +207,7 @@ class OfficialMarketUniverseSourceService:
             rows = list(provider.listing_rows(boards=("KOSPI", "KOSDAQ"), as_of=None))
             if self._kr_kospi_kosdaq_row_count(rows) > 0:
                 krx_listing_mode = "current_listing_fallback"
-                listing_as_of = self._seoul_today()
+                listing_as_of = requested_listing_as_of
         if self._kr_kospi_kosdaq_row_count(rows) == 0:
             raise ValueError("KR official universe fetch returned no KOSPI/KOSDAQ rows")
 

--- a/backend/tests/unit/test_bulk_data_fetcher_fast_info_fallback.py
+++ b/backend/tests/unit/test_bulk_data_fetcher_fast_info_fallback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import app.services.bulk_data_fetcher as bulk_data_fetcher_module
 from app.services.bulk_data_fetcher import BulkDataFetcher
 
 
@@ -132,3 +133,39 @@ def test_zero_from_info_is_preserved_not_replaced_by_fast_info():
     )
     assert result["market_cap"] == 0
     assert result["shares_outstanding"] == 0
+
+
+def test_fetch_batch_fundamentals_ignores_progress_callback_failures(monkeypatch, caplog):
+    class FakeTickers:
+        tickers = {
+            "AAPL": SimpleNamespace(
+                info={
+                    "marketCap": 1_000_000,
+                    "sharesOutstanding": 100_000,
+                    "currentPrice": 10.0,
+                }
+            )
+        }
+
+    monkeypatch.setattr(
+        bulk_data_fetcher_module,
+        "_new_yf_tickers",
+        lambda _symbols: FakeTickers(),
+    )
+    fetcher = BulkDataFetcher()
+
+    def broken_progress_callback(_completed, _total):
+        raise RuntimeError("telemetry sink unavailable")
+
+    caplog.set_level("WARNING", logger="app.services.bulk_data_fetcher")
+    result = fetcher.fetch_batch_fundamentals(
+        ["AAPL"],
+        batch_size=1,
+        include_quarterly=False,
+        delay_between_batches=0,
+        delay_per_ticker=0,
+        progress_callback=broken_progress_callback,
+    )
+
+    assert result["AAPL"]["market_cap"] == 1_000_000
+    assert "Ignoring progress callback failure at batch 1/1" in caplog.text

--- a/backend/tests/unit/test_hybrid_fundamentals_service_policy.py
+++ b/backend/tests/unit/test_hybrid_fundamentals_service_policy.py
@@ -178,6 +178,31 @@ class TestPhase3PolicyFiltering:
         assert progress_calls
         assert progress_calls[-1] == (len(symbols), len(symbols))
 
+    def test_progress_callback_reports_yfinance_batch_progress_without_finviz(self):
+        svc = _make_service()
+        symbols = [f"{index:04d}.HK" for index in range(100)]
+        market_by_symbol = {symbol: "HK" for symbol in symbols}
+        progress_calls = []
+
+        def fake_fetch_batch_fundamentals(batch_symbols, **kwargs):
+            kwargs["progress_callback"](50, 100)
+            kwargs["progress_callback"](100, 100)
+            return {symbol: {"market_cap": 1.0} for symbol in batch_symbols}
+
+        svc.bulk_fetcher.fetch_batch_fundamentals.side_effect = fake_fetch_batch_fundamentals
+
+        svc.fetch_fundamentals_batch(
+            symbols,
+            include_technicals=False,
+            include_finviz=False,
+            progress_callback=lambda current, total: progress_calls.append((current, total)),
+            market_by_symbol=market_by_symbol,
+        )
+
+        assert (15, 100) in progress_calls
+        assert (30, 100) in progress_calls
+        assert progress_calls[-1] == (100, 100)
+
     def test_parallel_hybrid_forwards_market_map_to_parallel_growth_extractor(self):
         svc = _make_service()
         svc.bulk_fetcher.fetch_fundamentals_parallel.return_value = {}

--- a/backend/tests/unit/test_hybrid_fundamentals_service_policy.py
+++ b/backend/tests/unit/test_hybrid_fundamentals_service_policy.py
@@ -203,6 +203,28 @@ class TestPhase3PolicyFiltering:
         assert (30, 100) in progress_calls
         assert progress_calls[-1] == (100, 100)
 
+    def test_progress_callback_uses_integer_nonzero_phase1_checkpoint_for_tiny_batch(self):
+        svc = _make_service()
+        progress_calls = []
+
+        def fake_fetch_batch_fundamentals(batch_symbols, **kwargs):
+            kwargs["progress_callback"](1, 1)
+            return {symbol: {"market_cap": 1.0} for symbol in batch_symbols}
+
+        svc.bulk_fetcher.fetch_batch_fundamentals.side_effect = fake_fetch_batch_fundamentals
+
+        svc.fetch_fundamentals_batch(
+            ["0700.HK"],
+            include_technicals=False,
+            include_finviz=False,
+            progress_callback=lambda current, total: progress_calls.append((current, total)),
+            market_by_symbol={"0700.HK": "HK"},
+        )
+
+        assert progress_calls
+        assert all(isinstance(current, int) for current, _total in progress_calls)
+        assert all(current >= 1 for current, _total in progress_calls)
+
     def test_parallel_hybrid_forwards_market_map_to_parallel_growth_extractor(self):
         svc = _make_service()
         svc.bulk_fetcher.fetch_fundamentals_parallel.return_value = {}

--- a/backend/tests/unit/test_official_market_universe_source_service.py
+++ b/backend/tests/unit/test_official_market_universe_source_service.py
@@ -289,6 +289,142 @@ def test_fetch_kr_snapshot_falls_back_to_previous_seoul_weekday_when_calendar_un
     assert snapshot.source_metadata["listing_as_of"] == "2026-05-01"
 
 
+def test_fetch_kr_snapshot_falls_back_to_current_listing_rows_when_historical_empty(monkeypatch):
+    provider_calls = []
+
+    class FakeKrxProvider:
+        def listing_rows(self, *, boards, as_of=None):
+            provider_calls.append((boards, as_of))
+            if as_of is not None:
+                return []
+            return [
+                {
+                    "symbol": "005930.KS",
+                    "local_code": "005930",
+                    "name": "Samsung Electronics",
+                    "exchange": "KOSPI",
+                },
+                {
+                    "symbol": "091990.KQ",
+                    "local_code": "091990",
+                    "name": "Celltrion Healthcare",
+                    "exchange": "KOSDAQ",
+                },
+            ]
+
+    market_calendar = MagicMock()
+    market_calendar.last_completed_trading_day.return_value = date(2026, 4, 30)
+    monkeypatch.setattr(
+        OfficialMarketUniverseSourceService,
+        "_seoul_today",
+        staticmethod(lambda: date(2026, 5, 1)),
+    )
+    service = OfficialMarketUniverseSourceService(
+        kr_provider=FakeKrxProvider(),
+        market_calendar=market_calendar,
+    )
+
+    snapshot = service.fetch_kr_snapshot()
+
+    assert provider_calls == [
+        (("KOSPI", "KOSDAQ"), date(2026, 4, 30)),
+        (("KOSPI", "KOSDAQ"), None),
+    ]
+    assert [row["symbol"] for row in snapshot.rows] == ["005930.KS", "091990.KQ"]
+    assert snapshot.snapshot_id == "krx-listings-2026-05-01"
+    assert snapshot.snapshot_as_of == "2026-05-01"
+    assert snapshot.source_metadata["requested_listing_as_of"] == "2026-04-30"
+    assert snapshot.source_metadata["listing_as_of"] == "2026-05-01"
+    assert snapshot.source_metadata["krx_listing_mode"] == "current_listing_fallback"
+    assert snapshot.source_metadata["historical_listing_empty"] is True
+
+
+def test_fetch_kr_snapshot_raises_when_historical_and_current_listing_rows_are_empty():
+    class EmptyKrxProvider:
+        def listing_rows(self, *, boards, as_of=None):
+            return []
+
+    market_calendar = MagicMock()
+    market_calendar.last_completed_trading_day.return_value = date(2026, 4, 30)
+    service = OfficialMarketUniverseSourceService(
+        kr_provider=EmptyKrxProvider(),
+        market_calendar=market_calendar,
+    )
+
+    with pytest.raises(ValueError, match="KR official universe fetch returned no KOSPI/KOSDAQ rows"):
+        service.fetch_kr_snapshot()
+
+
+def test_fetch_kr_snapshot_falls_back_when_historical_rows_have_no_supported_boards(monkeypatch):
+    provider_calls = []
+
+    class FakeKrxProvider:
+        def listing_rows(self, *, boards, as_of=None):
+            provider_calls.append((boards, as_of))
+            if as_of is not None:
+                return [
+                    {
+                        "symbol": "000001.KN",
+                        "local_code": "000001",
+                        "name": "Konex Only",
+                        "exchange": "KONEX",
+                    }
+                ]
+            return [
+                {
+                    "symbol": "005930.KS",
+                    "local_code": "005930",
+                    "name": "Samsung Electronics",
+                    "exchange": "KOSPI",
+                }
+            ]
+
+    market_calendar = MagicMock()
+    market_calendar.last_completed_trading_day.return_value = date(2026, 4, 30)
+    monkeypatch.setattr(
+        OfficialMarketUniverseSourceService,
+        "_seoul_today",
+        staticmethod(lambda: date(2026, 5, 1)),
+    )
+    service = OfficialMarketUniverseSourceService(
+        kr_provider=FakeKrxProvider(),
+        market_calendar=market_calendar,
+    )
+
+    snapshot = service.fetch_kr_snapshot()
+
+    assert provider_calls == [
+        (("KOSPI", "KOSDAQ"), date(2026, 4, 30)),
+        (("KOSPI", "KOSDAQ"), None),
+    ]
+    assert [row["symbol"] for row in snapshot.rows] == ["005930.KS"]
+    assert snapshot.source_metadata["row_counts"] == {"kospi": 1, "kosdaq": 0}
+    assert snapshot.source_metadata["krx_listing_mode"] == "current_listing_fallback"
+
+
+def test_fetch_kr_snapshot_raises_when_fallback_has_no_supported_boards():
+    class UnsupportedKrxProvider:
+        def listing_rows(self, *, boards, as_of=None):
+            return [
+                {
+                    "symbol": "000001.KN",
+                    "local_code": "000001",
+                    "name": "Konex Only",
+                    "exchange": "KONEX",
+                }
+            ]
+
+    market_calendar = MagicMock()
+    market_calendar.last_completed_trading_day.return_value = date(2026, 4, 30)
+    service = OfficialMarketUniverseSourceService(
+        kr_provider=UnsupportedKrxProvider(),
+        market_calendar=market_calendar,
+    )
+
+    with pytest.raises(ValueError, match="KR official universe fetch returned no KOSPI/KOSDAQ rows"):
+        service.fetch_kr_snapshot()
+
+
 @pytest.mark.parametrize(
     ("today", "expected_previous"),
     [

--- a/backend/tests/unit/test_official_market_universe_source_service.py
+++ b/backend/tests/unit/test_official_market_universe_source_service.py
@@ -402,6 +402,38 @@ def test_fetch_kr_snapshot_falls_back_when_historical_rows_have_no_supported_boa
     assert snapshot.source_metadata["krx_listing_mode"] == "current_listing_fallback"
 
 
+def test_fetch_kr_snapshot_filters_unsupported_boards_from_mixed_rows():
+    class MixedKrxProvider:
+        def listing_rows(self, *, boards, as_of=None):
+            return [
+                {
+                    "symbol": "005930.KS",
+                    "local_code": "005930",
+                    "name": "Samsung Electronics",
+                    "exchange": "KOSPI",
+                },
+                {
+                    "symbol": "000001.KN",
+                    "local_code": "000001",
+                    "name": "Konex Only",
+                    "exchange": "KONEX",
+                },
+            ]
+
+    market_calendar = MagicMock()
+    market_calendar.last_completed_trading_day.return_value = date(2026, 4, 30)
+    service = OfficialMarketUniverseSourceService(
+        kr_provider=MixedKrxProvider(),
+        market_calendar=market_calendar,
+    )
+
+    snapshot = service.fetch_kr_snapshot()
+
+    assert [row["symbol"] for row in snapshot.rows] == ["005930.KS"]
+    assert snapshot.source_metadata["row_counts"] == {"kospi": 1, "kosdaq": 0}
+    assert snapshot.source_metadata["source_count"] == 1
+
+
 def test_fetch_kr_snapshot_raises_when_fallback_has_no_supported_boards():
     class UnsupportedKrxProvider:
         def listing_rows(self, *, boards, as_of=None):

--- a/backend/tests/unit/test_official_market_universe_source_service.py
+++ b/backend/tests/unit/test_official_market_universe_source_service.py
@@ -317,7 +317,7 @@ def test_fetch_kr_snapshot_falls_back_to_current_listing_rows_when_historical_em
     monkeypatch.setattr(
         OfficialMarketUniverseSourceService,
         "_seoul_today",
-        staticmethod(lambda: date(2026, 5, 1)),
+        staticmethod(lambda: date(2026, 5, 2)),
     )
     service = OfficialMarketUniverseSourceService(
         kr_provider=FakeKrxProvider(),
@@ -331,10 +331,10 @@ def test_fetch_kr_snapshot_falls_back_to_current_listing_rows_when_historical_em
         (("KOSPI", "KOSDAQ"), None),
     ]
     assert [row["symbol"] for row in snapshot.rows] == ["005930.KS", "091990.KQ"]
-    assert snapshot.snapshot_id == "krx-listings-2026-05-01"
-    assert snapshot.snapshot_as_of == "2026-05-01"
+    assert snapshot.snapshot_id == "krx-listings-2026-04-30"
+    assert snapshot.snapshot_as_of == "2026-04-30"
     assert snapshot.source_metadata["requested_listing_as_of"] == "2026-04-30"
-    assert snapshot.source_metadata["listing_as_of"] == "2026-05-01"
+    assert snapshot.source_metadata["listing_as_of"] == "2026-04-30"
     assert snapshot.source_metadata["krx_listing_mode"] == "current_listing_fallback"
     assert snapshot.source_metadata["historical_listing_empty"] is True
 

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -241,11 +241,15 @@ def test_build_weekly_reference_bundle_runs_hk_official_path(monkeypatch, tmp_pa
     monkeypatch.setattr(build_script, "get_stock_universe_service", lambda: stock_universe_service)
 
     hybrid_calls: list[dict[str, object]] = []
+
+    def fake_fetch_fundamentals_batch(symbols, **kwargs):
+        hybrid_calls.append({"symbols": symbols, **kwargs})
+        kwargs["progress_callback"](1, len(symbols))
+        return {"0700.HK": {"market_cap": 456.0, "sector": "Technology"}}
+
     hybrid_service = SimpleNamespace(
-        fetch_fundamentals_batch=lambda symbols, **kwargs: hybrid_calls.append(
-            {"symbols": symbols, **kwargs}
-        )
-        or {"0700.HK": {"market_cap": 456.0, "sector": "Technology"}},
+        yfinance_delay_per_ticker=1.5,
+        fetch_fundamentals_batch=fake_fetch_fundamentals_batch,
         store_all_caches=lambda *args, **kwargs: {
             "fundamentals_stored": 1,
             "persisted_symbols": 1,
@@ -317,6 +321,8 @@ def test_build_weekly_reference_bundle_runs_hk_official_path(monkeypatch, tmp_pa
     assert fetch_calls == ["HK"]
     assert hybrid_calls[0]["include_finviz"] is False
     assert hybrid_calls[0]["market_by_symbol"] == {"0700.HK": "HK"}
+    assert callable(hybrid_calls[0]["progress_callback"])
+    assert hybrid_service.yfinance_delay_per_ticker == build_script._WEEKLY_NON_US_YFINANCE_DELAY_PER_TICKER
     assert published_rows[0]["snapshot_key"] == build_script.ProviderSnapshotService.snapshot_key_for_market("HK")
     assert published_rows[0]["market"] == "HK"
     assert export_calls[0]["output_path"] == (
@@ -326,7 +332,12 @@ def test_build_weekly_reference_bundle_runs_hk_official_path(monkeypatch, tmp_pa
     assert export_calls[0]["market"] == "HK"
     stdout = capsys.readouterr().out
     assert "Starting official universe refresh for HK..." in stdout
+    assert (
+        "Using weekly non-US yfinance per-ticker delay "
+        f"{build_script._WEEKLY_NON_US_YFINANCE_DELAY_PER_TICKER:.2f}s for HK"
+    ) in stdout
     assert "Starting hybrid fundamentals refresh for HK..." in stdout
+    assert "[fundamentals] HK 1/1 (100.0%)" in stdout
     assert "Fundamentals refresh complete:" in stdout
     assert "[publish] market=HK coverage=100.00% (min=70.00%) missing_ratio=0.00% (max=30.00%)" in stdout
     assert "Weekly reference bundle complete for HK:" in stdout


### PR DESCRIPTION
## Summary
- Add a KR KRX fallback from the last-completed trading-day listing snapshot to current listings when the historical fetch has no supported KOSPI/KOSDAQ rows.
- Preserve explicit KR metadata for requested historical date, fallback mode, fallback row counts, and baseline drift warnings.
- Add weekly Asia refresh progress output during yfinance fundamentals hydration and reduce non-US weekly yfinance per-ticker delay.
- Add focused tests for KR fallback behavior, empty fallback failure, IN official-source merge behavior, weekly script wiring, and yfinance progress reporting.

## Root Cause
- KR weekly refresh failed deterministically because KRX historical ticker calls for 2026-04-30 returned no usable KOSPI/KOSDAQ rows and the official universe path hard-failed instead of falling back to current listings.
- IN did not show an app exception in Actions; the hosted runner lost communication after a long weekly bundle build, likely during non-US yfinance fundamentals hydration.

## Validation
- `PYTHONPATH=. /Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest tests/unit/test_official_market_universe_source_service.py tests/unit/test_kr_market_data_service.py tests/unit/test_weekly_reference_scripts.py tests/unit/test_hybrid_fundamentals_service_policy.py -q` -> 51 passed.
- `git diff --check` passed.
- KR source smoke returned current fallback metadata with 2703 rows: 924 KOSPI and 1779 KOSDAQ.

## Notes
- Full backend `pytest` still has unrelated pre-existing failures, including localhost-dependent integration collection and unrelated unit failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time progress reporting during fundamentals batch fetch operations, enabling visibility into data processing stages.

* **Bug Fixes**
  * Enhanced Korea stock exchange (KRX) snapshot data retrieval with a two-stage fallback strategy. When historical listing data is unavailable, the system automatically falls back to current listings, improving data completeness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->