### PR TITLE
Seed predefined filter presets for live deployments

### DIFF
--- a/backend/alembic/versions/20260503_0018_seed_predefined_filter_presets.py
+++ b/backend/alembic/versions/20260503_0018_seed_predefined_filter_presets.py
@@ -15,6 +15,11 @@ Two static-site presets are intentionally excluded:
 
 Definitions are embedded inline so the migration is self-contained and stable
 even if ``preset_screens.py`` is later refactored.
+
+``downgrade()`` is content-aware: it only deletes rows whose name, filters,
+sort_by, and sort_order all still match what ``upgrade()`` inserted. Rows the
+upgrade skipped (because a user-created preset with the same name already
+existed) and rows the user has since edited are left untouched.
 """
 
 from __future__ import annotations
@@ -300,8 +305,24 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    """Remove only rows whose content still matches what upgrade() inserted.
+
+    A user may have (a) pre-existed with a same-named preset that upgrade
+    skipped, or (b) edited a seeded preset's filters / sort. In both cases the
+    row no longer represents migration-owned data, so we leave it in place to
+    avoid irreversible loss of user work.
+    """
+    bind = op.get_bind()
     table = _filter_presets_table()
-    seeded_names = [name for name, *_ in SEEDED_PRESETS]
-    op.execute(
-        table.delete().where(table.c.name.in_(seeded_names))
-    )
+
+    for name, _description, overrides, sort_by, sort_order in SEEDED_PRESETS:
+        bind.execute(
+            table.delete().where(
+                sa.and_(
+                    table.c.name == name,
+                    table.c.filters == _build_filters_payload(overrides),
+                    table.c.sort_by == sort_by,
+                    table.c.sort_order == sort_order,
+                )
+            )
+        )

--- a/backend/alembic/versions/20260503_0018_seed_predefined_filter_presets.py
+++ b/backend/alembic/versions/20260503_0018_seed_predefined_filter_presets.py
@@ -1,0 +1,307 @@
+"""Seed predefined filter presets (Minervini, CANSLIM, etc.) for live deployments.
+
+Mirrors the predefined screens that the static site exposes via
+``app.services.preset_screens.PRESET_SCREENS`` so that Docker / live deployments
+ship with the same starter set out of the box. Users can rename, edit, or delete
+these rows like any other ``filter_presets`` entry — Alembic only runs this
+migration once, so deletions stick across restarts.
+
+Two static-site presets are intentionally excluded:
+
+* ``movers_9m`` — uses ``minVolume`` interpreted as dollar volume; on the live
+  site ``min_volume`` is share count, so the same numeric value is meaningless.
+* ``club_97`` — relies on ``pctDay`` / ``pctWeek`` / ``pctMonth`` percentile
+  fields that exist only in the static-site row schema.
+
+Definitions are embedded inline so the migration is self-contained and stable
+even if ``preset_screens.py`` is later refactored.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20260503_0018"
+down_revision = "20260426_0017"
+branch_labels = None
+depends_on = None
+
+
+# Empty filter shape mirroring frontend/src/features/scan/defaultFilters.js
+# `buildDefaultScanFilters()`. Stored full-shape so seeded presets behave
+# identically to user-saved presets when loaded into the FilterPanel.
+def _empty_filter_shape() -> dict[str, Any]:
+    range_filter = {"min": None, "max": None}
+    return {
+        "symbolSearch": "",
+        "stage": None,
+        "ratings": [],
+        "ibdIndustries": {"values": [], "mode": "include"},
+        "gicsSectors": {"values": [], "mode": "include"},
+        "minVolume": None,
+        "minMarketCap": None,
+        "marketCapUsd": dict(range_filter),
+        "advUsd": dict(range_filter),
+        "markets": [],
+        "compositeScore": dict(range_filter),
+        "minerviniScore": dict(range_filter),
+        "canslimScore": dict(range_filter),
+        "ipoScore": dict(range_filter),
+        "customScore": dict(range_filter),
+        "volBreakthroughScore": dict(range_filter),
+        "seSetupScore": dict(range_filter),
+        "seDistanceToPivot": dict(range_filter),
+        "seBbSqueeze": dict(range_filter),
+        "seVolumeVs50d": dict(range_filter),
+        "seSetupReady": None,
+        "seRsLineNewHigh": None,
+        "rsRating": dict(range_filter),
+        "rs1m": dict(range_filter),
+        "rs3m": dict(range_filter),
+        "rs12m": dict(range_filter),
+        "epsRating": dict(range_filter),
+        "price": dict(range_filter),
+        "adrPercent": dict(range_filter),
+        "epsGrowth": dict(range_filter),
+        "salesGrowth": dict(range_filter),
+        "vcpScore": dict(range_filter),
+        "vcpPivot": dict(range_filter),
+        "vcpDetected": None,
+        "vcpReady": None,
+        "maAlignment": None,
+        "passesTemplate": None,
+        "perfDay": dict(range_filter),
+        "perfWeek": dict(range_filter),
+        "perfMonth": dict(range_filter),
+        "perf3m": dict(range_filter),
+        "perf6m": dict(range_filter),
+        "gapPercent": dict(range_filter),
+        "volumeSurge": dict(range_filter),
+        "ema10Distance": dict(range_filter),
+        "ema20Distance": dict(range_filter),
+        "ema50Distance": dict(range_filter),
+        "week52HighDistance": dict(range_filter),
+        "week52LowDistance": dict(range_filter),
+        "ipoAfter": None,
+        "beta": dict(range_filter),
+        "betaAdjRs": dict(range_filter),
+    }
+
+
+# (name, description, sparse_filter_overrides, sort_by, sort_order)
+SEEDED_PRESETS: list[tuple[str, str, dict[str, Any], str, str]] = [
+    (
+        "Minervini Trend Template",
+        "Stage 2 uptrend stocks passing the 8-point trend template.",
+        {
+            "minerviniScore": {"min": 70, "max": None},
+            "stage": 2,
+            "maAlignment": True,
+            "rsRating": {"min": 70, "max": None},
+        },
+        "minervini_score",
+        "desc",
+    ),
+    (
+        "CANSLIM",
+        "William O'Neil growth screen: strong earnings, RS, and institutional demand.",
+        {
+            "canslimScore": {"min": 70, "max": None},
+            "epsGrowth": {"min": 25, "max": None},
+            "rsRating": {"min": 80, "max": None},
+        },
+        "canslim_score",
+        "desc",
+    ),
+    (
+        "VCP Setups",
+        "Volatility contraction patterns with Minervini trend confirmation.",
+        {
+            "vcpDetected": True,
+            "minerviniScore": {"min": 50, "max": None},
+        },
+        "vcp_score",
+        "desc",
+    ),
+    (
+        "Volume Breakthrough",
+        "Record-volume breakouts across 1-year and 5-year lookbacks.",
+        {
+            "volBreakthroughScore": {"min": 33, "max": None},
+        },
+        "volume_breakthrough_score",
+        "desc",
+    ),
+    (
+        "Episodic Pivot",
+        "Qullamaggie-style gap-ups on massive volume.",
+        {
+            "gapPercent": {"min": 10, "max": None},
+            "volumeSurge": {"min": 2.0, "max": None},
+            "rsRating": {"min": 70, "max": None},
+        },
+        "gap_percent",
+        "desc",
+    ),
+    (
+        "Momentum Leaders",
+        "Top performers over 3-6 months in confirmed Stage 2 uptrends.",
+        {
+            "perf3m": {"min": 30, "max": None},
+            "perf6m": {"min": 80, "max": None},
+            "rsRating": {"min": 85, "max": None},
+            "stage": 2,
+        },
+        "perf_6m",
+        "desc",
+    ),
+    (
+        "Oliver Kell Growth",
+        "Growth stocks near highs with strong earnings and sales acceleration.",
+        {
+            "price": {"min": 20, "max": None},
+            "epsGrowth": {"min": 25, "max": None},
+            "salesGrowth": {"min": 15, "max": None},
+            "rsRating": {"min": 80, "max": None},
+            "week52HighDistance": {"min": -15, "max": None},
+        },
+        "composite_score",
+        "desc",
+    ),
+    (
+        "RS Power Play",
+        "Elite relative strength leaders in Stage 2 uptrends.",
+        {
+            "rsRating": {"min": 90, "max": None},
+            "rs3m": {"min": 85, "max": None},
+            "stage": 2,
+        },
+        "rs_rating",
+        "desc",
+    ),
+    (
+        "New Highs + Volume",
+        "Stocks at or near 52-week highs with above-average volume.",
+        {
+            "week52HighDistance": {"min": -5, "max": None},
+            "volumeSurge": {"min": 1.3, "max": None},
+            "rsRating": {"min": 70, "max": None},
+        },
+        "week_52_high_distance",
+        "desc",
+    ),
+    (
+        "Growth Rockets",
+        "Triple-digit EPS and sales growth with strong relative strength.",
+        {
+            "epsGrowth": {"min": 40, "max": None},
+            "salesGrowth": {"min": 30, "max": None},
+            "rsRating": {"min": 70, "max": None},
+        },
+        "eps_growth_qq",
+        "desc",
+    ),
+    (
+        "Tight Setups",
+        "Low-volatility bases with VCP characteristics in strong uptrends.",
+        {
+            "adrPercent": {"min": None, "max": 4},
+            "rsRating": {"min": 80, "max": None},
+            "vcpScore": {"min": 30, "max": None},
+            "stage": 2,
+        },
+        "vcp_score",
+        "desc",
+    ),
+    (
+        "Recent IPOs",
+        "High-scoring recent IPOs with strong early price action.",
+        {
+            "ipoScore": {"min": 50, "max": None},
+        },
+        "ipo_score",
+        "desc",
+    ),
+    (
+        "4% Daily Gainers",
+        "Stocks advancing 4%+ intraday — quick broad-market momentum scan.",
+        {
+            "perfDay": {"min": 4, "max": None},
+        },
+        "price_change_1d",
+        "desc",
+    ),
+    (
+        "20% Weekly Movers",
+        "Stocks up 20%+ over the past 5 sessions.",
+        {
+            "perfWeek": {"min": 20, "max": None},
+        },
+        "perf_week",
+        "desc",
+    ),
+]
+
+
+def _filter_presets_table() -> sa.Table:
+    return sa.table(
+        "filter_presets",
+        sa.column("id", sa.Integer),
+        sa.column("name", sa.String),
+        sa.column("description", sa.Text),
+        sa.column("filters", sa.Text),
+        sa.column("sort_by", sa.String),
+        sa.column("sort_order", sa.String),
+        sa.column("position", sa.Integer),
+    )
+
+
+def _build_filters_payload(overrides: dict[str, Any]) -> str:
+    payload = _empty_filter_shape()
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    table = _filter_presets_table()
+
+    existing_names = {
+        row[0]
+        for row in bind.execute(sa.select(table.c.name)).fetchall()
+    }
+    next_position = bind.execute(
+        sa.select(sa.func.coalesce(sa.func.max(table.c.position), -1))
+    ).scalar_one() + 1
+
+    rows_to_insert: list[dict[str, Any]] = []
+    for name, description, overrides, sort_by, sort_order in SEEDED_PRESETS:
+        if name in existing_names:
+            continue
+        rows_to_insert.append(
+            {
+                "name": name,
+                "description": description,
+                "filters": _build_filters_payload(overrides),
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+                "position": next_position,
+            }
+        )
+        next_position += 1
+
+    if rows_to_insert:
+        op.bulk_insert(table, rows_to_insert)
+
+
+def downgrade() -> None:
+    table = _filter_presets_table()
+    seeded_names = [name for name, *_ in SEEDED_PRESETS]
+    op.execute(
+        table.delete().where(table.c.name.in_(seeded_names))
+    )

