### PR TITLE
Fix sparkline validation to reject non-finite values

### DIFF
--- a/backend/app/infra/serialization.py
+++ b/backend/app/infra/serialization.py
@@ -6,7 +6,35 @@ pandas) and Python-native types suitable for JSON/SQLAlchemy persistence.
 
 from __future__ import annotations
 
+import math
 from datetime import date, datetime
+from typing import Any, Optional
+
+
+def sanitize_sparkline(value: Any) -> Optional[list[float]]:
+    """Return a finite-float list, or ``None`` if any element is null/non-finite.
+
+    Sparkline payloads serialised through ``convert_numpy_types`` get NaN/Inf
+    rewritten to ``None``, which then fails ``List[float]`` validation in the
+    response schemas.  Collapsing the whole sparkline to ``None`` keeps the
+    surrounding row exportable.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)):
+        return None
+    sanitized: list[float] = []
+    for element in value:
+        if element is None:
+            return None
+        try:
+            as_float = float(element)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(as_float):
+            return None
+        sanitized.append(as_float)
+    return sanitized
 
 
 def normalize_string_list(value: object) -> list[str]:

--- a/backend/app/scanners/criteria/price_sparkline.py
+++ b/backend/app/scanners/criteria/price_sparkline.py
@@ -51,13 +51,30 @@ class PriceSparklineCalculator:
             }
 
         try:
-            # Get last 30 trading days (most recent data)
-            stock_last_30 = stock_prices.iloc[-self.SPARKLINE_DAYS:].values
+            # Get last 30 trading days (most recent data) as float to make
+            # NaN/Inf checks consistent regardless of source dtype.
+            stock_last_30 = np.asarray(
+                stock_prices.iloc[-self.SPARKLINE_DAYS:].values, dtype=float
+            )
 
             price_change_1d = self._calculate_price_change_1d(stock_prices)
 
-            # Handle any NaN values
-            price_series = np.nan_to_num(stock_last_30, nan=stock_last_30[0])
+            # If the window contains no finite samples (all NaN/Inf), bail out
+            # to None instead of emitting [nan, ...] — downstream Pydantic
+            # serialization converts NaN to null and rejects List[None].
+            finite_mask = np.isfinite(stock_last_30)
+            if not finite_mask.any():
+                logger.debug("All-non-finite price series; returning None sparkline")
+                return {
+                    "price_data": None,
+                    "price_trend": 0,
+                    "price_change_1d": price_change_1d,
+                }
+
+            # Replace any NaN/Inf with the first finite value so the series is
+            # fully finite even when the leading bar is missing.
+            first_finite = float(stock_last_30[np.argmax(finite_mask)])
+            price_series = np.where(finite_mask, stock_last_30, first_finite)
 
             # Normalize to start at 1.0 if requested (better for visual comparison)
             if normalize and price_series[0] != 0:
@@ -80,6 +97,16 @@ class PriceSparklineCalculator:
 
             # Round values for JSON storage efficiency (4 decimal places)
             price_data = [round(float(v), 4) for v in price_series]
+
+            # Final safety net: if rounding/normalization produced any non-finite
+            # value, collapse the whole payload to None.
+            if not all(np.isfinite(v) for v in price_data):
+                logger.debug("Non-finite values after normalization; returning None sparkline")
+                return {
+                    "price_data": None,
+                    "price_trend": 0,
+                    "price_change_1d": price_change_1d,
+                }
 
             return {
                 "price_data": price_data,

--- a/backend/app/schemas/groups.py
+++ b/backend/app/schemas/groups.py
@@ -1,8 +1,9 @@
 """Pydantic schemas for IBD Industry Group Rankings API endpoints"""
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from datetime import date as Date
-from typing import Optional, List
+from typing import Any, Optional, List
 
+from ..infra.serialization import sanitize_sparkline
 from .scope import ScopedResponseMixin
 
 
@@ -68,11 +69,16 @@ class ConstituentStock(BaseModel):
     sales_growth_yy: Optional[float] = Field(None, description="Sales growth year-over-year %")
     composite_score: Optional[float] = Field(None, description="Composite screener score")
     stage: Optional[int] = Field(None, description="Weinstein stage (1-4)")
-    price_sparkline_data: Optional[list] = Field(None, description="30-day normalized price trend")
+    price_sparkline_data: Optional[List[float]] = Field(None, description="30-day normalized price trend")
     price_trend: Optional[int] = Field(None, description="Price trend: -1=down, 0=flat, 1=up")
     price_change_1d: Optional[float] = Field(None, description="1-day price change %")
-    rs_sparkline_data: Optional[list] = Field(None, description="30-day RS ratio trend")
+    rs_sparkline_data: Optional[List[float]] = Field(None, description="30-day RS ratio trend")
     rs_trend: Optional[int] = Field(None, description="RS trend: -1=declining, 0=flat, 1=improving")
+
+    @field_validator("price_sparkline_data", "rs_sparkline_data", mode="before")
+    @classmethod
+    def _validate_sparkline(cls, value: Any) -> Optional[List[float]]:
+        return sanitize_sparkline(value)
 
 
 class GroupDetailResponse(ScopedResponseMixin):

--- a/backend/app/schemas/scanning.py
+++ b/backend/app/schemas/scanning.py
@@ -7,10 +7,10 @@ paginated results, filter options, and score explanations.
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ..domain.scanning.models import ScanResultItemDomain, StockExplanation
-from ..infra.serialization import normalize_string_list
+from ..infra.serialization import normalize_string_list, sanitize_sparkline
 from .universe import UniverseDefinition
 
 
@@ -214,6 +214,11 @@ class ScanResultItem(BaseModel):
     unavailable_screeners: List[str] = Field(default_factory=list)
     composite_reason: Optional[str] = None
     ipo_bonus: Optional[float] = None
+
+    @field_validator("price_sparkline_data", "rs_sparkline_data", mode="before")
+    @classmethod
+    def _validate_sparkline(cls, value: Any) -> Optional[List[float]]:
+        return sanitize_sparkline(value)
 
     @classmethod
     def from_domain(

--- a/backend/tests/unit/test_price_sparkline.py
+++ b/backend/tests/unit/test_price_sparkline.py
@@ -1,0 +1,110 @@
+"""Regression tests for PriceSparklineCalculator and sparkline schema validation.
+
+CA and DE static-export pipelines crashed because price_sparkline_data contained
+30 nulls — ScanResultItem requires List[float] and Pydantic rejected the row.
+The regressions below cover the two upstream shapes that produced that output:
+an all-None list and an all-NaN price input.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.scanners.criteria.price_sparkline import PriceSparklineCalculator
+from app.schemas.scanning import ScanResultItem
+
+
+def test_all_nan_price_input_returns_none_payload():
+    series = pd.Series([float("nan")] * 30)
+
+    result = PriceSparklineCalculator().calculate_price_sparkline(series)
+
+    assert result["price_data"] is None
+    assert result["price_trend"] == 0
+    assert result["price_change_1d"] is None
+
+
+def test_all_inf_price_input_returns_none_payload():
+    series = pd.Series([math.inf] * 30)
+
+    result = PriceSparklineCalculator().calculate_price_sparkline(series)
+
+    assert result["price_data"] is None
+
+
+def test_leading_nan_uses_first_finite_fill():
+    values = [float("nan")] * 5 + [100.0 + i for i in range(25)]
+    series = pd.Series(values)
+
+    result = PriceSparklineCalculator().calculate_price_sparkline(series)
+
+    assert result["price_data"] is not None
+    assert len(result["price_data"]) == 30
+    for value in result["price_data"]:
+        assert math.isfinite(value)
+
+
+def test_clean_input_still_produces_finite_normalized_series():
+    closes = [10.0 + i * 0.5 for i in range(30)]
+    series = pd.Series(closes)
+
+    result = PriceSparklineCalculator().calculate_price_sparkline(series)
+
+    assert result["price_data"] is not None
+    assert len(result["price_data"]) == 30
+    assert result["price_data"][0] == pytest.approx(1.0)
+    assert result["price_trend"] == 1
+
+
+def test_scan_result_item_collapses_all_none_sparkline_to_none():
+    item = ScanResultItem(
+        symbol="DE-FOO",
+        rating="Watch",
+        price_sparkline_data=[None] * 30,
+        rs_sparkline_data=[None] * 30,
+    )
+
+    assert item.price_sparkline_data is None
+    assert item.rs_sparkline_data is None
+
+
+def test_scan_result_item_collapses_single_nan_element_to_none():
+    item = ScanResultItem(
+        symbol="CA-FOO",
+        rating="Watch",
+        price_sparkline_data=[1.0] * 29 + [float("nan")],
+    )
+
+    assert item.price_sparkline_data is None
+
+
+def test_scan_result_item_accepts_clean_float_sparkline():
+    clean = [1.0 + i * 0.01 for i in range(30)]
+
+    item = ScanResultItem(
+        symbol="OK",
+        rating="Buy",
+        price_sparkline_data=clean,
+        rs_sparkline_data=clean,
+    )
+
+    assert item.price_sparkline_data == clean
+    assert item.rs_sparkline_data == clean
+
+
+def test_scan_result_item_collapses_numpy_nan_serialized_to_none():
+    series = np.full(30, np.nan)
+    # Mirror the convert_numpy_types path: NaN floats become None in the list.
+    payload = [None if math.isnan(v) else float(v) for v in series]
+
+    item = ScanResultItem(
+        symbol="DE-NAN",
+        rating="Watch",
+        price_sparkline_data=payload,
+    )
+
+    assert item.price_sparkline_data is None


