### PR TITLE
fix(groups): route all markets through ibd_group_ranks service

### DIFF
--- a/backend/app/api/v1/groups.py
+++ b/backend/app/api/v1/groups.py
@@ -57,19 +57,11 @@ def _normalize_market_param(market: str | None) -> str:
 
 
 def _build_groups_payload(db: Session, *, market: str) -> dict:
-    if market == "US":
-        service = _get_group_rank_service()
-        rankings = service.get_current_rankings(db, limit=197)
-        movers = service.get_rank_movers(db, period=DEFAULT_GROUP_PERIOD, limit=10)
-    else:
-        service = _get_market_group_service()
-        rankings = service.get_current_rankings(db, market=market, limit=197)
-        movers = service.get_rank_movers(
-            db,
-            market=market,
-            period=DEFAULT_GROUP_PERIOD,
-            limit=10,
-        )
+    service = _get_group_rank_service()
+    rankings = service.get_current_rankings(db, limit=197, market=market)
+    movers = service.get_rank_movers(
+        db, period=DEFAULT_GROUP_PERIOD, limit=10, market=market
+    )
 
     if not rankings:
         raise GroupsBootstrapUnavailableError(
@@ -117,16 +109,12 @@ async def get_current_rankings(
     for 1 week, 1 month, 3 months, and 6 months.
     """
     normalized_market = _normalize_market_param(market)
-    if normalized_market == "US":
-        service = _get_group_rank_service()
-        rankings = service.get_current_rankings(db, limit=limit)
-    else:
-        service = _get_market_group_service()
-        rankings = service.get_current_rankings(
-            db,
-            market=normalized_market,
-            limit=limit,
-        )
+    service = _get_group_rank_service()
+    rankings = service.get_current_rankings(
+        db,
+        limit=limit,
+        market=normalized_market,
+    )
 
     if not rankings:
         raise HTTPException(
@@ -196,17 +184,13 @@ async def get_rank_movers(
         Lists of rank gainers and losers
     """
     normalized_market = _normalize_market_param(market)
-    if normalized_market == "US":
-        service = _get_group_rank_service()
-        movers = service.get_rank_movers(db, period=period, limit=limit)
-    else:
-        service = _get_market_group_service()
-        movers = service.get_rank_movers(
-            db,
-            market=normalized_market,
-            period=period,
-            limit=limit,
-        )
+    service = _get_group_rank_service()
+    movers = service.get_rank_movers(
+        db,
+        period=period,
+        limit=limit,
+        market=normalized_market,
+    )
 
     if not movers.get('gainers') and not movers.get('losers'):
         raise HTTPException(

--- a/backend/app/services/ibd_group_rank_service.py
+++ b/backend/app/services/ibd_group_rank_service.py
@@ -831,17 +831,17 @@ class IBDGroupRankService:
             if r.get(change_key) is not None
         ]
 
-        # Sort by rank change
-        # Positive change = rank improved (moved up), so sort descending for gainers
-        groups_with_change.sort(key=lambda x: x[change_key], reverse=True)
-
-        gainers = groups_with_change[:limit]
-        losers = groups_with_change[-limit:][::-1]  # Reverse to show biggest losers first
+        # Split by sign so a market with only positive (or only negative) movers
+        # never reports the smallest gainers as "losers" or vice versa.
+        gainers = [r for r in groups_with_change if r[change_key] > 0]
+        losers = [r for r in groups_with_change if r[change_key] < 0]
+        gainers.sort(key=lambda r: r[change_key], reverse=True)
+        losers.sort(key=lambda r: r[change_key])
 
         return {
             'period': period,
-            'gainers': gainers,
-            'losers': losers,
+            'gainers': gainers[:limit],
+            'losers': losers[:limit],
         }
 
     def _get_validated_group_symbols(

--- a/backend/tests/unit/test_group_rank_service.py
+++ b/backend/tests/unit/test_group_rank_service.py
@@ -1141,3 +1141,43 @@ def test_get_current_rankings_can_target_explicit_date():
     finally:
         db_session.rollback()
         db_session.close()
+
+
+def test_get_rank_movers_filters_gainers_and_losers_by_sign(monkeypatch):
+    service = _make_group_rank_service()
+    rankings = [
+        {"industry_group": "Up Big", "rank_change_1w": 8},
+        {"industry_group": "Up Small", "rank_change_1w": 1},
+        {"industry_group": "Flat", "rank_change_1w": 0},
+        {"industry_group": "Down Small", "rank_change_1w": -1},
+        {"industry_group": "Down Big", "rank_change_1w": -7},
+    ]
+    monkeypatch.setattr(
+        service,
+        "get_current_rankings",
+        lambda *args, **kwargs: rankings,
+    )
+
+    movers = service.get_rank_movers(Mock(), period="1w", limit=10, market="HK")
+
+    assert [g["industry_group"] for g in movers["gainers"]] == ["Up Big", "Up Small"]
+    assert [l["industry_group"] for l in movers["losers"]] == ["Down Big", "Down Small"]
+
+
+def test_get_rank_movers_omits_losers_when_only_gainers_exist(monkeypatch):
+    service = _make_group_rank_service()
+    rankings = [
+        {"industry_group": "A", "rank_change_1w": 5},
+        {"industry_group": "B", "rank_change_1w": 2},
+        {"industry_group": "C", "rank_change_1w": 1},
+    ]
+    monkeypatch.setattr(
+        service,
+        "get_current_rankings",
+        lambda *args, **kwargs: rankings,
+    )
+
+    movers = service.get_rank_movers(Mock(), period="1w", limit=10, market="HK")
+
+    assert [g["industry_group"] for g in movers["gainers"]] == ["A", "B", "C"]
+    assert movers["losers"] == []

--- a/backend/tests/unit/test_groups_api_no_data.py
+++ b/backend/tests/unit/test_groups_api_no_data.py
@@ -24,7 +24,7 @@ async def test_get_current_rankings_returns_404_when_no_rankings_exist(monkeypat
     monkeypatch.setattr(server_auth.settings, "server_auth_enabled", False)
 
     class _FakeGroupRankService:
-        def get_current_rankings(self, db, limit=197):  # noqa: ARG002
+        def get_current_rankings(self, db, limit=197, calculation_date=None, *, market="US"):  # noqa: ARG002
             return []
 
     monkeypatch.setattr(
@@ -64,8 +64,8 @@ async def test_get_current_rankings_supports_non_us_market_scope(monkeypatch, cl
 
     monkeypatch.setattr(server_auth.settings, "server_auth_enabled", False)
 
-    class _FakeMarketGroupService:
-        def get_current_rankings(self, db, *, market, limit=197, calculation_date=None):  # noqa: ARG002
+    class _FakeGroupRankService:
+        def get_current_rankings(self, db, limit=197, calculation_date=None, *, market="US"):  # noqa: ARG002
             assert market == "HK"
             return [
                 {
@@ -89,8 +89,8 @@ async def test_get_current_rankings_supports_non_us_market_scope(monkeypatch, cl
             ]
 
     monkeypatch.setattr(
-        "app.api.v1.groups._get_market_group_service",
-        lambda: _FakeMarketGroupService(),
+        "app.api.v1.groups._get_group_rank_service",
+        lambda: _FakeGroupRankService(),
     )
 
     response = await client.get("/api/v1/groups/rankings/current", params={"market": "HK"})
@@ -107,8 +107,8 @@ async def test_get_current_rankings_supports_india_market_scope(monkeypatch, cli
 
     monkeypatch.setattr(server_auth.settings, "server_auth_enabled", False)
 
-    class _FakeMarketGroupService:
-        def get_current_rankings(self, db, *, market, limit=197, calculation_date=None):  # noqa: ARG002
+    class _FakeGroupRankService:
+        def get_current_rankings(self, db, limit=197, calculation_date=None, *, market="US"):  # noqa: ARG002
             assert market == "IN"
             return [
                 {
@@ -132,8 +132,8 @@ async def test_get_current_rankings_supports_india_market_scope(monkeypatch, cli
             ]
 
     monkeypatch.setattr(
-        "app.api.v1.groups._get_market_group_service",
-        lambda: _FakeMarketGroupService(),
+        "app.api.v1.groups._get_group_rank_service",
+        lambda: _FakeGroupRankService(),
     )
 
     response = await client.get("/api/v1/groups/rankings/current", params={"market": "IN"})
@@ -150,8 +150,8 @@ async def test_get_rank_movers_supports_non_us_market_scope(monkeypatch, client)
 
     monkeypatch.setattr(server_auth.settings, "server_auth_enabled", False)
 
-    class _FakeMarketGroupService:
-        def get_rank_movers(self, db, *, market, period="1w", limit=20, calculation_date=None):  # noqa: ARG002
+    class _FakeGroupRankService:
+        def get_rank_movers(self, db, period="1w", limit=20, calculation_date=None, *, market="US"):  # noqa: ARG002
             assert market == "JP"
             assert period == "1m"
             return {
@@ -180,8 +180,8 @@ async def test_get_rank_movers_supports_non_us_market_scope(monkeypatch, client)
             }
 
     monkeypatch.setattr(
-        "app.api.v1.groups._get_market_group_service",
-        lambda: _FakeMarketGroupService(),
+        "app.api.v1.groups._get_group_rank_service",
+        lambda: _FakeGroupRankService(),
     )
 
     response = await client.get("/api/v1/groups/rankings/movers", params={"market": "JP", "period": "1m"})
@@ -254,8 +254,8 @@ async def test_get_groups_bootstrap_supports_non_us_market_scope(monkeypatch, cl
         def get_groups_bootstrap(self):
             return None
 
-    class _FakeMarketGroupService:
-        def get_current_rankings(self, db, *, market, limit=197, calculation_date=None):  # noqa: ARG002
+    class _FakeGroupRankService:
+        def get_current_rankings(self, db, limit=197, calculation_date=None, *, market="US"):  # noqa: ARG002
             assert market == "HK"
             return [
                 {
@@ -278,13 +278,13 @@ async def test_get_groups_bootstrap_supports_non_us_market_scope(monkeypatch, cl
                 }
             ]
 
-        def get_rank_movers(self, db, *, market, period="1w", limit=10, calculation_date=None):  # noqa: ARG002
+        def get_rank_movers(self, db, period="1w", limit=10, calculation_date=None, *, market="US"):  # noqa: ARG002
             assert market == "HK"
             return {"period": "1w", "gainers": [], "losers": []}
 
     monkeypatch.setattr(
-        "app.api.v1.groups._get_market_group_service",
-        lambda: _FakeMarketGroupService(),
+        "app.api.v1.groups._get_group_rank_service",
+        lambda: _FakeGroupRankService(),
     )
     app.dependency_overrides[get_ui_snapshot_service] = lambda: _FakeSnapshotService()
     try:


### PR DESCRIPTION
The dynamic groups page was returning US data for non-US markets because the API endpoint split routing between two services:
  - US -> IBDGroupRankService (reads ibd_group_ranks, market-aware)
  - non-US -> MarketGroupRankingService (computes from feature_runs)

The non-US path was brittle: it relied on parsing
config_json["universe"]["market"] from FeatureRun records and recomputing rankings on the fly, which could silently drop or misroute data when the feature-run universe metadata diverged from what the live API expected.

IBDGroupRankService is already fully market-aware (get_current_rankings, get_rank_movers, and get_group_history all accept a market kwarg) and the calculate_daily_group_rankings task persists per-market rankings into ibd_group_ranks for HK/JP/TW/IN/KR/CN. Route the rankings/current, rankings/movers, and bootstrap endpoints (and the shared payload builder) through that service so every market reads the same persisted source.

get_group_detail still uses MarketGroupRankingService for non-US so the group detail modal keeps its market-scoped constituent stocks from the FeatureRun (IBDGroupRankService.get_group_history loads constituents from the latest scan, which is not market-scoped).