### PR TITLE
Fix RS sparkline spike from non-finite value substitution

### DIFF
--- a/backend/app/scanners/criteria/rs_sparkline.py
+++ b/backend/app/scanners/criteria/rs_sparkline.py
@@ -57,15 +57,40 @@ class RSSparklineCalculator:
             }
 
         try:
-            # Get last 30 trading days (most recent data)
-            stock_last_30 = stock_prices.iloc[-self.SPARKLINE_DAYS:].values
-            spy_last_30 = spy_prices.iloc[-self.SPARKLINE_DAYS:].values
+            # Get last 30 trading days (most recent data) as float so NaN/Inf
+            # checks are consistent regardless of source dtype.
+            stock_last_30 = np.asarray(
+                stock_prices.iloc[-self.SPARKLINE_DAYS:].values, dtype=float
+            )
+            spy_last_30 = np.asarray(
+                spy_prices.iloc[-self.SPARKLINE_DAYS:].values, dtype=float
+            )
 
-            # Calculate RS ratio (stock / SPY)
-            rs_ratio = stock_last_30 / spy_last_30
+            # Calculate RS ratio (stock / SPY). Suppress the divide-by-zero
+            # warning so the downstream NaN/Inf scrubbing path stays quiet.
+            with np.errstate(divide="ignore", invalid="ignore"):
+                rs_ratio = stock_last_30 / spy_last_30
 
-            # Handle any NaN or inf values
-            rs_ratio = np.nan_to_num(rs_ratio, nan=1.0, posinf=1.0, neginf=1.0)
+            # If the window contains no finite samples, bail out to None.
+            # Previously NaN/Inf were rewritten to 1.0, which after the
+            # normalization step (divide by rs_ratio[0]) produced a large
+            # spike on the affected bar — most visible on markets where the
+            # raw ratio is far from 1 (e.g. CN stock_CNY / CSI300 ≈ 0.01,
+            # so a planted 1.0 became a ~100× spike on the latest date).
+            finite_mask = np.isfinite(rs_ratio)
+            if not finite_mask.any():
+                logger.debug("All-non-finite RS series; returning None sparkline")
+                return {
+                    "rs_data": None,
+                    "rs_trend": 0,
+                }
+
+            # Replace non-finite values with the first finite sample so the
+            # series is fully finite and the trailing bar flattens to the
+            # leading level (which normalization will collapse to 1.0)
+            # instead of producing a spike.
+            first_finite = float(rs_ratio[np.argmax(finite_mask)])
+            rs_ratio = np.where(finite_mask, rs_ratio, first_finite)
 
             # Normalize to start at 1.0 if requested (better for visual comparison)
             if normalize and rs_ratio[0] != 0:
@@ -89,6 +114,16 @@ class RSSparklineCalculator:
 
             # Round values for JSON storage efficiency (4 decimal places)
             rs_data = [round(float(v), 4) for v in rs_ratio]
