### PR TITLE
feat(config): add CN-specific universe-source timeout override

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -141,6 +141,7 @@ class Settings(BaseSettings):
     yfinance_batch_rate_limit_interval: float = 2.0  # seconds between yfinance batch downloads
     yfinance_per_ticker_delay: float = 0.2  # Deprecated: bulk scheduled jobs should not use per-ticker fetches
     universe_source_timeout_seconds: int = 60
+    universe_source_timeout_seconds_cn: int | None = 300
     universe_source_user_agent: str = (
         "StockScannerUniverseRefresh/1.0 (+https://github.com/xang1234/stock-screener)"
     )
@@ -450,6 +451,21 @@ class Settings(BaseSettings):
                 f"universe_source_timeout_seconds must be > 0, got {v}"
             )
         return v
+
+    @field_validator('universe_source_timeout_seconds_cn')
+    @classmethod
+    def validate_universe_source_timeout_seconds_cn(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError(
+                f"universe_source_timeout_seconds_cn must be > 0 when set, got {v}"
+            )
+        return v
+
+    def universe_source_timeout_for(self, market: str) -> int:
+        normalized = str(market or "").strip().upper()
+        if normalized == "CN" and self.universe_source_timeout_seconds_cn:
+            return self.universe_source_timeout_seconds_cn
+        return self.universe_source_timeout_seconds
 
     @field_validator(
         'provider_snapshot_min_active_coverage_us',

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -181,7 +181,7 @@ class CnMarketDataService:
         self._akshare_module = akshare_module
         self._baostock_module = baostock_module
         self._timeout_seconds = int(
-            timeout_seconds or settings.universe_source_timeout_seconds
+            timeout_seconds or settings.universe_source_timeout_for("CN")
         )
         self._listing_rows_cache: list[dict[str, Any]] | None = None
         self._akshare_ohlcv_consecutive_failures = 0

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -177,12 +177,20 @@ class CnMarketDataService:
         akshare_module: Any | None = None,
         baostock_module: Any | None = None,
         timeout_seconds: int | None = None,
+        listing_timeout_seconds: int | None = None,
     ) -> None:
         self._akshare_module = akshare_module
         self._baostock_module = baostock_module
         self._timeout_seconds = int(
-            timeout_seconds or settings.universe_source_timeout_for("CN")
+            timeout_seconds or settings.universe_source_timeout_seconds
         )
+        if listing_timeout_seconds is not None:
+            resolved_listing = listing_timeout_seconds
+        elif timeout_seconds is not None:
+            resolved_listing = timeout_seconds
+        else:
+            resolved_listing = settings.universe_source_timeout_for("CN")
+        self._listing_timeout_seconds = int(resolved_listing)
         self._listing_rows_cache: list[dict[str, Any]] | None = None
         self._akshare_ohlcv_consecutive_failures = 0
         self._akshare_ohlcv_disabled_until = 0.0
@@ -236,7 +244,7 @@ class CnMarketDataService:
             try:
                 frame = _call_with_timeout(
                     fallback_fetcher,
-                    timeout_seconds=self._timeout_seconds,
+                    timeout_seconds=self._listing_timeout_seconds,
                     operation_name="CN A-share code-name fetch",
                 )
                 if frame is not None and not frame.empty:
@@ -254,7 +262,7 @@ class CnMarketDataService:
     def _akshare_spot_frame(self) -> pd.DataFrame | None:
         frame = _call_with_timeout(
             self._akshare.stock_zh_a_spot_em,
-            timeout_seconds=self._timeout_seconds,
+            timeout_seconds=self._listing_timeout_seconds,
             operation_name="CN A-share listing fetch",
         )
         if frame is None or frame.empty:

--- a/backend/app/services/official_market_universe_source_service.py
+++ b/backend/app/services/official_market_universe_source_service.py
@@ -390,7 +390,8 @@ class OfficialMarketUniverseSourceService:
         if self._cn_provider is None:
             from .cn_market_data_service import CnMarketDataService
 
-            self._cn_provider = CnMarketDataService(timeout_seconds=self._timeout_seconds)
+            cn_timeout = settings.universe_source_timeout_for("CN")
+            self._cn_provider = CnMarketDataService(timeout_seconds=cn_timeout)
         return self._cn_provider
 
     @staticmethod

--- a/backend/app/services/official_market_universe_source_service.py
+++ b/backend/app/services/official_market_universe_source_service.py
@@ -116,6 +116,7 @@ class OfficialMarketUniverseSourceService:
         cn_provider: Any | None = None,
         market_calendar: Any | None = None,
     ) -> None:
