### PR TITLE
feat(breadth): attribute 4% movers to IBD industry groups on static site

### DIFF
--- a/backend/app/services/breadth_attribution_service.py
+++ b/backend/app/services/breadth_attribution_service.py
@@ -1,0 +1,196 @@
+"""Service for attributing daily breadth movers (4% up/down) to IBD industry groups.
+
+Given the symbol universe for a market and their cached price histories, this
+service classifies each ±4% daily mover into its IBD industry group (US) so the
+breadth UI can show "what is driving the breadth" per session. Symbols with no
+IBD group assignment fall into the synthetic "No Group" bucket.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import date
+from typing import Any, Iterable, Mapping
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+NO_GROUP_LABEL = "No Group"
+MOVER_THRESHOLD_PCT = 4.0
+
+
+class BreadthAttributionService:
+    """Compute per-date IBD-group attribution for ±4% daily movers."""
+
+    def __init__(self, *, threshold_pct: float = MOVER_THRESHOLD_PCT) -> None:
+        self._threshold_pct = float(threshold_pct)
+
+    def compute(
+        self,
+        *,
+        symbols_meta: Iterable[Mapping[str, Any]],
+        price_data: Mapping[str, pd.DataFrame | None],
+        target_dates: Iterable[date],
+    ) -> list[dict[str, Any]]:
+        """Return attribution rows ordered oldest → newest.
+
+        Args:
+            symbols_meta: Iterable of dicts with at minimum ``symbol``; optional
+                ``company_name`` and ``ibd_industry_group``.
+            price_data: ``{symbol: DataFrame}`` of cached price history (Close
+                required, datetime index). Missing/empty frames are skipped.
+            target_dates: Trading dates to attribute. Each yields one entry in
+                the returned list.
+
+        Each entry shape::
+
+            {
+                "date": "YYYY-MM-DD",
+                "stocks_up_4pct": int,
+                "stocks_down_4pct": int,
+                "groups": [
+                    {
+                        "group": str,
+                        "up_count": int,
+                        "down_count": int,
+                        "net": int,                # up - down
+                        "up_stocks":   [{symbol, name, pct_change, close}, ...],
+                        "down_stocks": [{symbol, name, pct_change, close}, ...],
+                    },
+                    ...
+                ],
+            }
+        """
+        meta_by_symbol: dict[str, Mapping[str, Any]] = {}
+        for entry in symbols_meta:
+            if not entry:
+                continue
+            symbol = entry.get("symbol")
+            if not symbol:
+                continue
+            meta_by_symbol[str(symbol).upper()] = entry
+
+        ordered_dates = sorted({d for d in target_dates if d is not None})
+        if not ordered_dates or not meta_by_symbol:
+            return []
+
+        date_index = pd.Index(ordered_dates)
+        per_date: dict[date, dict[str, dict[str, Any]]] = {d: {} for d in ordered_dates}
+
+        for symbol, meta in meta_by_symbol.items():
+            history = price_data.get(symbol)
+            if history is None or getattr(history, "empty", True):
+                continue
+            if "Close" not in history.columns:
+                continue
+
+            close_series = pd.Series(
+                history["Close"].to_numpy(),
+                index=[ts.date() for ts in pd.to_datetime(history.index)],
+            )
+            close_series = close_series[~close_series.index.duplicated(keep="last")].sort_index()
+            if close_series.empty:
+                continue
+
+            pct_1d = ((close_series / close_series.shift(1)) - 1.0) * 100.0
+            close_aligned = close_series.reindex(date_index)
+            pct_aligned = pct_1d.reindex(date_index)
+
+            group = self._resolve_group(meta.get("ibd_industry_group"))
+            name = meta.get("company_name") or meta.get("name")
+
+            for idx, d in enumerate(ordered_dates):
+                close_val = close_aligned.iloc[idx]
+                pct_val = pct_aligned.iloc[idx]
+                if pd.isna(close_val) or pd.isna(pct_val):
+                    continue
+                pct_val = float(pct_val)
+                if not math.isfinite(pct_val):
+                    continue
+
+                direction = self._classify(pct_val)
+                if direction is None:
+                    continue
+
+                close_float = float(close_val) if math.isfinite(float(close_val)) else None
+                stock_entry = {
+                    "symbol": symbol,
+                    "name": name,
+                    "pct_change": round(pct_val, 2),
+                    "close": round(close_float, 2) if close_float is not None else None,
+                }
+
+                bucket = per_date[d].setdefault(
+                    group,
+                    {"up_stocks": [], "down_stocks": []},
+                )
+                bucket[f"{direction}_stocks"].append(stock_entry)
+
+        results: list[dict[str, Any]] = []
+        for d in ordered_dates:
+            groups_for_day = per_date[d]
+            groups_payload: list[dict[str, Any]] = []
+            for group_name, bucket in groups_for_day.items():
+                up_stocks = sorted(
+                    bucket["up_stocks"],
+                    key=lambda row: row["pct_change"],
+                    reverse=True,
+                )
+                down_stocks = sorted(
+                    bucket["down_stocks"],
+                    key=lambda row: row["pct_change"],
+                )
+                up_count = len(up_stocks)
+                down_count = len(down_stocks)
+                if up_count == 0 and down_count == 0:
+                    continue
+                groups_payload.append(
+                    {
+                        "group": group_name,
+                        "up_count": up_count,
+                        "down_count": down_count,
+                        "net": up_count - down_count,
+                        "up_stocks": up_stocks,
+                        "down_stocks": down_stocks,
+                    }
+                )
+
+            # Sort by total activity descending, then net descending, then name.
+            groups_payload.sort(
+                key=lambda row: (
+                    -(row["up_count"] + row["down_count"]),
+                    -row["net"],
+                    row["group"],
+                )
+            )
+            total_up = sum(row["up_count"] for row in groups_payload)
+            total_down = sum(row["down_count"] for row in groups_payload)
+            results.append(
+                {
+                    "date": d.isoformat(),
+                    "stocks_up_4pct": total_up,
+                    "stocks_down_4pct": total_down,
+                    "groups": groups_payload,
+                }
+            )
+
+        return results
+
+    def _classify(self, pct_change: float) -> str | None:
+        if pct_change >= self._threshold_pct:
+            return "up"
+        if pct_change <= -self._threshold_pct:
+            return "down"
+        return None
+
+    @staticmethod
+    def _resolve_group(raw_group: Any) -> str:
+        if raw_group is None:
+            return NO_GROUP_LABEL
+        text = str(raw_group).strip()
+        if not text:
+            return NO_GROUP_LABEL
+        return text

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -1096,13 +1096,17 @@ class StaticSiteExportService:
             price_data=price_data,
             target_dates=attribution_dates,
         )
-        if not history:
+        has_any_mover = any(
+            (day.get("stocks_up_4pct", 0) + day.get("stocks_down_4pct", 0)) > 0
+            for day in history
+        )
+        if not history or not has_any_mover:
             return {
                 "available": False,
                 "reason": "No 4%+ movers were attributable for the lookback window.",
             }
 
-        latest = history[-1] if history else None
+        latest = history[-1]
         return {
             "available": True,
             "market": market,

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -30,6 +30,7 @@ from app.schemas.groups import (
     MoversResponse,
 )
 from app.schemas.scanning import FilterOptionsResponse, ScanResultItem
+from app.services.breadth_attribution_service import BreadthAttributionService
 from app.services.preset_screens import PRESET_SCREENS, get_preset_chart_symbols
 from app.services.ui_snapshot_service import UISnapshotService
 from app.wiring.bootstrap import (
@@ -55,6 +56,8 @@ STATIC_CHART_PRESET_TOP_N = 200
 STATIC_CHART_TOP_N_GROUPS = 50
 STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
 STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
+STATIC_BREADTH_ATTRIBUTION_LOOKBACK_DAYS = 10
+STATIC_BREADTH_ATTRIBUTION_MARKETS = ("US",)
 STATIC_DEFAULT_MARKET = "US"
 _MARKET_CATALOG = get_market_catalog()
 STATIC_SUPPORTED_MARKETS = tuple(_MARKET_CATALOG.supported_market_codes())
@@ -1019,6 +1022,12 @@ class StaticSiteExportService:
             period_days=31,
             end_date=expected_as_of_date,
         )
+        group_attribution = self._build_group_attribution(
+            market=market,
+            serialized_rows=serialized_rows,
+            price_data=price_data,
+            ordered_dates=ordered_dates,
+        )
         return {
             "schema_version": STATIC_SITE_SCHEMA_VERSION,
             "generated_at": generated_at,
@@ -1041,7 +1050,66 @@ class StaticSiteExportService:
                 "benchmark_symbol": benchmark_symbol,
                 "benchmark_overlay": benchmark_overlay,
                 "spy_overlay": benchmark_overlay,
+                "group_attribution": group_attribution,
             },
+        }
+
+    def _build_group_attribution(
+        self,
+        *,
+        market: str,
+        serialized_rows: list[dict[str, Any]],
+        price_data: dict[str, pd.DataFrame | None],
+        ordered_dates: list[date],
+    ) -> dict[str, Any]:
+        """Attribute ±4% movers to IBD industry groups for the most recent sessions.
+
+        Only enabled for markets in ``STATIC_BREADTH_ATTRIBUTION_MARKETS`` — non-US
+        taxonomies aren't wired in for the first cut. Returns an
+        ``{available: False, reason}`` payload when skipped so the static client
+        can hide the feature cleanly.
+        """
+        if market not in STATIC_BREADTH_ATTRIBUTION_MARKETS:
+            return {
+                "available": False,
+                "reason": f"Group attribution is not yet supported for market {market}.",
+            }
+        if not ordered_dates:
+            return {
+                "available": False,
+                "reason": "No trading dates were available to attribute.",
+            }
+
+        attribution_dates = ordered_dates[-STATIC_BREADTH_ATTRIBUTION_LOOKBACK_DAYS:]
+        symbols_meta = [
+            {
+                "symbol": row.get("symbol"),
+                "company_name": row.get("company_name"),
+                "ibd_industry_group": row.get("ibd_industry_group"),
+            }
+            for row in serialized_rows
+            if row.get("symbol")
+        ]
+        service = BreadthAttributionService()
+        history = service.compute(
+            symbols_meta=symbols_meta,
+            price_data=price_data,
+            target_dates=attribution_dates,
+        )
+        if not history:
+            return {
+                "available": False,
+                "reason": "No 4%+ movers were attributable for the lookback window.",
+            }
+
+        latest = history[-1] if history else None
+        return {
+            "available": True,
+            "market": market,
+            "threshold_pct": 4.0,
+            "lookback_days": STATIC_BREADTH_ATTRIBUTION_LOOKBACK_DAYS,
+            "latest_date": latest["date"] if latest else None,
+            "history": list(reversed(history)),
         }
 
     def _build_groups_payload(

--- a/backend/tests/unit/test_breadth_attribution_service.py
+++ b/backend/tests/unit/test_breadth_attribution_service.py
@@ -1,0 +1,191 @@
+"""Unit tests for ``BreadthAttributionService``."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from app.services.breadth_attribution_service import (
+    NO_GROUP_LABEL,
+    BreadthAttributionService,
+)
+
+
+def _frame(closes: list[float], start: str = "2026-05-01") -> pd.DataFrame:
+    idx = pd.date_range(start=start, periods=len(closes), freq="D")
+    return pd.DataFrame({"Close": closes}, index=idx)
+
+
+def test_compute_returns_empty_when_no_symbols():
+    service = BreadthAttributionService()
+    result = service.compute(
+        symbols_meta=[],
+        price_data={},
+        target_dates=[date(2026, 5, 5)],
+    )
+    assert result == []
+
+
+def test_compute_attributes_up_mover_to_ibd_group():
+    service = BreadthAttributionService()
+    # Day 1 = 100, Day 2 = 105 → +5%, exceeds 4% threshold.
+    price_data = {"PLTR": _frame([100.0, 105.0])}
+    symbols_meta = [
+        {
+            "symbol": "PLTR",
+            "company_name": "Palantir Technologies",
+            "ibd_industry_group": "Computer Software-Database",
+        }
+    ]
+
+    result = service.compute(
+        symbols_meta=symbols_meta,
+        price_data=price_data,
+        target_dates=[date(2026, 5, 2)],
+    )
+
+    assert len(result) == 1
+    day = result[0]
+    assert day["date"] == "2026-05-02"
+    assert day["stocks_up_4pct"] == 1
+    assert day["stocks_down_4pct"] == 0
+    assert len(day["groups"]) == 1
+    group = day["groups"][0]
+    assert group["group"] == "Computer Software-Database"
+    assert group["up_count"] == 1
+    assert group["down_count"] == 0
+    assert group["net"] == 1
+    assert group["up_stocks"][0]["symbol"] == "PLTR"
+    assert group["up_stocks"][0]["name"] == "Palantir Technologies"
+    assert group["up_stocks"][0]["pct_change"] == pytest.approx(5.0)
+    assert group["up_stocks"][0]["close"] == pytest.approx(105.0)
+
+
+def test_compute_attributes_down_mover():
+    service = BreadthAttributionService()
+    price_data = {"XYZ": _frame([100.0, 94.0])}  # -6%
+
+    result = service.compute(
+        symbols_meta=[{"symbol": "XYZ", "ibd_industry_group": "Banks-Money Center"}],
+        price_data=price_data,
+        target_dates=[date(2026, 5, 2)],
+    )
+
+    day = result[0]
+    assert day["stocks_up_4pct"] == 0
+    assert day["stocks_down_4pct"] == 1
+    group = day["groups"][0]
+    assert group["down_count"] == 1
+    assert group["net"] == -1
+    assert group["down_stocks"][0]["pct_change"] == pytest.approx(-6.0)
+
+
+def test_compute_buckets_missing_group_into_no_group():
+    service = BreadthAttributionService()
+    price_data = {
+        "AAA": _frame([100.0, 106.0]),  # +6%
+        "BBB": _frame([100.0, 108.0]),  # +8%
+    }
+    symbols_meta = [
+        {"symbol": "AAA"},  # No ibd_industry_group key
+        {"symbol": "BBB", "ibd_industry_group": "  "},  # Whitespace → No Group
+    ]
+
+    result = service.compute(
+        symbols_meta=symbols_meta,
+        price_data=price_data,
+        target_dates=[date(2026, 5, 2)],
+    )
+
+    day = result[0]
+    assert day["stocks_up_4pct"] == 2
+    assert len(day["groups"]) == 1
+    no_group = day["groups"][0]
+    assert no_group["group"] == NO_GROUP_LABEL
+    assert no_group["up_count"] == 2
+    assert {entry["symbol"] for entry in no_group["up_stocks"]} == {"AAA", "BBB"}
+
+
+def test_compute_skips_movers_below_threshold():
+    service = BreadthAttributionService()
+    # +3.5% — below the 4% threshold, should not appear.
+    price_data = {"FLAT": _frame([100.0, 103.5])}
+    result = service.compute(
+        symbols_meta=[{"symbol": "FLAT", "ibd_industry_group": "Retail"}],
+        price_data=price_data,
+        target_dates=[date(2026, 5, 2)],
+    )
+    assert result[0]["groups"] == []
+    assert result[0]["stocks_up_4pct"] == 0
+
+
+def test_compute_sorts_groups_by_total_activity_then_net():
+    service = BreadthAttributionService()
+    # Group A: 1 up, 0 down (activity=1, net=1)
+    # Group B: 2 up, 1 down (activity=3, net=1)
+    # Group C: 0 up, 2 down (activity=2, net=-2)
+    price_data = {
+        "A1": _frame([100.0, 110.0]),
+        "B1": _frame([100.0, 110.0]),
+        "B2": _frame([100.0, 110.0]),
+        "B3": _frame([100.0, 90.0]),
+        "C1": _frame([100.0, 90.0]),
+        "C2": _frame([100.0, 90.0]),
+    }
+    meta = [
+        {"symbol": "A1", "ibd_industry_group": "Alpha"},
+        {"symbol": "B1", "ibd_industry_group": "Bravo"},
+        {"symbol": "B2", "ibd_industry_group": "Bravo"},
+        {"symbol": "B3", "ibd_industry_group": "Bravo"},
+        {"symbol": "C1", "ibd_industry_group": "Charlie"},
+        {"symbol": "C2", "ibd_industry_group": "Charlie"},
+    ]
+    result = service.compute(
+        symbols_meta=meta,
+        price_data=price_data,
+        target_dates=[date(2026, 5, 2)],
+    )
+    groups = [g["group"] for g in result[0]["groups"]]
+    # Bravo first (highest activity=3), then Charlie (activity=2), then Alpha.
+    assert groups == ["Bravo", "Charlie", "Alpha"]
+
+
+def test_compute_returns_history_oldest_to_newest():
+    service = BreadthAttributionService()
+    # Three-day frame where day 2 has a +5% move and day 3 has -5%.
+    price_data = {"X": _frame([100.0, 105.0, 99.0])}
+    result = service.compute(
+        symbols_meta=[{"symbol": "X", "ibd_industry_group": "G"}],
+        price_data=price_data,
+        target_dates=[date(2026, 5, 2), date(2026, 5, 3)],
+    )
+    assert [day["date"] for day in result] == ["2026-05-02", "2026-05-03"]
+    assert result[0]["stocks_up_4pct"] == 1
+    assert result[1]["stocks_down_4pct"] == 1
+
+
+def test_compute_skips_dates_with_missing_price_data():
+    service = BreadthAttributionService()
+    price_data = {"X": _frame([100.0, 105.0])}  # Only covers 2026-05-01, 2026-05-02
+    result = service.compute(
+        symbols_meta=[{"symbol": "X", "ibd_industry_group": "G"}],
+        price_data=price_data,
+        target_dates=[date(2026, 5, 2), date(2026, 5, 10)],
+    )
+    # 2026-05-10 has no price → no group entry for that day.
+    by_date = {row["date"]: row for row in result}
+    assert by_date["2026-05-02"]["stocks_up_4pct"] == 1
+    assert by_date["2026-05-10"]["groups"] == []
+    assert by_date["2026-05-10"]["stocks_up_4pct"] == 0
+
+
+def test_compute_skips_symbols_without_price_data():
+    service = BreadthAttributionService()
+    result = service.compute(
+        symbols_meta=[{"symbol": "MISSING", "ibd_industry_group": "G"}],
+        price_data={"MISSING": None},
+        target_dates=[date(2026, 5, 2)],
+    )
+    assert result[0]["groups"] == []

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1183,6 +1183,53 @@ def test_build_breadth_payload_includes_us_group_attribution(
     assert "Retail-Apparel" not in groups_by_name
 
 
+def test_build_breadth_payload_marks_attribution_unavailable_when_no_movers(
+    service_and_session_factory,
+    monkeypatch,
+):
+    """History rows can be present yet all-zero — that must still flag unavailable."""
+    service, _session_factory = service_and_session_factory
+    idx = pd.date_range("2026-03-01", "2026-04-24", freq="D")
+
+    def flat_frame(price: float) -> pd.DataFrame:
+        closes = [price] * len(idx)
+        return pd.DataFrame(
+            {
+                "Open": closes,
+                "High": [value + 1 for value in closes],
+                "Low": [value - 1 for value in closes],
+                "Close": closes,
+                "Volume": [1000] * len(idx),
+            },
+            index=idx,
+        )
+
+    monkeypatch.setattr(
+        service,
+        "_get_market_benchmark_history",
+        lambda market, *, period: ("SPY", flat_frame(400.0)),
+    )
+    monkeypatch.setattr(
+        service,
+        "_get_cached_price_histories",
+        lambda symbols, *, period: {sym: flat_frame(100.0) for sym in symbols},
+    )
+
+    payload = service._build_breadth_payload(  # noqa: SLF001 - intentional unit coverage
+        generated_at="2026-04-24T22:00:00Z",
+        expected_as_of_date=date(2026, 4, 24),
+        market="US",
+        serialized_rows=[
+            {"symbol": "FLAT1", "ibd_industry_group": "Software"},
+            {"symbol": "FLAT2", "ibd_industry_group": "Banks"},
+        ],
+    )
+
+    attribution = payload["payload"]["group_attribution"]
+    assert attribution["available"] is False
+    assert "no 4%+ movers" in attribution["reason"].lower()
+
+
 def test_export_rejects_legacy_unscoped_run_for_market_bundle(
     service_and_session_factory,
     tmp_path,

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1064,6 +1064,123 @@ def test_build_breadth_payload_serialized_rows_emit_market_benchmark_overlay(
     assert breadth_payload["benchmark_symbol"] == "^HSI"
     assert breadth_payload["benchmark_overlay"] == breadth_payload["spy_overlay"]
     assert breadth_payload["benchmark_overlay"][-1]["date"] == "2026-04-24"
+    # Group attribution is US-only in the first cut.
+    assert breadth_payload["group_attribution"]["available"] is False
+
+
+def test_build_breadth_payload_includes_us_group_attribution(
+    service_and_session_factory,
+    monkeypatch,
+):
+    service, _session_factory = service_and_session_factory
+    idx = pd.date_range("2026-03-01", "2026-04-24", freq="D")
+
+    def flat_frame(price: float) -> pd.DataFrame:
+        closes = [price] * len(idx)
+        return pd.DataFrame(
+            {
+                "Open": closes,
+                "High": [value + 1 for value in closes],
+                "Low": [value - 1 for value in closes],
+                "Close": closes,
+                "Volume": [1000] * len(idx),
+            },
+            index=idx,
+        )
+
+    def gapping_frame(direction: str) -> pd.DataFrame:
+        # Holds at 100 until the second-to-last day, then jumps ±10% on the
+        # final session so only 2026-04-24 produces a mover.
+        closes = [100.0] * len(idx)
+        closes[-1] = 110.0 if direction == "up" else 90.0
+        return pd.DataFrame(
+            {
+                "Open": closes,
+                "High": [value + 1 for value in closes],
+                "Low": [value - 1 for value in closes],
+                "Close": closes,
+                "Volume": [1000] * len(idx),
+            },
+            index=idx,
+        )
+
+    histories = {
+        "PLTR": gapping_frame("up"),
+        "AAPL": gapping_frame("up"),
+        "BANK": gapping_frame("down"),
+        "FLAT": flat_frame(100.0),  # No 4% move at all
+        "NOGRP": gapping_frame("up"),
+    }
+    monkeypatch.setattr(
+        service,
+        "_get_market_benchmark_history",
+        lambda market, *, period: ("SPY", flat_frame(400.0)),
+    )
+    monkeypatch.setattr(
+        service,
+        "_get_cached_price_histories",
+        lambda symbols, *, period: {sym: histories.get(sym) for sym in symbols},
+    )
+
+    serialized_rows = [
+        {
+            "symbol": "PLTR",
+            "company_name": "Palantir Technologies",
+            "ibd_industry_group": "Computer Software-Database",
+        },
+        {
+            "symbol": "AAPL",
+            "company_name": "Apple Inc.",
+            "ibd_industry_group": "Computer Software-Database",
+        },
+        {
+            "symbol": "BANK",
+            "company_name": "Big Bank",
+            "ibd_industry_group": "Banks-Money Center",
+        },
+        {
+            "symbol": "FLAT",
+            "company_name": "No Move Corp",
+            "ibd_industry_group": "Retail-Apparel",
+        },
+        {
+            "symbol": "NOGRP",
+            "company_name": "Ungrouped Inc",
+            "ibd_industry_group": None,
+        },
+    ]
+
+    payload = service._build_breadth_payload(  # noqa: SLF001 - intentional unit coverage
+        generated_at="2026-04-24T22:00:00Z",
+        expected_as_of_date=date(2026, 4, 24),
+        market="US",
+        serialized_rows=serialized_rows,
+    )
+
+    attribution = payload["payload"]["group_attribution"]
+    assert attribution["available"] is True
+    assert attribution["market"] == "US"
+    assert attribution["threshold_pct"] == 4.0
+    assert attribution["latest_date"] == "2026-04-24"
+    assert attribution["lookback_days"] == 10
+    # history is newest-first
+    latest = attribution["history"][0]
+    assert latest["date"] == "2026-04-24"
+    assert latest["stocks_up_4pct"] == 3  # PLTR, AAPL, NOGRP
+    assert latest["stocks_down_4pct"] == 1  # BANK
+
+    groups_by_name = {row["group"]: row for row in latest["groups"]}
+    assert "Computer Software-Database" in groups_by_name
+    assert groups_by_name["Computer Software-Database"]["up_count"] == 2
+    assert {s["symbol"] for s in groups_by_name["Computer Software-Database"]["up_stocks"]} == {
+        "PLTR",
+        "AAPL",
+    }
+    assert groups_by_name["Banks-Money Center"]["down_count"] == 1
+    assert groups_by_name["No Group"]["up_count"] == 1
+    assert groups_by_name["No Group"]["up_stocks"][0]["symbol"] == "NOGRP"
+    # FLAT didn't move 4%, so Retail-Apparel should not appear.
+    assert "Retail-Apparel" not in groups_by_name
 
 
 def test_export_rejects_legacy_unscoped_run_for_market_bundle(

--- a/frontend/src/static/components/BreadthGroupAttribution.jsx
+++ b/frontend/src/static/components/BreadthGroupAttribution.jsx
@@ -78,16 +78,26 @@ function StockList({ title, stocks, color }) {
 function GroupRow({ row }) {
   const [open, setOpen] = useState(false);
   const totalActivity = row.up_count + row.down_count;
+  const toggle = () => setOpen((prev) => !prev);
 
   return (
     <>
       <TableRow
         hover
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={toggle}
         sx={{ cursor: 'pointer', '& > *': { borderBottom: 'unset' } }}
       >
         <TableCell sx={{ width: 32, py: 0.5 }}>
-          <IconButton size="small" sx={{ p: 0.25 }}>
+          <IconButton
+            size="small"
+            sx={{ p: 0.25 }}
+            aria-label={open ? `Collapse ${row.group}` : `Expand ${row.group}`}
+            aria-expanded={open}
+            onClick={(event) => {
+              event.stopPropagation();
+              toggle();
+            }}
+          >
             {open ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
           </IconButton>
         </TableCell>

--- a/frontend/src/static/components/BreadthGroupAttribution.jsx
+++ b/frontend/src/static/components/BreadthGroupAttribution.jsx
@@ -160,13 +160,15 @@ function BreadthGroupAttribution({ attribution }) {
     );
   }
 
-  if (!selectedDay || (selectedDay.groups || []).length === 0) {
+  if (!selectedDay) {
     return (
       <Alert severity="info" sx={{ fontSize: '12px' }}>
-        No 4%+ movers were attributed for the selected session.
+        No 4%+ movers were attributed for the lookback window.
       </Alert>
     );
   }
+
+  const hasGroups = (selectedDay.groups || []).length > 0;
 
   return (
     <Box>
@@ -208,37 +210,46 @@ function BreadthGroupAttribution({ attribution }) {
           />
           <Chip
             size="small"
-            label={`Groups: ${selectedDay.groups.length}`}
+            label={`Groups: ${(selectedDay.groups || []).length}`}
             variant="outlined"
           />
         </Box>
       </Box>
 
-      <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider' }}>
-        <TableContainer sx={{ maxHeight: 'calc(100vh - 320px)' }}>
-          <Table stickyHeader size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell sx={{ width: 32 }} />
-                <TableCell>IBD Industry Group</TableCell>
-                <TableCell align="right">Up 4%+</TableCell>
-                <TableCell align="right">Down 4%+</TableCell>
-                <TableCell align="right">Net</TableCell>
-                <TableCell align="right">Total</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {selectedDay.groups.map((row) => (
-                <GroupRow key={row.group} row={row} />
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Paper>
-      <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-        Click a group to expand its 4%+ movers. Stocks without an IBD industry group are bucketed
-        under &quot;No Group&quot;.
-      </Typography>
+      {hasGroups ? (
+        <>
+          <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider' }}>
+            <TableContainer sx={{ maxHeight: 'calc(100vh - 320px)' }}>
+              <Table stickyHeader size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ width: 32 }} />
+                    <TableCell>IBD Industry Group</TableCell>
+                    <TableCell align="right">Up 4%+</TableCell>
+                    <TableCell align="right">Down 4%+</TableCell>
+                    <TableCell align="right">Net</TableCell>
+                    <TableCell align="right">Total</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {selectedDay.groups.map((row) => (
+                    <GroupRow key={row.group} row={row} />
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Paper>
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+            Click a group to expand its 4%+ movers. Stocks without an IBD industry group are
+            bucketed under &quot;No Group&quot;.
+          </Typography>
+        </>
+      ) : (
+        <Alert severity="info" sx={{ fontSize: '12px' }}>
+          No 4%+ movers were attributed for {selectedDay.date}. Pick another session above to see
+          the groups that drove its breadth.
+        </Alert>
+      )}
     </Box>
   );
 }

--- a/frontend/src/static/components/BreadthGroupAttribution.jsx
+++ b/frontend/src/static/components/BreadthGroupAttribution.jsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  Collapse,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+
+const formatPct = (value) => {
+  if (value == null || Number.isNaN(value)) return '-';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}%`;
+};
+
+function StockList({ title, stocks, color }) {
+  if (!stocks || stocks.length === 0) {
+    return null;
+  }
+  return (
+    <Box sx={{ flex: 1, minWidth: 220 }}>
+      <Typography
+        variant="caption"
+        sx={{
+          fontSize: '10px',
+          fontWeight: 600,
+          color,
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+        }}
+      >
+        {title} ({stocks.length})
+      </Typography>
+      <Table size="small" sx={{ mt: 0.5 }}>
+        <TableBody>
+          {stocks.map((stock) => (
+            <TableRow key={stock.symbol}>
+              <TableCell sx={{ py: 0.25, fontFamily: 'monospace', fontWeight: 600, width: 70 }}>
+                {stock.symbol}
+              </TableCell>
+              <TableCell sx={{ py: 0.25, fontSize: '11px', color: 'text.secondary' }}>
+                {stock.name || ''}
+              </TableCell>
+              <TableCell
+                align="right"
+                sx={{ py: 0.25, fontFamily: 'monospace', color, fontWeight: 600, width: 80 }}
+              >
+                {formatPct(stock.pct_change)}
+              </TableCell>
+              <TableCell
+                align="right"
+                sx={{ py: 0.25, fontFamily: 'monospace', color: 'text.secondary', width: 70 }}
+              >
+                {stock.close != null ? `$${stock.close.toFixed(2)}` : '-'}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
+
+function GroupRow({ row }) {
+  const [open, setOpen] = useState(false);
+  const totalActivity = row.up_count + row.down_count;
+
+  return (
+    <>
+      <TableRow
+        hover
+        onClick={() => setOpen((prev) => !prev)}
+        sx={{ cursor: 'pointer', '& > *': { borderBottom: 'unset' } }}
+      >
+        <TableCell sx={{ width: 32, py: 0.5 }}>
+          <IconButton size="small" sx={{ p: 0.25 }}>
+            {open ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+          </IconButton>
+        </TableCell>
+        <TableCell sx={{ py: 0.5, fontWeight: 600 }}>{row.group}</TableCell>
+        <TableCell
+          align="right"
+          sx={{ py: 0.5, fontFamily: 'monospace', color: 'success.main', fontWeight: 600 }}
+        >
+          {row.up_count}
+        </TableCell>
+        <TableCell
+          align="right"
+          sx={{ py: 0.5, fontFamily: 'monospace', color: 'error.main', fontWeight: 600 }}
+        >
+          {row.down_count}
+        </TableCell>
+        <TableCell
+          align="right"
+          sx={{
+            py: 0.5,
+            fontFamily: 'monospace',
+            fontWeight: 700,
+            color: row.net > 0 ? 'success.main' : row.net < 0 ? 'error.main' : 'text.primary',
+          }}
+        >
+          {row.net > 0 ? `+${row.net}` : row.net}
+        </TableCell>
+        <TableCell align="right" sx={{ py: 0.5, fontFamily: 'monospace' }}>
+          {totalActivity}
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell sx={{ py: 0, borderBottom: open ? undefined : 'none' }} colSpan={6}>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', py: 1, px: 4 }}>
+              <StockList title="Up 4%+" stocks={row.up_stocks} color="success.main" />
+              <StockList title="Down 4%+" stocks={row.down_stocks} color="error.main" />
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}
+
+function BreadthGroupAttribution({ attribution }) {
+  const history = useMemo(() => attribution?.history || [], [attribution]);
+  const [selectedDate, setSelectedDate] = useState(history[0]?.date || null);
+
+  const selectedDay = useMemo(
+    () => history.find((day) => day.date === selectedDate) || history[0] || null,
+    [history, selectedDate]
+  );
+
+  if (!attribution || attribution.available === false) {
+    return (
+      <Alert severity="info" sx={{ fontSize: '12px' }}>
+        {attribution?.reason || 'Group attribution is not available for this market yet.'}
+      </Alert>
+    );
+  }
+
+  if (!selectedDay || (selectedDay.groups || []).length === 0) {
+    return (
+      <Alert severity="info" sx={{ fontSize: '12px' }}>
+        No 4%+ movers were attributed for the selected session.
+      </Alert>
+    );
+  }
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: 1.5,
+          mb: 1.5,
+          justifyContent: 'space-between',
+        }}
+      >
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="breadth-attribution-date-label">Session</InputLabel>
+          <Select
+            labelId="breadth-attribution-date-label"
+            label="Session"
+            value={selectedDay.date}
+            onChange={(event) => setSelectedDate(event.target.value)}
+          >
+            {history.map((day) => (
+              <MenuItem key={day.date} value={day.date}>
+                {day.date}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Chip
+            size="small"
+            label={`Up 4%+: ${selectedDay.stocks_up_4pct}`}
+            sx={{ bgcolor: 'rgba(76,175,80,0.16)', color: 'success.main', fontWeight: 600 }}
+          />
+          <Chip
+            size="small"
+            label={`Down 4%+: ${selectedDay.stocks_down_4pct}`}
+            sx={{ bgcolor: 'rgba(244,67,54,0.16)', color: 'error.main', fontWeight: 600 }}
+          />
+          <Chip
+            size="small"
+            label={`Groups: ${selectedDay.groups.length}`}
+            variant="outlined"
+          />
+        </Box>
+      </Box>
+
+      <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider' }}>
+        <TableContainer sx={{ maxHeight: 'calc(100vh - 320px)' }}>
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ width: 32 }} />
+                <TableCell>IBD Industry Group</TableCell>
+                <TableCell align="right">Up 4%+</TableCell>
+                <TableCell align="right">Down 4%+</TableCell>
+                <TableCell align="right">Net</TableCell>
+                <TableCell align="right">Total</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {selectedDay.groups.map((row) => (
+                <GroupRow key={row.group} row={row} />
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+      <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+        Click a group to expand its 4%+ movers. Stocks without an IBD industry group are bucketed
+        under &quot;No Group&quot;.
+      </Typography>
+    </Box>
+  );
+}
+
+export default BreadthGroupAttribution;

--- a/frontend/src/static/pages/StaticBreadthPage.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.jsx
@@ -6,15 +6,18 @@ import {
   CircularProgress,
   Grid,
   Paper,
+  Tab,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
+  Tabs,
   Typography,
 } from '@mui/material';
 import BreadthChart from '../../components/Charts/BreadthChart';
+import BreadthGroupAttribution from '../components/BreadthGroupAttribution';
 import { useStaticManifest, fetchStaticJson, resolveStaticMarketEntry } from '../dataClient';
 import { useStaticMarket } from '../StaticMarketContext';
 
@@ -47,8 +50,11 @@ function StaticBreadthPage() {
     staleTime: Infinity,
   });
   const [timeRange, setTimeRange] = useState('1M');
+  const [selectedTab, setSelectedTab] = useState(0);
 
   const payload = breadthQuery.data?.payload || {};
+  const groupAttribution = payload.group_attribution || null;
+  const attributionAvailable = Boolean(groupAttribution?.available);
   const displayName = marketEntry.display_name;
   const filteredChartData = useMemo(() => {
     const allData = payload.chart_data || payload.history_90d || [];
@@ -88,61 +94,80 @@ function StaticBreadthPage() {
         Breadth snapshot published {breadthQuery.data.published_at || breadthQuery.data.generated_at}.
       </Typography>
 
-      <Grid container spacing={1.5} sx={{ mb: 2 }}>
-        <Grid item xs={12} sm={6} md={3}>
-          <MetricCard label="Date" value={current.date} />
-        </Grid>
-        <Grid item xs={12} sm={6} md={3}>
-          <MetricCard label="Stocks Up 4%+" value={current.stocks_up_4pct} />
-        </Grid>
-        <Grid item xs={12} sm={6} md={3}>
-          <MetricCard label="Stocks Down 4%+" value={current.stocks_down_4pct} />
-        </Grid>
-        <Grid item xs={12} sm={6} md={3}>
-          <MetricCard label="10-day Ratio" value={current.ratio_10day?.toFixed?.(2) ?? '-'} />
-        </Grid>
-      </Grid>
+      <Tabs
+        value={selectedTab}
+        onChange={(_event, value) => setSelectedTab(value)}
+        sx={{ mb: 2, borderBottom: 1, borderColor: 'divider', minHeight: 36 }}
+      >
+        <Tab label="Overview" sx={{ minHeight: 36, fontSize: '12px' }} />
+        <Tab
+          label="By Group"
+          sx={{ minHeight: 36, fontSize: '12px' }}
+          disabled={!attributionAvailable && groupAttribution == null}
+        />
+      </Tabs>
 
-      <BreadthChart
-        breadthData={filteredChartData}
-        spyData={filteredSpyData}
-        benchmarkLabel={benchmarkLabel}
-        isLoading={false}
-        error={null}
-        timeRange={timeRange}
-        onTimeRangeChange={setTimeRange}
-        availableRanges={['1M', '3M']}
-      />
+      {selectedTab === 0 && (
+        <>
+          <Grid container spacing={1.5} sx={{ mb: 2 }}>
+            <Grid item xs={12} sm={6} md={3}>
+              <MetricCard label="Date" value={current.date} />
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <MetricCard label="Stocks Up 4%+" value={current.stocks_up_4pct} />
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <MetricCard label="Stocks Down 4%+" value={current.stocks_down_4pct} />
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <MetricCard label="10-day Ratio" value={current.ratio_10day?.toFixed?.(2) ?? '-'} />
+            </Grid>
+          </Grid>
 
-      <Paper elevation={0} sx={{ p: 1.5, border: '1px solid', borderColor: 'divider' }}>
-        <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: '13px', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 0.5 }}>
-          Recent Sessions
-        </Typography>
-        <TableContainer>
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Date</TableCell>
-                <TableCell align="right">Up 4%+</TableCell>
-                <TableCell align="right">Down 4%+</TableCell>
-                <TableCell align="right">5-day Ratio</TableCell>
-                <TableCell align="right">10-day Ratio</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {history.slice(0, 20).map((row) => (
-                <TableRow key={row.date}>
-                  <TableCell>{row.date}</TableCell>
-                  <TableCell align="right">{row.stocks_up_4pct}</TableCell>
-                  <TableCell align="right">{row.stocks_down_4pct}</TableCell>
-                  <TableCell align="right">{row.ratio_5day?.toFixed?.(2) ?? '-'}</TableCell>
-                  <TableCell align="right">{row.ratio_10day?.toFixed?.(2) ?? '-'}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Paper>
+          <BreadthChart
+            breadthData={filteredChartData}
+            spyData={filteredSpyData}
+            benchmarkLabel={benchmarkLabel}
+            isLoading={false}
+            error={null}
+            timeRange={timeRange}
+            onTimeRangeChange={setTimeRange}
+            availableRanges={['1M', '3M']}
+          />
+
+          <Paper elevation={0} sx={{ p: 1.5, border: '1px solid', borderColor: 'divider' }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: '13px', textTransform: 'uppercase', letterSpacing: '0.5px', mb: 0.5 }}>
+              Recent Sessions
+            </Typography>
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Date</TableCell>
+                    <TableCell align="right">Up 4%+</TableCell>
+                    <TableCell align="right">Down 4%+</TableCell>
+                    <TableCell align="right">5-day Ratio</TableCell>
+                    <TableCell align="right">10-day Ratio</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {history.slice(0, 20).map((row) => (
+                    <TableRow key={row.date}>
+                      <TableCell>{row.date}</TableCell>
+                      <TableCell align="right">{row.stocks_up_4pct}</TableCell>
+                      <TableCell align="right">{row.stocks_down_4pct}</TableCell>
+                      <TableCell align="right">{row.ratio_5day?.toFixed?.(2) ?? '-'}</TableCell>
+                      <TableCell align="right">{row.ratio_10day?.toFixed?.(2) ?? '-'}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Paper>
+        </>
+      )}
+
+      {selectedTab === 1 && <BreadthGroupAttribution attribution={groupAttribution} />}
     </Box>
   );
 }

--- a/frontend/src/static/pages/StaticBreadthPage.test.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.test.jsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { MemoryRouter } from 'react-router-dom';
@@ -153,5 +153,158 @@ describe('StaticBreadthPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Hong Kong Breadth' })).toBeInTheDocument();
     expect(screen.getByTestId('breadth-chart')).toHaveTextContent('^HSI:1');
+  });
+
+  it('renders the By Group tab with drill-down stock list when attribution data is present', async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      const path = String(url).split('/static-data/')[1];
+
+      if (path === 'manifest.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            default_market: 'US',
+            supported_markets: ['US'],
+            markets: {
+              US: {
+                display_name: 'United States',
+                pages: { breadth: { path: 'markets/us/breadth.json' } },
+              },
+            },
+            pages: {},
+          }),
+        };
+      }
+
+      if (path === 'markets/us/breadth.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            available: true,
+            generated_at: '2026-05-15T22:00:00Z',
+            payload: {
+              benchmark_symbol: 'SPY',
+              benchmark_overlay: [],
+              current: { market: 'US', date: '2026-05-15', stocks_up_4pct: 4, stocks_down_4pct: 1 },
+              chart_data: [],
+              history_90d: [],
+              group_attribution: {
+                available: true,
+                market: 'US',
+                threshold_pct: 4.0,
+                lookback_days: 10,
+                latest_date: '2026-05-15',
+                history: [
+                  {
+                    date: '2026-05-15',
+                    stocks_up_4pct: 4,
+                    stocks_down_4pct: 1,
+                    groups: [
+                      {
+                        group: 'Computer Software-Database',
+                        up_count: 2,
+                        down_count: 0,
+                        net: 2,
+                        up_stocks: [
+                          { symbol: 'PLTR', name: 'Palantir', pct_change: 7.2, close: 28.5 },
+                          { symbol: 'AAPL', name: 'Apple', pct_change: 4.5, close: 215.0 },
+                        ],
+                        down_stocks: [],
+                      },
+                      {
+                        group: 'No Group',
+                        up_count: 1,
+                        down_count: 1,
+                        net: 0,
+                        up_stocks: [
+                          { symbol: 'NEWCO', name: 'New Co', pct_change: 5.1, close: 12.4 },
+                        ],
+                        down_stocks: [
+                          { symbol: 'OLDCO', name: 'Old Co', pct_change: -4.3, close: 7.2 },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          }),
+        };
+      }
+
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'United States Breadth' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /by group/i }));
+
+    expect(await screen.findByText('Computer Software-Database')).toBeInTheDocument();
+    expect(screen.getByText('No Group')).toBeInTheDocument();
+
+    // Drill-down: clicking the group row should reveal the stock list.
+    fireEvent.click(screen.getByText('Computer Software-Database'));
+    expect(await screen.findByText('PLTR')).toBeInTheDocument();
+    expect(screen.getByText('AAPL')).toBeInTheDocument();
+  });
+
+  it('shows an info message inside the By Group tab when attribution is unavailable', async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      const path = String(url).split('/static-data/')[1];
+
+      if (path === 'manifest.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            default_market: 'US',
+            supported_markets: ['US', 'HK'],
+            markets: {
+              HK: {
+                display_name: 'Hong Kong',
+                pages: { breadth: { path: 'markets/hk/breadth.json' } },
+              },
+            },
+            pages: {},
+          }),
+        };
+      }
+
+      if (path === 'markets/hk/breadth.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            available: true,
+            generated_at: '2026-05-15T22:00:00Z',
+            payload: {
+              benchmark_symbol: '^HSI',
+              benchmark_overlay: [],
+              current: { market: 'HK', date: '2026-05-15', stocks_up_4pct: 6, stocks_down_4pct: 2 },
+              chart_data: [],
+              history_90d: [],
+              group_attribution: {
+                available: false,
+                reason: 'Group attribution is not yet supported for market HK.',
+              },
+            },
+          }),
+        };
+      }
+
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    renderPage('/breadth?market=HK');
+
+    expect(await screen.findByRole('heading', { name: 'Hong Kong Breadth' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /by group/i }));
+    expect(
+      await screen.findByText('Group attribution is not yet supported for market HK.')
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/static/pages/StaticBreadthPage.test.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.test.jsx
@@ -307,4 +307,95 @@ describe('StaticBreadthPage', () => {
       await screen.findByText('Group attribution is not yet supported for market HK.')
     ).toBeInTheDocument();
   });
+
+  it('keeps the session picker reachable when the latest session has no movers', async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      const path = String(url).split('/static-data/')[1];
+
+      if (path === 'manifest.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            default_market: 'US',
+            supported_markets: ['US'],
+            markets: {
+              US: {
+                display_name: 'United States',
+                pages: { breadth: { path: 'markets/us/breadth.json' } },
+              },
+            },
+            pages: {},
+          }),
+        };
+      }
+
+      if (path === 'markets/us/breadth.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            available: true,
+            generated_at: '2026-05-15T22:00:00Z',
+            payload: {
+              benchmark_symbol: 'SPY',
+              benchmark_overlay: [],
+              current: { market: 'US', date: '2026-05-15', stocks_up_4pct: 0, stocks_down_4pct: 0 },
+              chart_data: [],
+              history_90d: [],
+              group_attribution: {
+                available: true,
+                market: 'US',
+                threshold_pct: 4.0,
+                lookback_days: 10,
+                latest_date: '2026-05-15',
+                // History is newest-first. Latest session is quiet, prior session has movers.
+                history: [
+                  {
+                    date: '2026-05-15',
+                    stocks_up_4pct: 0,
+                    stocks_down_4pct: 0,
+                    groups: [],
+                  },
+                  {
+                    date: '2026-05-14',
+                    stocks_up_4pct: 1,
+                    stocks_down_4pct: 0,
+                    groups: [
+                      {
+                        group: 'Semiconductors',
+                        up_count: 1,
+                        down_count: 0,
+                        net: 1,
+                        up_stocks: [
+                          { symbol: 'NVDA', name: 'NVIDIA', pct_change: 6.1, close: 950.0 },
+                        ],
+                        down_stocks: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          }),
+        };
+      }
+
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'United States Breadth' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /by group/i }));
+
+    // The empty-session message is shown but the date picker remains usable.
+    expect(await screen.findByText(/No 4%\+ movers were attributed for 2026-05-15/i)).toBeInTheDocument();
+    const sessionCombobox = screen.getByRole('combobox', { name: /session/i });
+    fireEvent.mouseDown(sessionCombobox);
+    fireEvent.click(await screen.findByRole('option', { name: '2026-05-14' }));
+
+    // After switching, the prior session's groups render.
+    expect(await screen.findByText('Semiconductors')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Adds a "By Group" tab to the static breadth page that breaks down each
session's 4%+ daily movers (up/down) by IBD industry group, with
expandable rows showing the actual stocks driving each group's activity.
Stocks without an IBD group are bucketed under "No Group".

Backend (`BreadthAttributionService`) computes per-date attribution from
cached price histories and the scan-row IBD group metadata. The static
export wires this into `breadth.json` for the US market (last 10 trading
days). Non-US markets receive an `available: false` placeholder so the
client can hide or stub the tab cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added group attribution analysis displaying 4%+ movers organized by IBD Industry Group with per-group statistics (up/down counts and net activity)
* Introduced tabbed interface on breadth page with "Overview" and "By Group" tabs
* New "By Group" tab shows grouped mover statistics with expandable rows revealing individual stock details including percent change and close price

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->