### PR TITLE
fix(cn): retry transient listing disconnects

### DIFF
--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -167,7 +167,7 @@ def _call_listing_with_retries(
     attempts: int = _CN_LISTING_FETCH_ATTEMPTS,
     base_delay_seconds: float = _CN_LISTING_RETRY_BASE_DELAY_SECONDS,
 ):
-    last_error: Exception | None = None
+    """Call a CN listing fetcher with timeout and retry transient request failures."""
     for attempt in range(1, max(1, int(attempts)) + 1):
         try:
             return _call_with_timeout(
@@ -177,8 +177,7 @@ def _call_listing_with_retries(
             )
         except requests.exceptions.Timeout:
             raise
-        except Exception as exc:
-            last_error = exc
+        except requests.exceptions.RequestException as exc:
             if attempt >= attempts:
                 raise
             delay = max(0.0, float(base_delay_seconds)) * attempt
@@ -192,9 +191,6 @@ def _call_listing_with_retries(
             )
             if delay:
                 time.sleep(delay)
-    if last_error is not None:
-        raise last_error
-    return None
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 _AKSHARE_OHLCV_FAILURE_THRESHOLD = 2
 _AKSHARE_OHLCV_COOLDOWN_SECONDS = 300.0
+_CN_LISTING_FETCH_ATTEMPTS = 3
+_CN_LISTING_RETRY_BASE_DELAY_SECONDS = 5.0
 
 
 class CnDependencyError(RuntimeError):
@@ -157,6 +159,44 @@ def _call_with_timeout(fetcher, *, timeout_seconds: int, operation_name: str):
             )
 
 
+def _call_listing_with_retries(
+    fetcher,
+    *,
+    timeout_seconds: int,
+    operation_name: str,
+    attempts: int = _CN_LISTING_FETCH_ATTEMPTS,
+    base_delay_seconds: float = _CN_LISTING_RETRY_BASE_DELAY_SECONDS,
+):
+    last_error: Exception | None = None
+    for attempt in range(1, max(1, int(attempts)) + 1):
+        try:
+            return _call_with_timeout(
+                fetcher,
+                timeout_seconds=timeout_seconds,
+                operation_name=operation_name,
+            )
+        except requests.exceptions.Timeout:
+            raise
+        except Exception as exc:
+            last_error = exc
+            if attempt >= attempts:
+                raise
+            delay = max(0.0, float(base_delay_seconds)) * attempt
+            logger.warning(
+                "%s failed on attempt %d/%d: %s; retrying in %.1fs",
+                operation_name,
+                attempt,
+                attempts,
+                exc,
+                delay,
+            )
+            if delay:
+                time.sleep(delay)
+    if last_error is not None:
+        raise last_error
+    return None
+
+
 @dataclass(frozen=True)
 class CnDailyPriceRow:
     date: str
@@ -242,7 +282,7 @@ class CnMarketDataService:
         fallback_fetcher = getattr(self._akshare, "stock_info_a_code_name", None)
         if callable(fallback_fetcher):
             try:
-                frame = _call_with_timeout(
+                frame = _call_listing_with_retries(
                     fallback_fetcher,
                     timeout_seconds=self._listing_timeout_seconds,
                     operation_name="CN A-share code-name fetch",
@@ -260,7 +300,7 @@ class CnMarketDataService:
         return None
 
     def _akshare_spot_frame(self) -> pd.DataFrame | None:
-        frame = _call_with_timeout(
+        frame = _call_listing_with_retries(
             self._akshare.stock_zh_a_spot_em,
             timeout_seconds=self._listing_timeout_seconds,
             operation_name="CN A-share listing fetch",

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -167,6 +167,27 @@ def test_cn_market_data_service_retries_transient_spot_disconnect(monkeypatch):
     assert rows[0]["symbol"] == "600519.SS"
 
 
+def test_cn_market_data_service_does_not_retry_deterministic_spot_errors(monkeypatch):
+    sleeps: list[float] = []
+    attempts = {"count": 0}
+
+    class BrokenAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            attempts["count"] += 1
+            raise TypeError("unexpected listing schema")
+
+    monkeypatch.setattr(cn_market_data_module.time, "sleep", lambda delay: sleeps.append(delay))
+
+    service = CnMarketDataService(akshare_module=BrokenAkshare(), timeout_seconds=1)
+
+    with pytest.raises(TypeError, match="unexpected listing schema"):
+        service.listing_rows(as_of=date(2026, 4, 30))
+
+    assert attempts["count"] == 1
+    assert sleeps == []
+
+
 def test_cn_market_data_service_retries_transient_code_name_disconnect(monkeypatch):
     sleeps: list[float] = []
     fallback_attempts = {"count": 0}

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -144,6 +144,56 @@ def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_is_empty(
     assert rows[0]["board"] == "SSE_STAR"
 
 
+def test_cn_market_data_service_retries_transient_spot_disconnect(monkeypatch):
+    sleeps: list[float] = []
+    attempts = {"count": 0}
+
+    class FlakyAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise requests.exceptions.ConnectionError("eastmoney disconnected")
+            return pd.DataFrame([{"代码": "600519", "名称": "贵州茅台"}])
+
+    monkeypatch.setattr(cn_market_data_module.time, "sleep", lambda delay: sleeps.append(delay))
+
+    service = CnMarketDataService(akshare_module=FlakyAkshare(), timeout_seconds=1)
+
+    rows = service.listing_rows(as_of=date(2026, 4, 30))
+
+    assert attempts["count"] == 2
+    assert sleeps == [5.0]
+    assert rows[0]["symbol"] == "600519.SS"
+
+
+def test_cn_market_data_service_retries_transient_code_name_disconnect(monkeypatch):
+    sleeps: list[float] = []
+    fallback_attempts = {"count": 0}
+
+    class FlakyFallbackAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            raise requests.exceptions.ConnectionError("spot source disconnected")
+
+        @staticmethod
+        def stock_info_a_code_name():
+            fallback_attempts["count"] += 1
+            if fallback_attempts["count"] == 1:
+                raise requests.exceptions.ConnectionError("code-name source disconnected")
+            return pd.DataFrame([{"code": "000001", "name": "平安银行"}])
+
+    monkeypatch.setattr(cn_market_data_module.time, "sleep", lambda delay: sleeps.append(delay))
+
+    service = CnMarketDataService(akshare_module=FlakyFallbackAkshare(), timeout_seconds=1)
+
+    rows = service.listing_rows(as_of=date(2026, 4, 30))
+
+    assert fallback_attempts["count"] == 2
+    assert sleeps == [5.0, 10.0, 5.0]
+    assert rows[0]["symbol"] == "000001.SZ"
+
+
 @pytest.mark.skipif(not _SIGALRM_AVAILABLE, reason="SIGALRM timers are unavailable on this platform")
 def test_cn_market_data_service_falls_back_to_code_name_list_when_spot_times_out():
     class FallbackAkshare:


### PR DESCRIPTION
## Summary
- add retry/backoff around CN AKShare listing fetches
- retry both the primary spot listing endpoint and the code-name fallback endpoint
- keep long SIGALRM listing timeouts fail-fast so retries do not multiply 300s timeouts

## Verification
- `/Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest tests/unit/test_cn_market_data_service.py -q`
- `/Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest tests/unit/test_weekly_reference_scripts.py -q`

Fixes the manual CN weekly-reference failure where both AKShare listing endpoints disconnected before fundamentals began.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Enhanced Chinese market listing data retrieval with automatic retry logic and exponential backoff to gracefully handle transient failures before falling back to alternative data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->