### PR DESCRIPTION
## Summary

Fix a regression where CA and DE static-export pipelines crashed due to `price_sparkline_data` containing null values that failed Pydantic's `List[float]` validation. The issue occurred when price data was all-NaN or all-Inf, producing lists of nulls after serialization.

## Key Changes

- **`price_sparkline.py`**: Enhanced `PriceSparklineCalculator.calculate_price_sparkline()` to:
  - Detect all-non-finite input windows (all NaN/Inf) and return `None` instead of emitting `[nan, ...]`
  - Use first finite value for forward-fill instead of first element (handles leading NaN)
  - Add final safety check after normalization to catch any remaining non-finite values
  - Convert input to float dtype for consistent NaN/Inf detection across source types

- **`serialization.py`**: Added `sanitize_sparkline()` utility function to:
  - Validate sparkline lists contain only finite floats
  - Collapse entire sparkline to `None` if any element is null or non-finite
  - Serve as a defensive layer for downstream serialization issues

- **`schemas/scanning.py` & `schemas/groups.py`**: Added Pydantic field validators to:
  - Apply `sanitize_sparkline()` to `price_sparkline_data` and `rs_sparkline_data` fields
  - Ensure all sparkline payloads are either valid `List[float]` or `None`
  - Prevent schema validation failures from non-finite values

- **`test_price_sparkline.py`**: Added comprehensive regression tests covering:
  - All-NaN and all-Inf inputs returning `None` payload
  - Leading NaN values using first finite value for fill
  - Clean input producing normalized finite series
  - Pydantic schema collapsing all-None lists, single NaN elements, and numpy NaN serialization to `None`

## Implementation Details

The fix uses a three-layer defense strategy:
1. **Calculator layer**: Detect and bail early on all-non-finite windows
2. **Serialization layer**: Validate and sanitize sparkline lists before schema validation
3. **Schema layer**: Final Pydantic validators ensure type safety

This prevents null values from reaching downstream consumers while maintaining backward compatibility for valid sparkline data.

https://claude.ai/code/session_017nrBJmRknSSwzYcNSXTiuH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and handling of sparkline data fields to properly manage invalid or non-finite values, ensuring more reliable data representation in price and relative strength sparklines.

* **Tests**
  * Added comprehensive test coverage for sparkline calculation and validation logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->