### PR TITLE
fix: reuse static market artifacts from fallback run

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -277,21 +277,132 @@ jobs:
       - name: Install frontend dependencies
         run: cd frontend && npm ci
 
-      - name: Download market artifacts
+      - name: Download current market artifacts
         id: download-market-artifacts
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: static-market-*
-          path: /tmp/static-market-artifacts
+          path: /tmp/static-market-artifacts-current
+          merge-multiple: false
+
+      - name: Find latest successful static site fallback run
+        id: fallback-run
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          WORKFLOW_NAME: ${{ github.event.workflow || 'Static Site' }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          from urllib.parse import urlencode
+
+          repo = os.environ["REPOSITORY"]
+          current_run_id = int(os.environ["CURRENT_RUN_ID"])
+          branch_name = os.environ["BRANCH_NAME"]
+          workflow_name = os.environ["WORKFLOW_NAME"]
+          query = urlencode(
+              {
+                  "branch": branch_name,
+                  "status": "completed",
+                  "per_page": "100",
+              }
+          )
+          fallback_run_id = ""
+
+          def warn(message):
+              print(
+                  f"::warning::Unable to discover fallback static-site run: {message}",
+                  flush=True,
+              )
+
+          def extract_runs(payload):
+              if isinstance(payload, dict):
+                  workflow_runs = payload.get("workflow_runs")
+                  if not isinstance(workflow_runs, list):
+                      raise ValueError(
+                          "Unexpected GitHub API response shape: workflow_runs is not a list."
+                      )
+                  return [run for run in workflow_runs if isinstance(run, dict)]
+
+              if isinstance(payload, list):
+                  runs = []
+                  for page in payload:
+                      if not isinstance(page, dict):
+                          raise ValueError(
+                              "Unexpected GitHub API response shape: page is not an object."
+                          )
+                      workflow_runs = page.get("workflow_runs", [])
+                      if not isinstance(workflow_runs, list):
+                          raise ValueError(
+                              "Unexpected GitHub API response shape: workflow_runs is not a list."
+                          )
+                      runs.extend(run for run in workflow_runs if isinstance(run, dict))
+                  return runs
+
+              raise ValueError(
+                  "Unexpected GitHub API response shape: response is not an object or list."
+              )
+
+          try:
+              result = subprocess.run(
+                  [
+                      "gh",
+                      "api",
+                      "--paginate",
+                      "--slurp",
+                      f"repos/{repo}/actions/workflows/static-site.yml/runs?{query}",
+                  ],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+              pages = json.loads(result.stdout)
+              runs = extract_runs(pages)
+              for run in runs:
+                  if run.get("id") == current_run_id:
+                      continue
+                  if run.get("conclusion") == "success":
+                      fallback_run_id = str(run["id"])
+                      break
+          except subprocess.CalledProcessError as exc:
+              warn(f"GitHub API request failed with exit {exc.returncode}.")
+          except json.JSONDecodeError as exc:
+              warn(f"GitHub API response was not valid JSON ({exc}).")
+          except (AttributeError, KeyError, TypeError, ValueError) as exc:
+              warn(str(exc))
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"run_id={fallback_run_id}\n")
+
+          if fallback_run_id:
+              print(f"Using {workflow_name} fallback run {fallback_run_id} on {branch_name}.")
+          else:
+              print(f"No successful prior {workflow_name} fallback run found on {branch_name}.")
+          PY
+
+      - name: Download fallback market artifacts
+        if: ${{ steps.fallback-run.outputs.run_id != '' }}
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ steps.fallback-run.outputs.run_id }}
+          github-token: ${{ github.token }}
+          pattern: static-market-*
+          path: /tmp/static-market-artifacts-fallback
           merge-multiple: false
 
       - name: Validate market artifacts
         run: |
-          mkdir -p /tmp/static-market-artifacts
-          find /tmp/static-market-artifacts -type f -name 'manifest.market.json'
-          if ! find /tmp/static-market-artifacts -type f -name 'manifest.market.json' | grep -q .; then
-            echo "No market artifacts were produced by the matrix build." >&2
+          mkdir -p /tmp/static-market-artifacts-current /tmp/static-market-artifacts-fallback
+          find /tmp/static-market-artifacts-current /tmp/static-market-artifacts-fallback -type f -name 'manifest.market.json'
+          if ! find /tmp/static-market-artifacts-current /tmp/static-market-artifacts-fallback -type f -name 'manifest.market.json' | grep -q .; then
+            echo "No current or fallback market artifacts are available." >&2
             exit 1
           fi
 
