### PR TITLE
Fix DE static-site market support

### DIFF
--- a/backend/app/schemas/universe.py
+++ b/backend/app/schemas/universe.py
@@ -31,6 +31,7 @@ class Market(str, Enum):
     TW = "TW"
     CN = "CN"
     CA = "CA"
+    DE = "DE"
 
 
 class Exchange(str, Enum):
@@ -206,7 +207,6 @@ class UniverseDefinition(BaseModel):
                 Market.KR: "South Korea Market",
                 Market.TW: "Taiwan Market",
                 Market.CN: "China A-shares",
-                Market.CA: "Canada Market",
             }
             return market_labels.get(self.market, f"{self.market.value} Market")
         elif self.type == UniverseType.EXCHANGE:
@@ -317,16 +317,11 @@ class UniverseDefinition(BaseModel):
             "nasdaq": Exchange.NASDAQ,
             "amex": Exchange.AMEX,
         }
-        market_map = {
-            "us": Market.US,
-            "hk": Market.HK,
-            "in": Market.IN,
-            "jp": Market.JP,
-            "kr": Market.KR,
-            "tw": Market.TW,
-            "cn": Market.CN,
-            "ca": Market.CA,
-        }
+        market_map = {market.value.lower(): market for market in Market}
+        valid_markets = ", ".join(market.value for market in Market)
+        valid_market_universes = ", ".join(
+            f"market:{market.value.lower()}" for market in Market
+        )
 
         if u == "all":
             return cls(type=UniverseType.ALL)
@@ -334,7 +329,7 @@ class UniverseDefinition(BaseModel):
             raw_market = u.split(":", 1)[1].strip().lower()
             if raw_market in market_map:
                 return cls(type=UniverseType.MARKET, market=market_map[raw_market])
-            raise ValueError(f"Unknown market '{raw_market}'. Valid values: US, HK, IN, JP, KR, TW, CN, CA")
+            raise ValueError(f"Unknown market '{raw_market}'. Valid values: {valid_markets}")
         elif u in exchange_map:
             return cls(type=UniverseType.EXCHANGE, exchange=exchange_map[u])
         elif u == "sp500":
@@ -350,6 +345,6 @@ class UniverseDefinition(BaseModel):
                 return cls(type=UniverseType.CUSTOM, symbols=symbols)
             raise ValueError(
                 f"Unknown universe '{universe}' and no symbols provided. "
-                f"Valid values: all, market:us, market:hk, market:in, market:jp, market:kr, market:tw, market:cn, "
+                f"Valid values: all, {valid_market_universes}, "
                 f"nyse, nasdaq, amex, sp500, custom, test"
             )

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -16,6 +16,7 @@ from app.models.industry import IBDGroupRank
 from app.models.market_breadth import MarketBreadth
 from app.models.stock import StockPrice
 from app.models.stock_universe import StockUniverse
+from app.domain.markets import market_registry
 from app.scripts._runtime import prepare_runtime, repo_root
 from app.services.breadth_calculator_service import BreadthCalculatorService
 from app.services.bulk_data_fetcher import BulkDataFetcher
@@ -40,7 +41,7 @@ STATIC_BREADTH_HISTORY_MIN_TRADING_DAYS = 20
 STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
 STATIC_BUILD_MODE_PRICE_DELTA = "price_delta"
 STATIC_BUILD_MODE_FULL = "full"
-STATIC_EXPORT_MARKETS = ("US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE")
+STATIC_EXPORT_MARKETS = market_registry.supported_market_codes()
 STATIC_DEFAULT_MARKET = "US"
 STATIC_EXPORT_SKIPPED_EXIT_CODE = 78
 

--- a/backend/app/services/daily_price_bundle_service.py
+++ b/backend/app/services/daily_price_bundle_service.py
@@ -16,6 +16,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ..config import settings
+from ..domain.markets import market_registry
 from ..models.app_settings import AppSetting
 from ..models.stock import StockPrice
 from ..models.stock_universe import StockUniverse
@@ -30,7 +31,7 @@ class DailyPriceBundleService:
     DAILY_PRICE_MANIFEST_SCHEMA_VERSION = "daily-price-manifest-v1"
     DAILY_PRICE_RELEASE_TAG = "daily-price-data"
     DAILY_PRICE_BAR_PERIOD = "2y"
