### PR TITLE
feat(static): export charts for all top-50 group constituents, 2-per-…

### DIFF
--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -51,6 +51,7 @@ STATIC_CHART_PERIOD_DAYS = 180
 STATIC_CHART_LOOKUP_BATCH_SIZE = 250
 STATIC_DEFAULT_SCAN_FILTERS = {"minVolume": 100_000_000}
 STATIC_CHART_PRESET_TOP_N = 200
+STATIC_CHART_TOP_N_GROUPS = 50
 STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
 STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
 STATIC_DEFAULT_MARKET = "US"
@@ -305,26 +306,6 @@ class StaticSiteExportService:
             filter_options=filter_options,
             path_prefix=path_prefix,
         )
-        chart_manifest = self._export_chart_bundle(
-            output_dir=output_dir,
-            generated_at=generated_at,
-            run=latest_run,
-            rows=scan_rows,
-            serialized_rows=serialized_rows,
-            path_prefix=path_prefix,
-        )
-        breadth_payload = self._build_optional_section_payload(
-            section=f"{market} breadth",
-            warnings=warnings,
-            generated_at=generated_at,
-            expected_as_of_date=latest_run.as_of_date,
-            build=lambda: self._build_breadth_payload(
-                generated_at=generated_at,
-                expected_as_of_date=latest_run.as_of_date,
-                market=market,
-                serialized_rows=serialized_rows,
-            ),
-        )
         groups_payload = self._build_optional_section_payload(
             section=f"{market} groups",
             warnings=warnings,
@@ -337,6 +318,27 @@ class StaticSiteExportService:
                 market=market,
                 latest_run=latest_run,
                 current_rows=scan_rows,
+                serialized_rows=serialized_rows,
+            ),
+        )
+        chart_manifest = self._export_chart_bundle(
+            output_dir=output_dir,
+            generated_at=generated_at,
+            run=latest_run,
+            rows=scan_rows,
+            serialized_rows=serialized_rows,
+            path_prefix=path_prefix,
+            groups_payload=groups_payload,
+        )
+        breadth_payload = self._build_optional_section_payload(
+            section=f"{market} breadth",
+            warnings=warnings,
+            generated_at=generated_at,
+            expected_as_of_date=latest_run.as_of_date,
+            build=lambda: self._build_breadth_payload(
+                generated_at=generated_at,
+                expected_as_of_date=latest_run.as_of_date,
+                market=market,
                 serialized_rows=serialized_rows,
             ),
         )
@@ -679,6 +681,7 @@ class StaticSiteExportService:
         rows: list[Any],
         serialized_rows: list[dict[str, Any]] | None = None,
         path_prefix: Path | None = None,
+        groups_payload: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         normalized_prefix = Path() if path_prefix is None else Path(path_prefix)
         chart_dir = output_dir / normalized_prefix / "charts"
@@ -811,6 +814,74 @@ class StaticSiteExportService:
                     len(extra_symbols),
                 )
 
+        # --- Pass 3: expand coverage to all constituents of top-N groups ---
+        group_symbols = self._collect_top_group_constituent_symbols(
+            groups_payload=groups_payload,
+            top_n=STATIC_CHART_TOP_N_GROUPS,
+        )
+        if group_symbols:
+            exported_symbols = {e["symbol"] for e in entries}
+            extra_group_symbols = sorted(
+                group_symbols - exported_symbols - set(skipped_symbols)
+            )
+            entries_before_pass_3 = len(entries)
+
+            if extra_group_symbols:
+                ser_by_symbol = (
+                    {r["symbol"]: r for r in serialized_rows if r.get("symbol")}
+                    if serialized_rows is not None
+                    else {}
+                )
+                for row in ordered_rows:
+                    sym = getattr(row, "symbol", None)
+                    if sym and sym not in row_by_symbol:
+                        row_by_symbol[sym] = row
+
+                for batch_start in range(0, len(extra_group_symbols), STATIC_CHART_LOOKUP_BATCH_SIZE):
+                    batch = extra_group_symbols[batch_start:batch_start + STATIC_CHART_LOOKUP_BATCH_SIZE]
+                    price_data = self._price_cache.get_many_cached_only(batch, period="2y")
+                    fundamentals = self._fundamentals_cache.get_many_cached_only(batch)
+
+                    for symbol in batch:
+                        bars = self._serialize_chart_bars(price_data.get(symbol))
+                        if not bars:
+                            skipped_symbols.append(symbol)
+                            continue
+
+                        rel_path = self._chart_payload_path(symbol, path_prefix=normalized_prefix)
+                        domain_row = row_by_symbol.get(symbol)
+                        stock_data = (
+                            self._serialize_scan_row(domain_row)
+                            if domain_row
+                            else ser_by_symbol.get(symbol)
+                        )
+                        payload = {
+                            "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
+                            "generated_at": generated_at,
+                            "as_of_date": run.as_of_date.isoformat(),
+                            "symbol": symbol,
+                            "rank": None,
+                            "period": STATIC_CHART_PERIOD,
+                            "bars": bars,
+                            "stock_data": stock_data,
+                            "fundamentals": fundamentals.get(symbol),
+                        }
+                        self._write_json(output_dir / rel_path, payload)
+                        entries.append(
+                            {
+                                "symbol": symbol,
+                                "rank": None,
+                                "path": rel_path.as_posix(),
+                            }
+                        )
+
+                logger.info(
+                    "Top-%d groups expansion added %d charts (%d extra symbols attempted)",
+                    STATIC_CHART_TOP_N_GROUPS,
+                    len(entries) - entries_before_pass_3,
+                    len(extra_group_symbols),
+                )
+
         index_rel_path = normalized_prefix / "charts" / "index.json"
         index_payload = {
             "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
@@ -829,6 +900,35 @@ class StaticSiteExportService:
             "available": bool(entries),
             "skipped_symbols": skipped_symbols,
         }
