### PR TITLE
fix(frontend): address static home review findings

### DIFF
--- a/frontend/src/components/Scan/PriceSparkline.jsx
+++ b/frontend/src/components/Scan/PriceSparkline.jsx
@@ -121,7 +121,14 @@ function PriceSparkline({
         }}
       >
         {/* Sparkline Chart */}
-        <Box sx={{ width: showChange ? sparklineWidth : '100%', height: '100%', flex: showChange ? 'none' : 1 }}>
+        <Box
+          sx={{
+            width: showChange ? sparklineWidth : '100%',
+            height: '100%',
+            flex: showChange ? '1 1 auto' : 1,
+            minWidth: 0,
+          }}
+        >
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart
               data={chartData}
@@ -148,6 +155,7 @@ function PriceSparkline({
               fontFamily: 'monospace',
               color: changeColor,
               whiteSpace: 'nowrap',
+              flexShrink: 0,
             }}
           >
             {changeText}

--- a/frontend/src/static/pages/StaticHomePage.jsx
+++ b/frontend/src/static/pages/StaticHomePage.jsx
@@ -322,7 +322,7 @@ function StaticHomePage() {
                           industry={row.ibd_industry_group}
                           width={137}
                           height={28}
-                          sparklineWidth={92}
+                          sparklineWidth={86}
                         />
                       </Box>
                     ) : '-'}

--- a/frontend/src/static/pages/StaticHomePage.test.jsx
+++ b/frontend/src/static/pages/StaticHomePage.test.jsx
@@ -10,6 +10,7 @@ const useStaticManifest = vi.fn();
 const useStaticChartIndex = vi.fn();
 const useStaticMarket = vi.fn();
 const modalSpy = vi.fn();