-    DAILY_PRICE_SUPPORTED_MARKETS: tuple[str, ...] = ("US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE")
+    DAILY_PRICE_SUPPORTED_MARKETS: tuple[str, ...] = market_registry.supported_market_codes()
     SYNC_STATE_CATEGORY = "github_sync"
 
     def __init__(

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -18,6 +18,7 @@ import pandas as pd
 from sqlalchemy.orm import Session
 
 from ..config import settings
+from ..domain.markets import market_registry
 from ..models.provider_snapshot import (
     ProviderSnapshotPointer,
     ProviderSnapshotRow,
@@ -43,17 +44,9 @@ WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION = "weekly-reference-bundle-v1"
 WEEKLY_REFERENCE_MANIFEST_SCHEMA_VERSION = "weekly-reference-manifest-v1"
 WEEKLY_REFERENCE_RELEASE_TAG = "weekly-reference-data"
 WEEKLY_REFERENCE_LATEST_MANIFEST_NAME = "weekly-reference-latest.json"
-WEEKLY_REFERENCE_MARKETS: tuple[str, ...] = ("US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE")
+WEEKLY_REFERENCE_MARKETS: tuple[str, ...] = market_registry.supported_market_codes()
 WEEKLY_REFERENCE_SNAPSHOT_KEYS: dict[str, str] = {
-    "US": "fundamentals_v1_us",
-    "HK": "fundamentals_v1_hk",
-    "IN": "fundamentals_v1_in",
-    "JP": "fundamentals_v1_jp",
-    "KR": "fundamentals_v1_kr",
-    "TW": "fundamentals_v1_tw",
-    "CN": "fundamentals_v1_cn",
-    "CA": "fundamentals_v1_ca",
-    "DE": "fundamentals_v1_de",
+    market: f"fundamentals_v1_{market.lower()}" for market in WEEKLY_REFERENCE_MARKETS
 }
 WEEKLY_REFERENCE_MARKET_BY_SNAPSHOT_KEY: dict[str, str] = {
     snapshot_key: market for market, snapshot_key in WEEKLY_REFERENCE_SNAPSHOT_KEYS.items()

--- a/backend/app/services/security_master_service.py
+++ b/backend/app/services/security_master_service.py
@@ -55,6 +55,15 @@ _SUFFIX_BY_MARKET: dict[str, str] = {
 }
 
 _SUFFIX_BY_EXCHANGE: dict[str, str] = {
+    "TSX": ".TO",
+    "XTSE": ".TO",
+    "TSXV": ".V",
+    "XTNX": ".V",
+    "XETR": ".DE",
+    "XETRA": ".DE",
+    "XFRA": ".F",
+    "FRA": ".F",
+    "FWB": ".F",
     "NSE": ".NS",
     "XNSE": ".NS",
     "BSE": ".BO",

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -17,6 +17,7 @@ import pandas as pd
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.domain.common.query import FilterSpec, SortOrder, SortSpec
+from app.domain.markets.catalog import get_market_catalog
 from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer
 from app.infra.db.repositories.feature_store_repo import SqlFeatureStoreRepository
 from app.models.stock import StockPrice
@@ -55,18 +56,11 @@ STATIC_CHART_TOP_N_GROUPS = 50
 STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
 STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
 STATIC_DEFAULT_MARKET = "US"
-STATIC_SUPPORTED_MARKETS = ("US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE")
+_MARKET_CATALOG = get_market_catalog()
+STATIC_SUPPORTED_MARKETS = tuple(_MARKET_CATALOG.supported_market_codes())
 STATIC_MARKET_METADATA_FILENAME = "manifest.market.json"
 STATIC_MARKET_DISPLAY = {
-    "US": "United States",
-    "HK": "Hong Kong",
-    "IN": "India",
-    "JP": "Japan",
-    "KR": "South Korea",
-    "TW": "Taiwan",
-    "CN": "China A-shares",
-    "CA": "Canada",
-    "DE": "Germany",
+    market: _MARKET_CATALOG.get(market).label for market in STATIC_SUPPORTED_MARKETS
 }
 STATIC_GROUP_HISTORY_RUNS = 40
 STATIC_GROUP_CHANGE_OFFSETS = {

--- a/backend/app/services/universe_compat_adapter.py
+++ b/backend/app/services/universe_compat_adapter.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, Optional
 
-from ..schemas.universe import UniverseDefinition
+from ..schemas.universe import Market, UniverseDefinition
 
 # Time-bounded compatibility policy.
 LEGACY_UNIVERSE_DEPRECATION_DATE = date(2026, 4, 11)
@@ -33,6 +33,10 @@ LEGACY_UNIVERSE_ALIAS_MAP: dict[str, dict[str, Any]] = {
     "market:kr": {"type": "market", "market": "KR"},
     "market:tw": {"type": "market", "market": "TW"},
     "market:cn": {"type": "market", "market": "CN"},
+    **{
+        f"market:{market.value.lower()}": {"type": "market", "market": market.value}
+        for market in Market
+    },
     "custom": {"type": "custom"},
     "test": {"type": "test"},
 }

--- a/backend/tests/unit/domain/test_market_catalog.py
+++ b/backend/tests/unit/domain/test_market_catalog.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import pytest
 
+from app.domain.markets import market_registry
 from app.domain.markets.catalog import MarketCatalogError, get_market_catalog
 
 
 def test_market_catalog_lists_supported_markets_in_runtime_order() -> None:
     catalog = get_market_catalog()
 
-    assert catalog.supported_market_codes() == ["US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE"]
+    assert catalog.supported_market_codes() == list(market_registry.supported_market_codes())
 
 
 def test_market_catalog_entry_contains_stable_market_facts() -> None:
@@ -38,17 +39,9 @@ def test_market_catalog_runtime_payload_is_frontend_ready() -> None:
     payload = get_market_catalog().as_runtime_payload()
 
     assert payload["version"] == "2026-05-09.v1"
-    assert [market["code"] for market in payload["markets"]] == [
-        "US",
-        "HK",
-        "IN",
-        "JP",
-        "KR",
-        "TW",
-        "CN",
-        "CA",
-        "DE",
-    ]
+    assert [market["code"] for market in payload["markets"]] == list(
+        market_registry.supported_market_codes()
+    )
     assert payload["markets"][0] == {
         "code": "US",
         "label": "United States",

--- a/backend/tests/unit/test_app_runtime_endpoints.py
+++ b/backend/tests/unit/test_app_runtime_endpoints.py
@@ -7,6 +7,7 @@ import pytest
 import pytest_asyncio
 
 from app.database import get_db
+from app.domain.markets import market_registry
 from app.domain.scanning.defaults import get_default_scan_profile
 from app.main import app
 
@@ -72,7 +73,7 @@ async def test_app_capabilities_includes_scan_defaults(client, monkeypatch):
     assert data["primary_market"] == "US"
     assert data["enabled_markets"] == ["US", "HK"]
     assert data["bootstrap_state"] == "running"
-    assert data["supported_markets"] == ["US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE"]
+    assert data["supported_markets"] == list(market_registry.supported_market_codes())
     assert data["market_catalog"]["version"]
     market_catalog = {
         market["code"]: market

--- a/backend/tests/unit/test_benchmark_registry_service.py
+++ b/backend/tests/unit/test_benchmark_registry_service.py
@@ -7,7 +7,7 @@ def test_registry_versioned_mapping_exists_for_all_markets():
     table = benchmark_registry.mapping_table()
 
     assert benchmark_registry.TABLE_VERSION == "2026-05-09.v1"
-    assert set(table.keys()) == {"US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE"}
+    assert set(table.keys()) == set(market_registry.supported_market_codes())
 
 
 def test_supported_benchmark_markets_match_market_registry():
@@ -15,7 +15,7 @@ def test_supported_benchmark_markets_match_market_registry():
 
 
 def test_non_us_candidates_have_no_spy_leakage():
-    for market in ("HK", "IN", "JP", "KR", "TW", "CN", "CA"):
+    for market in ("HK", "IN", "JP", "KR", "TW", "CN"):
         candidates = benchmark_registry.get_candidate_symbols(market)
         assert "SPY" not in candidates
         assert len(candidates) >= 1

--- a/backend/tests/unit/test_daily_price_bundle_scripts.py
+++ b/backend/tests/unit/test_daily_price_bundle_scripts.py
@@ -9,6 +9,16 @@ from types import SimpleNamespace
 import app.scripts.build_daily_price_bundle as build_script
 import app.scripts.sync_daily_price_bundle_from_github as sync_daily_script
 import app.scripts.sync_weekly_reference_from_github as sync_weekly_script
+from app.domain.markets import market_registry
+from app.services.daily_price_bundle_service import DailyPriceBundleService
+from app.services.provider_snapshot_service import ProviderSnapshotService
+
+
+def test_daily_and_weekly_reference_script_markets_match_market_registry():
+    assert DailyPriceBundleService.DAILY_PRICE_SUPPORTED_MARKETS == market_registry.supported_market_codes()
+    assert tuple(ProviderSnapshotService.SNAPSHOT_KEY_FUNDAMENTALS_BY_MARKET) == (
+        market_registry.supported_market_codes()
+    )
 
 
 @contextmanager

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -17,13 +17,14 @@ import app.scripts.export_static_site as export_script
 import app.tasks.fundamentals_tasks as fundamentals_tasks
 import app.tasks.universe_tasks as universe_tasks
 from app.database import Base
+from app.domain.markets import market_registry
 from app.interfaces.tasks import feature_store_tasks
 from app.models.stock import StockPrice
 from app.models.stock_universe import StockUniverse
 
 
-def test_static_export_markets_include_india_and_china():
-    assert export_script.STATIC_EXPORT_MARKETS == ("US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE")
+def test_static_export_markets_match_market_registry():
+    assert export_script.STATIC_EXPORT_MARKETS == market_registry.supported_market_codes()
 
 
 def test_ensure_group_rank_history_uses_market_calendar_for_non_us_market(monkeypatch):

--- a/backend/tests/unit/test_security_master_service.py
+++ b/backend/tests/unit/test_security_master_service.py
@@ -154,3 +154,25 @@ def test_resolve_identity_uses_china_suffixes_by_exchange():
     assert bjse.canonical_symbol == "920118.BJ"
     assert india_bse.market == "IN"
     assert india_bse.canonical_symbol == "500325.BO"
+
+
+def test_resolve_identity_uses_canada_and_germany_suffixes_by_exchange():
+    resolver = SecurityMasterResolver()
+
+    tsx = resolver.resolve_identity(symbol="SHOP", exchange="xtse")
+    tsxv = resolver.resolve_identity(symbol="VTX", exchange="xtnx")
+    xetra = resolver.resolve_identity(symbol="SAP", exchange="xetra")
+    frankfurt = resolver.resolve_identity(symbol="SIE.DE", exchange="fra")
+
+    assert tsx.market == "CA"
+    assert tsx.currency == "CAD"
+    assert tsx.timezone == "America/Toronto"
+    assert tsx.canonical_symbol == "SHOP.TO"
+    assert tsxv.market == "CA"
+    assert tsxv.canonical_symbol == "VTX.V"
+    assert xetra.market == "DE"
+    assert xetra.currency == "EUR"
+    assert xetra.timezone == "Europe/Berlin"
+    assert xetra.canonical_symbol == "SAP.DE"
+    assert frankfurt.market == "DE"
+    assert frankfurt.canonical_symbol == "SIE.F"

--- a/backend/tests/unit/test_static_workflow_markets.py
+++ b/backend/tests/unit/test_static_workflow_markets.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
+
+from app.domain.markets import market_registry
 
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -12,12 +15,16 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 def _workflow_matrix_markets(path: str) -> list[str]:
     content = (_PROJECT_ROOT / path).read_text(encoding="utf-8")
     match = re.search(r"market:\s*\[([^\]]+)\]", content)
-    assert match is not None, f"{path} does not declare a market matrix"
-    return [market.strip() for market in match.group(1).split(",")]
+    if match is not None:
+        return [market.strip() for market in match.group(1).split(",")]
+
+    dispatch_matrix_match = re.search(r"\|\|\s*'(\[[^']+\])'", content)
+    assert dispatch_matrix_match is not None, f"{path} does not declare a market matrix"
+    return list(json.loads(dispatch_matrix_match.group(1)))
 
 
 def test_static_and_weekly_reference_workflows_cover_supported_markets():
-    expected = ["US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE"]
+    expected = list(market_registry.supported_market_codes())
 
     assert _workflow_matrix_markets(".github/workflows/static-site.yml") == expected
     assert _workflow_matrix_markets(".github/workflows/weekly-reference-data.yml") == expected

--- a/backend/tests/unit/test_ui_snapshot_service.py
+++ b/backend/tests/unit/test_ui_snapshot_service.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine, func, text
 from sqlalchemy.orm import sessionmaker
 
 from app.database import Base
+from app.domain.markets import market_registry
 from app.infra.db.models.feature_store import FeatureRun
 from app.models.industry import IBDGroupRank
 from app.models.market_breadth import MarketBreadth
@@ -256,7 +257,7 @@ def test_publish_all_skips_groups_when_rankings_are_missing(monkeypatch):
     assert published["breadth_hk"] == fake_snapshot
     assert published["breadth_in"] == fake_snapshot
     assert published["breadth_cn"] == fake_snapshot
-    assert published_breadth_markets == ["US", "HK", "IN", "JP", "KR", "TW", "CN", "CA", "DE"]
+    assert published_breadth_markets == list(market_registry.supported_market_codes())
     assert published["groups"] is None
 
 

--- a/backend/tests/unit/test_universe_compat_adapter.py
+++ b/backend/tests/unit/test_universe_compat_adapter.py
@@ -77,3 +77,16 @@ def test_market_cn_legacy_alias_maps_to_typed_market_with_hint():
     assert resolved.universe_def.type == UniverseType.MARKET
     assert resolved.universe_def.market.value == "CN"
     assert resolved.migration_hint == {"type": "market", "market": "CN"}
+
+
+def test_market_de_legacy_alias_maps_to_typed_market_with_hint():
+    resolved = resolve_scan_universe_request(
+        universe_def=None,
+        legacy_universe="market:de",
+        legacy_symbols=None,
+    )
+
+    assert resolved.used_legacy is True
+    assert resolved.universe_def.type == UniverseType.MARKET
+    assert resolved.universe_def.market.value == "DE"
+    assert resolved.migration_hint == {"type": "market", "market": "DE"}

--- a/backend/tests/unit/test_universe_schema.py
+++ b/backend/tests/unit/test_universe_schema.py
@@ -285,6 +285,11 @@ class TestFromLegacy:
         assert u.type == UniverseType.MARKET
         assert u.market == Market.CN
 
+    def test_market_prefixed_germany(self):
+        u = UniverseDefinition.from_legacy("market:de")
+        assert u.type == UniverseType.MARKET
+        assert u.market == Market.DE
+
     def test_market_short_code_without_prefix_is_not_legacy(self):
         with pytest.raises(ValueError, match="Unknown universe"):
             UniverseDefinition.from_legacy("hk")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ x-app-env: &app-env
   GROQ_API_KEYS: ${GROQ_API_KEYS:-}
   TAVILY_API_KEY: ${TAVILY_API_KEY:-}
   SERPER_API_KEY: ${SERPER_API_KEY:-}
+  X_INGEST_PROVIDER: ${X_INGEST_PROVIDER:-official}
+  TWITTER_BEARER_TOKEN: ${TWITTER_BEARER_TOKEN:-}
+  X_API_MAX_PAGES_PER_SOURCE: ${X_API_MAX_PAGES_PER_SOURCE:-10}
   XUI_ENABLED: ${XUI_ENABLED:-false}
   XUI_CONFIG_PATH: ${XUI_CONFIG_PATH:-/app/data/xui-reader/config.toml}
   XUI_PROFILE: ${XUI_PROFILE:-default}
@@ -207,6 +210,11 @@ services:
     profiles: ["market-cn"]
     command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q market_jobs_cn -n marketjobs-cn@%h
 
+  celery-marketjobs-ca:
+    <<: *worker-common
+    profiles: ["market-ca"]
+    command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q market_jobs_ca -n marketjobs-ca@%h
+
   celery-marketjobs-de:
     <<: *worker-common
     profiles: ["market-de"]
@@ -250,6 +258,11 @@ services:
     <<: *worker-common
     profiles: ["market-cn"]
     command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q user_scans_cn -n userscans-cn@%h
+
+  celery-userscans-ca:
+    <<: *worker-common
+    profiles: ["market-ca"]
+    command: celery -A app.celery_app worker --pool=prefork --loglevel=info --concurrency=1 --without-mingle --without-gossip -Q user_scans_ca -n userscans-ca@%h
 
   celery-userscans-de:
     <<: *worker-common


### PR DESCRIPTION
## Summary
- add DE to the typed legacy universe parsing path used by static feature snapshots
- derive static export, daily price bundle, weekly reference, and static manifest supported-market lists from the market registry/catalog
- add CA/DE exchange suffix normalization coverage for security-master canonical symbols

## Root cause
The static-site workflow matrix included DE, but the backend still had older hard-coded market allowlists in several static workflow services. The DE job failed when `market:de` reached `UniverseDefinition.from_legacy` and was rejected as an unknown market.

## Validation
- `cd backend && /Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest tests/unit/test_static_workflow_markets.py tests/unit/test_export_static_site_script.py::test_static_export_markets_match_market_registry tests/unit/test_daily_price_bundle_scripts.py::test_daily_and_weekly_reference_script_markets_match_market_registry tests/unit/test_security_master_service.py::test_resolve_identity_uses_canada_and_germany_suffixes_by_exchange tests/unit/test_universe_schema.py::TestFromLegacy::test_market_prefixed_germany tests/unit/test_universe_compat_adapter.py::test_market_de_legacy_alias_maps_to_typed_market_with_hint`

## Notes
- This PR was cut from `origin/main` into a clean branch because the previous working branch already had an unrelated open draft PR (#173).
