### PR TITLE
feat(static): add Charts tab to group detail popup for top-50 groups

### DIFF
--- a/frontend/src/static/StaticGroupChartsGrid.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.jsx
@@ -1,0 +1,246 @@
+import { useMemo } from 'react';
+import {
+  Alert,
+  Box,
+  Card,
+  CircularProgress,
+  Grid,
+  Typography,
+} from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+
+import CandlestickChart from '../components/Charts/CandlestickChart';
+import { getGroupRankColor } from '../utils/colorUtils';
+import { fetchStaticChartPayload, staticChartKeys } from './chartClient';
+
+const MAX_SYMBOLS = 50;
+const CHART_HEIGHT = 420;
+
+function StatBadge({ value, label, bgcolor }) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <Box
+        sx={{
+          borderRadius: 1,
+          px: 1.5,
+          py: 0.5,
+          minWidth: 36,
+          textAlign: 'center',
+          bgcolor,
+        }}
+      >
+        <Typography variant="body2" noWrap sx={{ fontSize: '0.8rem', color: 'white', fontWeight: 'bold' }}>
+          {value}
+        </Typography>
+      </Box>
+      <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem', mt: 0.25 }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+function StaticGroupChartCard({ symbol, entry }) {
+  const { data: payload, isLoading, isError } = useQuery({
+    queryKey: staticChartKeys.payload(symbol, entry?.path),
+    queryFn: () => fetchStaticChartPayload(entry.path),
+    enabled: Boolean(entry?.path),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  const stockData = payload?.stock_data || null;
+  const fundamentals = payload?.fundamentals || null;
+  const bars = payload?.bars || null;
+  const generatedAt = payload?.generated_at ? Date.parse(payload.generated_at) : null;
+  const lastClose = bars && bars.length > 0 ? bars[bars.length - 1].close : null;
+  const groupRank = stockData?.ibd_group_rank ?? null;
+  const adrValue = stockData?.adr_percent ?? fundamentals?.adr_percent ?? null;
+  const epsRating = stockData?.eps_rating ?? fundamentals?.eps_rating ?? null;
+  const companyName = stockData?.company_name || fundamentals?.company_name || null;
+
+  const adrBg = adrValue == null
+    ? null
+    : Number(adrValue) >= 4
+      ? 'success.main'
+      : Number(adrValue) >= 2
+        ? 'warning.main'
+        : 'error.main';
+
+  const epsBg = epsRating == null
+    ? null
+    : epsRating >= 80
+      ? 'success.main'
+      : epsRating >= 50
+        ? 'warning.main'
+        : 'error.main';
+
+  return (
+    <Card variant="outlined" sx={{ overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+          px: 2,
+          py: 1,
+          borderBottom: 1,
+          borderColor: 'divider',
+          bgcolor: 'background.default',
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+          <Box>
+            <Typography variant="h6" sx={{ fontFamily: 'monospace', fontWeight: 700, lineHeight: 1.1 }}>
+              {symbol}
+            </Typography>
+            {companyName ? (
+              <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+                {companyName}
+              </Typography>
+            ) : null}
+          </Box>
+          {groupRank != null ? (
+            <StatBadge value={groupRank} label="Grp Rnk" bgcolor={getGroupRankColor(groupRank)} />
+          ) : null}
+          {adrValue != null ? (
+            <StatBadge value={`${Number(adrValue).toFixed(1)}%`} label="ADR" bgcolor={adrBg} />
+          ) : null}
+          {epsRating != null ? (
+            <StatBadge value={epsRating} label="EPS Rtg" bgcolor={epsBg} />
+          ) : null}
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {lastClose != null ? (
+            <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+              {lastClose.toFixed(2)}
+            </Typography>
+          ) : null}
+        </Box>
+      </Box>
+
+      {isError ? (
+        <Box sx={{ height: CHART_HEIGHT, display: 'flex', alignItems: 'center', justifyContent: 'center', p: 2 }}>
+          <Alert severity="error" sx={{ width: '100%' }}>
+            Failed to load chart payload for {symbol}.
+          </Alert>
+        </Box>
+      ) : isLoading || !bars ? (
+        <Box sx={{ height: CHART_HEIGHT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <CircularProgress size={32} />
+        </Box>
+      ) : (
+        <CandlestickChart
+          symbol={symbol}
+          period="6mo"
+          height={CHART_HEIGHT}
+          priceData={bars}
+          dataUpdatedAtOverride={generatedAt}
+        />
+      )}
+    </Card>
+  );
+}
+
+/**
+ * Vertical list of full-featured candlestick charts for a group's constituent
+ * stocks, rendered from pre-generated static chart payloads (no live API).
+ *
+ * Each chart matches the appearance of `StaticChartViewerModal` (EMAs, OHLC
+ * legend, daily/weekly toggle) with a header carrying symbol, last close, and
+ * the same metric badges as the scan-result popup.
+ *
+ * @param {Object} props
+ * @param {string[]} props.symbols - Constituent ticker symbols
+ * @param {Object|null} props.chartIndex - Static chart index `{ symbols: [{ symbol, path }, ...] }`
+ */
+function StaticGroupChartsGrid({ symbols = [], chartIndex = null }) {
+  const entryBySymbol = useMemo(() => {
+    const entries = chartIndex?.symbols || [];
+    return new Map(entries.map((entry) => [entry.symbol, entry]));
+  }, [chartIndex]);
+
+  const normalizedSymbols = useMemo(
+    () => Array.from(
+      new Set(
+        (symbols || [])
+          .filter((s) => typeof s === 'string' && s.trim().length > 0)
+          .map((s) => s.trim().toUpperCase()),
+      ),
+    ),
+    [symbols],
+  );
+
+  const truncatedSymbols = useMemo(
+    () => normalizedSymbols.slice(0, MAX_SYMBOLS),
+    [normalizedSymbols],
+  );
+
+  if (normalizedSymbols.length === 0) {
+    return (
+      <Alert severity="info" sx={{ mt: 1 }}>
+        No constituent stocks to chart.
+      </Alert>
+    );
+  }
+
+  if (!chartIndex) {
+    return (
+      <Alert severity="warning" sx={{ mt: 1 }}>
+        Static chart payloads are unavailable for this market.
+      </Alert>
+    );
+  }
+
+  const truncated = normalizedSymbols.length > truncatedSymbols.length;
+
+  return (
+    <Box>
+      {truncated && (
+        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+          Showing first {truncatedSymbols.length} of {normalizedSymbols.length} stocks.
+        </Typography>
+      )}
+      <Grid container spacing={2}>
+        {truncatedSymbols.map((sym) => {
+          const entry = entryBySymbol.get(sym);
+          if (!entry) {
+            return (
+              <Grid item xs={12} key={sym}>
+                <Card variant="outlined">
+                  <Box
+                    sx={{
+                      px: 2,
+                      py: 1,
+                      borderBottom: 1,
+                      borderColor: 'divider',
+                      bgcolor: 'background.default',
+                    }}
+                  >
+                    <Typography variant="h6" sx={{ fontFamily: 'monospace', fontWeight: 700 }}>
+                      {sym}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ height: 80, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <Typography variant="body2" color="text.secondary">
+                      No price data
+                    </Typography>
+                  </Box>
+                </Card>
+              </Grid>
+            );
+          }
+          return (
+            <Grid item xs={12} key={sym}>
+              <StaticGroupChartCard symbol={sym} entry={entry} />
+            </Grid>
+          );
+        })}
+      </Grid>
+    </Box>
+  );
+}
+
+export default StaticGroupChartsGrid;

--- a/frontend/src/static/StaticGroupChartsGrid.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.jsx
@@ -52,6 +52,7 @@ function StaticGroupChartCard({ symbol, entry }) {
   const stockData = payload?.stock_data || null;
   const fundamentals = payload?.fundamentals || null;
   const bars = payload?.bars || null;
+  const hasBarsPayload = Array.isArray(bars);
   const generatedAt = payload?.generated_at ? Date.parse(payload.generated_at) : null;
   const lastClose = bars && bars.length > 0 ? bars[bars.length - 1].close : null;
   const groupRank = stockData?.ibd_group_rank ?? null;
@@ -127,9 +128,15 @@ function StaticGroupChartCard({ symbol, entry }) {
             Failed to load chart payload for {symbol}.
           </Alert>
         </Box>
-      ) : isLoading || !bars ? (
+      ) : isLoading ? (
         <Box sx={{ height: CHART_HEIGHT, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <CircularProgress size={32} />
+        </Box>
+      ) : !hasBarsPayload ? (
+        <Box sx={{ height: CHART_HEIGHT, display: 'flex', alignItems: 'center', justifyContent: 'center', p: 2 }}>
+          <Alert severity="warning" sx={{ width: '100%' }}>
+            No price data available for {symbol}.
+          </Alert>
         </Box>
       ) : (
         <CandlestickChart

--- a/frontend/src/static/StaticGroupChartsGrid.test.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.test.jsx
@@ -41,14 +41,14 @@ describe('StaticGroupChartsGrid', () => {
   });
 
   it('shows a no-data message when a loaded chart payload has no bars array', async () => {
-    globalThis.fetch = vi.fn(async () => ({
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => ({
         symbol: 'NVDA',
         stock_data: { symbol: 'NVDA', company_name: 'NVIDIA Corporation' },
       }),
-    }));
+    });
 
     renderGrid();
 

--- a/frontend/src/static/StaticGroupChartsGrid.test.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.test.jsx
@@ -1,0 +1,58 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import StaticGroupChartsGrid from './StaticGroupChartsGrid';
+
+vi.mock('../components/Charts/CandlestickChart', () => ({
+  default: (props) => (
+    <div data-testid="static-candlestick-chart">
+      {props.symbol}:{props.priceData?.length || 0}
+    </div>
+  ),
+}));
+
+const renderGrid = (props = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={createTheme()}>
+        <StaticGroupChartsGrid
+          symbols={['NVDA']}
+          chartIndex={{ symbols: [{ symbol: 'NVDA', path: 'charts/NVDA.json' }] }}
+          {...props}
+        />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe('StaticGroupChartsGrid', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows a no-data message when a loaded chart payload has no bars array', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        symbol: 'NVDA',
+        stock_data: { symbol: 'NVDA', company_name: 'NVIDIA Corporation' },
+      }),
+    }));
+
+    renderGrid();
+
+    expect(await screen.findByText('No price data available for NVDA.')).toBeInTheDocument();
+    expect(screen.queryByTestId('static-candlestick-chart')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -50,6 +50,13 @@ function StaticGroupDetailModal({ group, detail, chartIndex = null, open, onClos
     () => (detail?.stocks || []).map((stock) => stock.symbol).filter(Boolean),
     [detail?.stocks],
   );
+  const chartsTabLabel = chartsEnabled ? (
+    'Charts'
+  ) : (
+    <Tooltip title={`Charts available for top ${CHARTS_TOP_N_GROUPS} groups only`} describeChild>
+      <Box component="span">Charts</Box>
+    </Tooltip>
+  );
   const chartData = useMemo(() => {
     if (!detail?.history) return [];
     return [...detail.history].reverse().map((item) => {
@@ -84,15 +91,12 @@ function StaticGroupDetailModal({ group, detail, chartIndex = null, open, onClos
               sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
             >
               <Tab value="overview" label="Overview" />
-              {chartsEnabled ? (
-                <Tab value="charts" label="Charts" />
-              ) : (
-                <Tooltip title={`Charts available for top ${CHARTS_TOP_N_GROUPS} groups only`}>
-                  <span>
-                    <Tab value="charts" label="Charts" disabled />
-                  </span>
-                </Tooltip>
-              )}
+              <Tab
+                value="charts"
+                label={chartsTabLabel}
+                disabled={!chartsEnabled}
+                sx={!chartsEnabled ? { pointerEvents: 'auto' } : undefined}
+              />
             </Tabs>
 
             {activeTab === 'charts' && chartsEnabled ? (

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Dialog,
@@ -6,12 +6,15 @@ import {
   DialogContent,
   Grid,
   IconButton,
+  Tab,
+  Tabs,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
@@ -29,8 +32,24 @@ import RankChangeCell from '../components/shared/RankChangeCell';
 import PriceSparkline from '../components/Scan/PriceSparkline';
 import RSSparkline from '../components/Scan/RSSparkline';
 import TickerCell from '../components/common/TickerCell';
+import StaticGroupChartsGrid from './StaticGroupChartsGrid';
 
-function StaticGroupDetailModal({ group, detail, open, onClose }) {
+const CHARTS_TOP_N_GROUPS = 50;
+
+function StaticGroupDetailModal({ group, detail, chartIndex = null, open, onClose }) {
+  const [activeTab, setActiveTab] = useState('overview');
+
+  useEffect(() => {
+    if (open) {
+      setActiveTab('overview');
+    }
+  }, [open, group]);
+
+  const chartsEnabled = (detail?.current_rank ?? Infinity) <= CHARTS_TOP_N_GROUPS;
+  const chartSymbols = useMemo(
+    () => (detail?.stocks || []).map((stock) => stock.symbol).filter(Boolean),
+    [detail?.stocks],
+  );
   const chartData = useMemo(() => {
     if (!detail?.history) return [];
     return [...detail.history].reverse().map((item) => {
@@ -59,6 +78,27 @@ function StaticGroupDetailModal({ group, detail, open, onClose }) {
           <Typography color="text.secondary">No data available</Typography>
         ) : (
           <Box>
+            <Tabs
+              value={activeTab}
+              onChange={(_, value) => setActiveTab(value)}
+              sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+            >
+              <Tab value="overview" label="Overview" />
+              {chartsEnabled ? (
+                <Tab value="charts" label="Charts" />
+              ) : (
+                <Tooltip title={`Charts available for top ${CHARTS_TOP_N_GROUPS} groups only`}>
+                  <span>
+                    <Tab value="charts" label="Charts" disabled />
+                  </span>
+                </Tooltip>
+              )}
+            </Tabs>
+
+            {activeTab === 'charts' && chartsEnabled ? (
+              <StaticGroupChartsGrid symbols={chartSymbols} chartIndex={chartIndex} />
+            ) : (
+              <Box>
             {/* Current Stats */}
             <Grid container spacing={2} mb={3}>
               <Grid item xs={3}>
@@ -268,6 +308,8 @@ function StaticGroupDetailModal({ group, detail, open, onClose }) {
                   </Table>
                 </TableContainer>
               </>
+            )}
+              </Box>
             )}
           </Box>
         )}

--- a/frontend/src/static/StaticGroupDetailModal.test.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.test.jsx
@@ -1,0 +1,62 @@
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import StaticGroupDetailModal from './StaticGroupDetailModal';
+
+vi.mock('../components/Scan/PriceSparkline', () => ({
+  default: () => <div data-testid="price-sparkline" />,
+}));
+
+vi.mock('../components/Scan/RSSparkline', () => ({
+  default: () => <div data-testid="rs-sparkline" />,
+}));
+
+vi.mock('./StaticGroupChartsGrid', () => ({
+  default: () => <div data-testid="static-group-charts-grid" />,
+}));
+
+const detail = {
+  current_rank: 51,
+  current_avg_rs: 75.5,
+  num_stocks: 2,
+  top_symbol: 'NVDA',
+  top_rs_rating: 92,
+  stocks: [
+    {
+      symbol: 'NVDA',
+      company_name: 'NVIDIA Corporation',
+      rs_rating: 92,
+      price: 140.5,
+      market_cap: 1000000000,
+      price_history: [],
+      rs_history: [],
+    },
+  ],
+  history: [],
+};
+
+const renderModal = (props = {}) => render(
+  <ThemeProvider theme={createTheme()}>
+    <StaticGroupDetailModal
+      group="Semiconductors"
+      detail={detail}
+      open
+      onClose={vi.fn()}
+      {...props}
+    />
+  </ThemeProvider>
+);
+
+describe('StaticGroupDetailModal', () => {
+  it('keeps disabled Charts as a direct Tab child of Tabs', () => {
+    renderModal();
+
+    const tabList = screen.getByRole('tablist');
+    const tabChildren = Array.from(tabList.children);
+
+    expect(tabChildren).toHaveLength(2);
+    expect(tabChildren.every((child) => child.getAttribute('role') === 'tab')).toBe(true);
+    expect(screen.getByRole('tab', { name: 'Charts' })).toBeDisabled();
+  });
+});

--- a/frontend/src/static/pages/StaticGroupsPage.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.jsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useStaticManifest, fetchStaticJson, resolveStaticMarketEntry } from '../dataClient';
+import { useStaticChartIndex } from '../chartClient';
 import StaticGroupDetailModal from '../StaticGroupDetailModal';
 import RankChangeCell from '../../components/shared/RankChangeCell';
 import TickerCell from '../../components/common/TickerCell';
@@ -65,6 +66,7 @@ function StaticGroupsPage() {
     enabled: Boolean(marketEntry.pages?.groups?.path),
     staleTime: Infinity,
   });
+  const chartIndexQuery = useStaticChartIndex(marketEntry.assets?.charts?.path);
   const [selectedGroup, setSelectedGroup] = useState(null);
 
   if (manifestQuery.isLoading || groupsQuery.isLoading) {
@@ -162,6 +164,7 @@ function StaticGroupsPage() {
       <StaticGroupDetailModal
         group={selectedGroup}
         detail={selectedGroup ? groupDetails[selectedGroup] : null}
+        chartIndex={chartIndexQuery.data}
         open={!!selectedGroup}
         onClose={() => setSelectedGroup(null)}
       />


### PR DESCRIPTION
The static site's group detail popup now mirrors the live site by adding a
Charts tab alongside Overview. The tab renders full-featured TradingView
Lightweight candlestick charts (EMAs, OHLC legend, daily/weekly toggle) for
each constituent stock, matching the appearance of the scan-result chart popup.

The tab is restricted to groups ranked within the top 50 — for lower-ranked
groups it appears disabled with a tooltip. Charts are loaded lazily from the
existing per-symbol static chart payloads (no new API calls), capped at 50
constituents per group.

https://claude.ai/code/session_012Qav8n48vh6ex1YpwTJFsr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a candlestick card grid for group constituents with loading, error, missing-data warnings, and placeholder “No price data” cards.
  * Cards display company metadata and stat badges (group rank, ADR, EPS) with color-coded tiers; symbol list is normalized, de-duplicated and truncated with a “Showing first …” caption.
  * Group detail modal gains a tabbed UI; a Charts tab is enabled only for top-ranked groups and otherwise shows a tooltip/explanation.

* **Tests**
  * Added unit tests covering the grid and modal tab behavior, including missing-price-data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->