### PR TITLE
ci(markets): include SG in weekly-reference and static-site matrices

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        market: [US, HK, IN, JP, KR, TW, CN, CA, DE]
+        market: [US, HK, IN, JP, KR, TW, CN, CA, DE, SG]
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -22,6 +22,7 @@ on:
           - CN
           - CA
           - DE
+          - SG
       max_runtime_minutes:
         description: >-
           Per-market deadline in minutes for the fundamentals refresh. Blank
@@ -94,7 +95,7 @@ jobs:
         # that variant; otherwise (scheduled cron, or dispatch with market=all)
         # run the full matrix. ``github.event.inputs.market`` is null on
         # scheduled runs, so we coerce to '' before the equality check.
-        market: ${{ fromJSON((github.event.inputs.market || 'all') != 'all' && format('["{0}"]', github.event.inputs.market) || '["US","HK","IN","JP","KR","TW","CN","CA","DE"]') }}
+        market: ${{ fromJSON((github.event.inputs.market || 'all') != 'all' && format('["{0}"]', github.event.inputs.market) || '["US","HK","IN","JP","KR","TW","CN","CA","DE","SG"]') }}
     services:
       postgres:
         image: postgres:16-alpine

--- a/backend/app/scripts/build_weekly_reference_bundle.py
+++ b/backend/app/scripts/build_weekly_reference_bundle.py
@@ -321,6 +321,15 @@ def _ingest_official_market_snapshot(db, stock_universe_service, snapshot) -> di
             snapshot_as_of=snapshot.snapshot_as_of,
             source_metadata=snapshot.source_metadata,
         )
+    if snapshot.market == "SG":
+        return stock_universe_service.ingest_sg_snapshot_rows(
+            db,
+            rows=snapshot.rows,
+            source_name=snapshot.source_name,
+            snapshot_id=snapshot.snapshot_id,
+            snapshot_as_of=snapshot.snapshot_as_of,
+            source_metadata=snapshot.source_metadata,
+        )
     raise ValueError(f"Unsupported official weekly reference market {snapshot.market!r}")
 
 

