### PR TITLE
fix: skip closed static market exports

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -204,8 +204,10 @@ jobs:
             --allow-stale
 
       - name: Export market static data bundle
+        id: export-market
         run: |
           cd backend
+          set +e
           python -m app.scripts.export_static_site \
             --output-dir /tmp/static-data \
             --refresh-daily \
@@ -213,8 +215,20 @@ jobs:
             --skip-universe-refresh \
             --skip-fundamentals-refresh \
             --market "${{ matrix.market }}"
+          status=$?
+          set -e
+          if [ "$status" -eq 78 ]; then
+            echo "Market ${{ matrix.market }} is not a trading day; no current static artifact will be uploaded."
+            echo "has_artifact=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
+          echo "has_artifact=true" >> "$GITHUB_OUTPUT"
 
       - name: Build daily price bundle
+        if: ${{ steps.export-market.outputs.has_artifact == 'true' }}
         run: |
           cd backend
           python -m app.scripts.build_daily_price_bundle \
@@ -222,6 +236,7 @@ jobs:
             --output-dir /tmp/daily-price
 
       - name: Upload daily price assets
+        if: ${{ steps.export-market.outputs.has_artifact == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -238,6 +253,7 @@ jobs:
           gh release upload daily-price-data "$MANIFEST_PATH" --clobber
 
       - name: Upload market artifact
+        if: ${{ steps.export-market.outputs.has_artifact == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: static-market-${{ matrix.market }}

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -42,6 +42,7 @@ STATIC_BUILD_MODE_PRICE_DELTA = "price_delta"
 STATIC_BUILD_MODE_FULL = "full"
 STATIC_EXPORT_MARKETS = ("US", "HK", "IN", "JP", "KR", "TW", "CN")
 STATIC_DEFAULT_MARKET = "US"
+STATIC_EXPORT_SKIPPED_EXIT_CODE = 78
 
 
 def _default_output_dir() -> Path:
@@ -502,6 +503,18 @@ def _run_daily_refresh(
     return results, warnings
 
 
+def _market_refresh_skipped_not_trading_day(refresh_results: dict[str, Any], market: str | None) -> bool:
+    if market is None:
+        return False
+    feature_snapshots = refresh_results.get("feature_snapshots", {})
+    if not isinstance(feature_snapshots, dict):
+        return False
+    snapshot = feature_snapshots.get(market.upper())
+    if not isinstance(snapshot, dict):
+        return False
+    return snapshot.get("status") == "skipped" and snapshot.get("reason") == "not_trading_day"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -590,6 +603,12 @@ def main() -> int:
                 print(f"  - {name}: {result_item}")
             for warning in refresh_warnings:
                 print(f"  - warning: {warning}")
+
+            if _market_refresh_skipped_not_trading_day(refresh_results, args.market):
+                print(
+                    f"Static site export skipped for market {args.market} because it is not a trading day."
+                )
+                return STATIC_EXPORT_SKIPPED_EXIT_CODE
 
         service = StaticSiteExportService(SessionLocal)
         result = service.export(

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -825,3 +825,53 @@ def test_main_passes_fallback_artifacts_dir_to_combine(monkeypatch, tmp_path):
     assert export_script.main() == 0
 
     assert combine_calls == [(artifacts_dir, output_dir, fallback_dir, False)]
+
+
+def test_main_returns_skip_code_for_market_not_trading_day(monkeypatch, tmp_path, capsys):
+    export_calls: list[object] = []
+
+    monkeypatch.setattr(export_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(
+        export_script,
+        "_run_daily_refresh",
+        lambda **_kwargs: (
+            {
+                "feature_snapshots": {
+                    "TW": {
+                        "status": "skipped",
+                        "reason": "not_trading_day",
+                        "market": "TW",
+                        "as_of_date": "2026-05-01",
+                    }
+                }
+            },
+            ["Static export market TW snapshot returned status 'skipped' (not_trading_day)."],
+        ),
+    )
+
+    class ExportShouldNotRun:
+        def __init__(self, *_args, **_kwargs):
+            export_calls.append("constructed")
+
+        def export(self, *_args, **_kwargs):
+            raise AssertionError("market export should not run for not_trading_day")
+
+    monkeypatch.setattr(export_script, "StaticSiteExportService", ExportShouldNotRun)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_static_site.py",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--refresh-daily",
+            "--market",
+            "TW",
+        ],
+    )
+
+    assert export_script.main() == 78
+
+    captured = capsys.readouterr()
+    assert "Static site export skipped for market TW because it is not a trading day." in captured.out
+    assert export_calls == []

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -53,6 +53,35 @@ def test_static_site_daily_price_seed_allows_stale_bootstrap() -> None:
     assert "--allow-stale" in seed_step
 
 
+def test_static_site_market_export_skips_artifact_steps_for_closed_market() -> None:
+    build_market_job = _build_market_job()
+    export_step = build_market_job.split("      - name: Export market static data bundle\n", 1)[1].split(
+        "\n      - name: Build daily price bundle",
+        1,
+    )[0]
+    build_price_step = build_market_job.split("      - name: Build daily price bundle\n", 1)[1].split(
+        "\n      - name: Upload daily price assets",
+        1,
+    )[0]
+    upload_price_step = build_market_job.split("      - name: Upload daily price assets\n", 1)[1].split(
+        "\n      - name: Upload market artifact",
+        1,
+    )[0]
+    upload_market_step = build_market_job.split("      - name: Upload market artifact\n", 1)[1].split(
+        "\n\n  combine-and-build:",
+        1,
+    )[0]
+
+    assert "id: export-market" in export_step
+    assert "status=$?" in export_step
+    assert 'if [ "$status" -eq 78 ]; then' in export_step
+    assert "has_artifact=false" in export_step
+    assert "has_artifact=true" in export_step
+    assert "steps.export-market.outputs.has_artifact == 'true'" in build_price_step
+    assert "steps.export-market.outputs.has_artifact == 'true'" in upload_price_step
+    assert "steps.export-market.outputs.has_artifact == 'true'" in upload_market_step
+
+
 def test_static_site_combine_downloads_current_and_per_market_fallback_artifacts() -> None:
     combine_job = _combine_and_build_job()
 


### PR DESCRIPTION
## Summary
- Treat market-scoped static exports skipped for not_trading_day as an expected no-artifact outcome instead of a failed market job
- Return exit code 78 from export_static_site for market refreshes skipped because the market is closed
- Update the Static Site workflow to convert exit 78 into a successful no-artifact step and skip daily price/artifact uploads for that market
- Leave unexpected export failures as non-zero failures so real issues still surface

## Verification
- cd backend && source venv/bin/activate && pytest tests/unit/test_static_site_workflow.py tests/unit/test_export_static_site_script.py tests/unit/test_static_site_export_service.py -q
- Parsed static-site.yml and compiled the embedded fallback Python step
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Static site export workflow now intelligently detects when a market is not trading and automatically skips unnecessary artifact generation, daily price bundle building, and market asset upload steps. This improves efficiency and prevents redundant operations.

* **Tests**
  * Added comprehensive test coverage to verify conditional workflow execution and non-trading market state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->