### PR TITLE
feat(breadth): sortable, visually richer By Group attribution tab

### DIFF
--- a/frontend/src/static/components/BreadthGroupAttribution.jsx
+++ b/frontend/src/static/components/BreadthGroupAttribution.jsx
@@ -16,16 +16,37 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TableSortLabel,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+const UP_COLOR = '#4caf50';
+const DOWN_COLOR = '#f44336';
+const FLAT_COLOR = '#9e9e9e';
+const NO_GROUP_LABEL = 'No Group';
 
 const formatPct = (value) => {
   if (value == null || Number.isNaN(value)) return '-';
   const sign = value > 0 ? '+' : '';
   return `${sign}${value.toFixed(2)}%`;
 };
+
+const totalActivity = (row) => (row?.up_count ?? 0) + (row?.down_count ?? 0);
 
 function StockList({ title, stocks, color }) {
   if (!stocks || stocks.length === 0) {
@@ -75,10 +96,174 @@ function StockList({ title, stocks, color }) {
   );
 }
 
-function GroupRow({ row }) {
+function SplitBar({ upCount, downCount }) {
+  const total = upCount + downCount;
+  const tooltip = `${upCount} up, ${downCount} down`;
+  return (
+    <Tooltip title={tooltip} arrow placement="top">
+      <Box
+        role="img"
+        aria-label={tooltip}
+        sx={{
+          display: 'flex',
+          width: 80,
+          height: 8,
+          borderRadius: 0.5,
+          overflow: 'hidden',
+          border: '1px solid',
+          borderColor: 'divider',
+          bgcolor: total === 0 ? 'action.disabledBackground' : 'transparent',
+        }}
+      >
+        {upCount > 0 && (
+          <Box sx={{ flex: upCount, bgcolor: UP_COLOR }} />
+        )}
+        {downCount > 0 && (
+          <Box sx={{ flex: downCount, bgcolor: DOWN_COLOR }} />
+        )}
+      </Box>
+    </Tooltip>
+  );
+}
+
+function NetTrendSparkline({ data }) {
+  const latestNet = data?.length ? data[data.length - 1].net : 0;
+  const stroke = latestNet > 0 ? UP_COLOR : latestNet < 0 ? DOWN_COLOR : FLAT_COLOR;
+
+  if (!data || data.length === 0) {
+    return (
+      <Box
+        sx={{
+          width: 80,
+          height: 24,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'text.disabled',
+          fontSize: 10,
+        }}
+      >
+        -
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      data-testid="net-trend-sparkline"
+      sx={{ width: 80, height: 24 }}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 2, right: 0, left: 0, bottom: 2 }}>
+          <ReferenceLine y={0} stroke="#bdbdbd" strokeWidth={0.5} />
+          <Line
+            type="monotone"
+            dataKey="net"
+            stroke={stroke}
+            strokeWidth={1.5}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}
+
+function HeroBarChartTooltip({ active, payload }) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+  const entry = payload[0].payload;
+  return (
+    <Paper
+      elevation={3}
+      sx={{
+        px: 1.5,
+        py: 1,
+        fontSize: 11,
+        fontFamily: 'monospace',
+        border: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Typography sx={{ fontSize: 11, fontWeight: 700, mb: 0.5 }}>{entry.group}</Typography>
+      <Box sx={{ color: UP_COLOR }}>Up 4%+: {entry.up_count}</Box>
+      <Box sx={{ color: DOWN_COLOR }}>Down 4%+: {entry.down_count}</Box>
+      <Box sx={{ color: entry.net >= 0 ? UP_COLOR : DOWN_COLOR }}>
+        Net: {entry.net > 0 ? `+${entry.net}` : entry.net}
+      </Box>
+    </Paper>
+  );
+}
+
+function GroupActivityBarChart({ topGroups, date }) {
+  if (!topGroups.length) {
+    return null;
+  }
+
+  // Tall enough for ~26px per bar plus padding.
+  const chartHeight = Math.max(180, topGroups.length * 26 + 40);
+
+  return (
+    <Paper
+      elevation={0}
+      data-testid="group-activity-hero-chart"
+      sx={{ border: '1px solid', borderColor: 'divider', p: 1.5, mb: 1.5 }}
+    >
+      <Typography
+        variant="caption"
+        sx={{
+          fontSize: 11,
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          color: 'text.secondary',
+          display: 'block',
+          mb: 0.5,
+        }}
+      >
+        Top {topGroups.length} groups driving breadth · {date}
+      </Typography>
+      <Box sx={{ width: '100%', height: chartHeight }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={topGroups}
+            layout="vertical"
+            margin={{ top: 4, right: 16, bottom: 4, left: 0 }}
+            barCategoryGap={4}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#eeeeee" horizontal={false} />
+            <XAxis type="number" tick={{ fontSize: 10 }} allowDecimals={false} />
+            <YAxis
+              type="category"
+              dataKey="group"
+              tick={{ fontSize: 10 }}
+              width={170}
+              interval={0}
+            />
+            <RechartsTooltip content={<HeroBarChartTooltip />} cursor={{ fill: 'rgba(0,0,0,0.04)' }} />
+            <Bar dataKey="up_count" stackId="activity" fill={UP_COLOR} />
+            <Bar dataKey="down_count" stackId="activity" fill={DOWN_COLOR} />
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+    </Paper>
+  );
+}
+
+function GroupRow({ row, maxAbsNet, trendData }) {
   const [open, setOpen] = useState(false);
-  const totalActivity = row.up_count + row.down_count;
+  const total = totalActivity(row);
   const toggle = () => setOpen((prev) => !prev);
+
+  const netIntensity = maxAbsNet > 0 ? Math.min(Math.abs(row.net) / maxAbsNet, 1) : 0;
+  const netBgColor =
+    row.net > 0
+      ? `rgba(76, 175, 80, ${(netIntensity * 0.32).toFixed(3)})`
+      : row.net < 0
+        ? `rgba(244, 67, 54, ${(netIntensity * 0.32).toFixed(3)})`
+        : 'transparent';
 
   return (
     <>
@@ -102,6 +287,9 @@ function GroupRow({ row }) {
           </IconButton>
         </TableCell>
         <TableCell sx={{ py: 0.5, fontWeight: 600 }}>{row.group}</TableCell>
+        <TableCell sx={{ py: 0.5, width: 96 }}>
+          <SplitBar upCount={row.up_count} downCount={row.down_count} />
+        </TableCell>
         <TableCell
           align="right"
           sx={{ py: 0.5, fontFamily: 'monospace', color: 'success.main', fontWeight: 600 }}
@@ -121,16 +309,20 @@ function GroupRow({ row }) {
             fontFamily: 'monospace',
             fontWeight: 700,
             color: row.net > 0 ? 'success.main' : row.net < 0 ? 'error.main' : 'text.primary',
+            backgroundColor: netBgColor,
           }}
         >
           {row.net > 0 ? `+${row.net}` : row.net}
         </TableCell>
         <TableCell align="right" sx={{ py: 0.5, fontFamily: 'monospace' }}>
-          {totalActivity}
+          {total}
+        </TableCell>
+        <TableCell sx={{ py: 0.5, width: 96 }}>
+          <NetTrendSparkline data={trendData} />
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell sx={{ py: 0, borderBottom: open ? undefined : 'none' }} colSpan={6}>
+        <TableCell sx={{ py: 0, borderBottom: open ? undefined : 'none' }} colSpan={8}>
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', py: 1, px: 4 }}>
               <StockList title="Up 4%+" stocks={row.up_stocks} color="success.main" />
@@ -143,14 +335,106 @@ function GroupRow({ row }) {
   );
 }
 
+const getSortValue = (row, column) => {
+  if (column === 'group') return row.group ?? '';
+  if (column === 'up') return row.up_count;
+  if (column === 'down') return row.down_count;
+  if (column === 'net') return row.net;
+  if (column === 'total') return totalActivity(row);
+  return null;
+};
+
+const sortGroups = (groups, orderBy, order) => {
+  const dir = order === 'asc' ? 1 : -1;
+  return [...groups].sort((a, b) => {
+    // Pin "No Group" to the bottom regardless of direction — it's a synthetic bucket.
+    if (a.group === NO_GROUP_LABEL && b.group !== NO_GROUP_LABEL) return 1;
+    if (b.group === NO_GROUP_LABEL && a.group !== NO_GROUP_LABEL) return -1;
+
+    let aVal = getSortValue(a, orderBy);
+    let bVal = getSortValue(b, orderBy);
+
+    if (orderBy === 'group') {
+      return dir * String(aVal).localeCompare(String(bVal));
+    }
+
+    if (aVal == null) aVal = order === 'asc' ? Infinity : -Infinity;
+    if (bVal == null) bVal = order === 'asc' ? Infinity : -Infinity;
+
+    if (aVal < bVal) return -1 * dir;
+    if (aVal > bVal) return 1 * dir;
+    return 0;
+  });
+};
+
 function BreadthGroupAttribution({ attribution }) {
   const history = useMemo(() => attribution?.history || [], [attribution]);
   const [selectedDate, setSelectedDate] = useState(history[0]?.date || null);
+  const [orderBy, setOrderBy] = useState('total');
+  const [order, setOrder] = useState('desc');
 
   const selectedDay = useMemo(
     () => history.find((day) => day.date === selectedDate) || history[0] || null,
     [history, selectedDate]
   );
+
+  // Derive a per-group 10-day net trend from the existing history payload so
+  // each row can render a sparkline without any backend changes.
+  const groupTrendMap = useMemo(() => {
+    const trends = new Map();
+    if (!history.length) return trends;
+    const allGroups = new Set();
+    for (const day of history) {
+      for (const g of day.groups || []) {
+        allGroups.add(g.group);
+      }
+    }
+    // history is newest-first; reverse so the line plots oldest→newest left-to-right.
+    const ordered = [...history].reverse();
+    for (const groupName of allGroups) {
+      trends.set(
+        groupName,
+        ordered.map((day) => {
+          const entry = (day.groups || []).find((g) => g.group === groupName);
+          return { date: day.date, net: entry?.net ?? 0 };
+        })
+      );
+    }
+    return trends;
+  }, [history]);
+
+  const sortedGroups = useMemo(() => {
+    if (!selectedDay?.groups?.length) return [];
+    return sortGroups(selectedDay.groups, orderBy, order);
+  }, [selectedDay, orderBy, order]);
+
+  const maxAbsNet = useMemo(
+    () => sortedGroups.reduce((acc, g) => Math.max(acc, Math.abs(g.net ?? 0)), 0),
+    [sortedGroups]
+  );
+
+  const topGroups = useMemo(() => {
+    if (!selectedDay?.groups?.length) return [];
+    return [...selectedDay.groups]
+      .map((g) => ({
+        group: g.group,
+        up_count: g.up_count,
+        down_count: g.down_count,
+        net: g.net,
+        total: totalActivity(g),
+      }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 10);
+  }, [selectedDay]);
+
+  const handleSort = (column) => {
+    if (orderBy === column) {
+      setOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+      return;
+    }
+    setOrderBy(column);
+    setOrder(column === 'group' ? 'asc' : 'desc');
+  };
 
   if (!attribution || attribution.available === false) {
     return (
@@ -168,7 +452,19 @@ function BreadthGroupAttribution({ attribution }) {
     );
   }
 
-  const hasGroups = (selectedDay.groups || []).length > 0;
+  const hasGroups = sortedGroups.length > 0;
+
+  const sortableHeader = (column, label, align = 'left') => (
+    <TableCell align={align}>
+      <TableSortLabel
+        active={orderBy === column}
+        direction={orderBy === column ? order : 'asc'}
+        onClick={() => handleSort(column)}
+      >
+        {label}
+      </TableSortLabel>
+    </TableCell>
+  );
 
   return (
     <Box>
@@ -218,22 +514,31 @@ function BreadthGroupAttribution({ attribution }) {
 
       {hasGroups ? (
         <>
+          <GroupActivityBarChart topGroups={topGroups} date={selectedDay.date} />
+
           <Paper elevation={0} sx={{ border: '1px solid', borderColor: 'divider' }}>
             <TableContainer sx={{ maxHeight: 'calc(100vh - 320px)' }}>
               <Table stickyHeader size="small">
                 <TableHead>
                   <TableRow>
                     <TableCell sx={{ width: 32 }} />
-                    <TableCell>IBD Industry Group</TableCell>
-                    <TableCell align="right">Up 4%+</TableCell>
-                    <TableCell align="right">Down 4%+</TableCell>
-                    <TableCell align="right">Net</TableCell>
-                    <TableCell align="right">Total</TableCell>
+                    {sortableHeader('group', 'IBD Industry Group')}
+                    <TableCell sx={{ width: 96 }}>Split</TableCell>
+                    {sortableHeader('up', 'Up 4%+', 'right')}
+                    {sortableHeader('down', 'Down 4%+', 'right')}
+                    {sortableHeader('net', 'Net', 'right')}
+                    {sortableHeader('total', 'Total', 'right')}
+                    <TableCell sx={{ width: 96 }}>10-day Net</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {selectedDay.groups.map((row) => (
-                    <GroupRow key={row.group} row={row} />
+                  {sortedGroups.map((row) => (
+                    <GroupRow
+                      key={row.group}
+                      row={row}
+                      maxAbsNet={maxAbsNet}
+                      trendData={groupTrendMap.get(row.group)}
+                    />
                   ))}
                 </TableBody>
               </Table>

--- a/frontend/src/static/pages/StaticBreadthPage.test.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.test.jsx
@@ -187,7 +187,7 @@ describe('StaticBreadthPage', () => {
             payload: {
               benchmark_symbol: 'SPY',
               benchmark_overlay: [],
-              current: { market: 'US', date: '2026-05-15', stocks_up_4pct: 4, stocks_down_4pct: 1 },
+              current: { market: 'US', date: '2026-05-15', stocks_up_4pct: 3, stocks_down_4pct: 1 },
               chart_data: [],
               history_90d: [],
               group_attribution: {
@@ -199,7 +199,7 @@ describe('StaticBreadthPage', () => {
                 history: [
                   {
                     date: '2026-05-15',
-                    stocks_up_4pct: 4,
+                    stocks_up_4pct: 3,
                     stocks_down_4pct: 1,
                     groups: [
                       {

--- a/frontend/src/static/pages/StaticBreadthPage.test.jsx
+++ b/frontend/src/static/pages/StaticBreadthPage.test.jsx
@@ -155,7 +155,7 @@ describe('StaticBreadthPage', () => {
     expect(screen.getByTestId('breadth-chart')).toHaveTextContent('^HSI:1');
   });
 
-  it('renders the By Group tab with drill-down stock list when attribution data is present', async () => {
+  it('renders the By Group tab with drill-down stock list, hero chart, sparklines, and is sortable', async () => {
     globalThis.fetch = vi.fn(async (url) => {
       const path = String(url).split('/static-data/')[1];
 
@@ -227,6 +227,23 @@ describe('StaticBreadthPage', () => {
                       },
                     ],
                   },
+                  {
+                    date: '2026-05-14',
+                    stocks_up_4pct: 1,
+                    stocks_down_4pct: 0,
+                    groups: [
+                      {
+                        group: 'Computer Software-Database',
+                        up_count: 1,
+                        down_count: 0,
+                        net: 1,
+                        up_stocks: [
+                          { symbol: 'PLTR', name: 'Palantir', pct_change: 4.6, close: 26.4 },
+                        ],
+                        down_stocks: [],
+                      },
+                    ],
+                  },
                 ],
               },
             },
@@ -246,7 +263,34 @@ describe('StaticBreadthPage', () => {
     expect(await screen.findByText('Computer Software-Database')).toBeInTheDocument();
     expect(screen.getByText('No Group')).toBeInTheDocument();
 
-    // Drill-down: clicking the group row should reveal the stock list.
+    // The hero bar chart should be present once a session with groups is loaded.
+    expect(screen.getByTestId('group-activity-hero-chart')).toBeInTheDocument();
+
+    // Each row gets a 10-day net sparkline derived from the history payload.
+    expect(screen.getAllByTestId('net-trend-sparkline').length).toBeGreaterThanOrEqual(2);
+
+    // Default sort is Total desc; switching column defaults to desc too.
+    // Click Up header → sort by up_count desc: Software (up=2) ahead of No Group (up=1).
+    // Click again → asc: No Group (up=1) would lead, but "No Group" is pinned to the
+    // bottom regardless of direction, so Software still appears first.
+    const upHeader = screen.getByRole('button', { name: /^Up 4%\+/i });
+    fireEvent.click(upHeader); // desc
+    let rowNames = screen
+      .getAllByRole('row')
+      .map((row) => row.textContent || '')
+      .filter((text) => text.includes('Computer Software-Database') || text.includes('No Group'));
+    expect(rowNames[0]).toContain('Computer Software-Database');
+    expect(rowNames[rowNames.length - 1]).toContain('No Group');
+
+    fireEvent.click(upHeader); // asc, but No Group is pinned to bottom
+    rowNames = screen
+      .getAllByRole('row')
+      .map((row) => row.textContent || '')
+      .filter((text) => text.includes('Computer Software-Database') || text.includes('No Group'));
+    expect(rowNames[0]).toContain('Computer Software-Database');
+    expect(rowNames[rowNames.length - 1]).toContain('No Group');
+
+    // Drill-down: clicking the group name cell should reveal the stock list.
     fireEvent.click(screen.getByText('Computer Software-Database'));
     expect(await screen.findByText('PLTR')).toBeInTheDocument();
     expect(screen.getByText('AAPL')).toBeInTheDocument();

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom';
+
+// jsdom doesn't ship ResizeObserver, which Recharts' ResponsiveContainer
+// requires on mount. Stub it so components that render charts don't throw.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}


### PR DESCRIPTION
## Summary

- Make the static breadth "By Group" tab sortable (Group / Up / Down / Net / Total) with "No Group" pinned to the bottom regardless of direction.
- Layer five at-a-glance visuals on top of the existing table: inline up/down split bar per row, magnitude-scaled green/red Net cell heatmap, top-10 stacked-bar hero chart for the selected session, and a per-group 10-day net sparkline column.
- All sparkline data is derived on the frontend from the existing `history` payload, so no backend or schema changes were required.
- Add a global `ResizeObserver` polyfill to `src/test/setup.js` so Recharts' `ResponsiveContainer` mounts cleanly under jsdom for any current and future chart-rendering test.

## Test plan

- [x] `npx vitest run src/static/pages/StaticBreadthPage.test.jsx` — extended "By Group" test asserts hero chart presence, sparkline rendering, and the sort toggle behavior with "No Group" pinned at both directions.
- [x] `npm run test:run` — full frontend suite, 357/357 passing across 56 files.
- [x] `npx eslint src/static/components/BreadthGroupAttribution.jsx src/static/pages/StaticBreadthPage.test.jsx src/test/setup.js` — clean.
- [ ] Manual smoke against a freshly exported static bundle: visit `/breadth` → "By Group" tab, confirm hero chart, split bars, Net tint, and 10-day sparkline column render; verify each header reorders the table; flip sessions; confirm the HK tab still shows the "not yet supported" alert.

https://claude.ai/code/session_01TPkgqYBbVCP5JX1Er2KF8L

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPkgqYBbVCP5JX1Er2KF8L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added group-level visualizations with hero bar charts and net-trend sparklines
  * Implemented interactive sortable column headers for grouping analysis
  * Enhanced group activity display with visual intensity indicators

* **Tests**
  * Expanded coverage for group attribution analysis, sorting behavior, and sparkline rendering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->