@@ -300,7 +411,8 @@ jobs:
           cd backend
           python -m app.scripts.export_static_site \
             --output-dir ../frontend/public/static-data \
-            --combine-artifacts-dir /tmp/static-market-artifacts
+            --combine-artifacts-dir /tmp/static-market-artifacts-current \
+            --fallback-artifacts-dir /tmp/static-market-artifacts-fallback
 
       - name: Build static frontend
         env:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -524,6 +524,10 @@ def main() -> int:
         help="Combine previously exported market artifacts from this directory into one static-data bundle.",
     )
     parser.add_argument(
+        "--fallback-artifacts-dir",
+        help="Optional previous-run market artifacts directory used to fill markets missing from --combine-artifacts-dir.",
+    )
+    parser.add_argument(
         "--build-mode",
         choices=(STATIC_BUILD_MODE_PRICE_DELTA, STATIC_BUILD_MODE_FULL),
         default=STATIC_BUILD_MODE_PRICE_DELTA,
@@ -555,12 +559,19 @@ def main() -> int:
         raise SystemExit("--combine-artifacts-dir cannot be used together with --refresh-daily")
     if args.combine_artifacts_dir and args.market:
         raise SystemExit("--combine-artifacts-dir cannot be used together with --market")
+    if args.fallback_artifacts_dir and not args.combine_artifacts_dir:
+        raise SystemExit("--fallback-artifacts-dir requires --combine-artifacts-dir")
 
     refresh_warnings: list[str] = []
     if args.combine_artifacts_dir:
         result = StaticSiteExportService.combine_market_artifacts(
             Path(args.combine_artifacts_dir),
             Path(args.output_dir),
+            fallback_artifacts_dir=(
+                Path(args.fallback_artifacts_dir)
+                if args.fallback_artifacts_dir
+                else None
+            ),
             clean=not args.no_clean,
         )
     else:

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -230,6 +230,7 @@ class StaticSiteExportService:
         artifacts_dir: Path,
         output_dir: Path,
         *,
+        fallback_artifacts_dir: Path | None = None,
         clean: bool = True,
     ) -> StaticSiteExportResult:
         artifacts_dir = Path(artifacts_dir)
@@ -245,7 +246,20 @@ class StaticSiteExportService:
             artifacts_dir=artifacts_dir,
             output_dir=output_dir,
             warnings=warnings,
+            allow_empty=True,
         )
+        if fallback_artifacts_dir is not None:
+            fallback_entries, warnings = cls._collect_market_artifacts(
+                artifacts_dir=Path(fallback_artifacts_dir),
+                output_dir=output_dir,
+                warnings=warnings,
+                skip_markets=set(market_entries),
+                allow_empty=True,
+                fallback_source=True,
+            )
+            market_entries.update(fallback_entries)
+        if not market_entries:
+            raise RuntimeError("No market artifacts are available to combine into a static-site bundle")
         missing_markets = [
             market for market in STATIC_SUPPORTED_MARKETS if market not in market_entries
         ]
@@ -446,12 +460,31 @@ class StaticSiteExportService:
         artifacts_dir: Path,
         output_dir: Path,
         warnings: list[str],
+        skip_markets: set[str] | None = None,
+        allow_empty: bool = False,
+        fallback_source: bool = False,
     ) -> tuple[dict[str, dict[str, Any]], list[str]]:
         market_entries: dict[str, dict[str, Any]] = {}
-        metadata_paths = sorted(artifacts_dir.rglob(STATIC_MARKET_METADATA_FILENAME))
+        skipped = skip_markets or set()
+        metadata_paths = sorted(artifacts_dir.rglob(STATIC_MARKET_METADATA_FILENAME)) if artifacts_dir.exists() else []
         for metadata_path in metadata_paths:
             payload = json.loads(metadata_path.read_text(encoding="utf-8"))
             market = str(payload["market"]).upper()
