### PR TITLE
fix(de): send browser User-Agent so Xetra CSV fetch actually succeeds

### DIFF
--- a/backend/app/services/official_market_universe_source_service.py
+++ b/backend/app/services/official_market_universe_source_service.py
@@ -1017,6 +1017,15 @@ class OfficialMarketUniverseSourceService:
             live_meta = self._fetch_de_live()
         except (requests.exceptions.RequestException, ValueError) as exc:
             live_error = str(exc)
+            # ``logger.warning`` writes to stderr and the CI build-step log
+            # often misses it — surface the failure reason on stdout too so
+            # operators inspecting the workflow output can see why fallback
+            # fired without diving into the log viewer's stderr stream.
+            print(
+                f"[de] Live universe fetch failed: {live_error!s}. "
+                f"Falling back to bundled CSV at {settings.de_universe_fallback_csv_path}.",
+                flush=True,
+            )
             logger.warning(
                 "Live DE universe fetch failed (%s); falling back to bundled CSV at %s",
                 live_error,
@@ -1036,6 +1045,11 @@ class OfficialMarketUniverseSourceService:
             fetched_at = live_meta.get("fetched_at")
             last_modified = live_meta.get("http_last_modified")
             tls_verification_disabled = bool(live_meta.get("tls_verification_disabled"))
+            print(
+                f"[de] Live universe fetch succeeded: {len(rows)} Common Stock rows "
+                f"from {settings.de_universe_source_url}",
+                flush=True,
+            )
 
         if not rows:
             raise ValueError("DE official universe fetch returned no rows")
@@ -1086,9 +1100,26 @@ class OfficialMarketUniverseSourceService:
           universe (would silently deactivate curated names downstream).
         """
         url = settings.de_universe_source_url
+        # Deutsche Boerse Cash Market 403s the default bot-style User-Agent
+        # (``StockScannerUniverseRefresh/1.0 ...``) — a developer-machine
+        # curl with ``Mozilla/5.0`` reaches the CSV fine but a GH Actions
+        # runner using the bot UA falls straight into CSV fallback. Pass a
+        # browser-like UA + accompanying headers so the live path actually
+        # gets a response.
+        browser_headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/124.0.0.0 Safari/537.36"
+            ),
+            "Accept": "text/csv,application/vnd.ms-excel,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9,de;q=0.8",
+            "Referer": "https://www.xetra.com/xetra-en/instruments/all-tradable-instruments",
+        }
         fetched = self._http_get(
             url,
             allow_insecure_fallback=settings.de_universe_allow_insecure_fallback,
+            extra_headers=browser_headers,
         )
 
         rows = self._parse_de_xetra_csv(fetched.content)

--- a/backend/tests/unit/test_official_market_universe_source_service.py
+++ b/backend/tests/unit/test_official_market_universe_source_service.py
@@ -1429,7 +1429,7 @@ def test_fetch_de_snapshot_filters_xetra_common_stock(monkeypatch, tmp_path):
     ])
 
     service = OfficialMarketUniverseSourceService()
-    monkeypatch.setattr(service, "_http_get", lambda url, allow_insecure_fallback=False: _fetched_xetra(csv_bytes))
+    monkeypatch.setattr(service, "_http_get", lambda url, allow_insecure_fallback=False, extra_headers=None: _fetched_xetra(csv_bytes))
 
     snapshot = service.fetch_de_snapshot()
 
@@ -1466,7 +1466,7 @@ def test_fetch_de_snapshot_falls_back_on_http_error(monkeypatch, tmp_path):
     monkeypatch.setattr(app_settings, "de_universe_source_url", _DE_CSV_URL)
     monkeypatch.setattr(app_settings, "de_universe_fallback_csv_path", str(fallback_csv))
 
-    def fake_http_get(url, allow_insecure_fallback=False):
+    def fake_http_get(url, allow_insecure_fallback=False, extra_headers=None):
         raise requests.exceptions.ConnectionError("synthetic blob 404 / DNS outage")
 
     service = OfficialMarketUniverseSourceService()
@@ -1498,7 +1498,7 @@ def test_fetch_de_snapshot_falls_back_when_baseline_symbol_missing(monkeypatch, 
         _xetra_row(Mnemonic="SAP", ISIN="DE0007164600", WKN="000716460", Instrument="SAP SE"),
     ])
     service = OfficialMarketUniverseSourceService()
-    monkeypatch.setattr(service, "_http_get", lambda url, allow_insecure_fallback=False: _fetched_xetra(csv_bytes))
+    monkeypatch.setattr(service, "_http_get", lambda url, allow_insecure_fallback=False, extra_headers=None: _fetched_xetra(csv_bytes))
 
     snapshot = service.fetch_de_snapshot()
 
@@ -1529,7 +1529,7 @@ def test_fetch_de_snapshot_falls_back_when_universe_too_small(monkeypatch, tmp_p
         _xetra_row(Mnemonic="ALV", ISIN="DE0008404005", Instrument="Allianz"),
     ])
     service = OfficialMarketUniverseSourceService()
-    monkeypatch.setattr(service, "_http_get", lambda url, allow_insecure_fallback=False: _fetched_xetra(csv_bytes))
+    monkeypatch.setattr(service, "_http_get", lambda url, allow_insecure_fallback=False, extra_headers=None: _fetched_xetra(csv_bytes))
 
     # No bundled fallback rows for this test — empty baseline CSV — so the
     # fetcher will raise because there's nothing to fall back to.
@@ -1555,6 +1555,46 @@ def test_parse_de_xetra_csv_strips_wkn_zero_padding():
     assert len(rows) == 1
     assert rows[0]["symbol"] == "SAP.DE"
     assert rows[0]["wkn"] == "716460"
+
+
+def test_fetch_de_snapshot_sends_browser_user_agent(monkeypatch, tmp_path):
+    """Deutsche Boerse Cash Market 403s the default bot-style User-Agent.
+    The live path must override with a browser-like UA so the GH Actions
+    runner actually receives the CSV instead of falling straight back to
+    the bundled seed."""
+    from app.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "de_universe_source_url", _DE_CSV_URL)
+    monkeypatch.setattr(
+        app_settings, "de_universe_fallback_csv_path",
+        _write_de_baseline_csv(tmp_path),
+    )
+    monkeypatch.setattr(app_settings, "de_live_min_universe_size", 0)
+
+    csv_bytes = _xetra_csv_content([
+        _xetra_row(Mnemonic="SAP", ISIN="DE0007164600", Instrument="SAP SE"),
+    ])
+    captured_headers: list[dict] = []
+
+    def fake_http_get(url, allow_insecure_fallback=False, extra_headers=None):
+        captured_headers.append(extra_headers or {})
+        return _fetched_xetra(csv_bytes)
+
+    service = OfficialMarketUniverseSourceService()
+    monkeypatch.setattr(service, "_http_get", fake_http_get)
+
+    service.fetch_de_snapshot()
+
+    assert captured_headers, "expected the live path to invoke _http_get"
+    headers = captured_headers[0]
+    assert headers.get("User-Agent", "").startswith("Mozilla/5.0"), (
+        f"expected Mozilla UA, got {headers.get('User-Agent')!r}"
+    )
+    # The accompanying headers help the request blend in with browser
+    # traffic (some CDN bot-detection systems flag UA-only spoofs).
+    assert "Accept" in headers
+    assert "Accept-Language" in headers
+    assert "Referer" in headers and "xetra.com" in headers["Referer"]
 
 
 def test_parse_de_xetra_csv_tolerates_utf8_bom():
@@ -1625,7 +1665,7 @@ def test_fetch_de_snapshot_warns_when_baseline_csv_missing(monkeypatch, tmp_path
     service = OfficialMarketUniverseSourceService()
     monkeypatch.setattr(
         service, "_http_get",
-        lambda url, allow_insecure_fallback=False: _fetched_xetra(csv_bytes),
+        lambda url, allow_insecure_fallback=False, extra_headers=None: _fetched_xetra(csv_bytes),
     )
 
     with caplog.at_level("WARNING"):


### PR DESCRIPTION
## Summary

The 2026-05-11 weekly-reference DE run published only the 41-row CSV-fallback bundle even though PR #170 fixed the persistence bug — the live Xetra CSV fetch is silently going to fallback. From the build-step log, `fetch_de_snapshot` is taking its except branch but the `logger.warning` doesn't appear in the captured workflow output (logger writes to stderr; the GH log viewer drops it).

**Most likely cause**: Deutsche Börse Cash Market 403s the default bot-style `User-Agent: StockScannerUniverseRefresh/1.0 (+https://...)`. The user verified manually that `curl -H "User-Agent: Mozilla/5.0" ... cashmarket.deutsche-boerse.com/.../t7-xetr-allTradableInstruments.csv` works fine, so the URL and signing are correct — only the UA differs.

**Precedent in this codebase**: `_NSE_SOURCE_HEADERS` already overrides UA + sends `Accept` / `Accept-Language` / `Referer` for the same reason (NSE 403s bot UAs). DE just needed the same treatment.

## Changes

- **`_fetch_de_live`** now passes browser-like headers via `extra_headers` to `_http_get`:
  - `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36`
  - `Accept: text/csv,application/vnd.ms-excel,*/*;q=0.8`
  - `Accept-Language: en-US,en;q=0.9,de;q=0.8`
  - `Referer: https://www.xetra.com/xetra-en/instruments/all-tradable-instruments`
- **`fetch_de_snapshot`** mirrors the `logger.warning` with a stdout `print(..., flush=True)` on both the success and failure paths. The next workflow log will clearly show `[de] Live universe fetch succeeded: N rows from <url>` or `[de] Live universe fetch failed: <error>. Falling back to ...` — no more invisible fallbacks.

## Test plan

- [x] New `test_fetch_de_snapshot_sends_browser_user_agent` captures `extra_headers` forwarded to `_http_get` and asserts `User-Agent` starts with `Mozilla/5.0` plus presence of `Accept` / `Accept-Language` / `Referer` (with xetra.com)
- [x] Existing DE tests updated to accept the new `extra_headers` kwarg in their mocks (67 tests pass in the official-source suite; 191 across the related files)
- [ ] CI: Backend Quality Gates pass
- [ ] CI: Weekly Reference Data workflow `publish (DE)` shows either:
  - `[de] Live universe fetch succeeded: ~870 Common Stock rows from <url>` — UA was the issue and DE is fixed.
  - `[de] Live universe fetch failed: <other error>. Falling back to ...` — UA fixed but something else is wrong; follow-up needed.

## Caveat

This assumes UA-based bot detection. If the Deutsche Börse CDN actually blocks GH Actions runner IPs at the network layer, the new stdout print will surface that on the next run and we'll switch sources.

Follow-up to PR #170.

https://claude.ai/code/session_01LVNkvCqzEV6poVNhh7FhZc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVNkvCqzEV6poVNhh7FhZc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed error logging when German market snapshot live fetch fails, displaying fallback CSV path
  * Fetch success messages now display row count and live source URL

* **Improvements**
  * Updated HTTP request headers for German market live data fetches

* **Tests**
  * Added test verification ensuring German market uses browser-like HTTP headers

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/171)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->