--- a/backend/alembic/versions/20260503_0018_seed_predefined_filter_presets.py
+++ b/backend/alembic/versions/20260503_0018_seed_predefined_filter_presets.py
@@ -16,10 +16,13 @@ Two static-site presets are intentionally excluded:
 Definitions are embedded inline so the migration is self-contained and stable
 even if ``preset_screens.py`` is later refactored.
 
-``downgrade()`` is content-aware: it only deletes rows whose name, filters,
-sort_by, and sort_order all still match what ``upgrade()`` inserted. Rows the
-upgrade skipped (because a user-created preset with the same name already
-existed) and rows the user has since edited are left untouched.
+``downgrade()`` is content-aware: it only deletes rows whose name,
+description, filters, sort_by, and sort_order all still match what
+``upgrade()`` inserted. Rows the upgrade skipped (because a user-created
+preset with the same name already existed) and rows the user has since edited
+are left untouched. ``position`` is excluded from the match because it is
+auto-assigned at seed time and is mutated by the reorder API during normal
+use.
 """
 
 from __future__ import annotations
@@ -308,18 +311,25 @@ def downgrade() -> None:
     """Remove only rows whose content still matches what upgrade() inserted.
 
     A user may have (a) pre-existed with a same-named preset that upgrade
-    skipped, or (b) edited a seeded preset's filters / sort. In both cases the
-    row no longer represents migration-owned data, so we leave it in place to
-    avoid irreversible loss of user work.
+    skipped, (b) renamed, edited filters, changed the sort, or rewritten the
+    description on a seeded row. In any of those cases the row no longer
+    represents migration-owned data and we leave it in place to avoid
+    irreversible loss of user work.
+
+    ``position`` is intentionally excluded from the match. It is auto-assigned
+    at upgrade time based on the live table's max(position) and is mutated by
+    the reorder API, so it can drift from its seed value through normal use
+    without indicating that the row's content has been edited.
     """
     bind = op.get_bind()
     table = _filter_presets_table()
 
-    for name, _description, overrides, sort_by, sort_order in SEEDED_PRESETS:
+    for name, description, overrides, sort_by, sort_order in SEEDED_PRESETS:
         bind.execute(
             table.delete().where(
                 sa.and_(
                     table.c.name == name,
+                    table.c.description == description,
                     table.c.filters == _build_filters_payload(overrides),
                     table.c.sort_by == sort_by,
                     table.c.sort_order == sort_order,

--- a/backend/alembic/versions/20260503_0018_seed_predefined_filter_presets.py
+++ b/backend/alembic/versions/20260503_0018_seed_predefined_filter_presets.py
@@ -16,13 +16,16 @@ Two static-site presets are intentionally excluded:
 Definitions are embedded inline so the migration is self-contained and stable
 even if ``preset_screens.py`` is later refactored.
 
-``downgrade()`` is content-aware: it only deletes rows whose name,
-description, filters, sort_by, and sort_order all still match what
-``upgrade()`` inserted. Rows the upgrade skipped (because a user-created
-preset with the same name already existed) and rows the user has since edited
-are left untouched. ``position`` is excluded from the match because it is
+``downgrade()`` only removes rows that ``upgrade()`` actually inserted. To
+distinguish migration-owned rows from user data, ``upgrade()`` records each
+inserted primary key in an internal audit table (``_seed_predefined_filter
+_presets_audit``); ``downgrade()`` reads that list and deletes only those
+specific rows whose ``name``, ``description``, ``filters``, ``sort_by``, and
+``sort_order`` all still match the seed values. Pre-existing user rows
+(skipped by upgrade) and seeded rows the user has since edited are left
+untouched. ``position`` is excluded from the match because it is
 auto-assigned at seed time and is mutated by the reorder API during normal
-use.
+use. The audit table is dropped at the end of ``downgrade()``.
 """
 
 from __future__ import annotations
