### PR TITLE
Re-enrich IBD metadata after group rank backfill in daily refresh

### DIFF
--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -383,6 +383,7 @@ def _run_daily_refresh(
     hydrate_published_snapshot: bool = False,
 ) -> tuple[dict[str, Any], list[str]]:
     from app.interfaces.tasks.feature_store_tasks import (
+        _enrich_feature_run_with_ibd_metadata,
         build_daily_snapshot,
     )
     from app.tasks.fundamentals_tasks import refresh_all_fundamentals
@@ -456,6 +457,36 @@ def _run_daily_refresh(
                 market=selected_market,
             )
         results["group_rank_history_backfill"] = group_rank_history
+
+        # Re-enrich feature runs after the IBDGroupRank backfill above.
+        # build_daily_snapshot's inner enrichment runs *before* group ranks
+        # for `as_of_date` are populated, so US rows would otherwise carry
+        # `details_json["ibd_group_rank"] = None`.
+        ibd_metadata_refresh: dict[str, Any] = {}
+        for selected_market in selected_markets:
+            snapshot = feature_snapshots.get(selected_market, {})
+            if not _snapshot_ready(snapshot):
+                ibd_metadata_refresh[selected_market] = {
+                    "status": "skipped",
+                    "market": selected_market,
+                    "reason": "snapshot_not_ready",
+                }
+                continue
+            feature_run_id = (
+                snapshot.get("run_id") or snapshot.get("existing_run_id")
+            )
+            if feature_run_id is None:
+                ibd_metadata_refresh[selected_market] = {
+                    "status": "skipped",
+                    "market": selected_market,
+                    "reason": "no_run_id",
+                }
+                continue
+            ibd_metadata_refresh[selected_market] = _enrich_feature_run_with_ibd_metadata(
+                feature_run_id=feature_run_id,
+                ranking_date=as_of_date,
+            )
+        results["ibd_metadata_refresh"] = ibd_metadata_refresh
 
         for snapshot_market, snapshot in feature_snapshots.items():
             if snapshot_market == STATIC_DEFAULT_MARKET:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -462,6 +462,16 @@ def _run_daily_refresh(
         # build_daily_snapshot's inner enrichment runs *before* group ranks
         # for `as_of_date` are populated, so US rows would otherwise carry
         # `details_json["ibd_group_rank"] = None`.
+        #
+        # Only re-enrich when the backfill above actually succeeded
+        # (status "completed" — fresh ranks were written — or "skipped" —
+        # existing rows already cover ``as_of_date``). For any other
+        # status (e.g. "errored") the IBDGroupRank table is still missing
+        # rows, so calling the enricher would overwrite previously valid
+        # ``ibd_group_rank`` values with ``None`` — particularly harmful
+        # when ``build_daily_snapshot`` returned "already_published" and
+        # the existing run carries good ranks from an earlier successful
+        # refresh.
         ibd_metadata_refresh: dict[str, Any] = {}
         for selected_market in selected_markets:
             snapshot = feature_snapshots.get(selected_market, {})
@@ -470,6 +480,14 @@ def _run_daily_refresh(
                     "status": "skipped",
                     "market": selected_market,
                     "reason": "snapshot_not_ready",
+                }
+                continue
+            backfill_status = (group_rank_history.get(selected_market) or {}).get("status")
+            if backfill_status not in ("completed", "skipped"):
+                ibd_metadata_refresh[selected_market] = {
+                    "status": "skipped",
+                    "market": selected_market,
+                    "reason": f"group_rank_backfill_{backfill_status or 'missing'}",
                 }
                 continue
             feature_run_id = (

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -678,6 +678,148 @@ def test_refresh_static_daily_prices_filters_to_selected_market(monkeypatch):
     assert stored_batches == [{"symbols": ["0700.HK"], "also_store_db": True}]
 
 
+def test_run_daily_refresh_reenriches_ibd_metadata_after_group_rank_backfill(monkeypatch):
+    """Group ranks for ``as_of_date`` are backfilled by ``_ensure_group_rank_history``
+    only after ``build_daily_snapshot`` has already run its inner enrichment.
+    The driver must re-run ``_enrich_feature_run_with_ibd_metadata`` so the
+    static export reads up-to-date ``ibd_group_rank`` values from
+    ``details_json``."""
+
+    events: list[str] = []
+
+    def make_task(name: str):
+        def run(**kwargs):
+            events.append(name)
+            return {"task": name, "kwargs": kwargs, "run_id": 77, "status": "published"}
+
+        return SimpleNamespace(run=run)
+
+    enrich_calls: list[dict] = []
+
+    def fake_enrich(*, feature_run_id, ranking_date, **_kwargs):
+        events.append(f"enrich:{feature_run_id}")
+        enrich_calls.append({"feature_run_id": feature_run_id, "ranking_date": ranking_date})
+        return {"run_id": feature_run_id, "updated_rows": 3, "missing_rank_rows": 0}
+
+    group_rank_calls: list[dict] = []
+
+    def fake_ensure_group_rank_history(*, as_of_date, market):
+        events.append(f"group_rank:{market}")
+        group_rank_calls.append({"as_of_date": as_of_date, "market": market})
+        return {"status": "completed", "market": market, "missing_dates": 1}
+
+    monkeypatch.setattr(universe_tasks, "refresh_stock_universe", make_task("universe_refresh"))
+    monkeypatch.setattr(fundamentals_tasks, "refresh_all_fundamentals", make_task("fundamentals_refresh"))
+    monkeypatch.setattr(feature_store_tasks, "build_daily_snapshot", make_task("feature_snapshot"))
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "_enrich_feature_run_with_ibd_metadata",
+        fake_enrich,
+    )
+    monkeypatch.setattr(export_script, "_ensure_group_rank_history", fake_ensure_group_rank_history)
+    monkeypatch.setattr(
+        export_script,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date, market=None: {"task": "price_refresh", "market": market, "as_of_date": as_of_date.isoformat()},
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_resolve_latest_completed_us_trading_date",
+        lambda: date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        export_script.IBDIndustryService,
+        "load_from_csv",
+        lambda db, csv_path=None: 10105,
+    )
+    monkeypatch.setattr(export_script, "_upsert_feature_run_pointer", lambda **_kwargs: None)
+
+    results, warnings = export_script._run_daily_refresh(market="US")  # noqa: SLF001 - intentional unit test coverage
+
+    assert warnings == []
+    # Order matters: the re-enrich step must run *after* the group-rank
+    # backfill (otherwise it would re-read the same empty IBDGroupRank rows
+    # build_daily_snapshot already saw).
+    assert events == [
+        "universe_refresh",
+        "fundamentals_refresh",
+        "feature_snapshot",
+        "group_rank:US",
+        "enrich:77",
+    ]
+    assert group_rank_calls == [{"as_of_date": date(2026, 4, 2), "market": "US"}]
+    assert enrich_calls == [{"feature_run_id": 77, "ranking_date": date(2026, 4, 2)}]
+    assert results["ibd_metadata_refresh"]["US"] == {
+        "run_id": 77,
+        "updated_rows": 3,
+        "missing_rank_rows": 0,
+    }
+
+
+def test_run_daily_refresh_skips_reenrich_when_snapshot_not_ready(monkeypatch):
+    enrich_calls: list[dict] = []
+
+    def fake_enrich(**kwargs):
+        enrich_calls.append(kwargs)
+        return {"updated_rows": 0}
+
+    def build_snapshot(**kwargs):
+        if kwargs["market"] == "US":
+            return {"status": "failed", "run_id": 91}
+        return {"status": "published", "run_id": 77, "kwargs": kwargs}
+
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(run=build_snapshot),
+    )
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "_enrich_feature_run_with_ibd_metadata",
+        fake_enrich,
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_ensure_group_rank_history",
+        lambda **_kwargs: {"status": "completed"},
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date, market=None: {"task": "price_refresh"},
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_resolve_latest_completed_us_trading_date",
+        lambda: date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        export_script.IBDIndustryService,
+        "load_from_csv",
+        lambda db, csv_path=None: 10105,
+    )
+    monkeypatch.setattr(universe_tasks, "refresh_stock_universe", SimpleNamespace(run=lambda: {"task": "universe_refresh"}))
+    monkeypatch.setattr(
+        fundamentals_tasks,
+        "refresh_all_fundamentals",
+        SimpleNamespace(run=lambda: {"task": "fundamentals_refresh"}),
+    )
+    monkeypatch.setattr(export_script, "_upsert_feature_run_pointer", lambda **_kwargs: None)
+
+    results, _warnings = export_script._run_daily_refresh()  # noqa: SLF001 - intentional unit test coverage
+
+    # US returned status "failed" → not snapshot_ready → re-enrich must skip it
+    assert results["ibd_metadata_refresh"]["US"]["status"] == "skipped"
+    assert results["ibd_metadata_refresh"]["US"]["reason"] == "snapshot_not_ready"
+    # The other markets returned no status but a run_id, so they ARE re-enriched.
+    other_markets = [m for m in export_script.STATIC_EXPORT_MARKETS if m != "US"]
+    assert all(
+        results["ibd_metadata_refresh"][m]["updated_rows"] == 0
+        for m in other_markets
+    )
+    assert {call["feature_run_id"] for call in enrich_calls} == {77}
+
+
 def test_run_daily_refresh_warns_when_non_default_market_snapshot_is_not_publish_ready(monkeypatch):
     def build_snapshot(**kwargs):
         if kwargs["market"] == "HK":

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -756,6 +756,70 @@ def test_run_daily_refresh_reenriches_ibd_metadata_after_group_rank_backfill(mon
     }
 
 
