### PR TITLE
ci: enable live SG weekly universe source

### DIFF
--- a/.github/workflows/weekly-reference-data.yml
+++ b/.github/workflows/weekly-reference-data.yml
@@ -113,6 +113,7 @@ jobs:
     env:
       REDIS_ENABLED: "false"
       DATABASE_URL: postgresql://stockscanner:stockscanner@localhost:5432/stockscanner
+      SG_UNIVERSE_SOURCE_URL: ${{ matrix.market == 'SG' && 'https://api.sgx.com/securities/v1.1?excludetypes=bonds' || '' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Set SG_UNIVERSE_SOURCE_URL for the weekly-reference SG matrix job
- Keep non-SG weekly reference jobs unchanged

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/weekly-reference-data.yml'); puts 'yaml ok'"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to conditionally set an environment variable based on market conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->