--- a/backend/tests/unit/test_weekly_reference_scripts.py
+++ b/backend/tests/unit/test_weekly_reference_scripts.py
@@ -494,6 +494,150 @@ def test_build_weekly_reference_bundle_runs_de_official_path(monkeypatch, tmp_pa
     assert "Weekly reference bundle complete for DE:" in stdout
 
 
+def test_build_weekly_reference_bundle_runs_sg_official_path(monkeypatch, tmp_path, capsys):
+    """Mirror of the DE official-path test for the SG fetcher.
+
+    Verifies the build script (1) fetches the SG snapshot via the official
+    source service, (2) routes the snapshot to ``ingest_sg_snapshot_rows``
+    rather than raising on ``Unsupported official weekly reference market``,
+    and (3) publishes/exports the resulting bundle.
+    """
+    published_at = datetime(2026, 5, 17, 12, 10, 0)
+    active_rows = [
+        SimpleNamespace(
+            symbol="D05.SI",
+            market="SG",
+            exchange="XSES",
+            name="DBS Group Holdings",
+            sector="Banks",
+            industry="Banks",
+            market_cap=95.0,
+        )
+    ]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.order_by.return_value.all.return_value = active_rows
+    fake_db = MagicMock()
+    fake_db.query.return_value = fake_query
+
+    monkeypatch.setattr(build_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(build_script, "SessionLocal", lambda: _fake_session(fake_db))
+
+    fetch_calls: list[str] = []
+    official_service = SimpleNamespace(
+        fetch_market_snapshot=lambda market: fetch_calls.append(market)
+        or SimpleNamespace(
+            market=market,
+            source_name="sg_manual_csv",
+            snapshot_id="sg-csv-fallback-2026-05-17",
+            snapshot_as_of="2026-05-17",
+            source_metadata={"source_urls": [], "fetch_mode": "csv_fallback"},
+            rows=(
+                {
+                    "symbol": "D05.SI",
+                    "name": "DBS Group Holdings",
+                    "exchange": "XSES",
+                    "sector": "",
+                    "industry": "",
+                    "market_cap": None,
+                    "isin": "SG1L01001701",
+                },
+            ),
+        )
+    )
+    monkeypatch.setattr(build_script, "OfficialMarketUniverseSourceService", lambda: official_service)
+
+    ingest_calls: list[dict[str, object]] = []
+    stock_universe_service = SimpleNamespace(
+        ingest_sg_snapshot_rows=lambda db, **kwargs: ingest_calls.append(kwargs)
+        or {"added": 1, "updated": 0, "deactivated": 0},
+    )
+    monkeypatch.setattr(build_script, "get_stock_universe_service", lambda: stock_universe_service)
+
+    hybrid_service = SimpleNamespace(
+        yfinance_delay_per_ticker=1.5,
+        fetch_fundamentals_batch=lambda symbols, **kwargs: (
+            kwargs["progress_callback"](1, len(symbols))
+            or {"D05.SI": {"market_cap": 95.0, "sector": "Banks"}}
+        ),
+        store_all_caches=lambda *args, **kwargs: {
+            "fundamentals_stored": 1,
+            "persisted_symbols": 1,
+            "failed_persistence_symbols": 0,
+            "failed": 0,
+            "provider_error_counts": {},
+        },
+    )
+    monkeypatch.setattr(build_script, "get_hybrid_fundamentals_service", lambda: hybrid_service)
+    monkeypatch.setattr(
+        build_script,
+        "get_fundamentals_cache",
+        lambda: SimpleNamespace(
+            get_many=lambda symbols: {"D05.SI": {"market_cap": 95.0, "sector": "Banks"}}
+        ),
+    )
+
+    export_calls: list[dict[str, object]] = []
+    provider_snapshot_service = SimpleNamespace(
+        build_market_snapshot_row=lambda **kwargs: {
+            "symbol": kwargs["symbol"],
+            "exchange": kwargs["exchange"],
+            "row_hash": "row-hash",
+            "normalized_payload": kwargs["normalized_payload"],
+            "raw_payload": kwargs["raw_payload"],
+        },
+        publish_market_snapshot_run=lambda db, **kwargs: {
+            "published": True,
+            "source_revision": "fundamentals_v1_sg:20260517121000",
+            "snapshot_key": kwargs["snapshot_key"],
+            "coverage": {"snapshot_symbols": 1, "active_symbols": 1},
+            "coverage_thresholds": {
+                "market": "SG",
+                "active_coverage": 1.0,
+                "min_active_coverage": 0.70,
+                "missing_ratio": 0.0,
+                "max_missing_ratio": 0.30,
+            },
+        },
+        get_published_run=lambda db, snapshot_key: type(
+            "Run",
+            (),
+            {
+                "published_at": published_at,
+                "created_at": published_at,
+                "source_revision": "fundamentals_v1_sg:20260517121000",
+            },
+        )(),
+        export_weekly_reference_bundle=lambda db, **kwargs: export_calls.append(kwargs)
+        or {"bundle_path": str(kwargs["output_path"])},
+    )
+    monkeypatch.setattr(build_script, "get_provider_snapshot_service", lambda: provider_snapshot_service)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "build_weekly_reference_bundle",
+            "--market",
+            "SG",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert build_script.main() == 0
+    assert fetch_calls == ["SG"]
+    assert len(ingest_calls) == 1
+    assert ingest_calls[0]["source_name"] == "sg_manual_csv"
+    assert ingest_calls[0]["snapshot_id"] == "sg-csv-fallback-2026-05-17"
+    assert export_calls[0]["output_path"] == (
+        tmp_path / "weekly-reference-sg-20260517-fundamentals_v1_sg-20260517121000.json.gz"
+    )
+    assert export_calls[0]["latest_manifest_path"] == tmp_path / "weekly-reference-latest-sg.json"
+    assert export_calls[0]["market"] == "SG"
+    stdout = capsys.readouterr().out
+    assert "Starting official universe refresh for SG..." in stdout
+    assert "Weekly reference bundle complete for SG:" in stdout
+
+
 def _make_universe_row(symbol: str, market: str = "CN") -> SimpleNamespace:
     return SimpleNamespace(
         symbol=symbol,


### PR DESCRIPTION
## Summary

PR #186 added SG support to the application but didn't wire SG into the static-site CI pipeline, so the latest static-site run produced no SG bundle. Three gates blocked SG independently:

- **`.github/workflows/static-site.yml:42`** — per-market matrix listed 9 markets without SG. The export job never ran for SG, so no `static-market-SG` artifact existed for the combine step.
- **`.github/workflows/weekly-reference-data.yml`** — both the `workflow_dispatch` input choice list and the matrix JSON omitted SG. The upstream `weekly-reference-data` release therefore had no `weekly-reference-latest-sg.json`, which the static-site job's "Select weekly reference manifest" step requires.
- **`backend/app/scripts/build_weekly_reference_bundle.py::_ingest_official_snapshot_rows`** — per-market `if/elif` chain dispatched to `ingest_*_snapshot_rows` for 8 markets but hit `raise ValueError("Unsupported official weekly reference market 'SG'")` for SG. Added the SG branch that delegates to `ingest_sg_snapshot_rows` (the adapter from #186).

The three Python-side market allowlists (`STATIC_EXPORT_MARKETS`, `DAILY_PRICE_SUPPORTED_MARKETS`, `WEEKLY_REFERENCE_SNAPSHOT_KEYS`) all derive from `market_registry.supported_market_codes()` and already include SG — no further edits needed there.

## Test plan

- [x] `test_build_weekly_reference_bundle_runs_sg_official_path` (new) — mirrors the DE/HK official-path tests; verifies the SG fetch routes through `ingest_sg_snapshot_rows` and emits `weekly-reference-sg-*` bundle paths.
- [x] DE and HK official-path regression tests still pass.
- [x] 273-test SG-touched suite passes locally.
- [ ] After merge: trigger `Weekly Reference Data` once for SG via `workflow_dispatch` (`market=SG` or `market=all`) to produce `weekly-reference-latest-sg.json`. The next scheduled `Static Site` run will then pick up the SG matrix entry and publish an SG bundle alongside the other markets.
- [ ] First static-site run after the weekly seed will publish SG with `--allow-stale` price data (no `daily-price-data` SG bundle exists yet); subsequent runs populate it naturally via the `Upload daily price assets` step.

Refs the [static-site run](https://github.com/xang1234/stock-screener/actions/runs/25981576146) that surfaced the gap.

https://claude.ai/code/session_01WCQY7N8LaEwJFSJhJmkhH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCQY7N8LaEwJFSJhJmkhH9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded market coverage to include Singapore (SG) in static site builds and weekly reference data processing, enabling new market snapshot ingestion capabilities.

* **Tests**
  * Added comprehensive unit test validating the Singapore market workflow for weekly reference bundle generation, including manifest and artifact validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->