### PR TITLE
fix: use per-market static fallback artifacts

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -286,26 +286,29 @@ jobs:
           path: /tmp/static-market-artifacts-current
           merge-multiple: false
 
-      - name: Find latest successful static site fallback run
-        id: fallback-run
+      - name: Download per-market fallback artifacts
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           CURRENT_RUN_ID: ${{ github.run_id }}
           BRANCH_NAME: ${{ github.ref_name }}
-          WORKFLOW_NAME: ${{ github.event.workflow || 'Static Site' }}
+          FALLBACK_MARKETS: US HK IN JP KR TW
         run: |
           python - <<'PY'
           import json
           import os
+          import shutil
           import subprocess
+          from pathlib import Path
           from urllib.parse import urlencode
 
           repo = os.environ["REPOSITORY"]
           current_run_id = int(os.environ["CURRENT_RUN_ID"])
           branch_name = os.environ["BRANCH_NAME"]
-          workflow_name = os.environ["WORKFLOW_NAME"]
+          markets = os.environ["FALLBACK_MARKETS"].split()
+          fallback_dir = Path("/tmp/static-market-artifacts-fallback")
+          fallback_dir.mkdir(parents=True, exist_ok=True)
           query = urlencode(
               {
                   "branch": branch_name,
@@ -313,11 +316,11 @@ jobs:
                   "per_page": "100",
               }
           )
-          fallback_run_id = ""
+          remaining_markets = set(markets)
 
           def warn(message):
               print(
-                  f"::warning::Unable to discover fallback static-site run: {message}",
+                  f"::warning::Unable to download fallback market artifact: {message}",
                   flush=True,
               )
 
@@ -349,53 +352,139 @@ jobs:
                   "Unexpected GitHub API response shape: response is not an object or list."
               )
 
-          try:
+          def extract_artifacts(payload):
+              if isinstance(payload, dict):
+                  artifacts = payload.get("artifacts")
+                  if not isinstance(artifacts, list):
+                      raise ValueError(
+                          "Unexpected GitHub API response shape: artifacts is not a list."
+                      )
+                  return [artifact for artifact in artifacts if isinstance(artifact, dict)]
+
+              if isinstance(payload, list):
+                  artifacts = []
+                  for page in payload:
+                      if not isinstance(page, dict):
+                          raise ValueError(
+                              "Unexpected GitHub API response shape: page is not an object."
+                          )
+                      page_artifacts = page.get("artifacts", [])
+                      if not isinstance(page_artifacts, list):
+                          raise ValueError(
+                              "Unexpected GitHub API response shape: artifacts is not a list."
+                          )
+                      artifacts.extend(
+                          artifact for artifact in page_artifacts if isinstance(artifact, dict)
+                      )
+                  return artifacts
+
+              raise ValueError(
+                  "Unexpected GitHub API response shape: response is not an object or list."
+              )
+
+          def gh_json(args):
               result = subprocess.run(
-                  [
-                      "gh",
-                      "api",
-                      "--paginate",
-                      "--slurp",
-                      f"repos/{repo}/actions/workflows/static-site.yml/runs?{query}",
-                  ],
+                  ["gh", *args],
                   check=True,
                   capture_output=True,
                   text=True,
               )
-              pages = json.loads(result.stdout)
+              return json.loads(result.stdout)
+
+          try:
+              pages = gh_json(
+                  [
+                      "api",
+                      "--paginate",
+                      "--slurp",
+                      f"repos/{repo}/actions/workflows/static-site.yml/runs?{query}",
+                  ]
+              )
               runs = extract_runs(pages)
-              for run in runs:
-                  if run.get("id") == current_run_id:
-                      continue
-                  if run.get("conclusion") == "success":
-                      fallback_run_id = str(run["id"])
-                      break
           except subprocess.CalledProcessError as exc:
-              warn(f"GitHub API request failed with exit {exc.returncode}.")
+              warn(f"GitHub workflow runs API request failed with exit {exc.returncode}.")
+              runs = []
           except json.JSONDecodeError as exc:
-              warn(f"GitHub API response was not valid JSON ({exc}).")
+              warn(f"GitHub workflow runs API response was not valid JSON ({exc}).")
+              runs = []
           except (AttributeError, KeyError, TypeError, ValueError) as exc:
               warn(str(exc))