+const priceSparklineSpy = vi.fn();
 
 vi.mock('../dataClient', () => ({
   fetchStaticJson: (...args) => fetchStaticJson(...args),
@@ -38,7 +39,10 @@ vi.mock('../StaticChartViewerModal', () => ({
 }));
 
 vi.mock('../../components/Scan/PriceSparkline', () => ({
-  default: () => <span data-testid="price-sparkline" />,
+  default: (props) => {
+    priceSparklineSpy(props);
+    return <span data-testid="price-sparkline" />;
+  },
 }));
 
 vi.mock('../../components/Scan/RSSparkline', () => ({
@@ -61,9 +65,14 @@ const manifest = {
 };
 
 describe('StaticHomePage', () => {
+  let homePayload;
+  let scanManifestPayload;
+  let scanChunkPayload;
+
   beforeEach(() => {
     vi.clearAllMocks();
     modalSpy.mockClear();
+    priceSparklineSpy.mockClear();
     useStaticManifest.mockReturnValue({
       data: manifest,
       isLoading: false,
@@ -79,81 +88,149 @@ describe('StaticHomePage', () => {
         ],
       },
     });
+    homePayload = {
+      market_display_name: 'United States',
+      freshness: {
+        scan_as_of_date: '2026-04-24',
+        breadth_latest_date: '2026-04-24',
+        groups_latest_date: '2026-04-24',
+      },
+      key_markets: [],
+      scan_summary: {
+        top_results: [
+          { symbol: 'SUMMARYONLY', company_name: 'Home Summary Only', composite_score: 99.9 },
+        ],
+      },
+      top_groups: [],
+    };
+    scanManifestPayload = {
+      initial_rows: [
+        {
+          symbol: 'NVDA',
+          company_name: 'NVIDIA Corporation',
+          composite_score: 98.0,
+          current_price: 100,
+          rating: 'Strong Buy',
+          volume: 180_000_000,
+          market_cap: 2_000_000_000,
+          currency: 'USD',
+          price_sparkline_data: null,
+          rs_sparkline_data: null,
+        },
+      ],
+      chunks: [
+        { path: 'markets/us/scan/chunks/chunk-0001.json' },
+      ],
+    };
+    scanChunkPayload = {
+      rows: [
+        {
+          symbol: '0700.HK',
+          company_name: 'Tencent Holdings',
+          composite_score: 99.0,
+          current_price: 25,
+          rating: 'Buy',
+          volume: 170_000_000,
+          market_cap: 3_900_000_000_000,
+          market_cap_usd: 500_000_000,
+          currency: 'HKD',
+          price_sparkline_data: null,
+          rs_sparkline_data: null,
+        },
+        {
+          symbol: 'AAPL',
+          company_name: 'Apple Inc.',
+          composite_score: 97.0,
+          current_price: 200,
+          rating: 'Buy',
+          volume: 160_000_000,
+          market_cap: 3_000_000_000,
+          currency: 'USD',
+          price_sparkline_data: null,
+          rs_sparkline_data: null,
+        },
+      ],
+    };
+
     fetchStaticJson.mockImplementation(async (path) => {
       if (path === 'markets/us/home.json') {
-        return {
-          market_display_name: 'United States',
-          freshness: {
-            scan_as_of_date: '2026-04-24',
-            breadth_latest_date: '2026-04-24',
-            groups_latest_date: '2026-04-24',
-          },
-          key_markets: [],
-          scan_summary: {
-            top_results: [
-              { symbol: 'SUMMARYONLY', company_name: 'Home Summary Only', composite_score: 99.9 },
-            ],
-          },
-          top_groups: [],
-        };
+        return homePayload;
       }
 
       if (path === 'markets/us/scan/manifest.json') {
-        return {
-          initial_rows: [
-            {
-              symbol: 'NVDA',
-              company_name: 'NVIDIA Corporation',
-              composite_score: 98.0,
-              current_price: 100,
-              rating: 'Strong Buy',
-              volume: 180_000_000,
-              market_cap: 2_000_000_000,
-              currency: 'USD',
-              price_sparkline_data: null,
-              rs_sparkline_data: null,
-            },
-          ],
-          chunks: [
-            { path: 'markets/us/scan/chunks/chunk-0001.json' },
-          ],
-        };
+        return scanManifestPayload;
       }
 
       if (path === 'markets/us/scan/chunks/chunk-0001.json') {
-        return {
-          rows: [
-            {
-              symbol: '0700.HK',
-              company_name: 'Tencent Holdings',
-              composite_score: 99.0,
-              current_price: 25,
-              rating: 'Buy',
-              volume: 170_000_000,
-              market_cap: 3_900_000_000_000,
-              market_cap_usd: 500_000_000,
-              currency: 'HKD',
-              price_sparkline_data: null,
-              rs_sparkline_data: null,
-            },
-            {
-              symbol: 'AAPL',
-              company_name: 'Apple Inc.',
-              composite_score: 97.0,
-              current_price: 200,
-              rating: 'Buy',
-              volume: 160_000_000,
-              market_cap: 3_000_000_000,
-              currency: 'USD',
-              price_sparkline_data: null,
-              rs_sparkline_data: null,
-            },
-          ],
-        };
+        return scanChunkPayload;
       }
 
       throw new Error(`Unexpected static path: ${path}`);
     });
+  });
+
+  it('filters key market cards to entries with renderable close history', async () => {
+    homePayload.key_markets = [
+      {
+        symbol: 'VALID',
+        display_name: 'Valid Market',
+        currency: 'USD',
+        latest_close: 102,
+        change_1d: 2,
+        history: [{ close: 100 }, { close: null }, { close: 102 }],
+      },
+      {
+        symbol: 'NULLS',
+        display_name: 'Null History',
+        currency: 'USD',
+        latest_close: 10,
+        change_1d: null,
+        history: [{ close: null }],
+      },
+      {
+        symbol: 'SINGLE',
+        display_name: 'Single Close',
+        currency: 'USD',
+        latest_close: 20,
+        change_1d: null,
+        history: [{ close: 20 }],
+      },
+      {
+        symbol: 'MISSING',
+        display_name: 'Missing Price',
+        currency: 'USD',
+        latest_close: null,
+        change_1d: null,
+        history: [{ close: 19 }, { close: 20 }],
+      },
+    ];
+
+    renderWithProviders(<StaticHomePage />);
+
+    expect(await screen.findByText('VALID')).toBeInTheDocument();
+    expect(screen.queryByText('NULLS')).not.toBeInTheDocument();
+    expect(screen.queryByText('SINGLE')).not.toBeInTheDocument();
+    expect(screen.queryByText('MISSING')).not.toBeInTheDocument();
+    expect(priceSparklineSpy).toHaveBeenCalledWith(expect.objectContaining({
+      data: [100, 102],
+      showChange: false,
+    }));
+  });
+
+  it('keeps top candidate price sparklines within the compact table width', async () => {
+    scanChunkPayload.rows[0].price_sparkline_data = [20, 22, 24];
+    scanChunkPayload.rows[0].price_trend = 1;
+    scanChunkPayload.rows[0].price_change_1d = 12.3;
+
+    renderWithProviders(<StaticHomePage />);
+
+    expect(await screen.findByText('0700.HK')).toBeInTheDocument();
+    expect(priceSparklineSpy).toHaveBeenCalledWith(expect.objectContaining({
+      data: [20, 22, 24],
+      width: 137,
+      sparklineWidth: 86,
+      change1d: 12.3,
+    }));
   });
 
   it('loads top candidates from the static scan bundle, filters by market cap, and keeps chart navigation aligned', async () => {


### PR DESCRIPTION
## Summary\n- Keep static key market cards limited to entries with two renderable close values\n- Let PriceSparkline chart area shrink around the non-wrapping change label\n- Add regression coverage for key-market filtering and compact table sparkline props\n\n## Verification\n- npm run test:run -- src/static/pages/StaticHomePage.test.jsx\n- npm run lint -- src/static/pages/StaticHomePage.jsx src/components/Scan/PriceSparkline.jsx src/static/pages/StaticHomePage.test.jsx (0 errors; existing warnings in StockDetails and StaticMarketContext)\n- npm run build\n\nNote: PR #153 was merged before this follow-up could attach to it, so this PR carries the remaining review fix on top of main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined sparkline width and flex layout behavior in price trend display for improved visual presentation.
  * Enhanced styling of the 1-day change indicator to maintain consistent layout behavior.

* **Tests**
  * Expanded test coverage for price sparkline rendering and responsive layout calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->