### PR TITLE
Add per-market default volume filters for static site exports

### DIFF
--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -51,7 +51,38 @@ STATIC_CHART_LIMIT = 200
 STATIC_CHART_PERIOD = "6mo"
 STATIC_CHART_PERIOD_DAYS = 180
 STATIC_CHART_LOOKUP_BATCH_SIZE = 250
-STATIC_DEFAULT_SCAN_FILTERS = {"minVolume": 100_000_000}
+# Default minVolume thresholds are expressed in local-currency daily dollar
+# volume (avg_volume × current_price), not share count — the ``volume`` field
+# on each scan row is sourced from ``avg_dollar_volume`` in the local listing
+# currency. The US value preserves the historical USD 100M floor; non-US
+# values are sized to roughly USD 1M-equivalent so the full local universe is
+# visible by default, with users free to tighten via the filter panel.
+STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET: dict[str, dict[str, int | None]] = {
+    "US": {"minVolume": 100_000_000},      # USD 100M
+    "HK": {"minVolume":   8_000_000},      # ~USD 1M @ HKD 7.8
+    "IN": {"minVolume":  80_000_000},      # ~USD 1M @ INR 83
+    "JP": {"minVolume": 150_000_000},      # ~USD 1M @ JPY 150
+    "KR": {"minVolume": 1_000_000_000},    # ~USD 750k @ KRW 1380
+    "TW": {"minVolume":  30_000_000},      # ~USD 1M @ TWD 32
+    "CN": {"minVolume":   7_000_000},      # ~USD 1M @ CNY 7.2
+    "CA": {"minVolume":   1_400_000},      # ~USD 1M @ CAD 1.36
+    "DE": {"minVolume":     900_000},      # ~USD 1M @ EUR 0.92
+    "SG": {"minVolume":   1_300_000},      # ~USD 1M @ SGD 1.35
+}
+STATIC_DEFAULT_SCAN_FILTERS_FALLBACK: dict[str, int | None] = {"minVolume": None}
+
+
+def resolve_static_default_filters(market: str | None) -> dict[str, int | None]:
+    """Return the per-market default scan filters, or the no-op fallback."""
+
+    code = (market or "").upper()
+    return dict(
+        STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET.get(
+            code, STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
+        )
+    )
+
+
 STATIC_CHART_PRESET_TOP_N = 200
 STATIC_CHART_TOP_N_GROUPS = 50
 STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
@@ -327,6 +358,7 @@ class StaticSiteExportService:
             rows=scan_rows,
             filter_options=filter_options,
             path_prefix=path_prefix,