+            schema_version = payload.get("schema_version")
+            if schema_version != STATIC_SITE_SCHEMA_VERSION:
+                message = (
+                    f"{market} artifact uses schema_version {schema_version!r}; "
+                    f"expected {STATIC_SITE_SCHEMA_VERSION!r}."
+                )
+                if fallback_source:
+                    warnings.append(
+                        f"{market} fallback artifact uses schema_version {schema_version!r}; "
+                        f"expected {STATIC_SITE_SCHEMA_VERSION!r}. Skipping."
+                    )
+                    continue
+                raise RuntimeError(f"Invalid market metadata payload at {metadata_path}: {message}")
+            if market in skipped:
+                continue
             entry = payload.get("entry")
             if not isinstance(entry, dict):
                 raise RuntimeError(f"Invalid market metadata payload at {metadata_path}")
@@ -460,8 +493,12 @@ class StaticSiteExportService:
             shutil.copytree(source_market_dir, target_market_dir, dirs_exist_ok=True)
             market_entries[market] = entry
             warnings.extend(str(item) for item in payload.get("warnings", []))
+            if fallback_source:
+                warnings.append(
+                    f"{market} reused from previous successful static-site workflow run because the current run produced no artifact."
+                )
 
-        if not market_entries:
+        if not market_entries and not allow_empty:
             raise RuntimeError("No market artifacts are available to combine into a static-site bundle")
         return market_entries, warnings
 

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -757,3 +757,71 @@ def test_main_rejects_market_in_combine_mode(monkeypatch, tmp_path):
         export_script.main()
 
     assert combine_calls == []
