### PR TITLE
feat(weekly-reference): resume partial CN bootstrap

### DIFF
--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -24,8 +24,9 @@ on:
       max_runtime_minutes:
         description: >-
           Per-market deadline in minutes for the fundamentals refresh. Blank
-          uses the built-in defaults (CN=320, others=0). Set "0" to disable
-          the deadline entirely (e.g. for the first CN seeding run).
+          uses the built-in defaults (CN=300, others=0). CN bootstrap runs
+          should keep a deadline so a partial resumable bundle can publish
+          before the GitHub Actions job cap.
         required: false
         type: string
         default: ''
@@ -174,9 +175,9 @@ jobs:
         env:
           # Per-market wall-clock budget defaults for the fundamentals refresh.
           # CN is the slow path: ~5,500 sequential AKShare+yfinance round-trips
-          # can blow past 6h, so we leave ~30 min headroom under the 350-min
-          # job cap and opt-in to partial publish — skipped symbols inherit
-          # last week's bundle data. Workflow_dispatch inputs override either.
+          # can blow past 6h, so we leave ~50 min headroom under the 350-min
+          # job cap and opt in to partial publish. Initial bootstrap runs can
+          # publish partial bundles, and later CN runs resume from them.
           INPUT_RUNTIME: ${{ github.event.inputs.max_runtime_minutes }}
           INPUT_PARTIAL: ${{ github.event.inputs.allow_partial_publish }}
           MATRIX_MARKET: ${{ matrix.market }}
@@ -184,7 +185,7 @@ jobs:
           if [ -n "$INPUT_RUNTIME" ]; then
             RUNTIME="$INPUT_RUNTIME"
           elif [ "$MATRIX_MARKET" = "CN" ]; then
-            RUNTIME="320"
+            RUNTIME="300"
           else
             RUNTIME="0"
           fi
@@ -212,10 +213,15 @@ jobs:
       - name: Build weekly reference bundle
         run: |
           cd backend
+          RESUME_FLAG=""
+          if [ "${{ matrix.market }}" = "CN" ]; then
+            RESUME_FLAG="--resume-partial-seed"
+          fi
           python -m app.scripts.build_weekly_reference_bundle \
             --market "${{ matrix.market }}" \
             --output-dir /tmp/weekly-reference \
             --max-runtime-minutes "${{ steps.build_inputs.outputs.max_runtime_minutes }}" \
+            $RESUME_FLAG \
             ${{ steps.build_inputs.outputs.partial_flag }}
 
       - name: Upload weekly reference assets

--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -43,6 +43,17 @@ on:
           - default
           - enable
           - disable
+      cn_resume_partial_seed:
+        description: >-
+          CN only: continue an initial partial bootstrap by skipping symbols
+          already present in the partial bundle. Keep disabled for ordinary
+          weekly refreshes so stale prior-bundle rows are refreshed.
+        required: false
+        type: choice
+        default: disable
+        options:
+          - disable
+          - enable
 
 concurrency:
   group: weekly-reference-data
@@ -176,10 +187,13 @@ jobs:
           # Per-market wall-clock budget defaults for the fundamentals refresh.
           # CN is the slow path: ~5,500 sequential AKShare+yfinance round-trips
           # can blow past 6h, so we leave ~50 min headroom under the 350-min
-          # job cap and opt in to partial publish. Initial bootstrap runs can
-          # publish partial bundles, and later CN runs resume from them.
+          # job cap and opt in to partial publish. Initial bootstrap
+          # continuation requires explicitly enabling cn_resume_partial_seed on
+          # a manual CN run so ordinary weekly refreshes do not skip stale
+          # prior-bundle rows.
           INPUT_RUNTIME: ${{ github.event.inputs.max_runtime_minutes }}
           INPUT_PARTIAL: ${{ github.event.inputs.allow_partial_publish }}
+          INPUT_CN_RESUME_PARTIAL_SEED: ${{ github.event.inputs.cn_resume_partial_seed }}
           MATRIX_MARKET: ${{ matrix.market }}
         run: |
           if [ -n "$INPUT_RUNTIME" ]; then
