### PR TITLE
Add deadline-driven chunked fundamentals refresh with partial publish

### DIFF
--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -5,6 +5,42 @@ on:
     - cron: '10 8 * * 6'
       timezone: 'America/New_York'
   workflow_dispatch:
+    inputs:
+      market:
+        description: "Run only this market (or 'all' for the full matrix)."
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - US
+          - HK
+          - IN
+          - JP
+          - KR
+          - TW
+          - CN
+      max_runtime_minutes:
+        description: >-
+          Per-market deadline in minutes for the fundamentals refresh. Blank
+          uses the built-in defaults (CN=320, others=0). Set "0" to disable
+          the deadline entirely (e.g. for the first CN seeding run).
+        required: false
+        type: string
+        default: ''
+      allow_partial_publish:
+        description: >-
+          Whether to publish the bundle when the deadline trips. "default"
+          keeps the per-market default (CN=enable, others=disable); "enable"
+          forces partial publish on; "disable" forces it off (useful for
+          first-time CN runs where there is no prior bundle to fall back to).
+        required: false
+        type: choice
+        default: default
+        options:
+          - default
+          - enable
+          - disable
 
 concurrency:
   group: weekly-reference-data
@@ -40,7 +76,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        market: [US, HK, IN, JP, KR, TW, CN]
+        # When workflow_dispatch.market is set to a specific market, run only
+        # that variant; otherwise (scheduled cron, or dispatch with market=all)
+        # run the full matrix. ``github.event.inputs.market`` is null on
+        # scheduled runs, so we coerce to '' before the equality check.
+        market: ${{ fromJSON((github.event.inputs.market || 'all') != 'all' && format('["{0}"]', github.event.inputs.market) || '["US","HK","IN","JP","KR","TW","CN"]') }}
     services:
       postgres:
         image: postgres:16-alpine
@@ -128,22 +168,54 @@ jobs:
             echo "No prior weekly reference bundle found for ${{ matrix.market }}; continuing without seed."
           fi
 
-      - name: Build weekly reference bundle
+      - name: Resolve build inputs
+        id: build_inputs
         env:
-          # Per-market wall-clock budget (minutes) for the fundamentals refresh
-          # phase. CN is the slow path: ~5,500 sequential AKShare+yfinance
-          # round-trips can blow past 6h on a fresh run, so we leave ~30 min
-          # headroom under the 350-minute job cap and opt-in to partial
-          # publish — skipped symbols inherit last week's bundle data.
-          WEEKLY_REFERENCE_MAX_RUNTIME_MINUTES: ${{ matrix.market == 'CN' && '320' || '0' }}
-          WEEKLY_REFERENCE_ALLOW_PARTIAL: ${{ matrix.market == 'CN' && '--allow-partial-publish' || '' }}
+          # Per-market wall-clock budget defaults for the fundamentals refresh.
+          # CN is the slow path: ~5,500 sequential AKShare+yfinance round-trips
+          # can blow past 6h, so we leave ~30 min headroom under the 350-min
+          # job cap and opt-in to partial publish — skipped symbols inherit
+          # last week's bundle data. Workflow_dispatch inputs override either.
+          INPUT_RUNTIME: ${{ github.event.inputs.max_runtime_minutes }}
+          INPUT_PARTIAL: ${{ github.event.inputs.allow_partial_publish }}
+          MATRIX_MARKET: ${{ matrix.market }}
+        run: |
+          if [ -n "$INPUT_RUNTIME" ]; then
+            RUNTIME="$INPUT_RUNTIME"
+          elif [ "$MATRIX_MARKET" = "CN" ]; then
+            RUNTIME="320"
+          else
+            RUNTIME="0"
+          fi
+
+          case "$INPUT_PARTIAL" in
+            enable)
+              PARTIAL="--allow-partial-publish"
+              ;;
+            disable)
+              PARTIAL=""
+              ;;
+            *)
+              if [ "$MATRIX_MARKET" = "CN" ]; then
+                PARTIAL="--allow-partial-publish"
+              else
+                PARTIAL=""
+              fi
+              ;;
+          esac
+
+          echo "max_runtime_minutes=$RUNTIME" >> "$GITHUB_OUTPUT"
+          echo "partial_flag=$PARTIAL" >> "$GITHUB_OUTPUT"
+          echo "Resolved build inputs for $MATRIX_MARKET: runtime=$RUNTIME partial='$PARTIAL'"
+
+      - name: Build weekly reference bundle
         run: |
           cd backend
           python -m app.scripts.build_weekly_reference_bundle \
             --market "${{ matrix.market }}" \
             --output-dir /tmp/weekly-reference \
