### PR TITLE
fix(cn): add BaoStock listing fallback and seeded-universe rescue

### DIFF
--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -446,9 +446,37 @@ def _build_asia_bundle(
     _configure_weekly_hybrid_service(market, hybrid_service)
 
     print(f"Starting official universe refresh for {market}...", flush=True)
-    official_snapshot = official_source_service.fetch_market_snapshot(market)
-    universe_stats = _ingest_official_market_snapshot(db, stock_universe_service, official_snapshot)
-    print(f"Universe refresh complete: {universe_stats}", flush=True)
+    stale_universe = False
+    universe_error: str | None = None
+    try:
+        official_snapshot = official_source_service.fetch_market_snapshot(market)
+        universe_stats = _ingest_official_market_snapshot(db, stock_universe_service, official_snapshot)
+        print(f"Universe refresh complete: {universe_stats}", flush=True)
+    except Exception as exc:
+        if not allow_partial_publish:
+            raise
+        seeded_count = (
+            db.query(StockUniverse)
+            .filter(
+                StockUniverse.active_filter(),
+                StockUniverse.market == market,
+            )
+            .count()
+        )
+        if seeded_count == 0:
+            raise
+        stale_universe = True
+        universe_error = str(exc)
+        universe_stats = {
+            "stale_universe": True,
+            "error": universe_error,
+            "fallback_rows": seeded_count,
+        }
+        print(
+            f"[universe] {market} official fetch failed ({universe_error}); "
+            f"falling back to {seeded_count} seeded prior-week rows",
+            flush=True,
+        )
 
     active_rows = (
         db.query(StockUniverse)
@@ -505,9 +533,15 @@ def _build_asia_bundle(
         "missing_active_symbols": max(len(symbols) - len(snapshot_rows), 0),
         "attempted_symbols": len(attempted_symbols),
         "skipped_due_to_deadline": len(skipped_symbols) if deadline_hit else 0,
-        "partial_run": deadline_hit,
+        "partial_run": deadline_hit or stale_universe,
+        "stale_universe": stale_universe,
     }
     warnings: list[str] = []
+    if stale_universe:
+        warnings.append(
+            f"Official {market} universe fetch failed ({universe_error}); "
+            f"reused {len(symbols)} seeded prior-week rows."
+        )
     if fundamentals_stats.get("failed"):
         warnings.append(
             f"{fundamentals_stats['failed']} symbols failed during {market} hybrid fundamentals refresh"
@@ -538,7 +572,7 @@ def _build_asia_bundle(
         coverage_stats=coverage_stats,
         warnings=warnings,
         publish=publish,
-        force_publish=bool(allow_partial_publish and deadline_hit),
+        force_publish=bool(allow_partial_publish and (deadline_hit or stale_universe)),
     )
     summary = {
         "output_dir": output_dir,

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -458,11 +458,21 @@ def _build_asia_bundle(
         # _ingest_official_market_snapshot may have raised mid-transaction
         # (after bulk_save_objects but before commit), leaving the session in
         # a doomed state. Roll back before the seeded-rows query so we don't
-        # mask the original error with a PendingRollbackError.
+        # mask the original error with a PendingRollbackError. The rollback
+        # also reverts any partial bulk-insert, so the seeded-count below
+        # reflects only rows that pre-existed this run.
         try:
             db.rollback()
         except Exception:  # pragma: no cover - defensive; rollback failures fall through
             pass
+        # Assumption: the ``Seed prior weekly reference bundle`` step in
+        # weekly-reference-data.yml is the only writer of CN rows in the
+        # CI Postgres before this script runs, so any active rows present
+        # here came from ``import_weekly_reference_bundle``. The rollback
+        # above guarantees no partially-ingested rows survive. Long-running
+        # deployments without a fresh Postgres should not rely on this
+        # rescue path without first verifying that prior rows reflect the
+        # intended baseline.
         seeded_count = (
             db.query(StockUniverse)
             .filter(

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -455,6 +455,14 @@ def _build_asia_bundle(
     except Exception as exc:
         if not allow_partial_publish:
             raise
+        # _ingest_official_market_snapshot may have raised mid-transaction
+        # (after bulk_save_objects but before commit), leaving the session in
+        # a doomed state. Roll back before the seeded-rows query so we don't
+        # mask the original error with a PendingRollbackError.
+        try:
+            db.rollback()
+        except Exception:  # pragma: no cover - defensive; rollback failures fall through
+            pass
         seeded_count = (
             db.query(StockUniverse)
             .filter(
@@ -662,10 +670,13 @@ def main() -> int:
         "--allow-partial-publish",
         action="store_true",
         help=(
-            "When --max-runtime-minutes triggers an early exit, publish the "
-            "snapshot even if the coverage gate would otherwise block. "
-            "Skipped symbols inherit the prior weekly bundle's data; the "
-            "manifest records partial_run=True and a deadline warning."
+            "Allow partial publish in two scenarios: (a) --max-runtime-minutes "
+            "triggers an early exit between fundamentals chunks, or (b) the "
+            "official market-universe fetch fails and prior-week seeded "
+            "universe rows are available. The snapshot is force-published "
+            "even if the coverage gate would otherwise block. Skipped symbols "
+            "inherit the prior weekly bundle's data; the manifest records "
+            "partial_run=True with a deadline or stale_universe warning."
         ),
     )
     args = parser.parse_args()

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -250,16 +250,43 @@ class CnMarketDataService:
         return self._baostock_module
 
     def listing_rows(self, *, as_of: date | str | None = None) -> list[dict[str, Any]]:
-        """Return A-share listing rows from AKShare-backed no-key sources."""
+        """Return A-share listing rows from AKShare, with BaoStock fallback."""
         del as_of  # CN listing sources return the current source snapshot.
         if self._listing_rows_cache is not None:
             return [dict(row) for row in self._listing_rows_cache]
 
-        frame = self._listing_frame()
-        if frame is None or frame.empty:
-            return []
+        rows: list[dict[str, Any]] = []
+        akshare_error: Exception | None = None
+        try:
+            frame = self._listing_frame()
+        except CnDependencyError:
+            raise
+        except Exception as exc:
+            akshare_error = exc
+            frame = None
+        if frame is not None and not frame.empty:
+            rows = self._rows_from_listing_frame(frame)
 
-        rows = self._rows_from_listing_frame(frame)
+        if not rows:
+            try:
+                baostock_rows = self._baostock_listing_rows()
+            except CnDependencyError:
+                if akshare_error is not None:
+                    raise akshare_error
+                baostock_rows = []
+            except Exception as exc:
+                logger.warning("BaoStock CN listing fallback failed: %s", exc)
+                if akshare_error is not None:
+                    raise akshare_error from exc
+                baostock_rows = []
+            if baostock_rows:
+                logger.info(
+                    "Using BaoStock CN listing fallback (%d rows)", len(baostock_rows)
+                )
+                rows = baostock_rows
+            elif akshare_error is not None:
+                raise akshare_error
+
         self._listing_rows_cache = rows
         return [dict(row) for row in rows]
 
@@ -537,6 +564,74 @@ class CnMarketDataService:
                 )
             )
         return [row for row in result if row.date]
+
+    def _baostock_listing_rows(self) -> list[dict[str, Any]]:
+        """Fall back to BaoStock's all-stock query for the CN listing universe.
+
+        Returns rows in the shape produced by ``_rows_from_listing_frame`` with
+        ``None`` for fields BaoStock does not expose (market cap, P/E, etc.).
+        BaoStock only covers SSE and SZSE; Beijing-listed codes are skipped.
+        """
+        bs = self._baostock
+
+        def _fetch_rows() -> list[dict[str, Any]]:
+            today = date.today().strftime("%Y-%m-%d")
+            login_result = bs.login()
+            if getattr(login_result, "error_code", "0") != "0":
+                return []
+            rows: list[dict[str, Any]] = []
+            try:
+                query = bs.query_all_stock(day=today)
+                if getattr(query, "error_code", "0") != "0":
+                    return []
+                fields = list(getattr(query, "fields", []) or [])
+                while query.next():
+                    data = dict(zip(fields, query.get_row_data()))
+                    code = str(data.get("code") or "").strip()
+                    if not code:
+                        continue
+                    trade_status = str(data.get("tradeStatus") or "").strip()
+                    if trade_status and trade_status != "1":
+                        continue
+                    raw_code = code.split(".", 1)[1] if "." in code else code
+                    local_code = _normalize_code(raw_code)
+                    exchange = _exchange_for_code(local_code)
+                    if exchange is None or exchange == "BJSE":
+                        continue
+                    suffix = _suffix_for_exchange(exchange)
+                    board = _board_for_code(local_code, exchange)
+                    rows.append(
+                        {
+                            "symbol": f"{local_code}{suffix}",
+                            "local_code": local_code,
+                            "name": str(data.get("code_name") or "").strip(),
+                            "exchange": exchange,
+                            "board": board,
+                            "sector": infer_cn_sector(None, None, "", board=board),
+                            "industry_group": "",
+                            "industry": "",
+                            "sub_industry": "",
+                            "market_cap": None,
+                            "float_market_cap": None,
+                            "shares_outstanding": None,
+                            "pe_ratio": None,
+                            "price_to_book": None,
+                            "dividend_yield": None,
+                            "source_board": board,
+                        }
+                    )
+            finally:
+                try:
+                    bs.logout()
+                except Exception:  # pragma: no cover - defensive cleanup
+                    pass
+            return rows
+
+        return _call_with_timeout(
+            _fetch_rows,
+            timeout_seconds=self._listing_timeout_seconds,
+            operation_name="CN A-share BaoStock listing fetch",
+        )
 
     def _daily_ohlcv_from_baostock(
         self,

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -286,6 +286,10 @@ class CnMarketDataService:
                 rows = baostock_rows
             elif akshare_error is not None:
                 raise akshare_error
+            else:
+                raise CnDependencyError(
+                    "CN listing sources returned no rows (AKShare and BaoStock both empty)"
+                )
 
         self._listing_rows_cache = rows
         return [dict(row) for row in rows]

--- a/backend/app/services/cn_market_data_service.py
+++ b/backend/app/services/cn_market_data_service.py
@@ -250,7 +250,16 @@ class CnMarketDataService:
         return self._baostock_module
 
     def listing_rows(self, *, as_of: date | str | None = None) -> list[dict[str, Any]]:
-        """Return A-share listing rows from AKShare, with BaoStock fallback."""
+        """Return A-share listing rows from AKShare, with BaoStock fallback.
+
+        BaoStock fallback is restricted to transient AKShare failures only —
+        deterministic errors (parser/schema/type bugs) propagate so they fail
+        fast instead of being masked by a partial fallback. BaoStock does not
+        cover the Beijing Stock Exchange, so the fallback path emits a
+        prominent warning; callers that need full BJSE coverage should rely
+        on the build script's seeded prior-week universe rescue when this
+        path is taken.
+        """
         del as_of  # CN listing sources return the current source snapshot.
         if self._listing_rows_cache is not None:
             return [dict(row) for row in self._listing_rows_cache]
@@ -261,7 +270,7 @@ class CnMarketDataService:
             frame = self._listing_frame()
         except CnDependencyError:
             raise
-        except Exception as exc:
+        except (requests.exceptions.RequestException, OSError) as exc:
             akshare_error = exc
             frame = None
         if frame is not None and not frame.empty:
@@ -274,14 +283,18 @@ class CnMarketDataService:
                 if akshare_error is not None:
                     raise akshare_error
                 baostock_rows = []
-            except Exception as exc:
+            except (requests.exceptions.RequestException, OSError) as exc:
                 logger.warning("BaoStock CN listing fallback failed: %s", exc)
                 if akshare_error is not None:
                     raise akshare_error from exc
                 baostock_rows = []
             if baostock_rows:
-                logger.info(
-                    "Using BaoStock CN listing fallback (%d rows)", len(baostock_rows)
+                logger.warning(
+                    "Using BaoStock CN listing fallback (%d rows). BaoStock "
+                    "does not cover the Beijing Stock Exchange, so this "
+                    "snapshot omits BJSE listings; downstream consumers "
+                    "should treat it as partial.",
+                    len(baostock_rows),
                 )
                 rows = baostock_rows
             elif akshare_error is not None:

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -288,6 +288,145 @@ def test_cn_market_data_service_times_out_listing_fetch():
     assert time.monotonic() - started_at < 3
 
 
+class _FakeBaoLogin:
+    def __init__(self, error_code: str = "0") -> None:
+        self.error_code = error_code
+
+
+class _FakeBaoQuery:
+    error_code = "0"
+    fields = ["code", "tradeStatus", "code_name"]
+
+    def __init__(self, rows: list[list[str]]) -> None:
+        self._remaining = list(rows)
+
+    def next(self) -> bool:
+        return bool(self._remaining)
+
+    def get_row_data(self) -> list[str]:
+        return self._remaining.pop(0)
+
+
+class _FakeBaoStockListing:
+    def __init__(
+        self,
+        rows: list[list[str]],
+        *,
+        login_error_code: str = "0",
+        query_error_code: str = "0",
+    ) -> None:
+        self._rows = rows
+        self._login_error_code = login_error_code
+        self._query_error_code = query_error_code
+        self.login_calls = 0
+        self.logout_calls = 0
+        self.query_calls = 0
+
+    def login(self) -> _FakeBaoLogin:
+        self.login_calls += 1
+        return _FakeBaoLogin(self._login_error_code)
+
+    def query_all_stock(self, day: str) -> _FakeBaoQuery:
+        self.query_calls += 1
+        query = _FakeBaoQuery(self._rows)
+        query.error_code = self._query_error_code
+        return query
+
+    def logout(self) -> None:
+        self.logout_calls += 1
+
+
+def test_cn_market_data_service_falls_back_to_baostock_when_akshare_fails():
+    class FailingAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            raise requests.exceptions.Timeout("eastmoney listing timed out")
+
+        @staticmethod
+        def stock_info_a_code_name():
+            raise requests.exceptions.Timeout("code-name listing timed out")
+
+    baostock = _FakeBaoStockListing(
+        [
+            ["sh.600519", "1", "贵州茅台"],
+            ["sz.000001", "1", "平安银行"],
+        ]
+    )
+
+    service = CnMarketDataService(
+        akshare_module=FailingAkshare(),
+        baostock_module=baostock,
+        timeout_seconds=1,
+    )
+
+    rows = service.listing_rows(as_of=date(2026, 5, 9))
+
+    assert [row["symbol"] for row in rows] == ["600519.SS", "000001.SZ"]
+    assert all(row["market_cap"] is None for row in rows)
+    assert all(row["pe_ratio"] is None for row in rows)
+    assert all(row["shares_outstanding"] is None for row in rows)
+    assert rows[0]["exchange"] == "SSE"
+    assert rows[0]["board"] == "SSE_MAIN"
+    assert rows[0]["sector"] == "Other"
+    assert rows[0]["name"] == "贵州茅台"
+    assert rows[1]["exchange"] == "SZSE"
+    assert baostock.login_calls == 1
+    assert baostock.logout_calls == 1
+
+
+def test_cn_market_data_service_reraises_akshare_error_when_baostock_login_fails():
+    class FailingAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            raise requests.exceptions.Timeout("eastmoney listing timed out")
+
+    baostock = _FakeBaoStockListing(rows=[], login_error_code="10001")
+
+    service = CnMarketDataService(
+        akshare_module=FailingAkshare(),
+        baostock_module=baostock,
+        timeout_seconds=1,
+    )
+
+    with pytest.raises(
+        requests.exceptions.Timeout, match="eastmoney listing timed out"
+    ):
+        service.listing_rows(as_of=date(2026, 5, 9))
+
+    assert baostock.login_calls == 1
+
+
+def test_cn_market_data_service_baostock_listing_skips_suspended_and_beijing_codes():
+    class FailingAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            raise requests.exceptions.ConnectionError("eastmoney down")
+
+        @staticmethod
+        def stock_info_a_code_name():
+            raise requests.exceptions.ConnectionError("code-name down")
+
+    baostock = _FakeBaoStockListing(
+        [
+            ["sh.600519", "1", "贵州茅台"],
+            ["sz.000002", "0", "万科A (suspended)"],
+            ["bj.920118", "1", "太湖雪 (Beijing)"],
+            ["sz.300750", "1", "宁德时代"],
+        ]
+    )
+
+    service = CnMarketDataService(
+        akshare_module=FailingAkshare(),
+        baostock_module=baostock,
+        timeout_seconds=1,
+    )
+
+    rows = service.listing_rows(as_of=date(2026, 5, 9))
+
+    assert [row["symbol"] for row in rows] == ["600519.SS", "300750.SZ"]
+    assert rows[1]["board"] == "SZSE_CHINEXT"
+
+
 def test_cn_market_data_service_skips_baostock_ohlcv_for_beijing_codes():
     class FakeBaoStock:
         def login(self):  # pragma: no cover - should not be called

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -396,6 +396,34 @@ def test_cn_market_data_service_reraises_akshare_error_when_baostock_login_fails
     assert baostock.login_calls == 1
 
 
+def test_cn_market_data_service_does_not_fall_back_to_baostock_on_deterministic_error():
+    """Schema/parser bugs in AKShare must fail fast, not be masked by BaoStock."""
+
+    class BrokenAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            raise TypeError("unexpected listing schema")
+
+    baostock_calls = {"login": 0}
+
+    class FakeBaoStock:
+        @staticmethod
+        def login():  # pragma: no cover - should not be called
+            baostock_calls["login"] += 1
+            raise AssertionError("BaoStock must not be queried for deterministic AKShare errors")
+
+    service = CnMarketDataService(
+        akshare_module=BrokenAkshare(),
+        baostock_module=FakeBaoStock(),
+        timeout_seconds=1,
+    )
+
+    with pytest.raises(TypeError, match="unexpected listing schema"):
+        service.listing_rows(as_of=date(2026, 5, 9))
+
+    assert baostock_calls["login"] == 0
+
+
 def test_cn_market_data_service_raises_when_all_listing_sources_return_empty():
     """An outage that returns empty (rather than raising) must still surface as a hard failure."""
 

--- a/backend/tests/unit/test_cn_market_data_service.py
+++ b/backend/tests/unit/test_cn_market_data_service.py
@@ -396,6 +396,30 @@ def test_cn_market_data_service_reraises_akshare_error_when_baostock_login_fails
     assert baostock.login_calls == 1
 
 
+def test_cn_market_data_service_raises_when_all_listing_sources_return_empty():
+    """An outage that returns empty (rather than raising) must still surface as a hard failure."""
+
+    class EmptyAkshare:
+        @staticmethod
+        def stock_zh_a_spot_em():
+            return pd.DataFrame()
+
+        @staticmethod
+        def stock_info_a_code_name():
+            return pd.DataFrame()
+
+    baostock = _FakeBaoStockListing(rows=[])
+
+    service = CnMarketDataService(
+        akshare_module=EmptyAkshare(),
+        baostock_module=baostock,
+        timeout_seconds=1,
+    )
+
+    with pytest.raises(CnDependencyError, match="no rows"):
+        service.listing_rows(as_of=date(2026, 5, 9))
+
+
 def test_cn_market_data_service_baostock_listing_skips_suspended_and_beijing_codes():
     class FailingAkshare:
         @staticmethod

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -673,6 +673,244 @@ def test_build_weekly_reference_bundle_deadline_blocks_when_partial_disabled(
     assert publish_kwargs["coverage_stats"]["snapshot_symbols"] == 3
 
 
+def _patch_cn_dependencies(monkeypatch, *, raise_universe: bool, hybrid_failures: int = 0):
+    """Wire the supporting Asia-bundle services for stale-universe fallback tests."""
+
+    def fetch(market):
+        if raise_universe:
+            raise RuntimeError("AKShare CN spot disconnected")
+        return SimpleNamespace(
+            market=market,
+            source_name="cn_official",
+            snapshot_id="cn-2026-05-09",
+            snapshot_as_of="2026-05-09",
+            source_metadata={},
+            rows=(),
+        )
+
+    monkeypatch.setattr(
+        build_script,
+        "OfficialMarketUniverseSourceService",
+        lambda: SimpleNamespace(fetch_market_snapshot=fetch),
+    )
+    monkeypatch.setattr(
+        build_script,
+        "get_stock_universe_service",
+        lambda: SimpleNamespace(
+            ingest_cn_snapshot_rows=lambda db, **kwargs: {
+                "added": 0,
+                "updated": 0,
+                "deactivated": 0,
+            }
+        ),
+    )
+
+    monkeypatch.setattr(
+        build_script,
+        "get_hybrid_fundamentals_service",
+        lambda: SimpleNamespace(
+            yfinance_delay_per_ticker=1.5,
+            fetch_fundamentals_batch=lambda symbols, **kwargs: {
+                symbol: {"market_cap": 1000.0, "sector": "Industrials"} for symbol in symbols
+            },
+            store_all_caches=lambda data, _cache, **_kwargs: {
+                "fundamentals_stored": len(data),
+                "persisted_symbols": len(data),
+                "failed_persistence_symbols": 0,
+                "failed": hybrid_failures,
+                "provider_error_counts": {},
+            },
+        ),
+    )
+
+
+def _make_cn_db_mock(active_rows: list[SimpleNamespace], *, seeded_count: int | None = None):
+    fake_query = MagicMock()
+    fake_query.filter.return_value.order_by.return_value.all.return_value = active_rows
+    fake_query.filter.return_value.count.return_value = (
+        seeded_count if seeded_count is not None else len(active_rows)
+    )
+    fake_db = MagicMock()
+    fake_db.query.return_value = fake_query
+    return fake_db
+
+
+def test_build_asia_bundle_falls_back_to_seeded_universe_when_official_fetch_fails(
+    monkeypatch, tmp_path, capsys
+):
+    """When AKShare listing fails and partial publish is on, reuse seeded rows."""
+    published_at = datetime(2026, 5, 9, 12, 10, 0)
+    active_rows = [
+        _make_universe_row("600000.SS"),
+        _make_universe_row("000001.SZ"),
+    ]
+    fake_db = _make_cn_db_mock(active_rows)
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    _patch_cn_dependencies(monkeypatch, raise_universe=True)
+
+    cached = {
+        "600000.SS": {"market_cap": 1000.0, "sector": "Industrials"},
+        "000001.SZ": {"market_cap": 1000.0, "sector": "Industrials"},
+    }
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_many=lambda symbols: cached),
+    )
+
+    publish_calls: list[dict[str, object]] = []
+    export_calls: list[dict[str, object]] = []
+    provider_snapshot_service = SimpleNamespace(
+        build_market_snapshot_row=lambda **kwargs: {
+            "symbol": kwargs["symbol"],
+            "exchange": kwargs["exchange"],
+            "row_hash": "row-hash",
+            "normalized_payload": kwargs["normalized_payload"],
+            "raw_payload": kwargs["raw_payload"],
+        },
+        publish_market_snapshot_run=lambda db, **kwargs: publish_calls.append(kwargs)
+        or {
+            "published": True,
+            "force_published": kwargs.get("force_publish", False),
+            "source_revision": "fundamentals_v1_cn:20260509121000",
+            "snapshot_key": kwargs["snapshot_key"],
+            "coverage": dict(kwargs["coverage_stats"]),
+            "warnings": list(kwargs["warnings"]),
+            "coverage_thresholds": {
+                "market": "CN",
+                "active_coverage": 1.0,
+                "min_active_coverage": 0.70,
+                "missing_ratio": 0.0,
+                "max_missing_ratio": 0.30,
+            },
+        },
+        get_published_run=lambda db, snapshot_key: type(
+            "Run",
+            (),
+            {
+                "published_at": published_at,
+                "created_at": published_at,
+                "source_revision": "fundamentals_v1_cn:20260509121000",
+            },
+        )(),
+        export_weekly_reference_bundle=lambda db, **kwargs: export_calls.append(kwargs)
+        or {"bundle_path": str(kwargs["output_path"])},
+    )
+    monkeypatch.setattr(build_script, "get_provider_snapshot_service", lambda: provider_snapshot_service)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "CN",
+            "--output-dir",
+            str(tmp_path),
+            "--allow-partial-publish",
+        ],
+    )
+
+    assert build_script.main() == 0
+
+    publish_kwargs = publish_calls[0]
+    assert publish_kwargs["force_publish"] is True
+    assert publish_kwargs["coverage_stats"]["stale_universe"] is True
+    assert publish_kwargs["coverage_stats"]["partial_run"] is True
+    stale_warning = next(
+        (w for w in publish_kwargs["warnings"] if "Official CN universe fetch failed" in w),
+        None,
+    )
+    assert stale_warning is not None, publish_kwargs["warnings"]
+    assert "AKShare CN spot disconnected" in stale_warning
+    assert export_calls, "Bundle export should still run after a stale-universe fallback"
+
+    stdout = capsys.readouterr().out
+    assert "[universe] CN official fetch failed" in stdout
+    assert "falling back to 2 seeded prior-week rows" in stdout
+
+
+def test_build_asia_bundle_reraises_when_no_seeded_universe_rows(monkeypatch, tmp_path):
+    """If AKShare fails AND no prior-week rows are seeded, surface the original error."""
+    fake_db = _make_cn_db_mock([], seeded_count=0)
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    _patch_cn_dependencies(monkeypatch, raise_universe=True)
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_many=lambda symbols: {}),
+    )
+    monkeypatch.setattr(
+        build_script,
+        "get_provider_snapshot_service",
+        lambda: SimpleNamespace(
+            build_market_snapshot_row=lambda **kwargs: {},
+            publish_market_snapshot_run=lambda db, **kwargs: {"published": False, "warnings": []},
+        ),
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "CN",
+            "--output-dir",
+            str(tmp_path),
+            "--allow-partial-publish",
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="AKShare CN spot disconnected"):
+        build_script.main()
+
+
+def test_build_asia_bundle_reraises_when_partial_publish_disabled(monkeypatch, tmp_path):
+    """Without --allow-partial-publish, an AKShare failure must abort the run."""
+    active_rows = [_make_universe_row("600000.SS")]
+    fake_db = _make_cn_db_mock(active_rows)
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    _patch_cn_dependencies(monkeypatch, raise_universe=True)
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_many=lambda symbols: {}),
+    )
+    monkeypatch.setattr(
+        build_script,
+        "get_provider_snapshot_service",
+        lambda: SimpleNamespace(
+            build_market_snapshot_row=lambda **kwargs: {},
+            publish_market_snapshot_run=lambda db, **kwargs: {"published": False, "warnings": []},
+        ),
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "CN",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="AKShare CN spot disconnected"):
+        build_script.main()
+
+
 def test_import_weekly_reference_bundle_script_calls_service(monkeypatch, tmp_path, capsys):
     bundle_path = tmp_path / "weekly-reference.json.gz"
     bundle_path.write_bytes(b"bundle")


### PR DESCRIPTION
The weekly CN reference build aborts before fundamentals can run if both
AKShare endpoints fail (e.g. requests.exceptions.Timeout, which PR #158
intentionally does not retry). Add two layers of graceful degradation so
the job survives transient AKShare outages:

- CnMarketDataService.listing_rows() now falls back to BaoStock's
  query_all_stock when AKShare's spot + code-name endpoints both fail or
  return empty. BaoStock rows mirror the existing _rows_from_listing_frame
  shape with None for fields BaoStock does not expose (market cap, P/E,
  dividend yield, etc.). The original AKShare error still surfaces if
  BaoStock also yields nothing.
- _build_asia_bundle() catches exceptions from fetch_market_snapshot()
  and, when --allow-partial-publish is set and prior-week universe rows
  were already seeded by import_weekly_reference_bundle, proceeds with
  the seeded rows. The publish call is force-published with a
  stale_universe warning so coverage gates do not block, mirroring the
  existing deadline-hit partial-publish flow.

Adds unit coverage for both layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved resilience: Asia bundle generation now falls back to a seeded prior-week universe when official market-universe refresh fails and partial publishes are allowed.
  * Added an alternative market-listing fallback to retrieve CN listings when the primary source is unavailable.
  * Publication forcing expanded to allow forced publishes for partial runs caused by deadlines or stale universes.

* **Documentation**
  * CLI help text for allowing partial publishes updated to reflect the stale-universe scenario.

* **Tests**
  * Added tests covering fallback paths, failure cases, and partial-publish behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/160)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->