+              runs = []
 
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"run_id={fallback_run_id}\n")
+          for run in runs:
+              run_id = run.get("id")
+              if run_id == current_run_id:
+                  continue
+              if not remaining_markets:
+                  break
 
-          if fallback_run_id:
-              print(f"Using {workflow_name} fallback run {fallback_run_id} on {branch_name}.")
-          else:
-              print(f"No successful prior {workflow_name} fallback run found on {branch_name}.")
+              try:
+                  artifact_pages = gh_json(
+                      [
+                          "api",
+                          "--paginate",
+                          "--slurp",
+                          f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100",
+                      ]
+                  )
+                  artifacts = extract_artifacts(artifact_pages)
+              except subprocess.CalledProcessError as exc:
+                  warn(f"Artifact list API request for run {run_id} failed with exit {exc.returncode}.")
+                  continue
+              except json.JSONDecodeError as exc:
+                  warn(f"Artifact list API response for run {run_id} was not valid JSON ({exc}).")
+                  continue
+              except (AttributeError, KeyError, TypeError, ValueError) as exc:
+                  warn(f"Artifact list API response for run {run_id} was invalid: {exc}")
+                  continue
+
+              artifacts_by_name = {
+                  str(artifact.get("name")): artifact
+                  for artifact in artifacts
+                  if not artifact.get("expired")
+              }
+
+              for market in list(remaining_markets):
+                  artifact_name = f"static-market-{market}"
+                  if artifact_name not in artifacts_by_name:
+                      continue
+
+                  target_dir = fallback_dir / artifact_name
+                  if target_dir.exists():
+                      shutil.rmtree(target_dir)
+
+                  try:
+                      subprocess.run(
+                          [
+                              "gh",
+                              "run",
+                              "download",
+                              str(run_id),
+                              "--repo",
+                              repo,
+                              "--name",
+                              artifact_name,
+                              "--dir",
+                              str(target_dir),
+                          ],
+                          check=True,
+                          capture_output=True,
+                          text=True,
+                      )
+                  except subprocess.CalledProcessError as exc:
+                      warn(f"{artifact_name} from run {run_id} failed to download with exit {exc.returncode}.")
+                      continue
+
+                  remaining_markets.remove(market)
+                  print(
+                      f"Using fallback artifact {artifact_name} from Static Site run {run_id} on {branch_name}.",
+                      flush=True,
+                  )
+
+          for market in markets:
+              if market in remaining_markets:
+                  print(f"No fallback artifact static-market-{market} found on {branch_name}.")
           PY