@@ -206,22 +220,24 @@ jobs:
               ;;
           esac
 
+          RESUME=""
+          if [ "$MATRIX_MARKET" = "CN" ] && [ "$INPUT_CN_RESUME_PARTIAL_SEED" = "enable" ]; then
+            RESUME="--resume-partial-seed"
+          fi
+
           echo "max_runtime_minutes=$RUNTIME" >> "$GITHUB_OUTPUT"
           echo "partial_flag=$PARTIAL" >> "$GITHUB_OUTPUT"
-          echo "Resolved build inputs for $MATRIX_MARKET: runtime=$RUNTIME partial='$PARTIAL'"
+          echo "resume_flag=$RESUME" >> "$GITHUB_OUTPUT"
+          echo "Resolved build inputs for $MATRIX_MARKET: runtime=$RUNTIME partial='$PARTIAL' resume='$RESUME'"
 
       - name: Build weekly reference bundle
         run: |
           cd backend
-          RESUME_FLAG=""
-          if [ "${{ matrix.market }}" = "CN" ]; then
-            RESUME_FLAG="--resume-partial-seed"
-          fi
           python -m app.scripts.build_weekly_reference_bundle \
             --market "${{ matrix.market }}" \
             --output-dir /tmp/weekly-reference \
             --max-runtime-minutes "${{ steps.build_inputs.outputs.max_runtime_minutes }}" \
-            $RESUME_FLAG \
+            ${{ steps.build_inputs.outputs.resume_flag }} \
             ${{ steps.build_inputs.outputs.partial_flag }}
 
       - name: Upload weekly reference assets

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import math
 import time
 from datetime import datetime