@@ -256,16 +259,32 @@ SEEDED_PRESETS: list[tuple[str, str, dict[str, Any], str, str]] = [
 ]
 
 
+_AUDIT_TABLE_NAME = "_seed_predefined_filter_presets_audit"
+
+
 def _filter_presets_table() -> sa.Table:
-    return sa.table(
+    # Each call gets its own MetaData so the migration can be re-imported
+    # in tests without colliding on the shared global metadata registry.
+    metadata = sa.MetaData()
+    return sa.Table(
         "filter_presets",
-        sa.column("id", sa.Integer),
-        sa.column("name", sa.String),
-        sa.column("description", sa.Text),
-        sa.column("filters", sa.Text),
-        sa.column("sort_by", sa.String),
-        sa.column("sort_order", sa.String),
-        sa.column("position", sa.Integer),
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String),
+        sa.Column("description", sa.Text),
+        sa.Column("filters", sa.Text),
+        sa.Column("sort_by", sa.String),
+        sa.Column("sort_order", sa.String),
+        sa.Column("position", sa.Integer),
+    )
+
+
+def _audit_table_ref() -> sa.Table:
+    metadata = sa.MetaData()
+    return sa.Table(
+        _AUDIT_TABLE_NAME,
+        metadata,
+        sa.Column("filter_preset_id", sa.Integer, primary_key=True),
     )
 
 