-
-      - name: Download fallback market artifacts
-        if: ${{ steps.fallback-run.outputs.run_id != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          run-id: ${{ steps.fallback-run.outputs.run_id }}
-          github-token: ${{ github.token }}
-          pattern: static-market-*
-          path: /tmp/static-market-artifacts-fallback
-          merge-multiple: false
 
       - name: Validate market artifacts
         run: |

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -307,6 +307,7 @@ jobs:
           current_run_id = int(os.environ["CURRENT_RUN_ID"])
           branch_name = os.environ["BRANCH_NAME"]
           markets = os.environ["FALLBACK_MARKETS"].split()
+          current_dir = Path("/tmp/static-market-artifacts-current")
           fallback_dir = Path("/tmp/static-market-artifacts-fallback")
           fallback_dir.mkdir(parents=True, exist_ok=True)
           query = urlencode(
@@ -316,7 +317,6 @@ jobs:
                   "per_page": "100",
               }
           )
-          remaining_markets = set(markets)
 
           def warn(message):
               print(
@@ -351,6 +351,24 @@ jobs:
               raise ValueError(
                   "Unexpected GitHub API response shape: response is not an object or list."
               )
+
+          def collect_current_markets():
+              current_markets = set()
+              metadata_paths = (
+                  sorted(current_dir.rglob("manifest.market.json"))
+                  if current_dir.exists()
+                  else []
+              )
+              for metadata_path in metadata_paths:
+                  try:
+                      payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+                      market = str(payload.get("market", "")).upper()
+                  except (OSError, json.JSONDecodeError, TypeError) as exc:
+                      warn(f"Current artifact metadata at {metadata_path} could not be read ({exc}).")
+                      continue
+                  if market:
+                      current_markets.add(market)
+              return current_markets
 
           def extract_artifacts(payload):
               if isinstance(payload, dict):
@@ -410,6 +428,14 @@ jobs:
           except (AttributeError, KeyError, TypeError, ValueError) as exc:
               warn(str(exc))
               runs = []
+
+          current_markets = collect_current_markets()
+          remaining_markets = set(markets) - current_markets
+          if current_markets:
+              print(
+                  f"Current run already has market artifacts: {', '.join(sorted(current_markets))}.",
+                  flush=True,
+              )
 
           for run in runs:
               run_id = run.get("id")

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -293,7 +293,6 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           CURRENT_RUN_ID: ${{ github.run_id }}
           BRANCH_NAME: ${{ github.ref_name }}
-          FALLBACK_MARKETS: US HK IN JP KR TW
         run: |
           python - <<'PY'
           import json
@@ -306,7 +305,6 @@ jobs:
           repo = os.environ["REPOSITORY"]
           current_run_id = int(os.environ["CURRENT_RUN_ID"])
           branch_name = os.environ["BRANCH_NAME"]
-          markets = os.environ["FALLBACK_MARKETS"].split()
           current_dir = Path("/tmp/static-market-artifacts-current")
           fallback_dir = Path("/tmp/static-market-artifacts-fallback")
           fallback_dir.mkdir(parents=True, exist_ok=True)
@@ -323,6 +321,24 @@ jobs:
                   f"::warning::Unable to download fallback market artifact: {message}",
                   flush=True,
               )
+
+          def command_error_detail(exc, limit=800):
+              details = []
+              for stream_name, stream_value in (("stderr", exc.stderr), ("stdout", exc.stdout)):
+                  text = (stream_value or "").strip()
+                  if not text:
+                      continue
+                  text = " | ".join(text.splitlines())
+                  if len(text) > limit:
+                      text = f"{text[:limit]}..."
+                  details.append(f"{stream_name}: {text}")
+              return f" Details: {'; '.join(details)}" if details else ""
+
+          def market_from_artifact_name(artifact_name):
+              prefix = "static-market-"
+              if not artifact_name.startswith(prefix):
+                  return ""
+              return artifact_name[len(prefix):].upper()
 
           def extract_runs(payload):
               if isinstance(payload, dict):
@@ -420,7 +436,10 @@ jobs:
               )
               runs = extract_runs(pages)
           except subprocess.CalledProcessError as exc:
-              warn(f"GitHub workflow runs API request failed with exit {exc.returncode}.")
+              warn(
+                  "GitHub workflow runs API request failed "
+                  f"with exit {exc.returncode}.{command_error_detail(exc)}"
+              )
               runs = []
           except json.JSONDecodeError as exc:
               warn(f"GitHub workflow runs API response was not valid JSON ({exc}).")
@@ -430,7 +449,7 @@ jobs:
               runs = []
 
           current_markets = collect_current_markets()
-          remaining_markets = set(markets) - current_markets
+          fallback_markets = set()
           if current_markets:
               print(
                   f"Current run already has market artifacts: {', '.join(sorted(current_markets))}.",
@@ -441,9 +460,6 @@ jobs:
               run_id = run.get("id")
               if run_id == current_run_id:
                   continue
-              if not remaining_markets:
-                  break
-
               try:
                   artifact_pages = gh_json(
                       [
@@ -455,7 +471,10 @@ jobs:
                   )
                   artifacts = extract_artifacts(artifact_pages)
               except subprocess.CalledProcessError as exc:
-                  warn(f"Artifact list API request for run {run_id} failed with exit {exc.returncode}.")
+                  warn(
+                      f"Artifact list API request for run {run_id} failed "
+                      f"with exit {exc.returncode}.{command_error_detail(exc)}"
+                  )
                   continue
               except json.JSONDecodeError as exc:
                   warn(f"Artifact list API response for run {run_id} was not valid JSON ({exc}).")
@@ -470,9 +489,11 @@ jobs:
                   if not artifact.get("expired")
               }
 
-              for market in list(remaining_markets):
-                  artifact_name = f"static-market-{market}"
-                  if artifact_name not in artifacts_by_name:
+              for artifact_name in sorted(artifacts_by_name):
+                  market = market_from_artifact_name(artifact_name)
+                  if not market:
+                      continue
+                  if market in current_markets or market in fallback_markets:
                       continue
 
                   target_dir = fallback_dir / artifact_name
@@ -498,18 +519,25 @@ jobs:
                           text=True,
                       )
                   except subprocess.CalledProcessError as exc:
