### PR TITLE
Add China (CN) market to workflow matrix

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        market: [US, HK, IN, JP, KR, TW]
+        market: [US, HK, IN, JP, KR, TW, CN]
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        market: [US, HK, IN, JP, KR, TW]
+        market: [US, HK, IN, JP, KR, TW, CN]
     services:
       postgres:
         image: postgres:16-alpine

--- a/backend/tests/unit/test_static_workflow_markets.py
+++ b/backend/tests/unit/test_static_workflow_markets.py
@@ -16,8 +16,8 @@ def _workflow_matrix_markets(path: str) -> list[str]:
     return [market.strip() for market in match.group(1).split(",")]
 
 
-def test_static_and_weekly_reference_workflows_include_korea_market():
-    expected = ["US", "HK", "IN", "JP", "KR", "TW"]
+def test_static_and_weekly_reference_workflows_cover_supported_markets():
+    expected = ["US", "HK", "IN", "JP", "KR", "TW", "CN"]
 
     assert _workflow_matrix_markets(".github/workflows/static-site.yml") == expected
     assert _workflow_matrix_markets(".github/workflows/weekly-reference-data.yml") == expected


### PR DESCRIPTION
## Summary
This PR adds support for the China (CN) market to the static site and weekly reference data workflows.

## Key Changes
- Added `CN` to the market matrix in `.github/workflows/static-site.yml`
- Added `CN` to the market matrix in `.github/workflows/weekly-reference-data.yml`
- Updated the test case to reflect the new supported markets list and renamed it for clarity:
  - Renamed `test_static_and_weekly_reference_workflows_include_korea_market()` to `test_static_and_weekly_reference_workflows_cover_supported_markets()`
  - Updated expected markets from `["US", "HK", "IN", "JP", "KR", "TW"]` to `["US", "HK", "IN", "JP", "KR", "TW", "CN"]`

## Implementation Details
Both workflow files now include China in their market strategy matrix, enabling the workflows to run against the CN market alongside the existing US, HK, IN, JP, KR, and TW markets.

https://claude.ai/code/session_01MfyAWLUZn5ENdLE2eMeQwn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for China market in static site generation and weekly reference data build processes

* **Tests**
  * Updated market coverage tests to verify China is included alongside existing supported markets (United States, Hong Kong, India, Japan, Korea, and Taiwan)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->