@@ -303,36 +322,78 @@ def upgrade() -> None:
         )
         next_position += 1
 
-    if rows_to_insert:
-        op.bulk_insert(table, rows_to_insert)
+    # Always create the audit table so downgrade has a deterministic shape
+    # to read, even when nothing was inserted (e.g. every name pre-existed).
+    # Guard with has_table so a defensive re-run of upgrade() — which Alembic
+    # itself never does, but tests and recovery flows do — stays a no-op.
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(_AUDIT_TABLE_NAME):
+        op.create_table(
+            _AUDIT_TABLE_NAME,
+            sa.Column("filter_preset_id", sa.Integer, primary_key=True),
+        )
+
+    if not rows_to_insert:
+        return
+
+    audit = _audit_table_ref()
+    inserted_ids: list[int] = []
+    for row in rows_to_insert:
+        result = bind.execute(table.insert().values(**row))
+        # inserted_primary_key is a tuple-like; element 0 is the new id.
+        inserted_ids.append(int(result.inserted_primary_key[0]))
+
+    bind.execute(
+        audit.insert(),
+        [{"filter_preset_id": new_id} for new_id in inserted_ids],
+    )
 
 
 def downgrade() -> None:
-    """Remove only rows whose content still matches what upgrade() inserted.
+    """Remove only rows that ``upgrade()`` actually inserted and which the
+    user has not edited since.
 