-                      warn(f"{artifact_name} from run {run_id} failed to download with exit {exc.returncode}.")
+                      warn(
+                          f"{artifact_name} from run {run_id} failed to download "
+                          f"with exit {exc.returncode}.{command_error_detail(exc)}"
+                      )
                       continue
 
-                  remaining_markets.remove(market)
+                  fallback_markets.add(market)
                   print(
                       f"Using fallback artifact {artifact_name} from Static Site run {run_id} on {branch_name}.",
                       flush=True,
                   )
 
-          for market in markets:
-              if market in remaining_markets:
-                  print(f"No fallback artifact static-market-{market} found on {branch_name}.")
+          if fallback_markets:
+              print(
+                  f"Downloaded fallback market artifacts: {', '.join(sorted(fallback_markets))}.",
+                  flush=True,
+              )
+          else:
+              print(f"No fallback market artifacts found on {branch_name}.")
           PY
 
       - name: Validate market artifacts

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -495,7 +495,7 @@ class StaticSiteExportService:
             warnings.extend(str(item) for item in payload.get("warnings", []))
             if fallback_source:
                 warnings.append(
-                    f"{market} reused from previous successful static-site workflow run because the current run produced no artifact."
+                    f"{market} reused from a previous static-site market artifact because the current run produced no artifact."
                 )
 
         if not market_entries and not allow_empty:

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -763,7 +763,7 @@ def test_combine_market_artifacts_uses_fallback_only_for_missing_markets(tmp_pat
     assert json.loads((output_dir / "markets" / "hk" / "scan" / "manifest.json").read_text(encoding="utf-8")) == {
         "source": str(fallback_hk_dir)
     }
-    assert "HK reused from previous successful static-site workflow run because the current run produced no artifact." in manifest["warnings"]
+    assert "HK reused from a previous static-site market artifact because the current run produced no artifact." in manifest["warnings"]
     assert not any(warning.startswith("US reused from previous") for warning in manifest["warnings"])
 
 
@@ -805,7 +805,7 @@ def test_combine_market_artifacts_accepts_fallback_when_current_is_empty(tmp_pat
 
     assert result.manifest["supported_markets"] == ["JP"]
     assert (output_dir / "markets" / "jp" / "scan" / "manifest.json").exists()
-    assert "JP reused from previous successful static-site workflow run because the current run produced no artifact." in result.warnings
+    assert "JP reused from a previous static-site market artifact because the current run produced no artifact." in result.warnings
 
 
 def test_combine_market_artifacts_rejects_fallback_with_mismatched_schema(tmp_path):

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
+import shutil
+import stat
+import subprocess
+import textwrap
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -20,6 +26,15 @@ def _combine_and_build_job() -> str:
         "\n  deploy:",
         1,
     )[0]
+
+
+def _fallback_download_script() -> str:
+    step = _combine_and_build_job().split("      - name: Download per-market fallback artifacts\n", 1)[1].split(
+        "\n      - name: Validate market artifacts",
+        1,
+    )[0]
+    run = step.split("          python - <<'PY'\n", 1)[1].rsplit("\n          PY", 1)[0]
+    return textwrap.dedent(run)
 
 
 def test_static_site_market_build_failures_are_not_marked_continue_on_error() -> None:
@@ -56,9 +71,94 @@ def test_static_site_combine_downloads_current_and_per_market_fallback_artifacts
     assert '"download",' in combine_job
     assert "actions/runs/{run_id}/artifacts" in combine_job
     assert "artifact.get(\"expired\")" in combine_job
+    assert "current_markets" in combine_job
     assert "run.get(\"conclusion\") == \"success\"" not in combine_job
     assert "subprocess.CalledProcessError" in combine_job
     assert "::warning::Unable to download fallback market artifact" in combine_job
     assert "isinstance(payload, dict)" in combine_job
     assert "isinstance(page, dict)" in combine_job
     assert "Unexpected GitHub API response shape" in combine_job
+
+
+def test_static_site_fallback_downloader_only_fetches_missing_current_markets(tmp_path) -> None:
+    current_dir = Path("/tmp/static-market-artifacts-current")
+    fallback_dir = Path("/tmp/static-market-artifacts-fallback")
+    shutil.rmtree(current_dir, ignore_errors=True)
+    shutil.rmtree(fallback_dir, ignore_errors=True)
+    current_us_dir = current_dir / "static-market-US" / "markets" / "us"
+    current_us_dir.mkdir(parents=True)
+    (current_us_dir / "manifest.market.json").write_text(
+        json.dumps({"market": "US"}),
+        encoding="utf-8",
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    downloads_log = tmp_path / "downloads.jsonl"
+    fake_gh.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env python3
+            import json
+            import pathlib
+            import sys
+
+            downloads_log = pathlib.Path({str(downloads_log)!r})
+            args = sys.argv[1:]
+            if args[:3] == ["api", "--paginate", "--slurp"] and "actions/workflows/static-site.yml/runs" in args[3]:
+                print(json.dumps([{{"workflow_runs": [
+                    {{"id": 999, "conclusion": "failure"}},
+                    {{"id": 222, "conclusion": "failure"}}
+                ]}}]))
+            elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/222/artifacts" in args[3]:
+                print(json.dumps([{{"artifacts": [
+                    {{"name": "static-market-US", "expired": False}},
+                    {{"name": "static-market-TW", "expired": False}}
+                ]}}]))
+            elif args[:2] == ["run", "download"]:
+                artifact_name = args[args.index("--name") + 1]
+                target_dir = pathlib.Path(args[args.index("--dir") + 1])
+                target_dir.mkdir(parents=True, exist_ok=True)
+                (target_dir / "manifest.market.json").write_text(json.dumps({{"market": artifact_name.rsplit("-", 1)[1]}}))
+                with downloads_log.open("a", encoding="utf-8") as handle:
+                    handle.write(json.dumps({{"artifact": artifact_name}}) + "\\n")
+            else:
+                print(f"unexpected gh args: {{args}}", file=sys.stderr)
+                sys.exit(2)
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "REPOSITORY": "xang1234/stock-screener",
+            "CURRENT_RUN_ID": "999",
+            "BRANCH_NAME": "main",
+            "FALLBACK_MARKETS": "US TW",
+        }
+    )
+
+    try:
+        subprocess.run(
+            ["python", "-c", _fallback_download_script()],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        downloads = [
+            json.loads(line)
+            for line in downloads_log.read_text(encoding="utf-8").splitlines()
+        ]
+        assert downloads == [{"artifact": "static-market-TW"}]
+        assert not (fallback_dir / "static-market-US").exists()
+        assert (fallback_dir / "static-market-TW" / "manifest.market.json").exists()
+    finally:
+        shutil.rmtree(current_dir, ignore_errors=True)
+        shutil.rmtree(fallback_dir, ignore_errors=True)

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -38,20 +38,27 @@ def test_static_site_daily_price_seed_allows_stale_bootstrap() -> None:
     assert "--allow-stale" in seed_step
 
 
-def test_static_site_combine_downloads_current_and_fallback_market_artifacts() -> None:
+def test_static_site_combine_downloads_current_and_per_market_fallback_artifacts() -> None:
     combine_job = _combine_and_build_job()
 
-    assert "Find latest successful static site fallback run" in combine_job
+    assert "Download per-market fallback artifacts" in combine_job
     assert "Download current market artifacts" in combine_job
-    assert "Download fallback market artifacts" in combine_job
     assert "/tmp/static-market-artifacts-current" in combine_job
     assert "/tmp/static-market-artifacts-fallback" in combine_job
     assert "--fallback-artifacts-dir /tmp/static-market-artifacts-fallback" in combine_job
-    assert "github.event.workflow" in combine_job
+    assert "FALLBACK_MARKETS: US HK IN JP KR TW" in combine_job
     assert "github.ref_name" in combine_job
     assert "--paginate" in combine_job
+    assert "runs = extract_runs(pages)" in combine_job
+    assert "static-market-{market}" in combine_job
+    assert '"gh",' in combine_job
+    assert '"run",' in combine_job
+    assert '"download",' in combine_job
+    assert "actions/runs/{run_id}/artifacts" in combine_job
+    assert "artifact.get(\"expired\")" in combine_job
+    assert "run.get(\"conclusion\") == \"success\"" not in combine_job
     assert "subprocess.CalledProcessError" in combine_job
-    assert "::warning::Unable to discover fallback static-site run" in combine_job
+    assert "::warning::Unable to download fallback market artifact" in combine_job
     assert "isinstance(payload, dict)" in combine_job
     assert "isinstance(page, dict)" in combine_job
     assert "Unexpected GitHub API response shape" in combine_job

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -61,17 +61,19 @@ def test_static_site_combine_downloads_current_and_per_market_fallback_artifacts
     assert "/tmp/static-market-artifacts-current" in combine_job
     assert "/tmp/static-market-artifacts-fallback" in combine_job
     assert "--fallback-artifacts-dir /tmp/static-market-artifacts-fallback" in combine_job
-    assert "FALLBACK_MARKETS: US HK IN JP KR TW" in combine_job
+    assert "FALLBACK_MARKETS" not in combine_job
     assert "github.ref_name" in combine_job
     assert "--paginate" in combine_job
     assert "runs = extract_runs(pages)" in combine_job
-    assert "static-market-{market}" in combine_job
+    assert "market_from_artifact_name" in combine_job
     assert '"gh",' in combine_job
     assert '"run",' in combine_job
     assert '"download",' in combine_job
     assert "actions/runs/{run_id}/artifacts" in combine_job
     assert "artifact.get(\"expired\")" in combine_job
     assert "current_markets" in combine_job
+    assert "command_error_detail" in combine_job
+    assert "exc.stderr" in combine_job
     assert "run.get(\"conclusion\") == \"success\"" not in combine_job
     assert "subprocess.CalledProcessError" in combine_job
     assert "::warning::Unable to download fallback market artifact" in combine_job
@@ -113,11 +115,15 @@ def test_static_site_fallback_downloader_only_fetches_missing_current_markets(tm
                 ]}}]))
             elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/222/artifacts" in args[3]:
                 print(json.dumps([{{"artifacts": [
+                    {{"name": "static-market-HK", "expired": False}},
                     {{"name": "static-market-US", "expired": False}},
                     {{"name": "static-market-TW", "expired": False}}
                 ]}}]))
             elif args[:2] == ["run", "download"]:
                 artifact_name = args[args.index("--name") + 1]