+def test_run_daily_refresh_skips_reenrich_when_group_rank_backfill_errored(monkeypatch):
+    """If ``_ensure_group_rank_history`` fails, the IBDGroupRank table is
+    still missing ``as_of_date`` rows. Re-enriching in that state would
+    overwrite previously valid ``ibd_group_rank`` values with ``None``
+    (most damaging when ``build_daily_snapshot`` returned ``already_published``
+    and the existing run carries ranks from an earlier successful refresh).
+    The driver must skip re-enrich when the backfill did not succeed."""
+
+    enrich_calls: list[dict] = []
+
+    def fake_enrich(**kwargs):
+        enrich_calls.append(kwargs)
+        return {"updated_rows": 99}
+
+    monkeypatch.setattr(universe_tasks, "refresh_stock_universe", SimpleNamespace(run=lambda **_kwargs: {"task": "universe_refresh"}))
+    monkeypatch.setattr(fundamentals_tasks, "refresh_all_fundamentals", SimpleNamespace(run=lambda **_kwargs: {"task": "fundamentals_refresh"}))
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(
+            run=lambda **kwargs: {"status": "published", "run_id": 77, "kwargs": kwargs}
+        ),
+    )
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "_enrich_feature_run_with_ibd_metadata",
+        fake_enrich,
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_ensure_group_rank_history",
+        lambda *, as_of_date, market: {
+            "status": "errored",
+            "market": market,
+            "error": "Failed to fetch SPY benchmark data",
+        },
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date, market=None: {"task": "price_refresh"},
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_resolve_latest_completed_us_trading_date",
+        lambda: date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        export_script.IBDIndustryService,
+        "load_from_csv",
+        lambda db, csv_path=None: 10105,
+    )
+    monkeypatch.setattr(export_script, "_upsert_feature_run_pointer", lambda **_kwargs: None)
+
+    results, _warnings = export_script._run_daily_refresh(market="US")  # noqa: SLF001 - intentional unit test coverage
+
+    assert enrich_calls == []
+    assert results["ibd_metadata_refresh"]["US"] == {
+        "status": "skipped",
+        "market": "US",
+        "reason": "group_rank_backfill_errored",
+    }
+
+
 def test_run_daily_refresh_skips_reenrich_when_snapshot_not_ready(monkeypatch):
     enrich_calls: list[dict] = []
 