-    A user may have (a) pre-existed with a same-named preset that upgrade
-    skipped, (b) renamed, edited filters, changed the sort, or rewritten the
-    description on a seeded row. In any of those cases the row no longer
-    represents migration-owned data and we leave it in place to avoid
-    irreversible loss of user work.
+    Inserted IDs are read from the audit table written by ``upgrade()``. Even
+    if a row's content (name, description, filters, sort_by, sort_order)
+    matches a seed value byte-for-byte, it is preserved unless its primary
+    key is recorded as migration-owned. This handles the realistic edge case
+    where a user manually recreated a static preset with identical content
+    before this migration ran — ``upgrade()`` skipped it on the basis of a
+    name conflict, so ``downgrade()`` must not delete it either.
 
-    ``position`` is intentionally excluded from the match. It is auto-assigned
-    at upgrade time based on the live table's max(position) and is mutated by
-    the reorder API, so it can drift from its seed value through normal use
-    without indicating that the row's content has been edited.
+    A user-edited seeded row stays put because the content match fails;
+    ``position`` is intentionally not part of the match because it is
+    auto-assigned at seed time and is mutated by the reorder API during
+    normal use, so position drift is not an edit signal.
     """
     bind = op.get_bind()
     table = _filter_presets_table()
 
-    for name, description, overrides, sort_by, sort_order in SEEDED_PRESETS:
-        bind.execute(
-            table.delete().where(
-                sa.and_(
-                    table.c.name == name,
-                    table.c.description == description,
-                    table.c.filters == _build_filters_payload(overrides),
-                    table.c.sort_by == sort_by,
-                    table.c.sort_order == sort_order,
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(_AUDIT_TABLE_NAME):
+        # Nothing to roll back — upgrade was never applied (or the audit
+        # table was already dropped). Stay idempotent.
+        return
+
+    audit = _audit_table_ref()
+    inserted_ids = [
+        row[0]
+        for row in bind.execute(sa.select(audit.c.filter_preset_id)).fetchall()
+    ]
+
+    if inserted_ids:
+        for name, description, overrides, sort_by, sort_order in SEEDED_PRESETS:
+            bind.execute(
+                table.delete().where(
+                    sa.and_(
+                        table.c.id.in_(inserted_ids),
+                        table.c.name == name,
+                        table.c.description == description,
+                        table.c.filters == _build_filters_payload(overrides),
+                        table.c.sort_by == sort_by,
+                        table.c.sort_order == sort_order,
+                    )
                 )
             )
-        )
+
+    op.drop_table(_AUDIT_TABLE_NAME)

--- a/backend/tests/unit/test_seed_predefined_filter_presets_migration.py
+++ b/backend/tests/unit/test_seed_predefined_filter_presets_migration.py
@@ -303,3 +303,63 @@ def test_downgrade_preserves_user_edits_to_seeded_row():
     assert "CANSLIM" in kept_names
     # Untouched seeded presets are still removed.
     assert "VCP Setups" not in kept_names
+
+
+def test_downgrade_preserves_description_edits():
+    """A user-edited description marks the row as no longer migration-owned."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    with engine.begin() as conn:
+        _run_upgrade(migration, conn)
+        conn.execute(
+            sa.text(
+                "UPDATE filter_presets SET description = :desc "
+                "WHERE name = 'Minervini Trend Template'"
+            ),
+            {"desc": "My personalised notes about this screen"},
+        )
+
+        _run_downgrade(migration, conn)
+
+        survivor = conn.execute(
+            sa.text(
+                "SELECT description FROM filter_presets "
+                "WHERE name = 'Minervini Trend Template'"
+            )
+        ).scalar_one_or_none()
+
+    engine.dispose()
+
+    assert survivor == "My personalised notes about this screen"
+
+
+def test_downgrade_ignores_position_changes():
+    """Reordering a seeded preset must not block its removal on rollback —
+    position is auto-assigned and is mutated by the reorder API during normal use,
+    so it doesn't indicate a content edit.
+    """
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    with engine.begin() as conn:
+        _run_upgrade(migration, conn)
+
+        # Simulate the reorder endpoint shuffling positions.
+        conn.execute(
+            sa.text("UPDATE filter_presets SET position = position + 100")
+        )
+
+        _run_downgrade(migration, conn)
+
+        remaining = conn.execute(
+            sa.text("SELECT COUNT(*) FROM filter_presets")
+        ).scalar_one()
+
+    engine.dispose()
+
+    assert remaining == 0

