### PR TITLE
fix(de): register DE in field-capability + FX-currency registries

### DIFF
--- a/backend/app/services/field_capability_registry.py
+++ b/backend/app/services/field_capability_registry.py
@@ -76,6 +76,7 @@ class FieldCapabilityRegistryService:
         routing_policy.MARKET_TW,
         routing_policy.MARKET_CN,
         routing_policy.MARKET_CA,
+        routing_policy.MARKET_DE,
     )
     PROVIDER_ORDER: Tuple[str, ...] = (
         routing_policy.PROVIDER_FINVIZ,
@@ -405,6 +406,8 @@ class FieldCapabilityRegistryService:
                     routing_policy.MARKET_KR,
                     routing_policy.MARKET_TW,
                     routing_policy.MARKET_CN,
+                    routing_policy.MARKET_CA,
+                    routing_policy.MARKET_DE,
                 )
             ):
                 reason_code = REASON_CODE_NON_US_GAP

--- a/backend/app/services/fx_service.py
+++ b/backend/app/services/fx_service.py
@@ -64,6 +64,8 @@ MARKET_CURRENCY_MAP: Mapping[str, str] = {
     "KR": "KRW",
     "TW": "TWD",
     "CN": "CNY",
+    "CA": "CAD",
+    "DE": "EUR",
 }
 
 SUPPORTED_CURRENCIES = frozenset(MARKET_CURRENCY_MAP.values())

--- a/backend/app/tasks/universe_tasks.py
+++ b/backend/app/tasks/universe_tasks.py
@@ -189,6 +189,15 @@ def _ingest_official_snapshot(snapshot: Any) -> dict[str, Any]:
                 snapshot_as_of=snapshot.snapshot_as_of,
                 source_metadata=snapshot.source_metadata,
             )
+        if snapshot.market == "DE":
+            return stock_universe_service.ingest_de_snapshot_rows(
+                db,
+                rows=snapshot.rows,
+                source_name=snapshot.source_name,
+                snapshot_id=snapshot.snapshot_id,
+                snapshot_as_of=snapshot.snapshot_as_of,
+                source_metadata=snapshot.source_metadata,
+            )
         raise ValueError(f"Unsupported official universe snapshot market {snapshot.market!r}")
     finally:
         db.close()

--- a/backend/app/tasks/universe_tasks.py
+++ b/backend/app/tasks/universe_tasks.py
@@ -25,7 +25,7 @@ from .transient_database import raise_if_transient_database_error
 
 logger = logging.getLogger(__name__)
 
-_OFFICIAL_SOURCE_MARKETS = frozenset({"HK", "IN", "JP", "KR", "TW", "CN", "CA"})
+_OFFICIAL_SOURCE_MARKETS = frozenset({"HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE"})
 _GITHUB_SYNC_SUCCESS_STATUSES = frozenset({"success", "up_to_date"})
 _OFFICIAL_UNIVERSE_LOCK_RETRY_BASE_SECONDS = 300
 _OFFICIAL_UNIVERSE_LOCK_RETRY_MAX_SECONDS = 1800