+
+    @staticmethod
+    def _collect_top_group_constituent_symbols(
+        *,
+        groups_payload: dict[str, Any] | None,
+        top_n: int,
+    ) -> set[str]:
+        """Return constituent symbols across the top-N IBD industry groups.
+
+        Pulls from `groups_payload['payload']['group_details']`, which maps
+        group name → details (including `current_rank` and `stocks`).
+        """
+        if not groups_payload or not groups_payload.get("available"):
+            return set()
+        payload = groups_payload.get("payload") or {}
+        group_details = payload.get("group_details") or {}
+        symbols: set[str] = set()
+        for detail in group_details.values():
+            if not isinstance(detail, dict):
+                continue
+            rank = detail.get("current_rank")
+            if rank is None or rank > top_n:
+                continue
+            for stock in detail.get("stocks") or []:
+                if isinstance(stock, dict):
+                    symbol = stock.get("symbol")
+                    if symbol:
+                        symbols.add(symbol)
+        return symbols
 
     def _build_breadth_payload(
         self,

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1695,6 +1695,123 @@ def test_export_chart_bundle_skips_preset_symbols_without_cached_prices(
     assert manifest["symbols_total"] == 1
 
 
+def test_export_chart_bundle_expands_coverage_for_top_groups_constituents(
+    service_and_session_factory,
+    monkeypatch,
+    tmp_path,
+):
+    """Pass 3 should export charts for every constituent of the top-N IBD
+    industry groups even when those symbols fall outside the composite-score
+    top-N from Pass 1 and the preset-screen expansion from Pass 2.
+    """
+    service, session_factory = service_and_session_factory
+    _insert_runs(
+        session_factory,
+        FeatureRun(
+            id=21,
+            as_of_date=date(2026, 4, 2),
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 4, 2, 21, 30, 0),
+        ),
+        pointer_run_id=21,
+    )
+
+    monkeypatch.setattr(export_module, "STATIC_CHART_LIMIT", 1)
+    monkeypatch.setattr(export_module, "STATIC_CHART_LOOKUP_BATCH_SIZE", 5)
+    monkeypatch.setattr(export_module, "STATIC_CHART_PRESET_TOP_N", 0)
+    monkeypatch.setattr(export_module, "STATIC_CHART_TOP_N_GROUPS", 2)
+
+    service._price_cache = SimpleNamespace(
+        get_many_cached_only=lambda symbols, period="2y": {
+            symbol: _make_chart_price_frame(100.0 + i)
+            for i, symbol in enumerate(symbols)
+        }
+    )
+    service._fundamentals_cache = SimpleNamespace(
+        get_many_cached_only=lambda symbols: {s: {"symbol": s} for s in symbols}
+    )
+
+    rows = [
+        SimpleNamespace(
+            symbol="NVDA",
+            composite_score=99.0,
+            rating="Strong Buy",
+            current_price=100.0,
+            screeners_run=[],
+            extended_fields={},
+        ),
+        SimpleNamespace(
+            symbol="GROUP_A1",
+            composite_score=20.0,
+            rating="Hold",
+            current_price=50.0,
+            screeners_run=[],
+            extended_fields={},
+        ),
+        SimpleNamespace(
+            symbol="GROUP_B1",
+            composite_score=15.0,
+            rating="Hold",
+            current_price=40.0,
+            screeners_run=[],
+            extended_fields={},
+        ),
+        SimpleNamespace(
+            symbol="OUTSIDE_TOP",
+            composite_score=10.0,
+            rating="Hold",
+            current_price=30.0,
+            screeners_run=[],
+            extended_fields={},
+        ),
+    ]
+    serialized_rows = [
+        {"symbol": "NVDA", "composite_score": 99.0},
+        {"symbol": "GROUP_A1", "composite_score": 20.0},
+        {"symbol": "GROUP_B1", "composite_score": 15.0},
+        {"symbol": "OUTSIDE_TOP", "composite_score": 10.0},
+    ]
+
+    groups_payload = {
+        "available": True,
+        "payload": {
+            "group_details": {
+                "Group A": {
+                    "current_rank": 1,
+                    "stocks": [{"symbol": "NVDA"}, {"symbol": "GROUP_A1"}],
+                },
+                "Group B": {
+                    "current_rank": 2,
+                    "stocks": [{"symbol": "GROUP_B1"}],
+                },
+                "Group C": {
+                    "current_rank": 3,
+                    "stocks": [{"symbol": "OUTSIDE_TOP"}],
+                },
+            },
+        },
+    }
+
+    with session_factory() as db:
+        run = db.get(FeatureRun, 21)
+        manifest = service._export_chart_bundle(  # noqa: SLF001 - intentional unit coverage
+            output_dir=tmp_path,
+            generated_at="2026-04-02T22:00:00Z",
+            run=run,
+            rows=rows,
+            serialized_rows=serialized_rows,
+            groups_payload=groups_payload,
+        )
+
+    index_payload = json.loads((tmp_path / "charts" / "index.json").read_text(encoding="utf-8"))
+    exported = {entry["symbol"] for entry in index_payload["symbols"]}
+
+    assert exported == {"NVDA", "GROUP_A1", "GROUP_B1"}
+    assert "OUTSIDE_TOP" not in exported
+    assert manifest["symbols_total"] == 3
+
+
 def test_build_key_markets_skips_change_when_latest_close_is_null(service_and_session_factory):
     service, session_factory = service_and_session_factory
 

--- a/frontend/src/static/StaticGroupChartsGrid.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.jsx
@@ -14,7 +14,7 @@ import { getGroupRankColor } from '../utils/colorUtils';
 import { fetchStaticChartPayload, staticChartKeys } from './chartClient';
 
 const MAX_SYMBOLS = 50;
-const CHART_HEIGHT = 420;
+const CHART_HEIGHT = 360;
 
 function StatBadge({ value, label, bgcolor }) {
   return (
@@ -215,7 +215,7 @@ function StaticGroupChartsGrid({ symbols = [], chartIndex = null }) {
           const entry = entryBySymbol.get(sym);
           if (!entry) {
             return (
-              <Grid item xs={12} key={sym}>
+              <Grid item xs={12} md={6} key={sym}>
                 <Card variant="outlined">
                   <Box
                     sx={{
@@ -240,7 +240,7 @@ function StaticGroupChartsGrid({ symbols = [], chartIndex = null }) {
             );
           }
           return (
-            <Grid item xs={12} key={sym}>
+            <Grid item xs={12} md={6} key={sym}>
               <StaticGroupChartCard symbol={sym} entry={entry} />
             </Grid>
           );


### PR DESCRIPTION
…row grid

Adds a third pass to the static chart bundle that covers every constituent of the top-50 IBD industry groups, even when those symbols fall outside the composite-score top-N (Pass 1) and the preset-screen expansion (Pass 2). This ensures the new Charts tab in the static group detail popup is fully populated for the groups where it is offered.

The market export now builds the groups payload before the chart bundle so the top-50 group constituents can be passed into _export_chart_bundle.

Frontend: switches the constituent chart grid from 1 to 2 charts per row on md+ screens (xs={12} md={6}) and tightens the chart height to 360px for a more compact layout.

https://claude.ai/code/session_012Qav8n48vh6ex1YpwTJFsr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Charts now include top industry group constituents, expanding coverage up to 50 groups.

* **Style**
  * Charts now display in a two-column layout on medium-sized screens.
  * Optimized chart height for improved spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->