-            --max-runtime-minutes "${WEEKLY_REFERENCE_MAX_RUNTIME_MINUTES}" \
-            ${WEEKLY_REFERENCE_ALLOW_PARTIAL}
+            --max-runtime-minutes "${{ steps.build_inputs.outputs.max_runtime_minutes }}" \
+            ${{ steps.build_inputs.outputs.partial_flag }}
 
       - name: Upload weekly reference assets
         env:

--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -33,6 +33,10 @@ jobs:
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     needs: ensure_release
     runs-on: ubuntu-latest
+    # GitHub Actions hard-caps a job at 360 minutes. Setting an explicit ceiling
+    # below that gives the build script's --max-runtime-minutes deadline a
+    # chance to fire (and publish a partial bundle) before the runner is killed.
+    timeout-minutes: 350
     strategy:
       fail-fast: false
       matrix:
@@ -125,11 +129,21 @@ jobs:
           fi
 
       - name: Build weekly reference bundle
+        env:
+          # Per-market wall-clock budget (minutes) for the fundamentals refresh
+          # phase. CN is the slow path: ~5,500 sequential AKShare+yfinance
+          # round-trips can blow past 6h on a fresh run, so we leave ~30 min
+          # headroom under the 350-minute job cap and opt-in to partial
+          # publish — skipped symbols inherit last week's bundle data.
+          WEEKLY_REFERENCE_MAX_RUNTIME_MINUTES: ${{ matrix.market == 'CN' && '320' || '0' }}
+          WEEKLY_REFERENCE_ALLOW_PARTIAL: ${{ matrix.market == 'CN' && '--allow-partial-publish' || '' }}
         run: |
           cd backend
           python -m app.scripts.build_weekly_reference_bundle \
             --market "${{ matrix.market }}" \
-            --output-dir /tmp/weekly-reference
+            --output-dir /tmp/weekly-reference \
+            --max-runtime-minutes "${WEEKLY_REFERENCE_MAX_RUNTIME_MINUTES}" \
+            ${WEEKLY_REFERENCE_ALLOW_PARTIAL}
 
       - name: Upload weekly reference assets
         env:

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import math
+import time
 from datetime import datetime
 import os
 from pathlib import Path
@@ -23,6 +25,7 @@ from app.wiring.bootstrap import (
 )
 
 _WEEKLY_NON_US_YFINANCE_DELAY_PER_TICKER = 0.2
+_DEFAULT_FETCH_CHUNK_SIZE = 250
 
 
 def _default_output_dir() -> Path:
@@ -114,6 +117,39 @@ def _print_fundamentals_progress(market: str, completed: float, total: int) -> N
         f"[fundamentals] {market} {completed_count}/{total_count} ({percent:.1f}%)",
         flush=True,
     )
+
+
+_FUNDAMENTALS_STATS_NUMERIC_KEYS = (
+    "fundamentals_stored",
+    "quarterly_stored",
+    "ownership_updated",
+    "failed",
+    "persisted_symbols",
+    "failed_persistence_symbols",
+)
+
+
+def _empty_fundamentals_stats() -> dict[str, Any]:
+    stats: dict[str, Any] = {key: 0 for key in _FUNDAMENTALS_STATS_NUMERIC_KEYS}
+    stats["provider_error_counts"] = {}
+    return stats
+
+
+def _merge_fundamentals_stats(
+    accumulator: dict[str, Any],
+    chunk_stats: dict[str, Any] | None,
+) -> None:
+    if not chunk_stats:
+        return
+    for key in _FUNDAMENTALS_STATS_NUMERIC_KEYS:
+        accumulator[key] = int(accumulator.get(key, 0) or 0) + int(
+            chunk_stats.get(key, 0) or 0
+        )
+    chunk_errors = chunk_stats.get("provider_error_counts") or {}
+    if chunk_errors:
+        bucket = accumulator.setdefault("provider_error_counts", {})
+        for key, value in chunk_errors.items():
+            bucket[key] = int(bucket.get(key, 0) or 0) + int(value or 0)
 
 
 def _write_step_summary(market: str, summary: dict[str, Any]) -> None:
