### PR TITLE
fix(de): keep healthy Xetra universe on baseline drift

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -200,11 +200,9 @@ class Settings(BaseSettings):
     )
     # Minimum live-universe row count before the snapshot is considered
     # publishable. The Xetra reference CSV typically ships ~870 Common Stock
-    # rows; setting this to 200 lets a partial Xetra outage (e.g. status
-    # filters tightening) still publish while catching catastrophic universe
-    # shrinkage. Set to 0 to disable the floor (the CSV-superset check still
-    # applies regardless).
-    de_live_min_universe_size: int = 200
+    # rows; setting this near 800 catches catastrophic shrinkage without
+    # rejecting ordinary listing churn. Set to 0 to disable the floor.
+    de_live_min_universe_size: int = 800
     ibd_industry_csv_path: str = str(_PROJECT_ROOT / "data" / "IBD_industry_group.csv")
 
     # Per-market rate budget overrides. Each value is in requests-per-second

--- a/backend/app/services/official_market_universe_source_service.py
+++ b/backend/app/services/official_market_universe_source_service.py
@@ -992,10 +992,9 @@ class OfficialMarketUniverseSourceService:
         Finance uses as its ticker prefix.
 
         Fallback path: when the live CSV is unreachable (404 because the blob
-        hash rotated, network error, parse failure, fewer than
+        hash rotated, network error, parse failure, or fewer than
         ``settings.de_live_min_universe_size`` Common Stock rows survive the
-        filter, or the bundled DAX-40 baseline isn't a subset of the live
-        universe) the fetcher falls back to the bundled seed CSV at
+        filter) the fetcher falls back to the bundled seed CSV at
         ``settings.de_universe_fallback_csv_path``. The snapshot still
         publishes but with ``source_name == 'de_manual_csv'`` and
         ``fetch_mode == 'csv_fallback'`` so the coverage gate / operators can
@@ -1012,6 +1011,7 @@ class OfficialMarketUniverseSourceService:
         fetched_at: str | None = None
         last_modified: str | None = None
         tls_verification_disabled = False
+        live_meta: dict[str, Any] = {}
 
         try:
             live_meta = self._fetch_de_live()
@@ -1073,6 +1073,14 @@ class OfficialMarketUniverseSourceService:
                 "total": len(rows),
             },
         }
+        for key in (
+            "baseline_status",
+            "baseline_missing_count",
+            "baseline_missing_symbols",
+            "baseline_missing_symbols_truncated",
+        ):
+            if key in live_meta:
+                source_metadata[key] = live_meta[key]
         if fetch_mode == "csv_fallback":
             source_metadata["fallback_csv_path"] = settings.de_universe_fallback_csv_path
 
@@ -1096,8 +1104,9 @@ class OfficialMarketUniverseSourceService:
         * the CSV cannot be parsed,
         * fewer than ``settings.de_live_min_universe_size`` Common Stock rows
           survive the filter, or
-        * any symbol in the bundled baseline CSV is absent from the live
-          universe (would silently deactivate curated names downstream).
+        Missing symbols from the bundled baseline CSV are returned as warning
+        metadata instead of forcing fallback; the live Xetra CSV remains the
+        authoritative universe when it is otherwise healthy.
         """
         url = settings.de_universe_source_url
         # Deutsche Boerse Cash Market 403s the default bot-style User-Agent
@@ -1136,10 +1145,11 @@ class OfficialMarketUniverseSourceService:
                 "the Xetra blob URL likely rotated and needs refreshing"
             )
 
-        # Safety guard: the reconciler in ``ingest_de_snapshot_rows`` deactivates
-        # rows that are absent from the snapshot. A live universe that drops
-        # curated DAX-40 names would silently deactivate those positions. Force
-        # CSV fallback when that happens.
+        # Safety signal: the reconciler in ``ingest_de_snapshot_rows`` can
+        # deactivate rows that are absent from the snapshot. A live universe
+        # that drops curated DAX-40 names is worth surfacing, but it should not
+        # collapse an otherwise healthy 800+ row Xetra snapshot to the tiny
+        # fallback CSV.
         #
         # When the baseline CSV is absent from disk entirely (container layout
         # drift, image-build glitch, etc.) ``_load_de_csv_fallback`` returns an
@@ -1157,19 +1167,34 @@ class OfficialMarketUniverseSourceService:
             )
         csv_symbols = {row["symbol"] for row in baseline_rows}
         missing_csv_symbols = csv_symbols - live_symbols
+        baseline_metadata: dict[str, Any] = {
+            "baseline_status": "ok",
+            "baseline_missing_count": 0,
+            "baseline_missing_symbols": [],
+            "baseline_missing_symbols_truncated": False,
+        }
         if missing_csv_symbols:
-            sample = sorted(missing_csv_symbols)[:5]
-            raise ValueError(
-                f"DE live universe missing {len(missing_csv_symbols)} curated "
-                f"baseline symbols (e.g. {sample}); refusing to publish — would "
-                "deactivate known names"
+            missing_symbols = sorted(missing_csv_symbols)
+            sample = missing_symbols[:5]
+            logger.warning(
+                "DE live universe missing %s curated baseline symbols (e.g. %s); "
+                "publishing live Xetra universe with warning metadata.",
+                len(missing_symbols),
+                sample,
             )
+            baseline_metadata = {
+                "baseline_status": "missing_symbols",
+                "baseline_missing_count": len(missing_symbols),
+                "baseline_missing_symbols": missing_symbols[:25],
+                "baseline_missing_symbols_truncated": len(missing_symbols) > 25,
+            }
 
         return {
             "rows": sorted(rows, key=lambda row: row["symbol"]),
             "fetched_at": fetched.fetched_at,
             "http_last_modified": fetched.last_modified,
             "tls_verification_disabled": fetched.tls_verification_disabled,
+            **baseline_metadata,
         }
 
     @classmethod

--- a/backend/tests/unit/test_official_market_universe_source_service.py
+++ b/backend/tests/unit/test_official_market_universe_source_service.py
@@ -1481,9 +1481,9 @@ def test_fetch_de_snapshot_falls_back_on_http_error(monkeypatch, tmp_path):
     assert snapshot.snapshot_id.startswith("de-csv-fallback-")
 
 
-def test_fetch_de_snapshot_falls_back_when_baseline_symbol_missing(monkeypatch, tmp_path):
-    """A live universe that omits curated DAX names triggers fallback so the
-    reconciler doesn't deactivate known positions."""
+def test_fetch_de_snapshot_publishes_live_when_baseline_symbol_missing(monkeypatch, tmp_path):
+    """A healthy live Xetra universe should not collapse to the tiny curated
+    fallback CSV just because one seed symbol is no longer present."""
     from app.config import settings as app_settings
 
     monkeypatch.setattr(app_settings, "de_universe_source_url", _DE_CSV_URL)