### PR DESCRIPTION
## Summary
This change ensures that IBD group rank metadata is properly refreshed after the daily snapshot build completes. The issue was that `build_daily_snapshot` performs enrichment before group ranks for the current date are backfilled, resulting in stale `ibd_group_rank` values in the exported data.

## Key Changes
- Added a re-enrichment step in `_run_daily_refresh()` that runs **after** `_ensure_group_rank_history()` completes
- The re-enrichment calls `_enrich_feature_run_with_ibd_metadata()` for each market to update feature runs with current IBD metadata
- Implemented safeguards to skip re-enrichment when:
  - The snapshot is not ready (status is "failed" or missing)
  - No valid `run_id` is available from the snapshot
- Added comprehensive test coverage:
  - `test_run_daily_refresh_reenriches_ibd_metadata_after_group_rank_backfill`: Verifies the correct execution order and that re-enrichment happens after group rank backfill
  - `test_run_daily_refresh_skips_reenrich_when_snapshot_not_ready`: Ensures re-enrichment is properly skipped for failed snapshots

## Implementation Details
- The re-enrichment step is positioned after group rank backfill but before price refresh, ensuring the static export reads up-to-date `ibd_group_rank` values from `details_json`
- Results are tracked in a new `ibd_metadata_refresh` dictionary in the results output
- The implementation handles both successful snapshots and edge cases gracefully with appropriate status reporting

https://claude.ai/code/session_01AYKtMkncBCXpkxZYs1Fa3D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata enrichment process for per-market feature data during daily refresh operations. Enhanced error handling to skip processing when data snapshots are unavailable for specific markets.

* **Tests**
  * Added unit test coverage for metadata re-enrichment behavior and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->