@@ -312,6 +348,84 @@ def _build_us_bundle(
     return summary
 
 
+def _run_chunked_fundamentals_refresh(
+    *,
+    hybrid_service: Any,
+    fundamentals_cache: Any,
+    market: str,
+    symbols: list[str],
+    market_by_symbol: dict[str, str],
+    chunk_size: int,
+    max_runtime_seconds: float,
+) -> tuple[dict[str, Any], list[str], bool]:
+    """Fetch + persist fundamentals in chunks, honouring an optional wall-clock budget.
+
+    Returns ``(stats, attempted_symbols, deadline_hit)``. When the budget is
+    exhausted, the loop exits cleanly between chunks so anything already
+    persisted survives in the cache and DB. Skipped symbols inherit whatever
+    data was previously hydrated from the prior weekly bundle.
+    """
+    stats = _empty_fundamentals_stats()
+    attempted_symbols: list[str] = []
+    deadline_hit = False
+    if not symbols:
+        return stats, attempted_symbols, deadline_hit
+
+    chunk_size = max(1, int(chunk_size))
+    total = len(symbols)
+    chunks_total = math.ceil(total / chunk_size)
+    deadline = (
+        time.monotonic() + float(max_runtime_seconds)
+        if max_runtime_seconds and max_runtime_seconds > 0
+        else None
+    )
+
+    for chunk_index in range(chunks_total):
+        if deadline is not None and time.monotonic() >= deadline:
+            deadline_hit = True
+            print(
+                f"[fundamentals] {market} deadline reached before chunk "
+                f"{chunk_index + 1}/{chunks_total}; stopping with "
+                f"{len(attempted_symbols)}/{total} symbols attempted",
+                flush=True,
+            )
+            break
+
+        chunk = symbols[chunk_index * chunk_size : (chunk_index + 1) * chunk_size]
+        if not chunk:
+            break
+        chunk_market_by_symbol = {s: market_by_symbol[s] for s in chunk if s in market_by_symbol}
+        attempted_so_far = len(attempted_symbols)
+
+        def _chunk_progress_cb(completed: float, _chunk_total: int) -> None:
+            _print_fundamentals_progress(market, attempted_so_far + int(completed), total)
+
+        chunk_data = hybrid_service.fetch_fundamentals_batch(
+            chunk,
+            include_technicals=True,
+            include_finviz=False,
+            progress_callback=_chunk_progress_cb,
+            market_by_symbol=chunk_market_by_symbol,
+        )
+        chunk_stats = hybrid_service.store_all_caches(
+            chunk_data,
+            fundamentals_cache,
+            session_factory=SessionLocal,
+            include_quarterly=True,
+            market_by_symbol=chunk_market_by_symbol,
+        )
+        _merge_fundamentals_stats(stats, chunk_stats)
+        attempted_symbols.extend(chunk)
+        print(
+            f"[fundamentals] {market} chunk {chunk_index + 1}/{chunks_total} "
+            f"persisted={(chunk_stats or {}).get('persisted_symbols', 0)} "
+            f"failed={(chunk_stats or {}).get('failed', 0)}",
+            flush=True,
+        )
+
+    return stats, attempted_symbols, deadline_hit
+
+
 def _build_asia_bundle(
     db,
     *,
@@ -321,6 +435,9 @@ def _build_asia_bundle(
     output_dir: Path,
     bundle_name: str | None,
     latest_manifest_name: str,
+    max_runtime_seconds: float = 0.0,
+    fetch_chunk_size: int = _DEFAULT_FETCH_CHUNK_SIZE,
+    allow_partial_publish: bool = False,
 ) -> dict[str, Any]:
     snapshot_key = ProviderSnapshotService.snapshot_key_for_market(market)
     official_source_service = OfficialMarketUniverseSourceService()
@@ -349,24 +466,16 @@ def _build_asia_bundle(
     market_by_symbol = {row.symbol: market for row in active_rows}
 
     print(f"Starting hybrid fundamentals refresh for {market}...", flush=True)
-    all_data = hybrid_service.fetch_fundamentals_batch(
-        symbols,
-        include_technicals=True,
-        include_finviz=False,
-        progress_callback=lambda completed, total: _print_fundamentals_progress(
-            market,
-            completed,
-            total,
-        ),
+    fundamentals_stats, attempted_symbols, deadline_hit = _run_chunked_fundamentals_refresh(
+        hybrid_service=hybrid_service,
+        fundamentals_cache=fundamentals_cache,
+        market=market,
+        symbols=symbols,
         market_by_symbol=market_by_symbol,
+        chunk_size=fetch_chunk_size,
+        max_runtime_seconds=max_runtime_seconds,
     )
-    fundamentals_stats = hybrid_service.store_all_caches(
-        all_data,
-        fundamentals_cache,
-        session_factory=SessionLocal,
-        include_quarterly=True,
-        market_by_symbol=market_by_symbol,
-    )
+    skipped_symbols = [s for s in symbols if s not in set(attempted_symbols)]
     print(f"Fundamentals refresh complete: {fundamentals_stats}", flush=True)
 
     cached_fundamentals = fundamentals_cache.get_many(symbols)
@@ -394,6 +503,9 @@ def _build_asia_bundle(
         "snapshot_symbols": len(snapshot_rows),
         "covered_active_symbols": len(snapshot_rows),
         "missing_active_symbols": max(len(symbols) - len(snapshot_rows), 0),
+        "attempted_symbols": len(attempted_symbols),
+        "skipped_due_to_deadline": len(skipped_symbols) if deadline_hit else 0,
+        "partial_run": deadline_hit,
     }
     warnings: list[str] = []
     if fundamentals_stats.get("failed"):
@@ -405,6 +517,11 @@ def _build_asia_bundle(
             f"{fundamentals_stats['failed_persistence_symbols']} symbols failed to persist during "
             f"{market} hybrid fundamentals refresh"
         )
+    if deadline_hit:
+        warnings.append(
+            f"Weekly fetch deadline reached after {len(attempted_symbols)}/{len(symbols)} "
+            f"{market} symbols; {len(skipped_symbols)} symbols inherit prior-bundle data."
+        )
 
     source_revision = f"{snapshot_key}:{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
     snapshot_stats = provider_snapshot_service.publish_market_snapshot_run(
@@ -415,6 +532,7 @@ def _build_asia_bundle(
         rows=snapshot_rows,
         coverage_stats=coverage_stats,
         warnings=warnings,
+        force_publish=bool(allow_partial_publish and deadline_hit),
     )
     summary = {
         "output_dir": output_dir,
@@ -479,6 +597,37 @@ def main() -> int:
         default=None,
         help="Filename for the latest-pointer manifest JSON. Defaults to the market-scoped name.",
     )
+    parser.add_argument(
+        "--max-runtime-minutes",
+        type=float,
+        default=0.0,
+        help=(
+            "Soft wall-clock budget for the fundamentals refresh phase. "
+            "When > 0, the Asia path fetches in chunks and exits cleanly "
+            "between chunks once the budget is exhausted. The deadline is "
+            "checked before each chunk; leave at least one chunk's runtime "
+            "of headroom under the GitHub Actions 6-hour job cap."
+        ),
+    )
+    parser.add_argument(
+        "--fetch-chunk-size",
+        type=int,
+        default=_DEFAULT_FETCH_CHUNK_SIZE,
+        help=(
+            "Number of symbols processed per chunk when --max-runtime-minutes "
+            f"is set (default {_DEFAULT_FETCH_CHUNK_SIZE})."
+        ),
+    )
+    parser.add_argument(
+        "--allow-partial-publish",
+        action="store_true",
+        help=(
+            "When --max-runtime-minutes triggers an early exit, publish the "
+            "snapshot even if the coverage gate would otherwise block. "
+            "Skipped symbols inherit the prior weekly bundle's data; the "
+            "manifest records partial_run=True and a deadline warning."
+        ),
+    )
     args = parser.parse_args()
 
     prepare_runtime()
@@ -510,6 +659,9 @@ def main() -> int:
                 output_dir=output_dir,
                 bundle_name=args.bundle_name,
                 latest_manifest_name=latest_manifest_name,
+                max_runtime_seconds=max(0.0, float(args.max_runtime_minutes)) * 60.0,
+                fetch_chunk_size=max(1, int(args.fetch_chunk_size)),
+                allow_partial_publish=bool(args.allow_partial_publish),
             )
 
     _write_step_summary(market, summary)

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -522,8 +522,13 @@ def _build_asia_bundle(
             f"Weekly fetch deadline reached after {len(attempted_symbols)}/{len(symbols)} "
             f"{market} symbols; {len(skipped_symbols)} symbols inherit prior-bundle data."
         )
+        if not allow_partial_publish:
+            warnings.append(
+                "Partial publish disabled; blocking publish because the weekly fetch deadline was reached."
+            )
 
     source_revision = f"{snapshot_key}:{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+    publish = not (deadline_hit and not allow_partial_publish)
     snapshot_stats = provider_snapshot_service.publish_market_snapshot_run(
         db,
         snapshot_key=snapshot_key,
@@ -532,6 +537,7 @@ def _build_asia_bundle(
         rows=snapshot_rows,
         coverage_stats=coverage_stats,
         warnings=warnings,
+        publish=publish,
         force_publish=bool(allow_partial_publish and deadline_hit),
     )
     summary = {

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -474,8 +474,17 @@ class ProviderSnapshotService:
         warnings: Optional[list[str]] = None,
         run_mode: str = "publish",
         publish: bool = True,
+        force_publish: bool = False,
     ) -> Dict[str, Any]:
-        """Publish a pre-built market snapshot using the standard run/pointer tables."""
+        """Publish a pre-built market snapshot using the standard run/pointer tables.
+
+        ``force_publish`` lets the caller publish even when the coverage gate
+        would otherwise mark the run as ``publish_blocked``. Used by the weekly
+        builder when a deadline-driven partial run still produces a usable
+        bundle (skipped symbols inherit data from the prior bundle). The gate's
+        warnings are still recorded on the run so consumers can detect the
+        degraded state.
+        """
         normalized_market = str(market or "").strip().upper()
         parity_stats = {
             "market": normalized_market,
@@ -487,6 +496,13 @@ class ProviderSnapshotService:
         )
         all_warnings = list(warnings or [])
         all_warnings.extend(coverage_warnings)
+        force_override = bool(force_publish) and not coverage_ok and publish
+        if force_override:
+            all_warnings.append(
+                "force_publish=True: publishing despite coverage gate failure "
+                f"(active_coverage={coverage_thresholds.get('active_coverage', 0.0):.2%}, "
+                f"min={coverage_thresholds.get('min_active_coverage', 0.0):.2%})"
+            )
 
         run = ProviderSnapshotRun(
             snapshot_key=snapshot_key,
@@ -528,7 +544,7 @@ class ProviderSnapshotService:
         run.warnings_json = json.dumps(all_warnings, sort_keys=True) if all_warnings else None
         run.status = "preview_ready" if not publish else "published"
         published = False
-        if publish and coverage_ok:
+        if publish and (coverage_ok or force_override):
             published_at = datetime.utcnow()
             run.published_at = published_at
             pointer = db.query(ProviderSnapshotPointer).filter(
@@ -559,6 +575,7 @@ class ProviderSnapshotService:
             "warnings": all_warnings,
             "market": normalized_market,
             "coverage_thresholds": coverage_thresholds,
+            "force_published": force_override,
         }
 
     def _fetch_yahoo_only_fields(self, symbol: str) -> Dict[str, Any]:

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -349,6 +349,196 @@ def test_build_weekly_reference_bundle_runs_hk_official_path(monkeypatch, tmp_pa
     assert "| `yahoo_quote_not_found` | 2 |" in summary_text
 
 
+def _make_universe_row(symbol: str, market: str = "CN") -> SimpleNamespace:
+    return SimpleNamespace(
+        symbol=symbol,
+        market=market,
+        exchange="SSE" if symbol.endswith(".SS") else "SZSE",
+        name=f"Co-{symbol}",
+        sector="Industrials",
+        industry="Misc",
+        market_cap=1000.0,
+    )
+
+
+def test_build_weekly_reference_bundle_chunked_deadline_force_publishes(
+    monkeypatch, tmp_path, capsys
+):
+    """Asia path stops between chunks once the wall-clock budget is exhausted.
+
+    With --max-runtime-minutes set and the deadline tripping after the first
+    chunk, the second chunk is never fetched, the snapshot is published with
+    force_publish=True, and warnings record the deadline.
+    """
+
+    published_at = datetime(2026, 5, 5, 12, 10, 0)
+    active_rows = [
+        _make_universe_row("600000.SS"),
+        _make_universe_row("600001.SS"),
+        _make_universe_row("000001.SZ"),
+    ]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.order_by.return_value.all.return_value = active_rows
+    fake_db = MagicMock()
+    fake_db.query.return_value = fake_query
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    official_service = SimpleNamespace(
+        fetch_market_snapshot=lambda market: SimpleNamespace(
+            market=market,
+            source_name="cn_official",
+            snapshot_id="cn-2026-05-05",
+            snapshot_as_of="2026-05-05",
+            source_metadata={},
+            rows=tuple({"symbol": row.symbol} for row in active_rows),
+        )
+    )
+    monkeypatch.setattr(
+        build_script, "OfficialMarketUniverseSourceService", lambda: official_service
+    )
+    monkeypatch.setattr(
+        build_script,
+        "get_stock_universe_service",
+        lambda: SimpleNamespace(
+            ingest_cn_snapshot_rows=lambda db, **kwargs: {"added": 3, "updated": 0, "deactivated": 0}
+        ),
+    )
+
+    # Drive build_script.time.monotonic so the second chunk sees an exhausted
+    # deadline. Each call advances by 60 s, so a 1.5-minute (90 s) budget is
+    # consumed after the first chunk's start.
+    fake_clock = {"value": 0.0}
+
+    def fake_monotonic() -> float:
+        fake_clock["value"] += 60.0
+        return fake_clock["value"]
+
+    monkeypatch.setattr(build_script.time, "monotonic", fake_monotonic)
+
+    fetch_calls: list[list[str]] = []
+    store_calls: list[list[str]] = []
+
+    def fake_fetch_fundamentals_batch(symbols, **kwargs):
+        fetch_calls.append(list(symbols))
+        kwargs["progress_callback"](len(symbols), len(symbols))
+        return {symbol: {"market_cap": 1000.0, "sector": "Industrials"} for symbol in symbols}
+
+    def fake_store_all_caches(data, _cache, **_kwargs):
+        store_calls.append(list(data))
+        return {
+            "fundamentals_stored": len(data),
+            "persisted_symbols": len(data),
+            "failed_persistence_symbols": 0,
+            "failed": 0,
+            "provider_error_counts": {},
+        }
+
+    hybrid_service = SimpleNamespace(
+        yfinance_delay_per_ticker=1.5,
+        fetch_fundamentals_batch=fake_fetch_fundamentals_batch,
+        store_all_caches=fake_store_all_caches,
+    )
+    monkeypatch.setattr(build_script, "get_hybrid_fundamentals_service", lambda: hybrid_service)
+
+    # Cache returns fresh data for both attempted symbols and (simulated)
+    # last-week data for the symbol whose chunk was skipped — that's the whole
+    # point of force-publish: skipped symbols inherit the prior bundle.
+    cached = {
+        "600000.SS": {"market_cap": 1000.0, "sector": "Industrials"},
+        "600001.SS": {"market_cap": 1000.0, "sector": "Industrials"},
+        "000001.SZ": {"market_cap": 999.0, "sector": "Industrials", "data_source": "bundle_import"},
+    }
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_many=lambda symbols: cached),
+    )
+
+    publish_calls: list[dict[str, object]] = []
+    export_calls: list[dict[str, object]] = []
+    provider_snapshot_service = SimpleNamespace(
+        build_market_snapshot_row=lambda **kwargs: {
+            "symbol": kwargs["symbol"],
+            "exchange": kwargs["exchange"],
+            "row_hash": "row-hash",
+            "normalized_payload": kwargs["normalized_payload"],
+            "raw_payload": kwargs["raw_payload"],
+        },
+        publish_market_snapshot_run=lambda db, **kwargs: publish_calls.append(kwargs)
+        or {
+            "published": True,
+            "force_published": kwargs.get("force_publish", False),
+            "source_revision": "fundamentals_v1_cn:20260505121000",
+            "snapshot_key": kwargs["snapshot_key"],
+            "coverage": dict(kwargs["coverage_stats"]),
+            "warnings": list(kwargs["warnings"]),
+            "coverage_thresholds": {
+                "market": "CN",
+                "active_coverage": 1.0,
+                "min_active_coverage": 0.70,
+                "missing_ratio": 0.0,
+                "max_missing_ratio": 0.30,
+            },
+        },
+        get_published_run=lambda db, snapshot_key: type(
+            "Run",
+            (),
+            {
+                "published_at": published_at,
+                "created_at": published_at,
+                "source_revision": "fundamentals_v1_cn:20260505121000",
+            },
+        )(),
+        export_weekly_reference_bundle=lambda db, **kwargs: export_calls.append(kwargs)
+        or {"bundle_path": str(kwargs["output_path"])},
+    )
+    monkeypatch.setattr(
+        build_script, "get_provider_snapshot_service", lambda: provider_snapshot_service
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "CN",
+            "--output-dir",
+            str(tmp_path),
+            "--max-runtime-minutes",
+            "1.5",
+            "--fetch-chunk-size",
+            "2",
+            "--allow-partial-publish",
+        ],
+    )
+
+    assert build_script.main() == 0
+
+    # Only the first chunk fetched; the second chunk's deadline check tripped.
+    assert fetch_calls == [["600000.SS", "600001.SS"]]
+    assert store_calls == [["600000.SS", "600001.SS"]]
+
+    # Snapshot rows still cover all 3 symbols (skipped one inherited from cache).
+    publish_kwargs = publish_calls[0]
+    assert publish_kwargs["force_publish"] is True
+    assert publish_kwargs["coverage_stats"]["partial_run"] is True
+    assert publish_kwargs["coverage_stats"]["attempted_symbols"] == 2
+    assert publish_kwargs["coverage_stats"]["skipped_due_to_deadline"] == 1
+    assert publish_kwargs["coverage_stats"]["snapshot_symbols"] == 3
+    deadline_warning = next(
+        (w for w in publish_kwargs["warnings"] if "deadline reached" in w), None
+    )
+    assert deadline_warning is not None, publish_kwargs["warnings"]
+
+    stdout = capsys.readouterr().out
+    assert "[fundamentals] CN chunk 1/2" in stdout
+    assert "deadline reached before chunk 2/2" in stdout
+    assert export_calls, "Bundle export should still run after a partial publish"
+
+
 def test_import_weekly_reference_bundle_script_calls_service(monkeypatch, tmp_path, capsys):
     bundle_path = tmp_path / "weekly-reference.json.gz"
     bundle_path.write_bytes(b"bundle")

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -539,6 +539,140 @@ def test_build_weekly_reference_bundle_chunked_deadline_force_publishes(
     assert export_calls, "Bundle export should still run after a partial publish"
 
 
+def test_build_weekly_reference_bundle_deadline_blocks_when_partial_disabled(
+    monkeypatch, tmp_path
+):
+    """Disabling partial publish blocks deadline-hit runs even when cache coverage passes."""
+
+    active_rows = [
+        _make_universe_row("600000.SS"),
+        _make_universe_row("600001.SS"),
+        _make_universe_row("000001.SZ"),
+    ]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.order_by.return_value.all.return_value = active_rows
+    fake_db = MagicMock()
+    fake_db.query.return_value = fake_query
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(
+        build_script,
+        "OfficialMarketUniverseSourceService",
+        lambda: SimpleNamespace(
+            fetch_market_snapshot=lambda market: SimpleNamespace(
+                market=market,
+                source_name="cn_official",
+                snapshot_id="cn-2026-05-05",
+                snapshot_as_of="2026-05-05",
+                source_metadata={},
+                rows=tuple({"symbol": row.symbol} for row in active_rows),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        build_script,
+        "get_stock_universe_service",
+        lambda: SimpleNamespace(
+            ingest_cn_snapshot_rows=lambda db, **kwargs: {"added": 3, "updated": 0, "deactivated": 0}
+        ),
+    )
+
+    fake_clock = {"value": 0.0}
+
+    def fake_monotonic() -> float:
+        fake_clock["value"] += 60.0
+        return fake_clock["value"]
+
+    monkeypatch.setattr(build_script.time, "monotonic", fake_monotonic)
+
+    monkeypatch.setattr(
+        build_script,
+        "get_hybrid_fundamentals_service",
+        lambda: SimpleNamespace(
+            yfinance_delay_per_ticker=1.5,
+            fetch_fundamentals_batch=lambda symbols, **kwargs: {
+                symbol: {"market_cap": 1000.0, "sector": "Industrials"} for symbol in symbols
+            },
+            store_all_caches=lambda data, _cache, **_kwargs: {
+                "fundamentals_stored": len(data),
+                "persisted_symbols": len(data),
+                "failed_persistence_symbols": 0,
+                "failed": 0,
+                "provider_error_counts": {},
+            },
+        ),
+    )
+    cached = {
+        "600000.SS": {"market_cap": 1000.0, "sector": "Industrials"},
+        "600001.SS": {"market_cap": 1000.0, "sector": "Industrials"},
+        "000001.SZ": {"market_cap": 999.0, "sector": "Industrials", "data_source": "bundle_import"},
+    }
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_many=lambda symbols: cached),
+    )
+
+    publish_calls: list[dict[str, object]] = []
+
+    def fake_publish_market_snapshot_run(db, **kwargs):
+        publish_calls.append(kwargs)
+        return {
+            "published": False,
+            "source_revision": "fundamentals_v1_cn:20260505121000",
+            "snapshot_key": kwargs["snapshot_key"],
+            "coverage": dict(kwargs["coverage_stats"]),
+            "warnings": list(kwargs["warnings"]),
+            "coverage_thresholds": {
+                "market": "CN",
+                "active_coverage": 1.0,
+                "min_active_coverage": 0.70,
+                "missing_ratio": 0.0,
+                "max_missing_ratio": 0.30,
+            },
+        }
+
+    monkeypatch.setattr(
+        build_script,
+        "get_provider_snapshot_service",
+        lambda: SimpleNamespace(
+            build_market_snapshot_row=lambda **kwargs: {
+                "symbol": kwargs["symbol"],
+                "exchange": kwargs["exchange"],
+                "row_hash": "row-hash",
+                "normalized_payload": kwargs["normalized_payload"],
+                "raw_payload": kwargs["raw_payload"],
+            },
+            publish_market_snapshot_run=fake_publish_market_snapshot_run,
+        ),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "CN",
+            "--output-dir",
+            str(tmp_path),
+            "--max-runtime-minutes",
+            "1.5",
+            "--fetch-chunk-size",
+            "2",
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="Partial publish disabled"):
+        build_script.main()
+
+    publish_kwargs = publish_calls[0]
+    assert publish_kwargs["publish"] is False
+    assert publish_kwargs["force_publish"] is False
+    assert publish_kwargs["coverage_stats"]["partial_run"] is True
+    assert publish_kwargs["coverage_stats"]["snapshot_symbols"] == 3
+
+
 def test_import_weekly_reference_bundle_script_calls_service(monkeypatch, tmp_path, capsys):
     bundle_path = tmp_path / "weekly-reference.json.gz"
     bundle_path.write_bytes(b"bundle")


### PR DESCRIPTION
## Summary
Adds support for wall-clock budget enforcement during the weekly reference bundle build process, allowing the Asia market path to gracefully exit between chunks when a deadline is reached and optionally publish a partial bundle with skipped symbols inheriting data from the prior week.

## Key Changes

- **Chunked fundamentals refresh**: Introduced `_run_chunked_fundamentals_refresh()` to fetch and persist fundamentals in configurable chunks rather than all at once, enabling deadline checks between chunks
- **Deadline enforcement**: Added `--max-runtime-minutes` CLI argument to set a soft wall-clock budget; when exhausted, the loop exits cleanly between chunks without fetching remaining symbols
- **Partial publish support**: Added `--allow-partial-publish` flag and `force_publish` parameter to `publish_market_snapshot_run()` to publish snapshots even when coverage gates would normally block, with warnings recorded
- **Statistics tracking**: Extended coverage stats to track `attempted_symbols`, `skipped_due_to_deadline`, and `partial_run` flag; added helper functions `_empty_fundamentals_stats()` and `_merge_fundamentals_stats()` to accumulate stats across chunks
- **Workflow dispatch inputs**: Enhanced GitHub Actions workflow with manual inputs for `market`, `max_runtime_minutes`, and `allow_partial_publish` to support ad-hoc runs with custom parameters
- **Per-market defaults**: Configured CN market with 320-minute budget and partial publish enabled by default (skipped symbols inherit prior bundle data); other markets default to no deadline
- **Job timeout**: Set explicit 350-minute job timeout to allow the build script's deadline to fire before GitHub Actions hard-caps at 360 minutes

## Implementation Details

- Deadline is checked before each chunk using `time.monotonic()` to avoid wall-clock skew
- Skipped symbols are hydrated from the fundamentals cache (which contains prior bundle data), ensuring snapshot coverage remains complete even with partial fetches
- Warnings are appended to the snapshot run to record deadline hits and force-publish overrides
- Chunk size defaults to 250 symbols but is configurable via `--fetch-chunk-size`
- Comprehensive test coverage validates deadline triggering, partial publish behavior, and cache inheritance

https://claude.ai/code/session_014DaBzsmyYVRLQjeULRkS46