### PR TITLE
[codex] fix celery redis loading retries

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -52,6 +52,10 @@ celery_app = Celery(
         'app.interfaces.tasks.feature_store_tasks',  # Daily feature snapshot
     ]
 )
+celery_app.loader.override_backends = {
+    **celery_app.loader.override_backends,
+    "redis": "app.celery_redis_backend:RetryableRedisBackend",
+}
 
 # Configure Celery
 celery_app.conf.update(
@@ -65,6 +69,18 @@ celery_app.conf.update(
     task_soft_time_limit=82800,  # Soft limit at 23 hours
     worker_prefetch_multiplier=1,  # Don't prefetch tasks
     broker_connection_retry_on_startup=True,  # Retry connecting to broker on startup
+    result_backend_always_retry=True,
+    result_backend_base_sleep_between_retries_ms=100,
+    result_backend_max_sleep_between_retries_ms=5000,
+    result_backend_max_retries=120,
+    result_backend_transport_options={
+        'retry_policy': {
+            'max_retries': 120,
+            'interval_start': 0.2,
+            'interval_step': 0.5,
+            'interval_max': 5.0,
+        },
+    },
 )
 
 _logger = logging.getLogger(__name__)

--- a/backend/app/celery_redis_backend.py
+++ b/backend/app/celery_redis_backend.py
@@ -1,0 +1,15 @@
+"""Redis result backend extensions for Celery."""
+
+from __future__ import annotations
+
+from celery.backends.redis import RedisBackend
+
+
+class RetryableRedisBackend(RedisBackend):
+    """Redis backend that lets Celery retry transient Redis connection states."""
+
+    def exception_safe_to_retry(self, exc: Exception) -> bool:
+        return isinstance(exc, self.connection_errors)
+
+
+__all__ = ["RetryableRedisBackend"]

--- a/backend/tests/unit/test_celery_config.py
+++ b/backend/tests/unit/test_celery_config.py
@@ -2,9 +2,12 @@
 Tests for Celery schedule helpers and related settings validators.
 """
 import pytest
+from celery import Celery
 from pydantic import ValidationError
+from redis.exceptions import BusyLoadingError
 
-from app.celery_app import _offset_schedule
+from app.celery_app import _offset_schedule, celery_app
+from app.celery_redis_backend import RetryableRedisBackend
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +66,53 @@ class TestOffsetSchedule:
         """59 minutes + 121 offset = 180 total = 3 hours exactly."""
         h, m = _offset_schedule(10, 59, 121)
         assert (h, m) == (13, 0)
+
+
+# ---------------------------------------------------------------------------
+# Redis backend resilience
+# ---------------------------------------------------------------------------
+
+class TestRedisBackendRetryConfig:
+    """Tests for Celery Redis backend retry behavior."""
+
+    def test_result_backend_uses_retryable_redis_backend(self):
+        assert (
+            celery_app.loader.override_backends["redis"]
+            == "app.celery_redis_backend:RetryableRedisBackend"
+        )
+        assert isinstance(celery_app.backend, RetryableRedisBackend)
+        assert celery_app.conf.result_backend_always_retry is True
+
+    def test_result_backend_retries_busy_loading_during_metadata_read(self, monkeypatch):
+        app = Celery("test_retryable_backend")
+        app.conf.update(
+            result_serializer="json",
+            accept_content=["json"],
+            result_backend_always_retry=True,
+            result_backend_base_sleep_between_retries_ms=1,
+            result_backend_max_sleep_between_retries_ms=1,
+            result_backend_max_retries=3,
+        )
+        backend = RetryableRedisBackend(app=app, url="redis://localhost:6379/1")
+        get_calls = 0
+        set_calls = []
+        sleeps = []
+
+        def fake_get(_key):
+            nonlocal get_calls
+            get_calls += 1
+            if get_calls == 1:
+                raise BusyLoadingError("Redis is loading the dataset in memory")
+            return None
+
+        monkeypatch.setattr(backend, "get", fake_get)
+        monkeypatch.setattr(backend, "set", lambda key, value: set_calls.append((key, value)))
+        monkeypatch.setattr(backend, "_sleep", lambda amount: sleeps.append(amount))
+
+        assert backend.store_result("task-id", "ok", "SUCCESS") == "ok"
+        assert get_calls == 2
+        assert len(set_calls) == 1
+        assert len(sleeps) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,10 +84,11 @@ services:
     volumes:
       - redis_data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
+      test: ["CMD-SHELL", "redis-cli --raw INFO persistence | grep -q '^loading:0$'"]
+      interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 24
+      start_period: 120s
     restart: unless-stopped
 
   postgres:


### PR DESCRIPTION
## Summary
- Add a Celery Redis result backend subclass that marks Redis connection-state errors as retry-safe, including BusyLoadingError during result metadata reads.
- Keep result backend retry settings for retry timing and transport set paths.
- Gate Redis Compose health on loading:0 with a startup grace period for larger persisted datasets.
- Add a regression test that forces BusyLoadingError from backend get() during store_result().

## Root cause
Celery 5.3.4 result_backend_always_retry only retries exceptions when the backend reports them as safe. RedisBackend.exception_safe_to_retry returns False by default, so BusyLoadingError raised by _get_task_meta_for() during store_result() was not retried.

## Validation
- cd backend && /Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest tests/unit/test_celery_config.py (33 passed)
- SERVER_AUTH_PASSWORD=dummy docker compose config --quiet
- git diff --check