+        self._explicit_timeout_seconds = timeout_seconds
         self._timeout_seconds = int(
             timeout_seconds or settings.universe_source_timeout_seconds
         )
@@ -390,8 +391,9 @@ class OfficialMarketUniverseSourceService:
         if self._cn_provider is None:
             from .cn_market_data_service import CnMarketDataService
 
-            cn_timeout = settings.universe_source_timeout_for("CN")
-            self._cn_provider = CnMarketDataService(timeout_seconds=cn_timeout)
+            self._cn_provider = CnMarketDataService(
+                timeout_seconds=self._explicit_timeout_seconds,
+            )
         return self._cn_provider
 
     @staticmethod

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -358,3 +358,68 @@ def test_cn_market_data_service_raises_dependency_error_when_akshare_missing(mon
 
     with pytest.raises(CnDependencyError, match="akshare is required"):
         service.listing_rows()
+
+
+def test_cn_market_data_service_keeps_ohlcv_on_global_timeout_by_default(monkeypatch):
+    """OHLCV path must not pick up the longer CN listing default."""
+    from app.config import settings as settings_module
+
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds", 60)
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds_cn", 300)
+
+    service = CnMarketDataService(akshare_module=object())
+
+    assert service._timeout_seconds == 60
+    assert service._listing_timeout_seconds == 300
+
+
+def test_cn_market_data_service_explicit_timeout_applies_to_both_paths(monkeypatch):
+    """An explicit timeout_seconds (e.g. from tests) must apply to listing too."""
+    from app.config import settings as settings_module
+
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds", 60)
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds_cn", 300)
+
+    service = CnMarketDataService(akshare_module=object(), timeout_seconds=2)
+
+    assert service._timeout_seconds == 2
+    assert service._listing_timeout_seconds == 2
+
+
+def test_cn_market_data_service_listing_timeout_can_be_overridden_independently(monkeypatch):
+    from app.config import settings as settings_module
+
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds", 60)
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds_cn", 300)
+
+    service = CnMarketDataService(
+        akshare_module=object(),
+        listing_timeout_seconds=120,
+    )
+
+    assert service._timeout_seconds == 60
+    assert service._listing_timeout_seconds == 120
+
+
+def test_cn_market_data_service_uses_listing_timeout_for_spot_fetch(monkeypatch):
+    helper_calls: list[tuple[int, str]] = []
+
+    def fake_call_with_timeout(fetcher, *, timeout_seconds: int, operation_name: str):
+        helper_calls.append((timeout_seconds, operation_name))
+        return fetcher()
+
+    class FakeAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            return pd.DataFrame([{"代码": "600519", "名称": "贵州茅台"}])
+
+    monkeypatch.setattr(cn_market_data_module, "_call_with_timeout", fake_call_with_timeout)
+
+    service = CnMarketDataService(
+        akshare_module=FakeAkshare(),
+        timeout_seconds=60,
+        listing_timeout_seconds=240,
+    )
+    service.listing_rows(as_of=date(2026, 4, 30))
+
+    assert helper_calls == [(240, "CN A-share listing fetch")]

--- a/backend/tests/unit/test_official_market_universe_source_service.py
+++ b/backend/tests/unit/test_official_market_universe_source_service.py
@@ -571,6 +571,32 @@ def test_fetch_cn_snapshot_uses_akshare_provider_and_records_validated_baseline(
     assert snapshot.source_metadata["cn_baseline_status"] == "outside_static_baseline"
 
 
+def test_get_cn_provider_uses_cn_listing_default_when_timeout_not_overridden(monkeypatch):
+    from app.config import settings as settings_module
+
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds", 60)
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds_cn", 300)
+
+    service = OfficialMarketUniverseSourceService()
+    cn_provider = service._get_cn_provider()
+
+    assert cn_provider._timeout_seconds == 60
+    assert cn_provider._listing_timeout_seconds == 300
+
+
+def test_get_cn_provider_propagates_explicit_service_level_timeout(monkeypatch):
+    from app.config import settings as settings_module
+
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds", 60)
+    monkeypatch.setattr(settings_module, "universe_source_timeout_seconds_cn", 300)
+
+    service = OfficialMarketUniverseSourceService(timeout_seconds=2)
+    cn_provider = service._get_cn_provider()
+
+    assert cn_provider._timeout_seconds == 2
+    assert cn_provider._listing_timeout_seconds == 2
+
+
 def test_fetch_tw_snapshot_combines_twse_and_tpex_rows(monkeypatch):
     service = OfficialMarketUniverseSourceService()
     html_twse = _fixture_bytes("twse_stocks_fixture.html")

--- a/backend/tests/unit/test_settings_llm_keys.py
+++ b/backend/tests/unit/test_settings_llm_keys.py
@@ -30,6 +30,37 @@ def test_universe_source_timeout_seconds_must_be_positive() -> None:
         raise AssertionError("Expected invalid universe_source_timeout_seconds to fail")
 
 
+def test_universe_source_timeout_seconds_cn_must_be_positive_when_set() -> None:
+    try:
+        Settings(universe_source_timeout_seconds_cn=0)
+    except ValueError as exc:
+        assert "universe_source_timeout_seconds_cn must be > 0" in str(exc)
+    else:
+        raise AssertionError("Expected invalid universe_source_timeout_seconds_cn to fail")
+
+
+def test_universe_source_timeout_for_uses_cn_override() -> None:
+    settings = Settings(
+        universe_source_timeout_seconds=60,
+        universe_source_timeout_seconds_cn=240,
+    )
+
+    assert settings.universe_source_timeout_for("CN") == 240
+    assert settings.universe_source_timeout_for("cn") == 240
+    assert settings.universe_source_timeout_for("US") == 60
+    assert settings.universe_source_timeout_for("HK") == 60
+
+
+def test_universe_source_timeout_for_falls_back_when_cn_override_unset() -> None:
+    settings = Settings(
+        universe_source_timeout_seconds=45,
+        universe_source_timeout_seconds_cn=None,
+    )
+
+    assert settings.universe_source_timeout_for("CN") == 45
+    assert settings.universe_source_timeout_for("US") == 45
+
+
 def test_ibd_industry_csv_path_is_configurable(tmp_path, monkeypatch) -> None:
     override = tmp_path / "custom" / "ibd.csv"
     override.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The shared 60s universe_source_timeout_seconds is too tight for the CN universe path: AKShare's stock_zh_a_spot_em paginates through ~20 pages with 0.5-1.5s sleeps between each, then BaoStock fallback adds its own latency. From a US-region GitHub Actions runner the round trip to Eastmoney is much higher than from a developer laptop in APAC, and the weekly-reference-data job times out on the CN matrix.

Introduce universe_source_timeout_seconds_cn (default 300s) following the existing per-market settings pattern, and a Settings.universe_ source_timeout_for(market) helper. CnMarketDataService and the official source service's CN provider now resolve through the helper so the override flows end-to-end while leaving every other market on the original 60s budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * China market now supports region-specific data source timeout configuration, independent from global settings. Defaults to 300 seconds.

* **Tests**
  * Added unit tests validating China-specific timeout behavior and configuration fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->