--- a/backend/tests/unit/test_seed_predefined_filter_presets_migration.py
+++ b/backend/tests/unit/test_seed_predefined_filter_presets_migration.py
@@ -211,3 +211,95 @@ def test_downgrade_removes_seeded_presets_only():
     engine.dispose()
 
     assert [row[0] for row in remaining] == ["User Custom"]
+
+
+def test_downgrade_preserves_preexisting_user_row_with_seeded_name():
+    """A user-created 'CANSLIM' that pre-dates this migration must survive downgrade."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    user_payload = json.dumps({"customized_by": "user", "filters": {"epsRating": {"min": 95}}})
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO filter_presets "
+                "(name, description, filters, sort_by, sort_order, position) "
+                "VALUES "
+                "('CANSLIM', 'user copy', :filters, 'composite_score', 'asc', 0)"
+            ),
+            {"filters": user_payload},
+        )
+
+        _run_upgrade(migration, conn)
+        _run_downgrade(migration, conn)
+
+        survivors = conn.execute(
+            sa.text(
+                "SELECT name, description, filters, sort_by, sort_order "
+                "FROM filter_presets WHERE name = 'CANSLIM'"
+            )
+        ).fetchall()
+
+    engine.dispose()
+
+    assert len(survivors) == 1
+    name, description, filters_json, sort_by, sort_order = survivors[0]
+    assert name == "CANSLIM"
+    assert description == "user copy"
+    assert filters_json == user_payload
+    assert sort_by == "composite_score"
+    assert sort_order == "asc"
+
+
+def test_downgrade_preserves_user_edits_to_seeded_row():
+    """If a user changes a seeded preset's filters or sort, downgrade leaves it alone."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    with engine.begin() as conn:
+        _run_upgrade(migration, conn)
+
+        # User tightens the Minervini RS threshold from 70 to 90.
+        edited_filters = migration._empty_filter_shape()
+        edited_filters.update(
+            {
+                "minerviniScore": {"min": 70, "max": None},
+                "stage": 2,
+                "maAlignment": True,
+                "rsRating": {"min": 90, "max": None},
+            }
+        )
+        conn.execute(
+            sa.text(
+                "UPDATE filter_presets SET filters = :filters "
+                "WHERE name = 'Minervini Trend Template'"
+            ),
+            {"filters": json.dumps(edited_filters)},
+        )
+
+        # User flips CANSLIM sort to ascending.
+        conn.execute(
+            sa.text(
+                "UPDATE filter_presets SET sort_order = 'asc' WHERE name = 'CANSLIM'"
+            )
+        )
+
+        _run_downgrade(migration, conn)
+
+        kept_names = {
+            row[0]
+            for row in conn.execute(
+                sa.text("SELECT name FROM filter_presets")
+            ).fetchall()
+        }
+
+    engine.dispose()
+
+    assert "Minervini Trend Template" in kept_names
+    assert "CANSLIM" in kept_names
+    # Untouched seeded presets are still removed.
+    assert "VCP Setups" not in kept_names