+
+            # Final safety net: if rounding/normalization produced any
+            # non-finite value, collapse the whole payload to None so the
+            # schema sanitizer drops it cleanly.
+            if not all(np.isfinite(v) for v in rs_data):
+                logger.debug("Non-finite values after normalization; returning None sparkline")
+                return {
+                    "rs_data": None,
+                    "rs_trend": 0,
+                }
 
             return {
                 "rs_data": rs_data,

--- a/backend/tests/unit/test_rs_sparkline.py
+++ b/backend/tests/unit/test_rs_sparkline.py
@@ -91,8 +91,11 @@ def test_all_inf_stock_returns_none_payload():
 
 
 def test_leading_nan_uses_first_finite_fill():
-    stock = pd.Series([float("nan")] * 5 + [50.0 + i * 0.1 for i in range(35)])
-    benchmark = pd.Series([4000.0 + i for i in range(40)])
+    # Build a 30-element series so the leading NaNs land inside the iloc[-30:]
+    # window the calculator slices — a longer series would push them out and
+    # leave the fill path untested.
+    stock = pd.Series([float("nan")] * 5 + [50.0 + i * 0.1 for i in range(25)])
+    benchmark = pd.Series([4000.0 + i for i in range(30)])
 
     result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
 
@@ -100,6 +103,10 @@ def test_leading_nan_uses_first_finite_fill():
     assert len(result["rs_data"]) == 30
     for value in result["rs_data"]:
         assert math.isfinite(value)
+    # Leading NaN entries should be filled with the first finite RS ratio,
+    # which equals rs_ratio[0] after normalization → 1.0.
+    for value in result["rs_data"][:5]:
+        assert value == pytest.approx(1.0)
 
 
 def test_clean_input_still_produces_finite_normalized_series():

--- a/backend/tests/unit/test_rs_sparkline.py
+++ b/backend/tests/unit/test_rs_sparkline.py
@@ -1,0 +1,123 @@
+"""Regression tests for RSSparklineCalculator.
+
+The CN static-site page showed a large spike on the latest bar across all
+scan/group sparklines. Root cause: a single non-finite element in the raw
+``stock / benchmark`` ratio was rewritten to ``1.0`` by ``np.nan_to_num``,
+and the subsequent ``rs_ratio / rs_ratio[0]`` normalization amplified it
+because CN's raw ratio (CNY stock / CSI 300) is ~0.01, so the planted 1.0
+became a ~100x spike. The tests below pin the trailing-bar contamination
+cases that produced the visible artifact.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from app.scanners.criteria.rs_sparkline import RSSparklineCalculator
+
+
+def _cn_like_series(seed: int = 42, length: int = 40):
+    """Build CN-shaped (small ratio) stock/benchmark series for spike checks."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    stock = pd.Series(50 + np.cumsum(rng.standard_normal(length) * 0.5))
+    benchmark = pd.Series(4000 + np.cumsum(rng.standard_normal(length) * 5))
+    return stock, benchmark
+
+
+def test_benchmark_nan_on_latest_bar_does_not_spike():
+    stock, benchmark = _cn_like_series()
+    benchmark.iloc[-1] = float("nan")
+
+    result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
+
+    assert result["rs_data"] is not None
+    assert len(result["rs_data"]) == 30
+    for value in result["rs_data"]:
+        assert math.isfinite(value)
+    # Trailing bar must flatten to the leading level (1.0 after normalization)
+    # rather than reproduce the historical ~76x spike from the 1.0 substitute.
+    assert result["rs_data"][-1] < 5.0
+
+
+def test_benchmark_zero_on_latest_bar_does_not_spike():
+    stock, benchmark = _cn_like_series()
+    benchmark.iloc[-1] = 0.0
+
+    result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
+
+    assert result["rs_data"] is not None
+    for value in result["rs_data"]:
+        assert math.isfinite(value)
+    assert result["rs_data"][-1] < 5.0
+
+
+def test_stock_nan_on_latest_bar_does_not_spike():
+    stock, benchmark = _cn_like_series()
+    stock.iloc[-1] = float("nan")
+
+    result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
+
+    assert result["rs_data"] is not None
+    for value in result["rs_data"]:
+        assert math.isfinite(value)
+    assert result["rs_data"][-1] < 5.0
+
+
+def test_all_nan_stock_returns_none_payload():
+    stock = pd.Series([float("nan")] * 30)
+    benchmark = pd.Series([4000.0 + i for i in range(30)])
+
+    result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
+
+    assert result["rs_data"] is None
+    assert result["rs_trend"] == 0
+
+
+def test_all_inf_stock_returns_none_payload():
+    # finite / inf = 0.0 (still finite), so an all-inf benchmark collapses the
+    # series to zeros rather than non-finite. The user-visible failure mode is
+    # an all-inf stock series, which yields nan after division.
+    stock = pd.Series([math.inf] * 30)
+    benchmark = pd.Series([4000.0 + i for i in range(30)])
+
+    result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
+
+    assert result["rs_data"] is None
+
+
+def test_leading_nan_uses_first_finite_fill():
+    stock = pd.Series([float("nan")] * 5 + [50.0 + i * 0.1 for i in range(35)])
+    benchmark = pd.Series([4000.0 + i for i in range(40)])
+
+    result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
+
+    assert result["rs_data"] is not None
+    assert len(result["rs_data"]) == 30
+    for value in result["rs_data"]:
+        assert math.isfinite(value)
+
+
+def test_clean_input_still_produces_finite_normalized_series():
+    stock = pd.Series([50.0 + i * 0.1 for i in range(30)])
+    benchmark = pd.Series([4000.0 + i for i in range(30)])
+
+    result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
+
+    assert result["rs_data"] is not None
+    assert len(result["rs_data"]) == 30
+    assert result["rs_data"][0] == pytest.approx(1.0)
+
+
+def test_insufficient_data_returns_none():
+    stock = pd.Series([50.0] * 10)
+    benchmark = pd.Series([4000.0] * 10)
+
+    result = RSSparklineCalculator().calculate_rs_sparkline(stock, benchmark)
+
+    assert result["rs_data"] is None
+    assert result["rs_trend"] == 0


### PR DESCRIPTION
## Summary

Fixed a bug in `RSSparklineCalculator` where non-finite values (NaN, Inf) in the stock/benchmark ratio were being replaced with `1.0`, causing large visual spikes in sparklines—especially on markets with small ratios (e.g., CN stock/CSI300 ≈ 0.01, where the planted 1.0 became a ~100× spike after normalization).

## Key Changes

- **Replaced naive NaN/Inf substitution**: Instead of blanket `np.nan_to_num(rs_ratio, nan=1.0, posinf=1.0, neginf=1.0)`, now:
  - Detects if the entire window is non-finite and returns `None` payload early
  - Replaces non-finite values with the **first finite sample** in the series, so trailing-bar contamination flattens to the leading level (which normalization collapses to 1.0) rather than producing a spike
  
- **Added explicit NaN/Inf handling**: 
  - Suppressed divide-by-zero warnings with `np.errstate` to keep logging clean
  - Added a final safety net after normalization to catch any remaining non-finite values and return `None` payload

- **Comprehensive regression test suite** (`test_rs_sparkline.py`):
  - Tests for NaN/zero/Inf on latest bar (the spike-producing cases)
  - Tests for all-non-finite input (returns None)
  - Tests for leading NaN fill behavior
  - Tests for clean input and insufficient data edge cases
  - All tests verify that trailing bars remain finite and don't exceed 5.0× the normalized baseline

## Implementation Details

The fix preserves the normalization behavior (divide by first element to start at 1.0) while preventing the amplification of substituted values. By using the first finite sample as the fill value, non-finite bars naturally flatten to the leading level after normalization, eliminating the visible artifact on markets with small raw ratios.

https://claude.ai/code/session_01An6iGWbHr8JCvViEsJ8WHu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RS (Relative Strength) calculation now tolerates NaN/Inf and avoids outlier spikes by validating windows, filling non-finite values from the first finite element, and returning a safe "no-data" payload when results remain non-finite or data is insufficient.

* **Tests**
  * Added regression tests covering NaN/Inf edge cases, filling behavior, insufficient data, and clean-input expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xang1234/stock-screener/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->