@@ -1492,7 +1492,7 @@ def test_fetch_de_snapshot_falls_back_when_baseline_symbol_missing(monkeypatch, 
         app_settings, "de_universe_fallback_csv_path",
         _write_de_baseline_csv(tmp_path, ["SAP.DE", "ALV.DE"]),
     )
-    monkeypatch.setattr(app_settings, "de_live_min_universe_size", 0)
+    monkeypatch.setattr(app_settings, "de_live_min_universe_size", 1)
 
     csv_bytes = _xetra_csv_content([
         _xetra_row(Mnemonic="SAP", ISIN="DE0007164600", WKN="000716460", Instrument="SAP SE"),
@@ -1502,12 +1502,12 @@ def test_fetch_de_snapshot_falls_back_when_baseline_symbol_missing(monkeypatch, 
 
     snapshot = service.fetch_de_snapshot()
 
-    assert snapshot.source_metadata["fetch_mode"] == "csv_fallback"
-    live_error = snapshot.source_metadata["fetch_errors"]["live_http"]
-    assert "missing 1 curated baseline symbols" in live_error
-    assert "ALV.DE" in live_error
-    # Bundle now reflects the curated baseline, not the truncated live result.
-    assert {row["symbol"] for row in snapshot.rows} == {"SAP.DE", "ALV.DE"}
+    assert snapshot.source_name == "dbg_official"
+    assert snapshot.source_metadata["fetch_mode"] == "live_http"
+    assert snapshot.source_metadata["baseline_missing_symbols"] == ["ALV.DE"]
+    assert snapshot.source_metadata["baseline_missing_count"] == 1
+    assert snapshot.source_metadata["baseline_status"] == "missing_symbols"
+    assert {row["symbol"] for row in snapshot.rows} == {"SAP.DE"}
 
 
 def test_fetch_de_snapshot_falls_back_when_universe_too_small(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- keep healthy live Xetra DE snapshots as `dbg_official` when curated baseline symbols are missing
- record baseline drift in snapshot metadata instead of falling back to the 41-row DAX seed
- raise the DE live universe floor to 800 rows to catch genuinely truncated Xetra data

## Root Cause
The latest DE weekly reference run fetched and parsed the Xetra CSV successfully, but rejected the live 879-row universe because `1COV.DE` from the bundled DAX seed was absent. That forced fallback to `data/de_dax40_constituents.csv`, producing a 41-row bundle.

## Validation
- `pytest tests/unit/test_official_market_universe_source_service.py tests/unit/test_weekly_reference_scripts.py -q` -> 81 passed
- live sanity check returned `source_name=dbg_official`, `fetch_mode=live_http`, `rows=879`, `baseline_missing_symbols=['1COV.DE']`

## Notes
Full backend pytest is not currently clean on `origin/main`: collection hits an import-time localhost dependency in `tests/integration/test_production_performance.py`, and `tests/unit` has unrelated failures outside this change.