--- a/backend/tests/unit/test_seed_predefined_filter_presets_migration.py
+++ b/backend/tests/unit/test_seed_predefined_filter_presets_migration.py
@@ -1,0 +1,213 @@
+"""Tests for the predefined filter presets seed migration."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+MIGRATION_FILENAME = "20260503_0018_seed_predefined_filter_presets.py"
+
+
+def _load_migration():
+    path = MIGRATIONS_DIR / MIGRATION_FILENAME
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_filter_presets_table(engine: sa.Engine) -> None:
+    metadata = sa.MetaData()
+    sa.Table(
+        "filter_presets",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False, unique=True),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("filters", sa.Text, nullable=False),
+        sa.Column("sort_by", sa.String(50), nullable=False),
+        sa.Column("sort_order", sa.String(10), nullable=False),
+        sa.Column("position", sa.Integer, nullable=False),
+    )
+    metadata.create_all(engine)
+
+
+def _run_upgrade(module, connection) -> None:
+    context = MigrationContext.configure(connection)
+    module.op = Operations(context)
+    module.upgrade()
+
+
+def _run_downgrade(module, connection) -> None:
+    context = MigrationContext.configure(connection)
+    module.op = Operations(context)
+    module.downgrade()
+
+
+def test_seed_inserts_all_predefined_presets_into_empty_table():
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+    expected_names = [name for name, *_ in migration.SEEDED_PRESETS]
+
+    with engine.begin() as conn:
+        _run_upgrade(migration, conn)
+
+        rows = conn.execute(
+            sa.text("SELECT name, position, sort_by, sort_order, filters FROM filter_presets ORDER BY position")
+        ).fetchall()
+
+    engine.dispose()
+
+    assert [row[0] for row in rows] == expected_names
+    assert [row[1] for row in rows] == list(range(len(expected_names)))
+
+    # Every seeded row must be valid JSON containing the full default filter shape.
+    expected_keys = set(migration._empty_filter_shape().keys())
+    for _, _, _, _, filters_json in rows:
+        parsed = json.loads(filters_json)
+        assert set(parsed.keys()) == expected_keys
+
+
+def test_seed_excludes_static_only_presets():
+    """movers_9m and club_97 use semantics or fields the live site doesn't support."""
+    migration = _load_migration()
+    seeded_names = {name for name, *_ in migration.SEEDED_PRESETS}
+
+    assert "9M Movers" not in seeded_names
+    assert "97 Club" not in seeded_names
+
+
+def test_minervini_preset_carries_canonical_overrides():
+    migration = _load_migration()
+    overrides_by_name = {
+        name: overrides for name, _desc, overrides, *_ in migration.SEEDED_PRESETS
+    }
+
+    minervini = overrides_by_name["Minervini Trend Template"]
+    assert minervini["minerviniScore"] == {"min": 70, "max": None}
+    assert minervini["stage"] == 2
+    assert minervini["maAlignment"] is True
+    assert minervini["rsRating"] == {"min": 70, "max": None}
+
+    canslim = overrides_by_name["CANSLIM"]
+    assert canslim["canslimScore"] == {"min": 70, "max": None}
+    assert canslim["epsGrowth"] == {"min": 25, "max": None}
+    assert canslim["rsRating"] == {"min": 80, "max": None}
+
+
+def test_seed_skips_presets_whose_names_already_exist():
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    user_minervini_payload = json.dumps({"customized": True})
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO filter_presets "
+                "(name, description, filters, sort_by, sort_order, position) "
+                "VALUES "
+                "('Minervini Trend Template', 'user copy', :filters, 'composite_score', 'desc', 0)"
+            ),
+            {"filters": user_minervini_payload},
+        )
+        _run_upgrade(migration, conn)
+
+        existing = conn.execute(
+            sa.text(
+                "SELECT filters FROM filter_presets WHERE name = 'Minervini Trend Template'"
+            )
+        ).scalar_one()
+        total = conn.execute(sa.text("SELECT COUNT(*) FROM filter_presets")).scalar_one()
+
+    engine.dispose()
+
+    assert existing == user_minervini_payload  # untouched
+    # Original user row + every seeded preset except the skipped Minervini one.
+    assert total == 1 + (len(migration.SEEDED_PRESETS) - 1)
+
+
+def test_seed_starts_position_after_existing_max():
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO filter_presets "
+                "(name, description, filters, sort_by, sort_order, position) "
+                "VALUES "
+                "('User Pinned', NULL, '{}', 'composite_score', 'desc', 7)"
+            )
+        )
+        _run_upgrade(migration, conn)
+
+        seeded_positions = conn.execute(
+            sa.text(
+                "SELECT position FROM filter_presets "
+                "WHERE name <> 'User Pinned' ORDER BY position"
+            )
+        ).fetchall()
+
+    engine.dispose()
+
+    positions = [row[0] for row in seeded_positions]
+    assert positions == list(range(8, 8 + len(migration.SEEDED_PRESETS)))
+
+
+def test_seed_is_idempotent_when_run_twice():
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    with engine.begin() as conn:
+        _run_upgrade(migration, conn)
+        first_count = conn.execute(sa.text("SELECT COUNT(*) FROM filter_presets")).scalar_one()
+        _run_upgrade(migration, conn)
+        second_count = conn.execute(sa.text("SELECT COUNT(*) FROM filter_presets")).scalar_one()
+
+    engine.dispose()
+
+    assert first_count == len(migration.SEEDED_PRESETS)
+    assert second_count == first_count
+
+
+def test_downgrade_removes_seeded_presets_only():
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO filter_presets "
+                "(name, description, filters, sort_by, sort_order, position) "
+                "VALUES "
+                "('User Custom', NULL, '{}', 'composite_score', 'desc', 0)"
+            )
+        )
+        _run_upgrade(migration, conn)
+        _run_downgrade(migration, conn)
+
+        remaining = conn.execute(
+            sa.text("SELECT name FROM filter_presets")
+        ).fetchall()
+
+    engine.dispose()
+
+    assert [row[0] for row in remaining] == ["User Custom"]