+                if artifact_name == "static-market-HK":
+                    print("download denied for HK", file=sys.stderr)
+                    sys.exit(7)
                 target_dir = pathlib.Path(args[args.index("--dir") + 1])
                 target_dir.mkdir(parents=True, exist_ok=True)
                 (target_dir / "manifest.market.json").write_text(json.dumps({{"market": artifact_name.rsplit("-", 1)[1]}}))
@@ -139,12 +145,11 @@ def test_static_site_fallback_downloader_only_fetches_missing_current_markets(tm
             "REPOSITORY": "xang1234/stock-screener",
             "CURRENT_RUN_ID": "999",
             "BRANCH_NAME": "main",
-            "FALLBACK_MARKETS": "US TW",
         }
     )
 
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["python", "-c", _fallback_download_script()],
             check=True,
             capture_output=True,
@@ -158,7 +163,9 @@ def test_static_site_fallback_downloader_only_fetches_missing_current_markets(tm
         ]
         assert downloads == [{"artifact": "static-market-TW"}]
         assert not (fallback_dir / "static-market-US").exists()
+        assert not (fallback_dir / "static-market-HK").exists()
         assert (fallback_dir / "static-market-TW" / "manifest.market.json").exists()
+        assert "exit 7. Details: stderr: download denied for HK" in result.stdout
     finally:
         shutil.rmtree(current_dir, ignore_errors=True)
         shutil.rmtree(fallback_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- Change static-site fallback discovery to search completed workflow runs per market artifact instead of requiring one prior successful workflow run
- Allow fallback artifacts from failed/partial runs when the individual `static-market-*` artifact exists and is not expired
- Update fallback manifest warning wording and workflow/service tests

## Verification
- `cd backend && source venv/bin/activate && pytest tests/unit/test_static_site_workflow.py tests/unit/test_export_static_site_script.py tests/unit/test_static_site_export_service.py -q`
- Parsed `.github/workflows/static-site.yml` and compiled the embedded fallback Python step
- Ran a fake-`gh` harness proving TW can be downloaded from a failed prior run while another market falls back to an older run