+            market=market,
         )
         groups_payload = self._build_optional_section_payload(
             section=f"{market} groups",
@@ -629,6 +661,7 @@ class StaticSiteExportService:
         rows: list[Any] | None = None,
         filter_options: Any | None = None,
         path_prefix: Path | None = None,
+        market: str | None = None,
     ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         if rows is None or filter_options is None:
             repo = SqlFeatureStoreRepository(db)
@@ -648,7 +681,10 @@ class StaticSiteExportService:
         serialized_rows = [self._serialize_scan_row(row) for row in rows]
         self._annotate_percentile_ranks(serialized_rows)
         serialized_rows = self._sort_static_scan_rows(serialized_rows)
-        default_filtered_rows = self._apply_static_default_filters(serialized_rows)
+        resolved_default_filters = resolve_static_default_filters(market)
+        default_filtered_rows = self._apply_static_default_filters(
+            serialized_rows, default_filters=resolved_default_filters
+        )
         chunk_refs: list[dict[str, Any]] = []
         for index in range(0, len(serialized_rows), SCAN_CHUNK_SIZE):
             chunk_rows = serialized_rows[index:index + SCAN_CHUNK_SIZE]
@@ -679,7 +715,7 @@ class StaticSiteExportService:
             "default_page_size": 50,
             "chunk_size": SCAN_CHUNK_SIZE,
             "rows_total": len(serialized_rows),
-            "default_filters": dict(STATIC_DEFAULT_SCAN_FILTERS),
+            "default_filters": dict(resolved_default_filters),
             "default_filtered_rows_total": len(default_filtered_rows),
             "filter_options": FilterOptionsResponse(
                 ibd_industries=list(filter_options.ibd_industries),
@@ -1918,8 +1954,13 @@ class StaticSiteExportService:
                 pos = end + 1
 
     @staticmethod
-    def _apply_static_default_filters(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        min_volume = STATIC_DEFAULT_SCAN_FILTERS.get("minVolume")
+    def _apply_static_default_filters(
+        rows: list[dict[str, Any]],
+        *,
+        default_filters: dict[str, int | None] | None = None,
+    ) -> list[dict[str, Any]]:
+        filters = default_filters or STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
+        min_volume = filters.get("minVolume")
         if min_volume is None:
             return list(rows)
         return [

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -72,17 +72,6 @@ STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET: dict[str, dict[str, int | None]] = {
 STATIC_DEFAULT_SCAN_FILTERS_FALLBACK: dict[str, int | None] = {"minVolume": None}
 
 
-def resolve_static_default_filters(market: str | None) -> dict[str, int | None]:
-    """Return the per-market default scan filters, or the no-op fallback."""
-
-    code = (market or "").upper()
-    return dict(
-        STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET.get(
-            code, STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
-        )
-    )
-
-
 STATIC_CHART_PRESET_TOP_N = 200
 STATIC_CHART_TOP_N_GROUPS = 50
 STATIC_GROUP_DETAIL_HISTORY_DAYS = 100
@@ -681,7 +670,7 @@ class StaticSiteExportService:
         serialized_rows = [self._serialize_scan_row(row) for row in rows]
         self._annotate_percentile_ranks(serialized_rows)
         serialized_rows = self._sort_static_scan_rows(serialized_rows)
-        resolved_default_filters = resolve_static_default_filters(market)
+        resolved_default_filters = self.resolve_static_default_filters(market)
         default_filtered_rows = self._apply_static_default_filters(
             serialized_rows, default_filters=resolved_default_filters
         )
@@ -1952,6 +1941,19 @@ class StaticSiteExportService:
                     row_idx, _ = ranked[idx]
                     rows[row_idx][dst_field] = percentile
                 pos = end + 1
+
+    @staticmethod
+    def resolve_static_default_filters(
+        market: str | None,
+    ) -> dict[str, int | None]:
+        """Return the per-market default scan filters, or the no-op fallback."""
+
+        code = (market or "").upper()
+        return dict(
+            STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET.get(
+                code, STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
+            )
+        )
 
     @staticmethod
     def _apply_static_default_filters(

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -22,7 +22,6 @@ from app.services.static_site_export_service import (
     STATIC_SITE_SCHEMA_VERSION,
     StaticSiteSectionUnavailableError,
     StaticSiteExportService,
-    resolve_static_default_filters,
 )
 
 
@@ -507,11 +506,12 @@ def test_export_scan_bundle_chunks_large_result_sets(service_and_session_factory
 
 
 def test_resolve_static_default_filters_returns_per_market_threshold():
-    assert resolve_static_default_filters("US") == {"minVolume": 100_000_000}
-    assert resolve_static_default_filters("sg") == {"minVolume": 1_300_000}
-    assert resolve_static_default_filters("HK") == STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET["HK"]
-    assert resolve_static_default_filters("ZZ") == STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
-    assert resolve_static_default_filters(None) == STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
+    resolve = StaticSiteExportService.resolve_static_default_filters
+    assert resolve("US") == {"minVolume": 100_000_000}
+    assert resolve("sg") == {"minVolume": 1_300_000}
+    assert resolve("HK") == STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET["HK"]
+    assert resolve("ZZ") == STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
+    assert resolve(None) == STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
 
 
 def test_export_scan_bundle_uses_sg_threshold_for_sg_market(

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -16,10 +16,13 @@ from app.database import Base
 from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer
 from app.models.stock import StockPrice
 from app.services.static_site_export_service import (
+    STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET,
+    STATIC_DEFAULT_SCAN_FILTERS_FALLBACK,
     STATIC_MARKET_METADATA_FILENAME,
     STATIC_SITE_SCHEMA_VERSION,
     StaticSiteSectionUnavailableError,
     StaticSiteExportService,
+    resolve_static_default_filters,
 )
 
 
@@ -486,6 +489,7 @@ def test_export_scan_bundle_chunks_large_result_sets(service_and_session_factory
             output_dir=tmp_path,
             generated_at="2026-03-31T22:00:00Z",
             run=run,
+            market="US",
         )
 
     first_chunk = json.loads((tmp_path / "scan" / "chunks" / "chunk-0001.json").read_text(encoding="utf-8"))
@@ -500,6 +504,138 @@ def test_export_scan_bundle_chunks_large_result_sets(service_and_session_factory
     assert [chunk["count"] for chunk in manifest["chunks"]] == [3, 2]
     assert [row["symbol"] for row in first_chunk["rows"]] == ["SYM0", "SYM1", "SYM2"]
     assert [row["symbol"] for row in second_chunk["rows"]] == ["SYM3", "SYM4"]
+
+
+def test_resolve_static_default_filters_returns_per_market_threshold():
+    assert resolve_static_default_filters("US") == {"minVolume": 100_000_000}
+    assert resolve_static_default_filters("sg") == {"minVolume": 1_300_000}
+    assert resolve_static_default_filters("HK") == STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET["HK"]
+    assert resolve_static_default_filters("ZZ") == STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
+    assert resolve_static_default_filters(None) == STATIC_DEFAULT_SCAN_FILTERS_FALLBACK
+
+
+def test_export_scan_bundle_uses_sg_threshold_for_sg_market(
+    service_and_session_factory,
+    monkeypatch,
+    tmp_path,
+):
+    service, session_factory = service_and_session_factory
+    _insert_runs(
+        session_factory,
+        FeatureRun(
+            id=21,
+            as_of_date=date(2026, 3, 31),
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 3, 31, 21, 30, 0),
+        ),
+        pointer_run_id=21,
+    )
+
+    rows = [
+        SimpleNamespace(index=0, volume=50_000_000),    # SG large-cap turnover
+        SimpleNamespace(index=1, volume=5_000_000),     # SG mid-cap turnover
+        SimpleNamespace(index=2, volume=1_500_000),     # just above SG threshold
+        SimpleNamespace(index=3, volume=500_000),       # below SG threshold
+        SimpleNamespace(index=4, volume=None),
+    ]
+    monkeypatch.setattr(
+        export_module.SqlFeatureStoreRepository,
+        "query_all_as_scan_results",
+        lambda self, *_args, **_kwargs: rows,
+    )
+    monkeypatch.setattr(
+        export_module.SqlFeatureStoreRepository,
+        "get_filter_options_for_run",
+        lambda self, _run_id: SimpleNamespace(
+            ibd_industries=(),
+            gics_sectors=(),
+            ratings=("Strong Buy",),
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "_serialize_scan_row",
+        lambda row: {
+            "symbol": f"SG{row.index}",
+            "composite_score": 100 - row.index,
+            "volume": row.volume,
+        },
+    )
+
+    with session_factory() as db:
+        run = db.get(FeatureRun, 21)
+        manifest, _serialized = service._export_scan_bundle(  # noqa: SLF001
+            db=db,
+            output_dir=tmp_path,
+            generated_at="2026-03-31T22:00:00Z",
+            run=run,
+            market="SG",
+        )
+
+    assert manifest["default_filters"] == {"minVolume": 1_300_000}
+    assert manifest["default_filtered_rows_total"] == 3
+    assert [row["symbol"] for row in manifest["initial_rows"]] == ["SG0", "SG1", "SG2"]
+
+
+def test_export_scan_bundle_unknown_market_disables_volume_filter(
+    service_and_session_factory,
+    monkeypatch,
+    tmp_path,
+):
+    service, session_factory = service_and_session_factory
+    _insert_runs(
+        session_factory,
+        FeatureRun(
+            id=22,
+            as_of_date=date(2026, 3, 31),
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 3, 31, 21, 30, 0),
+        ),
+        pointer_run_id=22,
+    )
+
+    rows = [
+        SimpleNamespace(index=0, volume=10),
+        SimpleNamespace(index=1, volume=None),
+    ]
+    monkeypatch.setattr(
+        export_module.SqlFeatureStoreRepository,
+        "query_all_as_scan_results",
+        lambda self, *_args, **_kwargs: rows,
+    )
+    monkeypatch.setattr(
+        export_module.SqlFeatureStoreRepository,
+        "get_filter_options_for_run",
+        lambda self, _run_id: SimpleNamespace(
+            ibd_industries=(),
+            gics_sectors=(),
+            ratings=(),
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "_serialize_scan_row",
+        lambda row: {
+            "symbol": f"X{row.index}",
+            "composite_score": 100 - row.index,
+            "volume": row.volume,
+        },
+    )
+
+    with session_factory() as db:
+        run = db.get(FeatureRun, 22)
+        manifest, _serialized = service._export_scan_bundle(  # noqa: SLF001
+            db=db,
+            output_dir=tmp_path,
+            generated_at="2026-03-31T22:00:00Z",
+            run=run,
+            market=None,
+        )
+
+    assert manifest["default_filters"] == {"minVolume": None}
+    assert manifest["default_filtered_rows_total"] == manifest["rows_total"] == 2
 
 
 def test_export_scan_bundle_prioritizes_full_rows_before_ipo_weighted_and_listing_only(
@@ -559,6 +695,7 @@ def test_export_scan_bundle_prioritizes_full_rows_before_ipo_weighted_and_listin
             output_dir=tmp_path,
             generated_at="2026-03-31T22:00:00Z",
             run=run,
+            market="US",
         )
 
     assert [row["symbol"] for row in manifest["initial_rows"]] == ["FULL80", "FULL70", "IPO95"]


### PR DESCRIPTION
## Summary
Implement market-specific default volume filters for static site scan exports, replacing the hardcoded USD 100M threshold with localized thresholds that provide consistent ~USD 1M visibility across different markets while preserving the historical US floor.

## Changes
- **New constants and function** in `static_site_export_service.py`:
  - `STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET`: Dictionary mapping market codes (US, HK, IN, JP, KR, TW, CN, CA, DE, SG) to their respective minVolume thresholds in local currency
  - `STATIC_DEFAULT_SCAN_FILTERS_FALLBACK`: No-op filter (`{"minVolume": None}`) for unknown markets
  - `resolve_static_default_filters(market)`: Helper function that returns per-market filters or fallback based on market code (case-insensitive)

- **Updated `_export_scan_bundle()` method**:
  - Added `market` parameter to enable market-aware filtering
  - Calls `resolve_static_default_filters()` to get appropriate filters for the market
  - Passes resolved filters to `_apply_static_default_filters()` instead of using hardcoded constant
  - Updates manifest to reflect the resolved market-specific filters

- **Enhanced `_apply_static_default_filters()` method**:
  - Added `default_filters` keyword-only parameter to accept custom filter configurations
  - Falls back to `STATIC_DEFAULT_SCAN_FILTERS_FALLBACK` if no filters provided
  - Maintains backward compatibility with existing callers

- **Updated `_export_market_bundle()` method**:
  - Passes `market` parameter to `_export_scan_bundle()` call

- **Test coverage**:
  - `test_resolve_static_default_filters_returns_per_market_threshold()`: Validates filter resolution for various markets
  - `test_export_scan_bundle_uses_sg_threshold_for_sg_market()`: Verifies SG market uses 1.3M threshold and filters correctly
  - `test_export_scan_bundle_unknown_market_disables_volume_filter()`: Confirms unknown markets disable volume filtering
  - Updated existing tests to pass `market="US"` parameter

## Implementation Details
- Volume thresholds are expressed in local-currency daily dollar volume (avg_volume × current_price), sourced from `avg_dollar_volume` field
- All non-US thresholds are calibrated to approximately USD 1M equivalent using current exchange rates, ensuring consistent global visibility
- US threshold preserved at USD 100M for backward compatibility
- Market code matching is case-insensitive (normalized to uppercase)
- Unknown or null market codes gracefully fall back to no-op filtering (all rows included)

https://claude.ai/code/session_01JcETMrLTh6qwTBvYTwbhmN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scan export filtering now uses market-specific minimum-volume defaults, records those defaults in the export manifest, and can disable volume filtering for unspecified/unknown markets.

* **Tests**
  * Added unit tests covering per-market threshold resolution, manifest behavior, and filtering (including unknown/None market disabling the volume filter).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->