--- a/backend/tests/unit/test_seed_predefined_filter_presets_migration.py
+++ b/backend/tests/unit/test_seed_predefined_filter_presets_migration.py
@@ -336,6 +336,86 @@ def test_downgrade_preserves_description_edits():
     assert survivor == "My personalised notes about this screen"
 
 
+def test_downgrade_preserves_preexisting_row_with_byte_identical_seed_content():
+    """If a user pre-existed with a row whose name+description+filters+sort
+    match the seed exactly, upgrade() skips it and downgrade() must not
+    delete it — the migration never owned that primary key.
+    """
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    # Pick the Minervini seed and reproduce it byte-for-byte.
+    name, description, overrides, sort_by, sort_order = next(
+        item
+        for item in migration.SEEDED_PRESETS
+        if item[0] == "Minervini Trend Template"
+    )
+    seed_filters_json = migration._build_filters_payload(overrides)
+
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO filter_presets "
+                "(name, description, filters, sort_by, sort_order, position) "
+                "VALUES "
+                "(:name, :description, :filters, :sort_by, :sort_order, 0)"
+            ),
+            {
+                "name": name,
+                "description": description,
+                "filters": seed_filters_json,
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+            },
+        )
+        preexisting_id = conn.execute(
+            sa.text("SELECT id FROM filter_presets WHERE name = :n"),
+            {"n": name},
+        ).scalar_one()
+
+        _run_upgrade(migration, conn)
+        _run_downgrade(migration, conn)
+
+        survivor_id = conn.execute(
+            sa.text("SELECT id FROM filter_presets WHERE name = :n"),
+            {"n": name},
+        ).scalar_one_or_none()
+
+    engine.dispose()
+
+    assert survivor_id == preexisting_id
+
+
+def test_downgrade_is_safe_when_audit_table_missing():
+    """downgrade() must be a no-op if upgrade() never ran (audit table absent)."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    _make_filter_presets_table(engine)
+
+    migration = _load_migration()
+
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO filter_presets "
+                "(name, description, filters, sort_by, sort_order, position) "
+                "VALUES "
+                "('Some User Preset', NULL, '{}', 'composite_score', 'desc', 0)"
+            )
+        )
+
+        _run_downgrade(migration, conn)
+
+        remaining = conn.execute(
+            sa.text("SELECT name FROM filter_presets")
+        ).fetchall()
+
+    engine.dispose()
+
+    assert [row[0] for row in remaining] == ["Some User Preset"]
+
+
 def test_downgrade_ignores_position_changes():
     """Reordering a seeded preset must not block its removal on rollback —
     position is auto-assigned and is mutated by the reorder API during normal use,


### PR DESCRIPTION
## Summary
Adds an Alembic migration that seeds a curated set of 14 predefined filter presets (Minervini Trend Template, CANSLIM, VCP Setups, etc.) into the `filter_presets` table for live deployments. This mirrors the preset screens exposed by the static site, ensuring Docker deployments ship with the same starter set out of the box.

## Key Changes
- **Migration `20260503_0018`**: Seeds 14 predefined filter presets with full filter configurations, sort orders, and descriptions
  - Intentionally excludes `movers_9m` (uses incompatible dollar volume semantics) and `club_97` (relies on static-site-only percentile fields)
  - Stores full filter shape (matching frontend defaults) so seeded presets behave identically to user-saved presets
  - Skips insertion if a preset name already exists, allowing users to customize without migration conflicts
  - Positions new presets after existing ones to preserve user ordering
  - Downgrade removes only seeded presets, preserving user-created ones

- **Comprehensive test suite**: 8 tests covering:
  - Correct insertion of all 14 presets into empty table
  - Exclusion of static-site-only presets
  - Canonical filter overrides for key presets (Minervini, CANSLIM)
  - Idempotency (safe to run multiple times)
  - Proper handling of existing presets with same names
  - Position sequencing after existing data
  - Clean downgrade behavior

## Implementation Details
- Migration is self-contained with embedded preset definitions, ensuring stability if `preset_screens.py` is later refactored
- Uses Alembic's bulk insert for efficiency
- Validates that all seeded presets contain the complete default filter shape as JSON
- Positions are auto-incremented from the current maximum, preventing collisions with user data

https://claude.ai/code/session_01MMtWQQbvwehKShT2wSngsj