@@ -150,6 +151,17 @@ def _merge_fundamentals_stats(
         bucket = accumulator.setdefault("provider_error_counts", {})
         for key, value in chunk_errors.items():
             bucket[key] = int(bucket.get(key, 0) or 0) + int(value or 0)
+
+
+def _published_run_is_partial(provider_snapshot_service: Any, db, snapshot_key: str) -> bool:
+    published_run = provider_snapshot_service.get_published_run(db, snapshot_key=snapshot_key)
+    if published_run is None or not published_run.coverage_stats_json:
+        return False
+    try:
+        coverage = json.loads(published_run.coverage_stats_json)
+    except (TypeError, ValueError):
+        return False
+    return bool(coverage.get("partial_run"))
 
 
 def _write_step_summary(market: str, summary: dict[str, Any]) -> None:
@@ -447,6 +459,7 @@ def _build_asia_bundle(
     max_runtime_seconds: float = 0.0,
     fetch_chunk_size: int = _DEFAULT_FETCH_CHUNK_SIZE,
     allow_partial_publish: bool = False,
+    resume_partial_seed: bool = False,
 ) -> dict[str, Any]:
     snapshot_key = ProviderSnapshotService.snapshot_key_for_market(market)
     official_source_service = OfficialMarketUniverseSourceService()
@@ -519,18 +532,33 @@ def _build_asia_bundle(
 
     symbols = [row.symbol for row in active_rows]
     market_by_symbol = {row.symbol: market for row in active_rows}
+    seeded_symbols: list[str] = []
+    if resume_partial_seed and _published_run_is_partial(
+        provider_snapshot_service, db, snapshot_key
+    ):
+        seeded_payloads = fundamentals_cache.get_many(symbols)
+        seeded_symbols = [symbol for symbol in symbols if seeded_payloads.get(symbol)]
+        if seeded_symbols:
+            print(
+                f"[fundamentals] {market} resuming partial seed: "
+                f"skipping {len(seeded_symbols)} cached symbols and fetching "
+                f"{len(symbols) - len(seeded_symbols)} remaining symbols",
+                flush=True,
+            )
+    seeded_symbol_set = set(seeded_symbols)
+    fetch_symbols = [symbol for symbol in symbols if symbol not in seeded_symbol_set]
 
     print(f"Starting hybrid fundamentals refresh for {market}...", flush=True)
     fundamentals_stats, attempted_symbols, deadline_hit = _run_chunked_fundamentals_refresh(
         hybrid_service=hybrid_service,
         fundamentals_cache=fundamentals_cache,
         market=market,
-        symbols=symbols,
+        symbols=fetch_symbols,
         market_by_symbol=market_by_symbol,
         chunk_size=fetch_chunk_size,
         max_runtime_seconds=max_runtime_seconds,
     )
-    skipped_symbols = [s for s in symbols if s not in set(attempted_symbols)]
+    skipped_symbols = [s for s in fetch_symbols if s not in set(attempted_symbols)]
     print(f"Fundamentals refresh complete: {fundamentals_stats}", flush=True)
 
     cached_fundamentals = fundamentals_cache.get_many(symbols)
@@ -559,6 +587,8 @@ def _build_asia_bundle(
         "covered_active_symbols": len(snapshot_rows),
         "missing_active_symbols": max(len(symbols) - len(snapshot_rows), 0),
         "attempted_symbols": len(attempted_symbols),
+        "seeded_symbols": len(seeded_symbols),
+        "fetch_symbols": len(fetch_symbols),
         "skipped_due_to_deadline": len(skipped_symbols) if deadline_hit else 0,
         "partial_run": deadline_hit or stale_universe,
         "stale_universe": stale_universe,
@@ -581,7 +611,8 @@ def _build_asia_bundle(
     if deadline_hit:
         warnings.append(
             f"Weekly fetch deadline reached after {len(attempted_symbols)}/{len(symbols)} "
-            f"{market} symbols; {len(skipped_symbols)} symbols inherit prior-bundle data."
+            f"{market} symbols ({len(seeded_symbols)} seeded); "
+            f"{len(skipped_symbols)} symbols inherit prior-bundle data."
         )
         if not allow_partial_publish:
             warnings.append(
@@ -698,6 +729,15 @@ def main() -> int:
             "partial_run=True with a deadline or stale_universe warning."
         ),
     )
+    parser.add_argument(
+        "--resume-partial-seed",
+        action="store_true",
+        help=(
+            "When the seeded prior bundle is marked partial_run=True, skip symbols "
+            "already present in the hydrated fundamentals cache and fetch only the "
+            "remaining symbols. Intended for initial CN bootstrap continuation."
+        ),
+    )
     args = parser.parse_args()
 
     prepare_runtime()
@@ -732,6 +772,7 @@ def main() -> int:
                 max_runtime_seconds=max(0.0, float(args.max_runtime_minutes)) * 60.0,
                 fetch_chunk_size=max(1, int(args.fetch_chunk_size)),
                 allow_partial_publish=bool(args.allow_partial_publish),
+                resume_partial_seed=bool(args.resume_partial_seed),
             )
 
     _write_step_summary(market, summary)

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -153,7 +153,17 @@ def _merge_fundamentals_stats(
             bucket[key] = int(bucket.get(key, 0) or 0) + int(value or 0)
 
 
-def _published_run_is_partial(provider_snapshot_service: Any, db, snapshot_key: str) -> bool:
+def _as_nonnegative_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return max(parsed, 0)
+
+
+def _published_run_is_incomplete_partial_seed(
+    provider_snapshot_service: Any, db, snapshot_key: str
+) -> bool:
     published_run = provider_snapshot_service.get_published_run(db, snapshot_key=snapshot_key)
     if published_run is None or not published_run.coverage_stats_json:
         return False
@@ -161,7 +171,23 @@ def _published_run_is_partial(provider_snapshot_service: Any, db, snapshot_key: 
         coverage = json.loads(published_run.coverage_stats_json)
     except (TypeError, ValueError):
         return False
-    return bool(coverage.get("partial_run"))
+    if not coverage.get("partial_run"):
+        return False
+
+    missing_active_symbols = _as_nonnegative_int(coverage.get("missing_active_symbols"))
+    if missing_active_symbols is not None:
+        return missing_active_symbols > 0
+
+    active_symbols = _as_nonnegative_int(coverage.get("active_symbols"))
+    snapshot_symbols = _as_nonnegative_int(coverage.get("snapshot_symbols"))
+    if active_symbols is not None and snapshot_symbols is not None:
+        return snapshot_symbols < active_symbols
+
+    covered_active_symbols = _as_nonnegative_int(coverage.get("covered_active_symbols"))
+    if active_symbols is not None and covered_active_symbols is not None:
+        return covered_active_symbols < active_symbols
+
+    return False
 
 
 def _write_step_summary(market: str, summary: dict[str, Any]) -> None:
@@ -533,7 +559,7 @@ def _build_asia_bundle(
     symbols = [row.symbol for row in active_rows]
     market_by_symbol = {row.symbol: market for row in active_rows}
     seeded_symbols: list[str] = []
-    if resume_partial_seed and _published_run_is_partial(
+    if resume_partial_seed and _published_run_is_incomplete_partial_seed(
         provider_snapshot_service, db, snapshot_key
     ):
         seeded_payloads = fundamentals_cache.get_many(symbols)
@@ -558,7 +584,8 @@ def _build_asia_bundle(
         chunk_size=fetch_chunk_size,
         max_runtime_seconds=max_runtime_seconds,
     )
-    skipped_symbols = [s for s in fetch_symbols if s not in set(attempted_symbols)]
+    attempted_symbol_set = set(attempted_symbols)
+    skipped_symbols = [s for s in fetch_symbols if s not in attempted_symbol_set]
     print(f"Fundamentals refresh complete: {fundamentals_stats}", flush=True)
 
     cached_fundamentals = fundamentals_cache.get_many(symbols)

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -911,6 +911,125 @@ def test_build_asia_bundle_reraises_when_partial_publish_disabled(monkeypatch, t
         build_script.main()
 
 
+def test_build_weekly_reference_bundle_resumes_partial_seed_by_skipping_cached_symbols(
+    monkeypatch, tmp_path
+):
+    active_rows = [
+        _make_universe_row("600000.SS"),
+        _make_universe_row("600001.SS"),
+        _make_universe_row("000001.SZ"),
+    ]
+    fake_db = _make_cn_db_mock(active_rows)
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    _patch_cn_dependencies(monkeypatch, raise_universe=False)
+
+    fetch_calls: list[list[str]] = []
+    cached = {
+        "600000.SS": {
+            "market_cap": 999.0,
+            "sector": "Industrials",
+            "data_source": "bundle_import",
+        },
+    }
+
+    def fake_fetch_fundamentals_batch(symbols, **kwargs):
+        fetch_calls.append(list(symbols))
+        kwargs["progress_callback"](len(symbols), len(symbols))
+        return {symbol: {"market_cap": 1000.0, "sector": "Industrials"} for symbol in symbols}
+
+    def fake_store_all_caches(data, _cache, **_kwargs):
+        cached.update(data)
+        return {
+            "fundamentals_stored": len(data),
+            "persisted_symbols": len(data),
+            "failed_persistence_symbols": 0,
+            "failed": 0,
+            "provider_error_counts": {},
+        }
+
+    monkeypatch.setattr(
+        build_script,
+        "get_hybrid_fundamentals_service",
+        lambda: SimpleNamespace(
+            yfinance_delay_per_ticker=1.5,
+            fetch_fundamentals_batch=fake_fetch_fundamentals_batch,
+            store_all_caches=fake_store_all_caches,
+        ),
+    )
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_many=lambda symbols: {s: cached[s] for s in symbols if s in cached}),
+    )
+
+    published_at = datetime(2026, 5, 5, 12, 10, 0)
+    publish_calls: list[dict[str, object]] = []
+    export_calls: list[dict[str, object]] = []
+    provider_snapshot_service = SimpleNamespace(
+        build_market_snapshot_row=lambda **kwargs: {
+            "symbol": kwargs["symbol"],
+            "exchange": kwargs["exchange"],
+            "row_hash": "row-hash",
+            "normalized_payload": kwargs["normalized_payload"],
+            "raw_payload": kwargs["raw_payload"],
+        },
+        publish_market_snapshot_run=lambda db, **kwargs: publish_calls.append(kwargs)
+        or {
+            "published": True,
+            "force_published": False,
+            "source_revision": "fundamentals_v1_cn:20260505121000",
+            "snapshot_key": kwargs["snapshot_key"],
+            "coverage": dict(kwargs["coverage_stats"]),
+            "warnings": list(kwargs["warnings"]),
+            "coverage_thresholds": {
+                "market": "CN",
+                "active_coverage": 1.0,
+                "min_active_coverage": 0.70,
+                "missing_ratio": 0.0,
+                "max_missing_ratio": 0.30,
+            },
+        },
+        get_published_run=lambda db, snapshot_key: SimpleNamespace(
+            published_at=published_at,
+            created_at=published_at,
+            source_revision="fundamentals_v1_cn:20260505121000",
+            coverage_stats_json='{"partial_run": true}',
+        ),
+        export_weekly_reference_bundle=lambda db, **kwargs: export_calls.append(kwargs)
+        or {"bundle_path": str(kwargs["output_path"])},
+    )
+    monkeypatch.setattr(
+        build_script, "get_provider_snapshot_service", lambda: provider_snapshot_service
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "CN",
+            "--output-dir",
+            str(tmp_path),
+            "--fetch-chunk-size",
+            "2",
+            "--resume-partial-seed",
+        ],
+    )
+
+    assert build_script.main() == 0
+
+    assert fetch_calls == [["600001.SS", "000001.SZ"]]
+    publish_kwargs = publish_calls[0]
+    assert publish_kwargs["coverage_stats"]["seeded_symbols"] == 1
+    assert publish_kwargs["coverage_stats"]["fetch_symbols"] == 2
+    assert publish_kwargs["coverage_stats"]["attempted_symbols"] == 2
+    assert publish_kwargs["coverage_stats"]["partial_run"] is False
+    assert publish_kwargs["coverage_stats"]["snapshot_symbols"] == 3
+    assert export_calls, "Bundle export should run after completing a resumed seed"
+
+
 def test_import_weekly_reference_bundle_script_calls_service(monkeypatch, tmp_path, capsys):
     bundle_path = tmp_path / "weekly-reference.json.gz"
     bundle_path.write_bytes(b"bundle")

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -996,7 +996,10 @@ def test_build_weekly_reference_bundle_resumes_partial_seed_by_skipping_cached_s
             published_at=published_at,
             created_at=published_at,
             source_revision="fundamentals_v1_cn:20260505121000",
-            coverage_stats_json='{"partial_run": true}',
+            coverage_stats_json=(
+                '{"partial_run": true, "active_symbols": 3, '
+                '"snapshot_symbols": 1, "missing_active_symbols": 2}'
+            ),
         ),
         export_weekly_reference_bundle=lambda db, **kwargs: export_calls.append(kwargs)
         or {"bundle_path": str(kwargs["output_path"])},
@@ -1028,6 +1031,124 @@ def test_build_weekly_reference_bundle_resumes_partial_seed_by_skipping_cached_s
     assert publish_kwargs["coverage_stats"]["partial_run"] is False
     assert publish_kwargs["coverage_stats"]["snapshot_symbols"] == 3
     assert export_calls, "Bundle export should run after completing a resumed seed"
+
+
+def test_build_weekly_reference_bundle_does_not_resume_full_coverage_partial_seed(
+    monkeypatch, tmp_path
+):
+    active_rows = [
+        _make_universe_row("600000.SS"),
+        _make_universe_row("600001.SS"),
+        _make_universe_row("000001.SZ"),
+    ]
+    fake_db = _make_cn_db_mock(active_rows)
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    _patch_cn_dependencies(monkeypatch, raise_universe=False)
+
+    fetch_calls: list[list[str]] = []
+    cached = {
+        row.symbol: {
+            "market_cap": 999.0,
+            "sector": "Industrials",
+            "data_source": "bundle_import",
+        }
+        for row in active_rows
+    }
+
+    def fake_fetch_fundamentals_batch(symbols, **kwargs):
+        fetch_calls.append(list(symbols))
+        kwargs["progress_callback"](len(symbols), len(symbols))
+        return {symbol: {"market_cap": 1000.0, "sector": "Industrials"} for symbol in symbols}
+
+    def fake_store_all_caches(data, _cache, **_kwargs):
+        cached.update(data)
+        return {
+            "fundamentals_stored": len(data),
+            "persisted_symbols": len(data),
+            "failed_persistence_symbols": 0,
+            "failed": 0,
+            "provider_error_counts": {},
+        }
+
+    monkeypatch.setattr(
+        build_script,
+        "get_hybrid_fundamentals_service",
+        lambda: SimpleNamespace(
+            yfinance_delay_per_ticker=1.5,
+            fetch_fundamentals_batch=fake_fetch_fundamentals_batch,
+            store_all_caches=fake_store_all_caches,
+        ),
+    )
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(get_many=lambda symbols: {s: cached[s] for s in symbols if s in cached}),
+    )
+
+    published_at = datetime(2026, 5, 5, 12, 10, 0)
+    publish_calls: list[dict[str, object]] = []
+    provider_snapshot_service = SimpleNamespace(
+        build_market_snapshot_row=lambda **kwargs: {
+            "symbol": kwargs["symbol"],
+            "exchange": kwargs["exchange"],
+            "row_hash": "row-hash",
+            "normalized_payload": kwargs["normalized_payload"],
+            "raw_payload": kwargs["raw_payload"],
+        },
+        publish_market_snapshot_run=lambda db, **kwargs: publish_calls.append(kwargs)
+        or {
+            "published": True,
+            "force_published": False,
+            "source_revision": "fundamentals_v1_cn:20260505121000",
+            "snapshot_key": kwargs["snapshot_key"],
+            "coverage": dict(kwargs["coverage_stats"]),
+            "warnings": list(kwargs["warnings"]),
+            "coverage_thresholds": {
+                "market": "CN",
+                "active_coverage": 1.0,
+                "min_active_coverage": 0.70,
+                "missing_ratio": 0.0,
+                "max_missing_ratio": 0.30,
+            },
+        },
+        get_published_run=lambda db, snapshot_key: SimpleNamespace(
+            published_at=published_at,
+            created_at=published_at,
+            source_revision="fundamentals_v1_cn:20260505121000",
+            coverage_stats_json=(
+                '{"partial_run": true, "active_symbols": 3, '
+                '"snapshot_symbols": 3, "missing_active_symbols": 0}'
+            ),
+        ),
+        export_weekly_reference_bundle=lambda db, **kwargs: {"bundle_path": str(kwargs["output_path"])},
+    )
+    monkeypatch.setattr(
+        build_script, "get_provider_snapshot_service", lambda: provider_snapshot_service
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "CN",
+            "--output-dir",
+            str(tmp_path),
+            "--fetch-chunk-size",
+            "2",
+            "--resume-partial-seed",
+        ],
+    )
+
+    assert build_script.main() == 0
+
+    assert fetch_calls == [["600000.SS", "600001.SS"], ["000001.SZ"]]
+    publish_kwargs = publish_calls[0]
+    assert publish_kwargs["coverage_stats"]["seeded_symbols"] == 0
+    assert publish_kwargs["coverage_stats"]["fetch_symbols"] == 3
+    assert publish_kwargs["coverage_stats"]["attempted_symbols"] == 3
 
 
 def test_import_weekly_reference_bundle_script_calls_service(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- make CN weekly-reference runs use a 300-minute soft deadline by default so partial bootstrap bundles publish before the GitHub job cap
- add `--resume-partial-seed` to skip symbols already hydrated from a prior partial seed bundle
- enable the resume flag for CN in the workflow so subsequent runs continue with missing symbols instead of restarting from the beginning

## Verification
- `/Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest tests/unit/test_weekly_reference_scripts.py -q`
- `/Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest tests/unit/test_cn_market_data_service.py -q`

Context: the initial CN seed reached chunk 12/23 but was cancelled by the Actions job limit before upload. This makes the next CN bootstrap publish partial state before timeout and resume from that partial state on later runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resume capability for partial weekly bundle builds using previously cached data.

* **Chores**
  * Updated CN build workflow runtime baseline to 300 minutes.
  * Enhanced bundle build process with conditional resume flag for partial seed operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->