--- a/backend/tests/unit/test_field_capability_registry.py
+++ b/backend/tests/unit/test_field_capability_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from app.services.field_capability_registry import (
     FALLBACK_BEHAVIOR_COMPUTED,
     FALLBACK_BEHAVIOR_FALLBACK,
@@ -25,8 +27,10 @@ from app.services.fundamentals_completeness import (
     screening_fields,
 )
 from app.services.provider_routing_policy import (
+    KNOWN_MARKETS,
     MARKET_CA,
     MARKET_CN,
+    MARKET_DE,
     MARKET_HK,
     MARKET_IN,
     MARKET_JP,
@@ -61,6 +65,7 @@ def test_registry_is_versioned_and_shape_is_deterministic():
         MARKET_TW,
         MARKET_CN,
         MARKET_CA,
+        MARKET_DE,
     ]
     assert artifact["providers"] == [
         "finviz",
@@ -263,3 +268,51 @@ def test_us_missing_supported_ownership_field_is_marked_missing():
     )
     assert availability["institutional_ownership"]["status"] == SUPPORT_STATE_MISSING
     assert availability["institutional_ownership"]["reason_code"] == REASON_CODE_MISSING_SUPPORTED
+
+
+@pytest.mark.parametrize("market", sorted(KNOWN_MARKETS))
+def test_derive_ownership_sentiment_availability_covers_every_known_market(market):
+    """Regression for the weekly-ref DE workflow failure: when a new market
+    was added to ``routing_policy.KNOWN_MARKETS`` but not to
+    ``FieldCapabilityRegistryService.MARKET_ORDER``, ``entry.markets[market]``
+    raised ``KeyError`` inside ``derive_ownership_sentiment_availability``.
+    That cascaded through ``fundamentals_cache.store`` and the persistence
+    step recorded 100% failure with empty ``provider_error_counts``, blocking
+    the coverage gate.
+
+    Iterating over ``KNOWN_MARKETS`` keeps the next added market from
+    silently regressing — any market in the routing policy must also resolve
+    in the capability registry."""
+    availability = field_capability_registry.derive_ownership_sentiment_availability(
+        data={},
+        market=market,
+    )
+    assert isinstance(availability, dict)
+    # Every entry must report a status; missing markets used to crash with
+    # KeyError before this regression was filed.
+    for field_name, info in availability.items():
+        assert info.get("status"), (
+            f"market={market} field={field_name} info={info}"
+        )
+
+
+def test_de_missing_ownership_fields_surface_non_us_gap_reason():
+    """DE routes to yfinance only (no Finviz), so ownership/sentiment fields
+    that are unavailable from Yahoo for non-US should surface the
+    non-US-gap reason code rather than the US-style ``missing_supported``."""
+    availability = field_capability_registry.derive_ownership_sentiment_availability(
+        data={},
+        market=MARKET_DE,
+    )
+    assert availability["institutional_ownership"]["status"] == SUPPORT_STATE_UNSUPPORTED
+    assert availability["institutional_ownership"]["reason_code"] == REASON_CODE_NON_US_GAP
+
+
+def test_ca_missing_ownership_fields_surface_non_us_gap_reason():
+    """CA routes to yfinance only — same non-US-gap classification as DE/HK."""
+    availability = field_capability_registry.derive_ownership_sentiment_availability(
+        data={},
+        market=MARKET_CA,
+    )
+    assert availability["institutional_ownership"]["status"] == SUPPORT_STATE_UNSUPPORTED
+    assert availability["institutional_ownership"]["reason_code"] == REASON_CODE_NON_US_GAP

--- a/backend/tests/unit/test_fx_service.py
+++ b/backend/tests/unit/test_fx_service.py
@@ -32,6 +32,8 @@ class TestCurrencyForMarket:
         assert currency_for_market("KR") == "KRW"
         assert currency_for_market("TW") == "TWD"
         assert currency_for_market("CN") == "CNY"
+        assert currency_for_market("CA") == "CAD"
+        assert currency_for_market("DE") == "EUR"
 
     def test_case_insensitive_and_trimmed(self):
         assert currency_for_market("  hk  ") == "HKD"

--- a/backend/tests/unit/test_provider_routing_policy.py
+++ b/backend/tests/unit/test_provider_routing_policy.py
@@ -8,6 +8,7 @@ import pytest
 from app.services import provider_routing_policy as policy
 from app.services.provider_routing_policy import (
     MARKET_CA,
+    MARKET_DE,
     MARKET_HK,
     MARKET_CN,
     MARKET_IN,
@@ -47,6 +48,7 @@ class TestMatrixShape:
         assert supported_markets() == (
             MARKET_CA,
             MARKET_CN,
+            MARKET_DE,
             MARKET_HK,
             MARKET_IN,
             MARKET_JP,

--- a/backend/tests/unit/test_universe_tasks.py
+++ b/backend/tests/unit/test_universe_tasks.py
@@ -315,3 +315,49 @@ def test_refresh_sp500_membership_retries_transient_database_error_from_task_bod
     assert retry_calls[0]["countdown"] == 5
     assert retry_calls[0]["max_retries"] == 12
     fake_lock.release.assert_called_once_with("task-123", market=None)
+
+
+@pytest.mark.parametrize(
+    "market",
+    sorted(__import__("app.tasks.universe_tasks", fromlist=["_OFFICIAL_SOURCE_MARKETS"])._OFFICIAL_SOURCE_MARKETS),
+)
+def test_ingest_official_snapshot_handles_every_allowlisted_market(monkeypatch, market):
+    """Drift guard for PR #170 review: every market in
+    ``_OFFICIAL_SOURCE_MARKETS`` must have a matching ``snapshot.market ==
+    "..."`` branch in ``_ingest_official_snapshot``. Otherwise the
+    allowlist lets a refresh through and the dispatcher raises
+    ``ValueError`` in production. Iterating the allowlist guarantees the
+    next added market trips this test instead of failing silently."""
+    import app.tasks.universe_tasks as module
+
+    fake_db = MagicMock()
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+
+    ingest_calls: list[str] = []
+
+    class FakeUniverseService:
+        def __getattr__(self, name: str):
+            # Record every ``ingest_<market>_snapshot_rows`` call so we can
+            # assert the dispatcher targeted the right method.
+            def _stub(db, **kwargs):
+                ingest_calls.append(name)
+                return {"added": 0, "updated": 0, "total": 0}
+            return _stub
+
+    monkeypatch.setattr(
+        module, "get_stock_universe_service", lambda: FakeUniverseService()
+    )
+
+    snapshot = SimpleNamespace(
+        market=market,
+        rows=(),
+        source_name="test_source",
+        snapshot_id="test-snapshot-id",
+        snapshot_as_of="2026-05-11",
+        source_metadata={},
+    )
+
+    # Must not raise — every allowlisted market needs a dispatcher branch.
+    result = module._ingest_official_snapshot(snapshot)
+    assert result["added"] == 0
+    assert ingest_calls == [f"ingest_{market.lower()}_snapshot_rows"]


### PR DESCRIPTION
## Summary

The weekly-reference DE workflow on `e60dc33` (merged PR #169) fetched the 41-row fallback CSV but then failed with `Active snapshot coverage 0.00%`. yfinance returned data for all 41 symbols, but the **persistence step** exploded for every one — `failed_persistence_symbols=41` with `provider_error_counts={}`.

### Root cause

`FieldCapabilityRegistryService.MARKET_ORDER` listed US/HK/IN/JP/KR/TW/CN/CA but not DE. The persistence path calls `derive_ownership_sentiment_availability(data, market="DE")`, which does `entry.markets[resolved_market]` — a direct dict lookup. With no `"DE"` key, every field KeyError'd. The exception propagated up through `_enrich_with_quality_metadata` → `fundamentals_cache.store` and got caught generically in `hybrid_fundamentals_service.store_all_caches` as a per-symbol failure. Coverage dropped to 0% and the gate blocked publish.

### Fixes

| File | Change |
|---|---|
| `field_capability_registry.py` | Add `MARKET_DE` to `MARKET_ORDER`. Add `MARKET_CA` + `MARKET_DE` to the non-US-gap reason-code tuple (CA was missed in the original CA PR too — cosmetic but consistent). |
| `fx_service.py` | Add `DE→EUR` and `CA→CAD` to `MARKET_CURRENCY_MAP`. The drift-prevention test `test_agrees_with_security_master_defaults` was already failing locally; it just isn't run in any of the CI Quality Gates so it was silently red. |
| `universe_tasks.py` | Add DE to `_OFFICIAL_SOURCE_MARKETS` so the periodic `refresh_official_market_universe` Celery task can refresh DE (was rejecting DE even though `fetch_market_snapshot` now supports it). |

### Regression coverage

- **`test_derive_ownership_sentiment_availability_covers_every_known_market`** — new parametrized test iterating `routing_policy.KNOWN_MARKETS`. The next market that gets added to `KNOWN_MARKETS` but not to `MARKET_ORDER` will fail this test instead of silently producing a 100% persistence-failure in production.
- Added explicit DE + CA non-US-gap reason-code assertions.
- Updated `test_registry_is_versioned_and_shape_is_deterministic` to include DE in the expected `markets` list.
- Added DE + CA to `test_fx_service.test_known_markets`; the drift test now passes.
- Updated `test_supported_markets_covers_us_and_asia` to include DE (latent miss from the original DE feature commit).

189 unit tests pass across the affected files plus weekly-reference, launch-gates, app-runtime, benchmark-registry, and taxonomy regression suites. `make gate-identity` and `make gate-check` clean.

## Test plan

- [x] 189 unit tests pass
- [x] New regression test fails when DE is dropped from `MARKET_ORDER` (verified locally by reverting the line)
- [x] FX drift-prevention test passes
- [ ] CI: Backend Quality Gates pass
- [ ] CI: Weekly Reference Data workflow `publish (DE)` matrix entry — the 41-row CSV-fallback path should now publish successfully (coverage gate should clear once Yahoo fundamentals can land). The Xetra live-CSV path is a separate question — `cashmarket.deutsche-boerse.com` reachability from GH Actions IPs is still unverified.

https://claude.ai/code/session_01LVNkvCqzEV6poVNhh7FhZc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVNkvCqzEV6poVNhh7FhZc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Germany (DE) market is now available with full field capabilities and EUR currency support.
  * Canada (CA) market now includes complete currency mapping (CAD).
  * Market universe expanded to support Germany as an official source market.

* **Chores**
  * Field capability registry updated to version 2026.05.09.1.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/170)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->