+
+
+def test_main_rejects_fallback_artifacts_without_combine_mode(monkeypatch, tmp_path):
+    combine_calls: list[tuple[object, object, object, bool]] = []
+
+    monkeypatch.setattr(
+        export_script.StaticSiteExportService,
+        "combine_market_artifacts",
+        lambda artifacts_dir, output_dir, *, fallback_artifacts_dir=None, clean=True: combine_calls.append(
+            (artifacts_dir, output_dir, fallback_artifacts_dir, clean)
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_static_site.py",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--fallback-artifacts-dir",
+            str(tmp_path / "fallback"),
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="--fallback-artifacts-dir requires --combine-artifacts-dir"):
+        export_script.main()
+
+    assert combine_calls == []
+
+
+def test_main_passes_fallback_artifacts_dir_to_combine(monkeypatch, tmp_path):
+    combine_calls: list[tuple[object, object, object, bool]] = []
+    output_dir = tmp_path / "out"
+    artifacts_dir = tmp_path / "artifacts"
+    fallback_dir = tmp_path / "fallback"
+
+    monkeypatch.setattr(
+        export_script.StaticSiteExportService,
+        "combine_market_artifacts",
+        lambda artifacts_dir, output_dir, *, fallback_artifacts_dir=None, clean=True: combine_calls.append(
+            (artifacts_dir, output_dir, fallback_artifacts_dir, clean)
+        )
+        or SimpleNamespace(
+            output_dir=output_dir,
+            generated_at="2026-04-05T22:00:00Z",
+            as_of_date="2026-04-05",
+            warnings=(),
+            manifest={},
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_static_site.py",
+            "--output-dir",
+            str(output_dir),
+            "--combine-artifacts-dir",
+            str(artifacts_dir),
+            "--fallback-artifacts-dir",
+            str(fallback_dir),
+            "--no-clean",
+        ],
+    )
+
+    assert export_script.main() == 0
+
+    assert combine_calls == [(artifacts_dir, output_dir, fallback_dir, False)]

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -689,6 +689,189 @@ def test_combine_market_artifacts_builds_manifest_from_subset(tmp_path):
     assert any("TW" in warning for warning in manifest["warnings"])
 
 
+def test_combine_market_artifacts_uses_fallback_only_for_missing_markets(tmp_path):
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    output_dir = tmp_path / "combined"
+
+    current_us_dir = current_dir / "static-market-US" / "markets" / "us"
+    fallback_us_dir = fallback_dir / "static-market-US" / "markets" / "us"
+    fallback_hk_dir = fallback_dir / "static-market-HK" / "markets" / "hk"
+    for market_dir in (current_us_dir, fallback_us_dir, fallback_hk_dir):
+        (market_dir / "scan").mkdir(parents=True)
+        (market_dir / "scan" / "manifest.json").write_text(
+            json.dumps({"source": str(market_dir)}),
+            encoding="utf-8",
+        )
+
+    current_us_entry = {
+        "market": "US",
+        "display_name": "United States",
+        "as_of_date": "2026-04-05",
+        "features": {"scan": True, "breadth": True, "groups": True, "charts": True},
+        "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
+    }
+    fallback_us_entry = {
+        "market": "US",
+        "display_name": "United States",
+        "as_of_date": "2026-04-04",
+        "features": {"scan": True, "breadth": True, "groups": True, "charts": True},
+        "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
+    }
+    fallback_hk_entry = {
+        "market": "HK",
+        "display_name": "Hong Kong",
+        "as_of_date": "2026-04-03",
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": False},
+        "pages": {"scan": {"path": "markets/hk/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/hk/charts/index.json", "limit": 200, "symbols_total": 0}},
+    }
+
+    for market_dir, market, entry in (
+        (current_us_dir, "US", current_us_entry),
+        (fallback_us_dir, "US", fallback_us_entry),
+        (fallback_hk_dir, "HK", fallback_hk_entry),
+    ):
+        (market_dir / STATIC_MARKET_METADATA_FILENAME).write_text(
+            json.dumps(
+                {
+                    "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                    "generated_at": "2026-04-05T22:00:00Z",
+                    "market": market,
+                    "entry": entry,
+                    "warnings": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    result = StaticSiteExportService.combine_market_artifacts(
+        current_dir,
+        output_dir,
+        fallback_artifacts_dir=fallback_dir,
+    )
+
+    manifest = result.manifest
+    assert manifest["supported_markets"] == ["US", "HK"]
+    assert manifest["markets"]["US"]["as_of_date"] == "2026-04-05"
+    assert manifest["markets"]["HK"]["as_of_date"] == "2026-04-03"
+    assert json.loads((output_dir / "markets" / "us" / "scan" / "manifest.json").read_text(encoding="utf-8")) == {
+        "source": str(current_us_dir)
+    }
+    assert json.loads((output_dir / "markets" / "hk" / "scan" / "manifest.json").read_text(encoding="utf-8")) == {
+        "source": str(fallback_hk_dir)
+    }
+    assert "HK reused from previous successful static-site workflow run because the current run produced no artifact." in manifest["warnings"]
+    assert not any(warning.startswith("US reused from previous") for warning in manifest["warnings"])
+
+
+def test_combine_market_artifacts_accepts_fallback_when_current_is_empty(tmp_path):
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    fallback_jp_dir = fallback_dir / "static-market-JP" / "markets" / "jp"
+    output_dir = tmp_path / "combined"
+
+    current_dir.mkdir()
+    (fallback_jp_dir / "scan").mkdir(parents=True)
+    (fallback_jp_dir / "scan" / "manifest.json").write_text('{"ok": true}\n', encoding="utf-8")
+    fallback_entry = {
+        "market": "JP",
+        "display_name": "Japan",
+        "as_of_date": "2026-04-03",
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": False},
+        "pages": {"scan": {"path": "markets/jp/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/jp/charts/index.json", "limit": 200, "symbols_total": 0}},
+    }
+    (fallback_jp_dir / STATIC_MARKET_METADATA_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                "generated_at": "2026-04-03T22:00:00Z",
+                "market": "JP",
+                "entry": fallback_entry,
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = StaticSiteExportService.combine_market_artifacts(
+        current_dir,
+        output_dir,
+        fallback_artifacts_dir=fallback_dir,
+    )
+
+    assert result.manifest["supported_markets"] == ["JP"]
+    assert (output_dir / "markets" / "jp" / "scan" / "manifest.json").exists()
+    assert "JP reused from previous successful static-site workflow run because the current run produced no artifact." in result.warnings
+
+
+def test_combine_market_artifacts_rejects_fallback_with_mismatched_schema(tmp_path):
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    current_us_dir = current_dir / "static-market-US" / "markets" / "us"
+    fallback_jp_dir = fallback_dir / "static-market-JP" / "markets" / "jp"
+    output_dir = tmp_path / "combined"
+
+    (current_us_dir / "scan").mkdir(parents=True)
+    (current_us_dir / "scan" / "manifest.json").write_text('{"ok": true}\n', encoding="utf-8")
+    (fallback_jp_dir / "scan").mkdir(parents=True)
+    (fallback_jp_dir / "scan" / "manifest.json").write_text('{"ok": true}\n', encoding="utf-8")
+    current_entry = {
+        "market": "US",
+        "display_name": "United States",
+        "as_of_date": "2026-04-05",
+        "features": {"scan": True, "breadth": True, "groups": True, "charts": True},
+        "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
+    }
+    fallback_entry = {
+        "market": "JP",
+        "display_name": "Japan",
+        "as_of_date": "2026-04-03",
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": False},
+        "pages": {"scan": {"path": "markets/jp/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/jp/charts/index.json", "limit": 200, "symbols_total": 0}},
+    }
+    (current_us_dir / STATIC_MARKET_METADATA_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                "generated_at": "2026-04-05T22:00:00Z",
+                "market": "US",
+                "entry": current_entry,
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (fallback_jp_dir / STATIC_MARKET_METADATA_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": "static-site-v1",
+                "generated_at": "2026-04-03T22:00:00Z",
+                "market": "JP",
+                "entry": fallback_entry,
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = StaticSiteExportService.combine_market_artifacts(
+        current_dir,
+        output_dir,
+        fallback_artifacts_dir=fallback_dir,
+    )
+
+    assert result.manifest["supported_markets"] == ["US"]
+    assert "JP fallback artifact uses schema_version 'static-site-v1'; expected 'static-site-v2'. Skipping." in result.warnings
+    assert (output_dir / "markets" / "us" / "scan" / "manifest.json").exists()
+    assert not (output_dir / "markets" / "jp").exists()
+
+
 def test_build_manifest_orders_india_between_hk_and_jp():
     market_entries = {
         "US": {

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -14,6 +14,14 @@ def _build_market_job() -> str:
     )[0]
 
 
+def _combine_and_build_job() -> str:
+    content = (ROOT / ".github" / "workflows" / "static-site.yml").read_text()
+    return content.split("  combine-and-build:\n", 1)[1].split(
+        "\n  deploy:",
+        1,
+    )[0]
+
+
 def test_static_site_market_build_failures_are_not_marked_continue_on_error() -> None:
     build_market_job = _build_market_job()
 
@@ -28,3 +36,22 @@ def test_static_site_daily_price_seed_allows_stale_bootstrap() -> None:
     )[0]
 
     assert "--allow-stale" in seed_step
+
+
+def test_static_site_combine_downloads_current_and_fallback_market_artifacts() -> None:
+    combine_job = _combine_and_build_job()
+
+    assert "Find latest successful static site fallback run" in combine_job
+    assert "Download current market artifacts" in combine_job
+    assert "Download fallback market artifacts" in combine_job
+    assert "/tmp/static-market-artifacts-current" in combine_job
+    assert "/tmp/static-market-artifacts-fallback" in combine_job
+    assert "--fallback-artifacts-dir /tmp/static-market-artifacts-fallback" in combine_job
+    assert "github.event.workflow" in combine_job
+    assert "github.ref_name" in combine_job
+    assert "--paginate" in combine_job
+    assert "subprocess.CalledProcessError" in combine_job
+    assert "::warning::Unable to discover fallback static-site run" in combine_job
+    assert "isinstance(payload, dict)" in combine_job
+    assert "isinstance(page, dict)" in combine_job
+    assert "Unexpected GitHub API response shape" in combine_job


### PR DESCRIPTION
## Summary
- Add static export fallback artifact support so current market artifacts win and missing markets can be filled from a prior successful static-site run.
- Update the Static Site workflow to download current market artifacts separately from prior-run fallback artifacts, with paginated best-effort fallback discovery.
- Add regression coverage for CLI validation, artifact precedence/reuse, fallback-only combine behavior, and workflow wiring.

## Test Plan
- `cd backend && source venv/bin/activate && pytest tests/unit/test_static_site_workflow.py tests/unit/test_export_static_site_script.py tests/unit/test_static_site_export_service.py`
- Result: `52 passed, 19 warnings`

## Notes
- Fallback lookup is optional: GitHub API/JSON failures emit a workflow warning and continue with current artifacts.
- Existing local unstaged `.beads`, `.plans`, `CONTEXT.md`, telemetry, and docs files were not included in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Static site builds now support using previously exported market artifacts as a fallback when current artifacts are missing or incomplete.

* **Chores**
  * Updated build workflow and export script to manage fallback artifact directories.

* **Tests**
  * Added tests for artifact fallback behavior across the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->