### PR TITLE
Add interactive chart selection to StaticGroupChartsGrid

### DIFF
--- a/frontend/src/components/Charts/CandlestickChart.jsx
+++ b/frontend/src/components/Charts/CandlestickChart.jsx
@@ -375,11 +375,15 @@ function CandlestickChart({
     return new Date(effectiveDataUpdatedAt).toLocaleDateString();
   }, [effectiveDataUpdatedAt]);
 
+  // When the timeframe toggle is hidden, force daily so the chart can't
+  // remain on a stale weekly aggregation chosen before the toggle disappeared.
+  const effectiveTimeframe = hideTimeframeToggle ? 'daily' : timeframe;
+
   // Transform data - memoized to avoid expensive EMA recalculations on every render
   const chartData = useMemo(() => {
     if (!apiData) return null;
-    return transformToCandlestickData(apiData, timeframe);
-  }, [apiData, timeframe]);
+    return transformToCandlestickData(apiData, effectiveTimeframe);
+  }, [apiData, effectiveTimeframe]);
 
   // Initialize chart on mount using useLayoutEffect for synchronous DOM access
   useLayoutEffect(() => {

--- a/frontend/src/components/Charts/CandlestickChart.jsx
+++ b/frontend/src/components/Charts/CandlestickChart.jsx
@@ -295,6 +295,8 @@ const transformToCandlestickData = (apiData, timeframe = 'daily') => {
  * @param {Array|null} props.priceData - Optional static OHLCV payload to render without API calls
  * @param {number|null} props.dataUpdatedAtOverride - Optional timestamp (ms) for static bundles
  * @param {boolean} props.compact - When true, hides overlays (Daily/Weekly toggle, OHLC legend, updated-at indicator) for dense grid layouts
+ * @param {boolean} props.hideTimeframeToggle - When true, hides only the Daily/Weekly toggle (other overlays stay) and forces the daily timeframe
+ * @param {boolean} props.interactive - When false, disables time-axis pan/zoom (mouse wheel, drag, pinch) until re-enabled
  */
 function CandlestickChart({
   symbol,
@@ -305,6 +307,8 @@ function CandlestickChart({
   priceData = null,
   dataUpdatedAtOverride = null,
   compact = false,
+  hideTimeframeToggle = false,
+  interactive = true,
 }) {
   const chartContainerRef = useRef(null);
   const chartRef = useRef(null);
@@ -413,6 +417,8 @@ function CandlestickChart({
         timeVisible: true,
         secondsVisible: false,
       },
+      handleScroll: interactive,
+      handleScale: interactive,
     });
 
     chartRef.current = chart;
@@ -526,6 +532,11 @@ function CandlestickChart({
       ema20SeriesRef.current = null;
       ema50SeriesRef.current = null;
     };
+    // `interactive` is intentionally not in the deps: it's only used as the
+    // chart's initial handleScroll/handleScale value here, and the dedicated
+    // applyOptions effect below picks up subsequent changes without remounting
+    // the chart (which would reset visible range / EMAs).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [height, isDarkMode, symbol, compact]); // Re-initialize only when required visual inputs change
 
   // Track symbol changes - set flag to restore range when symbol changes
@@ -536,6 +547,16 @@ function CandlestickChart({
     }
     prevSymbolRef.current = symbol;
   }, [symbol]);
+
+  // Toggle pan/zoom handlers without re-initializing the chart so user state
+  // (visible range, EMAs) is preserved when interactivity is enabled/disabled.
+  useEffect(() => {
+    if (!chartRef.current) return;
+    chartRef.current.applyOptions({
+      handleScroll: interactive,
+      handleScale: interactive,
+    });
+  }, [interactive]);
 
   // Subscribe to visible time range changes
   useEffect(() => {
@@ -660,7 +681,7 @@ function CandlestickChart({
       }}
     >
       {/* Timeframe Toggle - only show when chart has data */}
-      {!compact && !showLoading && !showError && !showNoData && (
+      {!compact && !hideTimeframeToggle && !showLoading && !showError && !showNoData && (
         <Box
           sx={{
             position: 'absolute',

--- a/frontend/src/static/StaticGroupChartsGrid.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.jsx
@@ -76,19 +76,38 @@ function StaticGroupChartCard({ symbol, entry, isSelected, onSelect }) {
         ? 'warning.main'
         : 'error.main';
 
+  const handleSelect = (e) => {
+    e.stopPropagation();
+    onSelect?.(symbol);
+  };
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelect?.(symbol);
+    }
+  };
+
   return (
     <Card
       variant="outlined"
-      onClick={(e) => {
-        e.stopPropagation();
-        onSelect?.(symbol);
-      }}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      aria-label={`${symbol} chart — ${isSelected ? 'selected, zoom enabled' : 'click to enable zoom'}`}
+      onClick={handleSelect}
+      onKeyDown={handleKeyDown}
       sx={{
         overflow: 'hidden',
         cursor: 'pointer',
         borderWidth: 2,
         borderColor: isSelected ? 'success.main' : 'divider',
         transition: 'border-color 120ms ease-in-out',
+        '&:focus-visible': {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: 2,
+        },
       }}
     >
       <Box

--- a/frontend/src/static/StaticGroupChartsGrid.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Alert,
   Box,
@@ -40,7 +40,7 @@ function StatBadge({ value, label, bgcolor }) {
   );
 }
 
-function StaticGroupChartCard({ symbol, entry }) {
+function StaticGroupChartCard({ symbol, entry, isSelected, onSelect }) {
   const { data: payload, isLoading, isError } = useQuery({
     queryKey: staticChartKeys.payload(symbol, entry?.path),
     queryFn: () => fetchStaticChartPayload(entry.path),
@@ -77,7 +77,20 @@ function StaticGroupChartCard({ symbol, entry }) {
         : 'error.main';
 
   return (
-    <Card variant="outlined" sx={{ overflow: 'hidden' }}>
+    <Card
+      variant="outlined"
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect?.(symbol);
+      }}
+      sx={{
+        overflow: 'hidden',
+        cursor: 'pointer',
+        borderWidth: 2,
+        borderColor: isSelected ? 'success.main' : 'divider',
+        transition: 'border-color 120ms ease-in-out',
+      }}
+    >
       <Box
         sx={{
           display: 'flex',
@@ -145,6 +158,8 @@ function StaticGroupChartCard({ symbol, entry }) {
           height={CHART_HEIGHT}
           priceData={bars}
           dataUpdatedAtOverride={generatedAt}
+          hideTimeframeToggle
+          interactive={isSelected}
         />
       )}
     </Card>
@@ -155,15 +170,18 @@ function StaticGroupChartCard({ symbol, entry }) {
  * Vertical list of full-featured candlestick charts for a group's constituent
  * stocks, rendered from pre-generated static chart payloads (no live API).
  *
- * Each chart matches the appearance of `StaticChartViewerModal` (EMAs, OHLC
- * legend, daily/weekly toggle) with a header carrying symbol, last close, and
- * the same metric badges as the scan-result popup.
+ * Charts render daily-only (no Daily/Weekly toggle) with EMAs and the OHLC
+ * legend. Time-axis pan/zoom is locked unless the card is clicked, at which
+ * point its border turns green and interactions are enabled. Clicking another
+ * card or the surrounding area deselects.
  *
  * @param {Object} props
  * @param {string[]} props.symbols - Constituent ticker symbols
  * @param {Object|null} props.chartIndex - Static chart index `{ symbols: [{ symbol, path }, ...] }`
  */
 function StaticGroupChartsGrid({ symbols = [], chartIndex = null }) {
+  const [selectedSymbol, setSelectedSymbol] = useState(null);
+
   const entryBySymbol = useMemo(() => {
     const entries = chartIndex?.symbols || [];
     return new Map(entries.map((entry) => [entry.symbol, entry]));
@@ -204,7 +222,7 @@ function StaticGroupChartsGrid({ symbols = [], chartIndex = null }) {
   const truncated = normalizedSymbols.length > truncatedSymbols.length;
 
   return (
-    <Box>
+    <Box onClick={() => setSelectedSymbol(null)}>
       {truncated && (
         <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
           Showing first {truncatedSymbols.length} of {normalizedSymbols.length} stocks.
@@ -241,7 +259,12 @@ function StaticGroupChartsGrid({ symbols = [], chartIndex = null }) {
           }
           return (
             <Grid item xs={12} md={6} key={sym}>
-              <StaticGroupChartCard symbol={sym} entry={entry} />
+              <StaticGroupChartCard
+                symbol={sym}
+                entry={entry}
+                isSelected={selectedSymbol === sym}
+                onSelect={setSelectedSymbol}
+              />
             </Grid>
           );
         })}

--- a/frontend/src/static/StaticGroupChartsGrid.test.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.test.jsx
@@ -1,13 +1,19 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import StaticGroupChartsGrid from './StaticGroupChartsGrid';
 
 vi.mock('../components/Charts/CandlestickChart', () => ({
   default: (props) => (
-    <div data-testid="static-candlestick-chart">
+    <div
+      data-testid="static-candlestick-chart"
+      data-symbol={props.symbol}
+      data-interactive={String(Boolean(props.interactive))}
+      data-hide-timeframe-toggle={String(Boolean(props.hideTimeframeToggle))}
+    >
       {props.symbol}:{props.priceData?.length || 0}
     </div>
   ),
@@ -54,5 +60,64 @@ describe('StaticGroupChartsGrid', () => {
 
     expect(await screen.findByText('No price data available for NVDA.')).toBeInTheDocument();
     expect(screen.queryByTestId('static-candlestick-chart')).not.toBeInTheDocument();
+  });
+
+  it('locks zoom and hides Daily/Weekly toggle until a card is clicked, and unlocks the clicked card', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path) => {
+      const sym = String(path).includes('AAPL') ? 'AAPL' : 'NVDA';
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          symbol: sym,
+          stock_data: { symbol: sym, company_name: `${sym} Corp` },
+          bars: [{ date: '2026-01-02', open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 }],
+          generated_at: '2026-01-02T00:00:00Z',
+        }),
+      };
+    });
+
+    renderGrid({
+      symbols: ['NVDA', 'AAPL'],
+      chartIndex: {
+        symbols: [
+          { symbol: 'NVDA', path: 'charts/NVDA.json' },
+          { symbol: 'AAPL', path: 'charts/AAPL.json' },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('static-candlestick-chart')).toHaveLength(2);
+    });
+
+    const findChart = (symbol) =>
+      screen.getAllByTestId('static-candlestick-chart').find((el) => el.dataset.symbol === symbol);
+
+    // Daily/Weekly toggle is always hidden in the static groups grid.
+    screen.getAllByTestId('static-candlestick-chart').forEach((chart) => {
+      expect(chart.dataset.hideTimeframeToggle).toBe('true');
+      expect(chart.dataset.interactive).toBe('false');
+    });
+
+    const user = userEvent.setup();
+
+    // Click the NVDA card → only NVDA becomes interactive.
+    await user.click(findChart('NVDA'));
+    expect(findChart('NVDA').dataset.interactive).toBe('true');
+    expect(findChart('AAPL').dataset.interactive).toBe('false');
+
+    // Click AAPL card → selection moves over.
+    await user.click(findChart('AAPL'));
+    expect(findChart('NVDA').dataset.interactive).toBe('false');
+    expect(findChart('AAPL').dataset.interactive).toBe('true');
+
+    // Click the wrapper Box that holds the click-away handler → deselects.
+    const gridContainer = document.querySelector('.MuiGrid-container');
+    expect(gridContainer).toBeTruthy();
+    await user.click(gridContainer.parentElement);
+    screen.getAllByTestId('static-candlestick-chart').forEach((chart) => {
+      expect(chart.dataset.interactive).toBe('false');
+    });
   });
 });

--- a/frontend/src/static/StaticGroupChartsGrid.test.jsx
+++ b/frontend/src/static/StaticGroupChartsGrid.test.jsx
@@ -120,4 +120,56 @@ describe('StaticGroupChartsGrid', () => {
       expect(chart.dataset.interactive).toBe('false');
     });
   });
+
+  it('exposes button semantics on the chart cards and supports keyboard selection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path) => {
+      const sym = String(path).includes('AAPL') ? 'AAPL' : 'NVDA';
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          symbol: sym,
+          stock_data: { symbol: sym, company_name: `${sym} Corp` },
+          bars: [{ date: '2026-01-02', open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 }],
+          generated_at: '2026-01-02T00:00:00Z',
+        }),
+      };
+    });
+
+    renderGrid({
+      symbols: ['NVDA', 'AAPL'],
+      chartIndex: {
+        symbols: [
+          { symbol: 'NVDA', path: 'charts/NVDA.json' },
+          { symbol: 'AAPL', path: 'charts/AAPL.json' },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('static-candlestick-chart')).toHaveLength(2);
+    });
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+    const nvdaButton = buttons.find((b) => /NVDA chart/.test(b.getAttribute('aria-label') || ''));
+    const aaplButton = buttons.find((b) => /AAPL chart/.test(b.getAttribute('aria-label') || ''));
+    expect(nvdaButton).toBeTruthy();
+    expect(aaplButton).toBeTruthy();
+    expect(nvdaButton).toHaveAttribute('aria-pressed', 'false');
+    expect(nvdaButton).toHaveAttribute('tabindex', '0');
+
+    const user = userEvent.setup();
+    nvdaButton.focus();
+    await user.keyboard('{Enter}');
+
+    expect(nvdaButton).toHaveAttribute('aria-pressed', 'true');
+    expect(aaplButton).toHaveAttribute('aria-pressed', 'false');
+
+    aaplButton.focus();
+    await user.keyboard(' ');
+
+    expect(nvdaButton).toHaveAttribute('aria-pressed', 'false');
+    expect(aaplButton).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -79,8 +79,14 @@ function StaticGroupDetailModal({ group, detail, chartIndex = null, open, onClos
       PaperProps={{
         // Inline style (rather than sx) so the 95vw contract is observable in
         // tests via getComputedStyle/toHaveStyle.
+        //
+        // Paper margin is forced to 0 so it does not stack on top of the
+        // viewport-relative width. The 95vw target already leaves 2.5vw on
+        // each side as breathing room, and overriding MUI's default 32px
+        // Paper margin prevents `95vw + margin > 100vw` overflow on narrow
+        // viewports.
         style: { width: '95vw', maxWidth: '95vw' },
-        sx: { m: 2 },
+        sx: { m: 0 },
       }}
     >
       <DialogTitle>

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -76,7 +76,12 @@ function StaticGroupDetailModal({ group, detail, chartIndex = null, open, onClos
       onClose={onClose}
       maxWidth={false}
       fullWidth
-      PaperProps={{ sx: { width: '95vw', maxWidth: '95vw', m: 2 } }}
+      PaperProps={{
+        // Inline style (rather than sx) so the 95vw contract is observable in
+        // tests via getComputedStyle/toHaveStyle.
+        style: { width: '95vw', maxWidth: '95vw' },
+        sx: { m: 2 },
+      }}
     >
       <DialogTitle>
         <Box display="flex" justifyContent="space-between" alignItems="center">

--- a/frontend/src/static/StaticGroupDetailModal.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.jsx
@@ -71,7 +71,13 @@ function StaticGroupDetailModal({ group, detail, chartIndex = null, open, onClos
   }, [detail?.history]);
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={false}
+      fullWidth
+      PaperProps={{ sx: { width: '95vw', maxWidth: '95vw', m: 2 } }}
+    >
       <DialogTitle>
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <Typography variant="h6">{group}</Typography>

--- a/frontend/src/static/StaticGroupDetailModal.test.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.test.jsx
@@ -60,12 +60,14 @@ describe('StaticGroupDetailModal', () => {
     expect(screen.getByRole('tab', { name: 'Charts' })).toBeDisabled();
   });
 
-  it('renders the dialog paper at 95vw so charts have room to breathe', () => {
+  it('renders the dialog paper at 95vw with zero margin so it never overflows the viewport', () => {
     renderModal();
 
     const dialogPaper = screen.getByRole('dialog');
     // Asserting the actual inline style (set via PaperProps.style) so the
-    // contract regresses if the width or maxWidth is ever changed.
+    // contract regresses if the width is ever changed. Paper margin is
+    // forced to 0 (via sx) so 95vw + margin can never exceed 100vw on
+    // narrow viewports.
     expect(dialogPaper).toHaveStyle({ width: '95vw', maxWidth: '95vw' });
     // maxWidth={false} on Dialog must remain so MUI doesn't cap the width.
     expect(dialogPaper.className).toMatch(/MuiDialog-paperWidthFalse/);

--- a/frontend/src/static/StaticGroupDetailModal.test.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.test.jsx
@@ -59,4 +59,14 @@ describe('StaticGroupDetailModal', () => {
     expect(tabChildren.every((child) => child.getAttribute('role') === 'tab')).toBe(true);
     expect(screen.getByRole('tab', { name: 'Charts' })).toBeDisabled();
   });
+
+  it('opts out of MUI maxWidth so the dialog paper can stretch to 95vw', () => {
+    renderModal();
+
+    // Setting maxWidth={false} on Dialog applies the paperWidthFalse class
+    // (instead of paperWidthLg). Combined with PaperProps.sx={ width: '95vw' }
+    // this is what lets the modal cover ~95% of the viewport.
+    const dialogPaper = screen.getByRole('dialog');
+    expect(dialogPaper.className).toMatch(/MuiDialog-paperWidthFalse/);
+  });
 });

--- a/frontend/src/static/StaticGroupDetailModal.test.jsx
+++ b/frontend/src/static/StaticGroupDetailModal.test.jsx
@@ -60,13 +60,14 @@ describe('StaticGroupDetailModal', () => {
     expect(screen.getByRole('tab', { name: 'Charts' })).toBeDisabled();
   });
 
-  it('opts out of MUI maxWidth so the dialog paper can stretch to 95vw', () => {
+  it('renders the dialog paper at 95vw so charts have room to breathe', () => {
     renderModal();
 
-    // Setting maxWidth={false} on Dialog applies the paperWidthFalse class
-    // (instead of paperWidthLg). Combined with PaperProps.sx={ width: '95vw' }
-    // this is what lets the modal cover ~95% of the viewport.
     const dialogPaper = screen.getByRole('dialog');
+    // Asserting the actual inline style (set via PaperProps.style) so the
+    // contract regresses if the width or maxWidth is ever changed.
+    expect(dialogPaper).toHaveStyle({ width: '95vw', maxWidth: '95vw' });
+    // maxWidth={false} on Dialog must remain so MUI doesn't cap the width.
     expect(dialogPaper.className).toMatch(/MuiDialog-paperWidthFalse/);
   });
 });


### PR DESCRIPTION
## Summary
Adds interactive chart selection to the StaticGroupChartsGrid component, allowing users to click on individual chart cards to enable pan/zoom interactions. Only one chart can be interactive at a time, with visual feedback via a green border on the selected card.

## Key Changes

- **StaticGroupChartsGrid.jsx**: 
  - Added state management for tracking the selected chart symbol
  - Pass `isSelected` and `onSelect` props to chart cards
  - Added click handler to the container Box to deselect when clicking outside cards
  - Updated component documentation to reflect new interaction model

- **StaticGroupChartCard.jsx**:
  - Made cards clickable with visual feedback (green border when selected)
  - Pass `hideTimeframeToggle` and `interactive` props to CandlestickChart
  - Added cursor pointer and smooth border color transition styling

- **CandlestickChart.jsx**:
  - Added `hideTimeframeToggle` prop to hide only the Daily/Weekly toggle while keeping other overlays
  - Added `interactive` prop to control pan/zoom functionality via `handleScroll` and `handleScale` options
  - Implemented separate effect to toggle interactivity without remounting the chart, preserving user state (visible range, EMAs)
  - Updated JSDoc to document new props

- **StaticGroupDetailModal.jsx**:
  - Changed Dialog `maxWidth` from `"lg"` to `false` to allow custom width
  - Added `PaperProps` with `width: '95vw'` to make modal stretch to 95% of viewport width
  - Added corresponding test to verify the paperWidthFalse class is applied

- **StaticGroupChartsGrid.test.jsx**:
  - Enhanced mock CandlestickChart to expose `symbol`, `interactive`, and `hideTimeframeToggle` as data attributes for testing
  - Added comprehensive test verifying the selection behavior: charts start non-interactive, become interactive when clicked, and deselect when clicking outside

## Implementation Details

The interactivity toggle is implemented via a dedicated `useEffect` that calls `applyOptions()` on the chart instance rather than remounting it. This preserves the user's visible range and EMA state when toggling interactivity on/off. The `interactive` prop is intentionally excluded from the chart initialization effect's dependency array to avoid unnecessary remounts.

https://claude.ai/code/session_01ByUBcRR5kaDAgYn84LC5J3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Charts now support individual selection with independent pan/zoom controls when selected.
  * Added keyboard support (Enter/Space) for selecting chart cards.
  * Chart timeframe toggle can be optionally hidden per display configuration.

* **Improvements**
  * Enhanced dialog sizing for better responsive layout behavior across screen sizes.

* **Tests**
  * Added comprehensive test coverage for chart selection interactions and dialog sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->