### PR TITLE
feat(scanner): hybrid weekly IBD industry-group classifier

### DIFF
--- a/.github/workflows/ibd-classification.yml
+++ b/.github/workflows/ibd-classification.yml
@@ -1,0 +1,186 @@
+name: IBD Classification
+
+# Classifies every active universe symbol that lacks an IBD industry group — for
+# all markets, including those with no curated taxonomy — using the hybrid
+# cascade (crosswalk → local embedding → optional LLM tiebreaker). Publishes an
+# `ibd-classification-data` release artifact the daily static-site build consumes.
+#
+# Runs after "Weekly Reference Data" publishes (so the universe is fresh), and is
+# also manually dispatchable / scheduled as a fallback.
+
+on:
+  workflow_run:
+    workflows: ["Weekly Reference Data"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      market:
+        description: "Run only this market (or 'all' for the full matrix)."
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - US
+          - HK
+          - IN
+          - JP
+          - KR
+          - TW
+          - CN
+          - CA
+          - DE
+          - SG
+          - MY
+  schedule:
+    # Fallback ~3h after the Saturday weekly-reference cron (10:08 ET) in case
+    # the workflow_run trigger is missed.
+    - cron: '10 11 * * 6'
+      timezone: 'America/New_York'
+
+concurrency:
+  group: ibd-classification
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  ensure_release:
+    # On workflow_run, only proceed when the upstream build succeeded.
+    if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure IBD classification release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view ibd-classification-data \
+            --repo "${{ github.repository }}" >/dev/null 2>&1 || \
+          gh release create ibd-classification-data \
+            --repo "${{ github.repository }}" \
+            --title "IBD Classification Data" \
+            --notes "Automated hybrid IBD industry-group classifications for static-site builds."
+
+  classify:
+    if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    needs: ensure_release
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        # Specific market on dispatch, full matrix otherwise (inputs are null on
+        # workflow_run / schedule, so coerce to 'all').
+        market: ${{ fromJSON((github.event.inputs.market || 'all') != 'all' && format('["{0}"]', github.event.inputs.market) || '["US","HK","IN","JP","KR","TW","CN","CA","DE","SG","MY"]') }}
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: stockscanner
+          POSTGRES_USER: stockscanner
+          POSTGRES_PASSWORD: stockscanner
+        options: >-
+          --health-cmd "pg_isready -U stockscanner -d stockscanner"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      REDIS_ENABLED: "false"
+      DATABASE_URL: postgresql://stockscanner:stockscanner@localhost:5432/stockscanner
+      # LLM tiebreaker — provider-agnostic, swap by editing these env vars in the
+      # repo's GitHub Environment. Unset → classifier runs free-only.
+      IBD_LLM_API_BASE: ${{ vars.IBD_LLM_API_BASE }}
+      IBD_LLM_MODEL: ${{ vars.IBD_LLM_MODEL }}
+      IBD_LLM_API_KEY: ${{ secrets.IBD_LLM_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Seed weekly reference bundle (universe to classify)
+        id: seed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/weekly-reference-seed
+          export MARKET_LOWER="$(echo "${{ matrix.market }}" | tr '[:upper:]' '[:lower:]')"
+          BUNDLE_ASSET_NAME=""
+
+          if gh release download weekly-reference-data \
+            --pattern "weekly-reference-latest-${MARKET_LOWER}.json" \
+            --dir /tmp/weekly-reference-seed >/dev/null 2>&1; then
+            BUNDLE_ASSET_NAME="$(python - <<'PY'
+          import json, os
+          from pathlib import Path
+          market = os.environ["MARKET_LOWER"]
+          manifest = json.loads(Path(f"/tmp/weekly-reference-seed/weekly-reference-latest-{market}.json").read_text(encoding="utf-8"))
+          print(manifest["bundle_asset_name"])
+          PY
+            )"
+          elif [ "${{ matrix.market }}" = "US" ] && gh release download weekly-reference-data \
+            --pattern "weekly-reference-latest.json" \
+            --dir /tmp/weekly-reference-seed >/dev/null 2>&1; then
+            BUNDLE_ASSET_NAME="$(python - <<'PY'
+          import json
+          from pathlib import Path
+          manifest = json.loads(Path("/tmp/weekly-reference-seed/weekly-reference-latest.json").read_text(encoding="utf-8"))
+          print(manifest["bundle_asset_name"])
+          PY
+            )"
+          fi
+
+          if [ -n "$BUNDLE_ASSET_NAME" ] && gh release download weekly-reference-data \
+            --pattern "$BUNDLE_ASSET_NAME" \
+            --dir /tmp/weekly-reference-seed >/dev/null 2>&1; then
+            cd backend
+            python -m app.scripts.import_weekly_reference_bundle \
+              --input "/tmp/weekly-reference-seed/${BUNDLE_ASSET_NAME}" \
+              --hydrate-mode full
+            echo "seeded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No weekly reference bundle available for ${{ matrix.market }}; skipping classification."
+            echo "seeded=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Load curated IBD CSV (canonical taxonomy + US seed)
+        if: ${{ steps.seed.outputs.seeded == 'true' }}
+        run: |
+          cd backend
+          python -m app.scripts.load_ibd_industry_groups
+
+      - name: Build IBD classification bundle
+        if: ${{ steps.seed.outputs.seeded == 'true' }}
+        run: |
+          cd backend
+          python -m app.scripts.build_ibd_classification_bundle \
+            --market "${{ matrix.market }}" \
+            --output-dir /tmp/ibd-classification
+
+      - name: Upload IBD classification assets
+        if: ${{ steps.seed.outputs.seeded == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MARKET_LOWER="$(echo "${{ matrix.market }}" | tr '[:upper:]' '[:lower:]')"
+          BUNDLE_PATH="$(find /tmp/ibd-classification -maxdepth 1 -name "ibd-classification-${MARKET_LOWER}-*.json.gz" | head -n 1)"
+          MANIFEST_PATH="/tmp/ibd-classification/ibd-classification-latest-${MARKET_LOWER}.json"
+
+          if [ -z "$BUNDLE_PATH" ] || [ ! -f "$MANIFEST_PATH" ]; then
+            echo "Missing IBD classification outputs" >&2
+            exit 1
+          fi
+
+          gh release upload ibd-classification-data "$BUNDLE_PATH" --clobber
+          gh release upload ibd-classification-data "$MANIFEST_PATH" --clobber

--- a/.github/workflows/ibd-classification.yml
+++ b/.github/workflows/ibd-classification.yml
@@ -64,9 +64,96 @@ jobs:
             --title "IBD Classification Data" \
             --notes "Automated hybrid IBD industry-group classifications for static-site builds."
 
-  classify:
+  # The deterministic crosswalk is US-derived (curated CSV ∩ US universe), so it
+  # is built once here and shared with every per-market classify job as an
+  # artifact rather than rebuilt per job. Best-effort: if the US weekly-reference
+  # bundle is unavailable, no artifact is produced and classify degrades to
+  # embedding+LLM.
+  build_crosswalk:
     if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     needs: ensure_release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: stockscanner
+          POSTGRES_USER: stockscanner
+          POSTGRES_PASSWORD: stockscanner
+        options: >-
+          --health-cmd "pg_isready -U stockscanner -d stockscanner"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      REDIS_ENABLED: "false"
+      DATABASE_URL: postgresql://stockscanner:stockscanner@localhost:5432/stockscanner
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+      - name: Install backend dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Seed US weekly reference bundle
+        id: seed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/weekly-reference-seed
+          BUNDLE_ASSET_NAME=""
+          if gh release download weekly-reference-data \
+            --pattern "weekly-reference-latest-us.json" \
+            --dir /tmp/weekly-reference-seed >/dev/null 2>&1; then
+            MANIFEST=/tmp/weekly-reference-seed/weekly-reference-latest-us.json
+          elif gh release download weekly-reference-data \
+            --pattern "weekly-reference-latest.json" \
+            --dir /tmp/weekly-reference-seed >/dev/null 2>&1; then
+            MANIFEST=/tmp/weekly-reference-seed/weekly-reference-latest.json
+          else
+            MANIFEST=""
+          fi
+          if [ -n "$MANIFEST" ]; then
+            BUNDLE_ASSET_NAME="$(python -c "import json,sys;print(json.load(open(sys.argv[1]))['bundle_asset_name'])" "$MANIFEST")"
+          fi
+          if [ -n "$BUNDLE_ASSET_NAME" ] && gh release download weekly-reference-data \
+            --pattern "$BUNDLE_ASSET_NAME" \
+            --dir /tmp/weekly-reference-seed >/dev/null 2>&1; then
+            cd backend
+            python -m app.scripts.import_weekly_reference_bundle \
+              --input "/tmp/weekly-reference-seed/${BUNDLE_ASSET_NAME}" \
+              --hydrate-mode full
+            echo "seeded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No US weekly reference bundle available; skipping crosswalk build."
+            echo "seeded=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build crosswalk from curated CSV + US universe
+        if: ${{ steps.seed.outputs.seeded == 'true' }}
+        continue-on-error: true
+        run: |
+          cd backend
+          python -m app.scripts.load_ibd_industry_groups
+          python -m app.scripts.build_ibd_crosswalk
+
+      - name: Upload crosswalk artifact
+        if: ${{ steps.seed.outputs.seeded == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ibd-crosswalk
+          path: data/ibd_crosswalk.json
+          if-no-files-found: warn
+
+  classify:
+    if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    needs: [ensure_release, build_crosswalk]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -109,6 +196,16 @@ jobs:
 
       - name: Install backend dependencies
         run: pip install -r backend/requirements.txt
+
+      # Pull the shared US-derived crosswalk into data/ where
+      # build_ibd_classification_bundle expects it. Non-fatal: if the prep job
+      # produced none, the cascade runs embedding+LLM only.
+      - name: Download IBD crosswalk
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ibd-crosswalk
+          path: data
 
       - name: Seed weekly reference bundle (universe to classify)
         id: seed

--- a/.github/workflows/ibd-classification.yml
+++ b/.github/workflows/ibd-classification.yml
@@ -32,9 +32,10 @@ on:
           - CA
           - DE
           - SG
+          - AU
           - MY
   schedule:
-    # Fallback ~3h after the Saturday weekly-reference cron (10:08 ET) in case
+    # Fallback ~3h after the Saturday weekly-reference cron (08:10 ET) in case
     # the workflow_run trigger is missed.
     - cron: '10 11 * * 6'
       timezone: 'America/New_York'
@@ -73,7 +74,7 @@ jobs:
       matrix:
         # Specific market on dispatch, full matrix otherwise (inputs are null on
         # workflow_run / schedule, so coerce to 'all').
-        market: ${{ fromJSON((github.event.inputs.market || 'all') != 'all' && format('["{0}"]', github.event.inputs.market) || '["US","HK","IN","JP","KR","TW","CN","CA","DE","SG","MY"]') }}
+        market: ${{ fromJSON((github.event.inputs.market || 'all') != 'all' && format('["{0}"]', github.event.inputs.market) || '["US","HK","IN","JP","KR","TW","CN","CA","DE","SG","AU","MY"]') }}
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/release-asset-cleanup.yml
+++ b/.github/workflows/release-asset-cleanup.yml
@@ -71,6 +71,16 @@ jobs:
                       re.compile(r"^weekly-reference-(?P<date>\d{8})-.+\.json\.gz$"),
                   ),
               ),
+              Policy(
+                  release="ibd-classification-data",
+                  keep=4,
+                  mode="dates",
+                  patterns=(
+                      re.compile(
+                          r"^ibd-classification-(?P<market>[a-z]{2})-(?P<date>\d{8})-.+\.json\.gz$"
+                      ),
+                  ),
+              ),
           )
 
           def gh_json(args: list[str]) -> dict:

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -202,6 +202,20 @@ jobs:
           python -m app.scripts.load_ibd_industry_groups \
             --csv ../data/IBD_industry_group.csv
 
+      # Fills IBD groups for symbols/markets the curated CSV doesn't cover (new
+      # listings, non-US markets) without overwriting CSV/manual rows. Additive
+      # and non-fatal: if the classification release isn't published yet, the
+      # build proceeds with CSV-only coverage.
+      - name: Apply IBD classification (fills gaps beyond the CSV seed)
+        continue-on-error: true
+        env:
+          GITHUB_DATA_TOKEN: ${{ github.token }}
+        run: |
+          cd backend
+          python -m app.scripts.sync_ibd_classification_from_github \
+            --market "${{ matrix.market }}" \
+            --allow-stale
+
       - name: Seed daily price bundle from GitHub
         env:
           GITHUB_DATA_TOKEN: ${{ github.token }}

--- a/backend/alembic/versions/20260601_0020_add_provenance_to_ibd_industry_groups.py
+++ b/backend/alembic/versions/20260601_0020_add_provenance_to_ibd_industry_groups.py
@@ -1,0 +1,74 @@
+"""Add provenance columns to ibd_industry_groups for the hybrid classifier.
+
+The table was US-only and populated solely from the curated CSV. The hybrid IBD
+classifier now also fills symbols/markets the CSV doesn't cover, so each row needs
+to record how it was assigned (``source``), how confident the classifier was
+(``confidence``), the finer method tag (``method``), the model identifier
+(``model_version``), and which market it belongs to (``market``).
+
+Backfill strategy mirrors ``20260424_0015_add_market_to_ibd_group_ranks``: add the
+NOT NULL columns with a server_default so existing rows fill cleanly, then drop the
+server_default so every future write must set ``source``/``market`` explicitly —
+a silent default of ``csv`` would corrupt the authoritative-override invariant.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260601_0020"
+down_revision = "20260529_0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add columns. NOT NULL columns get a server_default so existing rows
+    #    (all curated CSV/US) backfill without a rewrite.
+    op.add_column(
+        "ibd_industry_groups",
+        sa.Column("market", sa.String(length=8), nullable=False, server_default="US"),
+    )
+    op.add_column(
+        "ibd_industry_groups",
+        sa.Column("source", sa.String(length=20), nullable=False, server_default="csv"),
+    )
+    op.add_column(
+        "ibd_industry_groups",
+        sa.Column("confidence", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "ibd_industry_groups",
+        sa.Column("method", sa.String(length=40), nullable=True),
+    )
+    op.add_column(
+        "ibd_industry_groups",
+        sa.Column("model_version", sa.String(length=80), nullable=True),
+    )
+
+    op.create_index(
+        "idx_ibd_industry_group_market", "ibd_industry_groups", ["market"]
+    )
+    op.create_index(
+        "idx_ibd_industry_group_source", "ibd_industry_groups", ["source"]
+    )
+
+    # 2. Drop the server_defaults now that existing rows are backfilled — new rows
+    #    must set market/source explicitly so classifier rows can never be silently
+    #    mislabelled as authoritative ``csv``.
+    with op.batch_alter_table("ibd_industry_groups") as batch_op:
+        batch_op.alter_column("market", server_default=None)
+        batch_op.alter_column("source", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_ibd_industry_group_source", table_name="ibd_industry_groups")
+    op.drop_index("idx_ibd_industry_group_market", table_name="ibd_industry_groups")
+    with op.batch_alter_table("ibd_industry_groups") as batch_op:
+        batch_op.drop_column("model_version")
+        batch_op.drop_column("method")
+        batch_op.drop_column("confidence")
+        batch_op.drop_column("source")
+        batch_op.drop_column("market")

--- a/backend/app/models/industry.py
+++ b/backend/app/models/industry.py
@@ -87,7 +87,21 @@ class SectorRotation(Base):
 
 
 class IBDIndustryGroup(Base):
-    """IBD Industry Group Classifications"""
+    """IBD Industry Group Classifications.
+
+    Historically populated US-only from the tracked ``data/IBD_industry_group.csv``.
+    The hybrid classifier (see ``IBDClassificationService``) now also fills symbols
+    and markets the CSV doesn't cover, so each row records its provenance:
+
+    - ``source``  — how the group was assigned: ``csv`` (curated, authoritative) /
+      ``manual`` (human) / ``crosswalk`` (GICS→IBD) / ``embedding`` / ``llm``.
+    - ``confidence`` — 0..1 score for auto-classified rows (NULL for csv/manual).
+    - ``method`` — finer-grained method tag (e.g. ``gics_subindustry``, ``centroid_nn``).
+    - ``model_version`` — classifier/model identifier for LLM/embedding rows.
+
+    ``csv`` and ``manual`` rows are authoritative: the classifier skips symbols that
+    already carry them, and ``import_ibd_classification_bundle`` never overwrites them.
+    """
 
     __tablename__ = "ibd_industry_groups"
 
@@ -95,12 +109,25 @@ class IBDIndustryGroup(Base):
     symbol = Column(String(20), nullable=False, unique=True, index=True)
     industry_group = Column(String(100), nullable=False, index=True)
 
+    # Market the symbol belongs to (symbols are already market-namespaced, e.g.
+    # ``0700.HK``, so ``symbol`` stays globally unique; ``market`` is for filtering
+    # and per-market coverage reporting).
+    market = Column(String(8), nullable=False, default="US", index=True)
+
+    # Provenance of the classification.
+    source = Column(String(20), nullable=False, default="csv", index=True)
+    confidence = Column(Float)
+    method = Column(String(40))
+    model_version = Column(String(80))
+
     # Metadata
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     __table_args__ = (
         Index("idx_ibd_industry_group", "industry_group"),
+        Index("idx_ibd_industry_group_market", "market"),
+        Index("idx_ibd_industry_group_source", "source"),
     )
 
 

--- a/backend/app/scripts/build_ibd_classification_bundle.py
+++ b/backend/app/scripts/build_ibd_classification_bundle.py
@@ -1,0 +1,134 @@
+"""Classify a market's universe into IBD groups and write a release bundle.
+
+Runs the hybrid cascade (crosswalk → local embedding → optional LLM tiebreaker)
+over every active universe symbol for ``--market`` that lacks an authoritative
+group, then writes ``ibd-classification-<market>-<date>-<rev>.json.gz`` plus the
+``ibd-classification-latest-<market>.json`` manifest into ``--output-dir``.
+
+Expects the universe + curated CSV already loaded into the DB (the GitHub Action
+imports the weekly-reference bundle and loads the CSV in prior steps). The LLM
+tiebreaker is configured purely via env vars (``IBD_LLM_*``) — see
+``app.services.llm.openai_compatible_client``.
+
+Usage:
+    python -m app.scripts.build_ibd_classification_bundle --market SG --output-dir /tmp/ibd
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+from app.database import SessionLocal
+from app.scripts._runtime import prepare_runtime, repo_root
+from app.services.ibd_classification_bundle import (
+    bundle_asset_name,
+    build_manifest,
+    build_payload,
+    latest_manifest_name,
+    write_bundle,
+    write_manifest,
+)
+from app.services.ibd_classification_service import IBDClassificationService
+from app.services.ibd_crosswalk import IBDCrosswalk
+
+
+def _default_crosswalk_path() -> Path:
+    return repo_root() / "data" / "ibd_crosswalk.json"
+
+
+def _load_crosswalk(path: Path) -> IBDCrosswalk | None:
+    if path.exists():
+        return IBDCrosswalk.load(path)
+    print(f"WARNING: crosswalk file {path} not found; skipping deterministic tier", flush=True)
+    return None
+
+
+def _build_engine(disabled: bool):
+    if disabled:
+        return None
+    try:
+        from app.services.theme_embedding_service import ThemeEmbeddingEngine
+
+        return ThemeEmbeddingEngine("all-MiniLM-L6-v2")
+    except Exception as exc:  # noqa: BLE001
+        print(f"WARNING: embedding engine unavailable ({exc}); skipping embedding tier", flush=True)
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--market", required=True)
+    parser.add_argument("--output-dir", default=str(repo_root() / ".tmp" / "ibd-classification"))
+    parser.add_argument("--crosswalk", default=str(_default_crosswalk_path()))
+    parser.add_argument("--bundle-name", default=None)
+    parser.add_argument("--latest-manifest-name", default=None)
+    parser.add_argument("--no-llm", action="store_true", help="Disable the LLM tiebreaker tier.")
+    parser.add_argument(
+        "--no-embedding",
+        action="store_true",
+        help="Disable the embedding tier. The LLM tiebreaker ranks the embedding "
+        "shortlist, so this also disables the LLM tier (crosswalk-only).",
+    )
+    parser.add_argument("--as-of", default=None, help="Override as-of date (YYYY-MM-DD).")
+    args = parser.parse_args()
+
+    prepare_runtime()
+    market = args.market.strip().upper()
+
+    crosswalk = _load_crosswalk(Path(args.crosswalk))
+    engine = _build_engine(args.no_embedding)
+
+    tiebreaker = None
+    model_id = None
+    if not args.no_llm:
+        from app.services.llm.openai_compatible_client import build_ibd_tiebreaker
+
+        tiebreaker, model_id = build_ibd_tiebreaker()
+
+    now = datetime.utcnow().replace(microsecond=0)
+    as_of_date = args.as_of or now.date().isoformat()
+    as_of_compact = as_of_date.replace("-", "")
+    source_revision = f"ibd:{now.strftime('%Y%m%d%H%M%S')}"
+
+    with SessionLocal() as db:
+        service = IBDClassificationService(
+            crosswalk=crosswalk,
+            embedding_engine=engine,
+            llm_tiebreaker=tiebreaker,
+            llm_model_id=model_id,
+        )
+        result = service.classify_market(db, market)
+
+    summary = result.summary()
+    payload = build_payload(
+        market=market,
+        as_of_date=as_of_date,
+        source_revision=source_revision,
+        generated_at=now.isoformat() + "Z",
+        model_id=model_id,
+        assignments=result.assignments,
+        summary=summary,
+    )
+
+    output_dir = Path(args.output_dir)
+    resolved_bundle_name = args.bundle_name or bundle_asset_name(market, as_of_compact, source_revision)
+    resolved_manifest_name = args.latest_manifest_name or latest_manifest_name(market)
+    bundle_path = output_dir / resolved_bundle_name
+    manifest_path = output_dir / resolved_manifest_name
+
+    sha256 = write_bundle(bundle_path, payload)
+    manifest = build_manifest(payload=payload, bundle_name=resolved_bundle_name, sha256=sha256)
+    write_manifest(manifest_path, manifest)
+
+    print("IBD classification bundle complete:")
+    print(f"  - market:   {market}")
+    print(f"  - summary:  {summary}")
+    print(f"  - bundle:   {bundle_path}")
+    print(f"  - manifest: {manifest_path}")
+    print(f"  - sha256:   {sha256}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/scripts/build_ibd_crosswalk.py
+++ b/backend/app/scripts/build_ibd_crosswalk.py
@@ -1,0 +1,106 @@
+"""Derive the GICS/sector → IBD industry-group crosswalk from curated labels.
+
+Reads the curated ``data/IBD_industry_group.csv`` (authoritative ``symbol → IBD
+group``) and joins it against the classification attributes already in the DB
+(``stock_industry`` GICS sub-industry, ``stock_universe`` sector/industry) to
+majority-vote an IBD group per attribute key. Writes ``data/ibd_crosswalk.json``.
+
+This is a one-time / regenerable dev step — run it after the curated CSV or GICS
+data changes. The committed JSON is what the classifier loads at runtime, so the
+classifier does not need ``stock_industry`` populated in CI.
+
+Usage:
+    python -m app.scripts.build_ibd_crosswalk [--csv PATH] [--output PATH] [--as-of ISO8601]
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+from app.database import SessionLocal
+from app.models.stock import StockIndustry
+from app.models.stock_universe import StockUniverse
+from app.scripts._runtime import prepare_runtime, repo_root
+from app.services.ibd_crosswalk import build_crosswalk
+
+
+def _default_csv_path() -> Path:
+    return repo_root() / "data" / "IBD_industry_group.csv"
+
+
+def _default_output_path() -> Path:
+    return repo_root() / "data" / "ibd_crosswalk.json"
+
+
+def _parse_csv(csv_path: Path) -> dict[str, str]:
+    symbol_to_group: dict[str, str] = {}
+    with open(csv_path, "r", encoding="utf-8") as f:
+        for row in csv.reader(f):
+            if len(row) != 2:
+                continue
+            symbol, group = row[0].strip().upper(), row[1].strip()
+            if symbol and group:
+                symbol_to_group[symbol] = group
+    return symbol_to_group
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", default=str(_default_csv_path()))
+    parser.add_argument("--output", default=str(_default_output_path()))
+    parser.add_argument(
+        "--as-of",
+        default=None,
+        help="ISO timestamp stamped into the artifact (defaults to unset for determinism).",
+    )
+    args = parser.parse_args()
+
+    prepare_runtime()
+
+    symbol_to_group = _parse_csv(Path(args.csv))
+    symbols = list(symbol_to_group.keys())
+
+    symbol_to_subindustry: dict[str, str] = {}
+    symbol_to_sector_industry: dict[str, tuple[str, str]] = {}
+
+    with SessionLocal() as db:
+        for start in range(0, len(symbols), 500):
+            chunk = symbols[start:start + 500]
+            for sym, sub in db.query(
+                StockIndustry.symbol, StockIndustry.sub_industry
+            ).filter(StockIndustry.symbol.in_(chunk)).all():
+                if sub:
+                    symbol_to_subindustry[sym] = sub
+            for sym, sector, industry in db.query(
+                StockUniverse.symbol, StockUniverse.sector, StockUniverse.industry
+            ).filter(StockUniverse.symbol.in_(chunk)).all():
+                symbol_to_sector_industry[sym] = (sector or "", industry or "")
+
+    crosswalk = build_crosswalk(
+        symbol_to_group=symbol_to_group,
+        symbol_to_subindustry=symbol_to_subindustry,
+        symbol_to_sector_industry=symbol_to_sector_industry,
+        generated_at=args.as_of,
+    )
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with open(output, "w", encoding="utf-8") as f:
+        json.dump(crosswalk, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    print("IBD crosswalk build complete:")
+    print(f"  - labelled symbols:        {len(symbol_to_group)}")
+    print(f"  - with GICS sub-industry:  {len(symbol_to_subindustry)}")
+    print(f"  - with sector/industry:    {len(symbol_to_sector_industry)}")
+    print(f"  - gics_subindustry keys:   {len(crosswalk['gics_subindustry'])}")
+    print(f"  - sector_industry keys:    {len(crosswalk['sector_industry'])}")
+    print(f"  - sector keys:             {len(crosswalk['sector'])}")
+    print(f"  - output: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/scripts/import_ibd_classification_bundle.py
+++ b/backend/app/scripts/import_ibd_classification_bundle.py
@@ -1,0 +1,39 @@
+"""Import an IBD classification bundle into the local database.
+
+Upserts the bundle's classifications into ``ibd_industry_groups`` without ever
+overwriting authoritative (``csv``/``manual``) rows. Run after loading the curated
+CSV so the CSV remains the seed/override layer.
+
+Usage:
+    python -m app.scripts.import_ibd_classification_bundle --input /tmp/ibd/ibd-classification-sg-...json.gz
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from app.database import SessionLocal
+from app.scripts._runtime import prepare_runtime
+from app.services.ibd_classification_bundle import import_classifications, read_bundle
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Path to the .json.gz bundle.")
+    args = parser.parse_args()
+
+    prepare_runtime()
+    payload = read_bundle(Path(args.input))
+
+    with SessionLocal() as db:
+        stats = import_classifications(db, payload)
+
+    print("IBD classification import complete:")
+    print(f"  - input: {args.input}")
+    for key, value in stats.items():
+        print(f"  - {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/scripts/sync_ibd_classification_from_github.py
+++ b/backend/app/scripts/sync_ibd_classification_from_github.py
@@ -1,0 +1,78 @@
+"""Sync the latest IBD classification bundle from the GitHub release into the DB.
+
+Downloads ``ibd-classification-latest-<market>.json`` + its bundle from the
+``ibd-classification-data`` release (validating sha256) and imports the
+classifications, preserving authoritative CSV/manual rows. Used by the daily
+static-site build after the curated CSV is loaded.
+
+Usage:
+    python -m app.scripts.sync_ibd_classification_from_github --market SG [--allow-stale]
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from app.config import settings
+from app.database import SessionLocal
+from app.scripts._runtime import prepare_runtime
+from app.services.github_release_sync_service import GitHubReleaseSyncService
+from app.services.ibd_classification_bundle import (
+    IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION,
+    RELEASE_TAG,
+    import_classifications,
+    latest_manifest_name,
+    read_bundle,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--market", required=True)
+    parser.add_argument("--output-dir", default=str(Path(".tmp") / "ibd-classification"))
+    parser.add_argument("--allow-stale", action="store_true")
+    args = parser.parse_args()
+
+    prepare_runtime()
+    market = args.market.strip().upper()
+
+    repository = getattr(settings, "github_data_repository", "") or ""
+    api_base = getattr(settings, "github_data_api_base", "https://api.github.com")
+    token = getattr(settings, "github_data_token", "") or None
+    timeout = int(getattr(settings, "github_data_timeout_seconds", 60) or 60)
+    source_mode = getattr(settings, "market_data_source_mode", "github_first")
+
+    sync = GitHubReleaseSyncService(api_base=api_base)
+    result = sync.fetch_latest_bundle(
+        repository_full_name=repository,
+        release_tag=RELEASE_TAG,
+        manifest_asset_name=latest_manifest_name(market),
+        source_mode=source_mode,
+        expected_manifest_schema=str(IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION),
+        required_manifest_keys=("bundle_asset_name", "sha256"),
+        allow_stale=args.allow_stale,
+        github_token=token,
+        request_timeout_seconds=timeout,
+        output_dir=args.output_dir,
+    )
+
+    status = result.get("status")
+    print(f"IBD classification GitHub sync: status={status}")
+    if status != "success":
+        for key in ("reason", "error", "stale_reason"):
+            if result.get(key):
+                print(f"  - {key}: {result[key]}")
+        # live_only / up_to_date are non-fatal; anything else is a soft failure.
+        return 0 if status in {"live_only", "up_to_date"} else 1
+
+    payload = read_bundle(Path(result["bundle_path"]))
+    with SessionLocal() as db:
+        stats = import_classifications(db, payload)
+    print("Imported:")
+    for key, value in stats.items():
+        print(f"  - {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/scripts/sync_ibd_classification_from_github.py
+++ b/backend/app/scripts/sync_ibd_classification_from_github.py
@@ -48,7 +48,7 @@ def main() -> int:
         release_tag=RELEASE_TAG,
         manifest_asset_name=latest_manifest_name(market),
         source_mode=source_mode,
-        expected_manifest_schema=str(IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION),
+        expected_manifest_schema=IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION,
         required_manifest_keys=("bundle_asset_name", "sha256"),
         allow_stale=args.allow_stale,
         github_token=token,

--- a/backend/app/services/ibd_classification_bundle.py
+++ b/backend/app/services/ibd_classification_bundle.py
@@ -1,0 +1,159 @@
+"""Bundle/manifest format + import for the IBD classification release artifact.
+
+Mirrors the weekly-reference / daily-price convention: a gzipped JSON ``bundle``
+plus a small ``latest`` manifest carrying the bundle filename and its sha256.
+The artifact is published to the ``ibd-classification-data`` GitHub release and
+consumed by the daily static-site build.
+"""
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from sqlalchemy.orm import Session
+
+from ..models.industry import IBDIndustryGroup
+from .ibd_industry_service import IBDIndustryService
+
+IBD_CLASSIFICATION_BUNDLE_SCHEMA_VERSION = 1
+IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION = 1
+
+RELEASE_TAG = "ibd-classification-data"
+
+
+def bundle_asset_name(market: str, as_of_compact: str, revision: str) -> str:
+    rev = (revision or "snapshot").replace(":", "-").replace("/", "-")
+    return f"ibd-classification-{market.lower()}-{as_of_compact}-{rev}.json.gz"
+
+
+def latest_manifest_name(market: str) -> str:
+    return f"ibd-classification-latest-{market.lower()}.json"
+
+
+def write_bundle(output_path: Path, payload: dict) -> str:
+    """Write the gzipped JSON bundle; return its sha256 hex digest."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    # mtime=0 keeps the gzip header deterministic for a given payload.
+    with gzip.GzipFile(filename=str(output_path), mode="wb", mtime=0) as gz:
+        gz.write(data)
+    return hashlib.sha256(output_path.read_bytes()).hexdigest()
+
+
+def read_bundle(input_path: Path) -> dict:
+    with gzip.open(input_path, "rb") as gz:
+        return json.loads(gz.read().decode("utf-8"))
+
+
+def build_payload(
+    *,
+    market: str,
+    as_of_date: str,
+    source_revision: str,
+    generated_at: str | None,
+    model_id: str | None,
+    assignments: Iterable[Any],
+    summary: dict,
+) -> dict:
+    rows = [
+        {
+            "symbol": a.symbol,
+            "market": a.market,
+            "industry_group": a.industry_group,
+            "source": a.source,
+            "confidence": a.confidence,
+            "method": a.method,
+            "model_id": a.model_id,
+        }
+        for a in assignments
+    ]
+    return {
+        "schema_version": IBD_CLASSIFICATION_BUNDLE_SCHEMA_VERSION,
+        "market": market.upper(),
+        "generated_at": generated_at,
+        "as_of_date": as_of_date,
+        "source_revision": source_revision,
+        "generator": "ibd_classification",
+        "model_id": model_id,
+        "summary": summary,
+        "classifications": rows,
+    }
+
+
+def build_manifest(*, payload: dict, bundle_name: str, sha256: str) -> dict:
+    return {
+        "schema_version": IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION,
+        "market": payload["market"],
+        "generated_at": payload.get("generated_at"),
+        "as_of_date": payload.get("as_of_date"),
+        "source_revision": payload.get("source_revision"),
+        "bundle_asset_name": bundle_name,
+        "sha256": sha256,
+        "summary": payload.get("summary"),
+    }
+
+
+def write_manifest(path: Path, manifest: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def import_classifications(db: Session, payload: dict) -> dict:
+    """Upsert a bundle's classifications into ``ibd_industry_groups``.
+
+    Authoritative rows (``source in {csv, manual}``) are never overwritten — the
+    curated CSV and human overrides win. Non-authoritative rows are updated in
+    place; missing symbols are inserted.
+    """
+    if payload.get("schema_version") != IBD_CLASSIFICATION_BUNDLE_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported IBD classification bundle schema: {payload.get('schema_version')}"
+        )
+
+    rows = payload.get("classifications", [])
+    symbols = [r["symbol"] for r in rows]
+
+    existing: dict[str, IBDIndustryGroup] = {}
+    for start in range(0, len(symbols), 500):
+        chunk = symbols[start:start + 500]
+        for row in db.query(IBDIndustryGroup).filter(IBDIndustryGroup.symbol.in_(chunk)).all():
+            existing[row.symbol] = row
+
+    inserted = updated = skipped_authoritative = 0
+    for r in rows:
+        symbol = r["symbol"]
+        current = existing.get(symbol)
+        if current is not None and current.source in IBDIndustryService.AUTHORITATIVE_SOURCES:
+            skipped_authoritative += 1
+            continue
+        if current is None:
+            db.add(IBDIndustryGroup(
+                symbol=symbol,
+                industry_group=r["industry_group"],
+                market=r.get("market") or payload.get("market") or "US",
+                source=r.get("source") or "embedding",
+                confidence=r.get("confidence"),
+                method=r.get("method"),
+                model_version=r.get("model_id"),
+            ))
+            inserted += 1
+        else:
+            current.industry_group = r["industry_group"]
+            current.market = r.get("market") or current.market
+            current.source = r.get("source") or current.source
+            current.confidence = r.get("confidence")
+            current.method = r.get("method")
+            current.model_version = r.get("model_id")
+            updated += 1
+
+    db.commit()
+    return {
+        "market": payload.get("market"),
+        "rows": len(rows),
+        "inserted": inserted,
+        "updated": updated,
+        "skipped_authoritative": skipped_authoritative,
+    }

--- a/backend/app/services/ibd_classification_bundle.py
+++ b/backend/app/services/ibd_classification_bundle.py
@@ -18,8 +18,12 @@ from sqlalchemy.orm import Session
 from ..models.industry import IBDIndustryGroup
 from .ibd_industry_service import IBDIndustryService
 
-IBD_CLASSIFICATION_BUNDLE_SCHEMA_VERSION = 1
-IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION = 1
+# String schema identifiers, matching the weekly-reference convention. The
+# GitHub release-sync service compares the manifest's schema_version against the
+# expected value with ``!=``, so producer and consumer must use the same type;
+# strings avoid the int-vs-str mismatch that would silently reject every import.
+IBD_CLASSIFICATION_BUNDLE_SCHEMA_VERSION = "ibd-classification-bundle-v1"
+IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION = "ibd-classification-manifest-v1"
 
 RELEASE_TAG = "ibd-classification-data"
 
@@ -37,9 +41,11 @@ def write_bundle(output_path: Path, payload: dict) -> str:
     """Write the gzipped JSON bundle; return its sha256 hex digest."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
     data = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
-    # mtime=0 keeps the gzip header deterministic for a given payload.
-    with gzip.GzipFile(filename=str(output_path), mode="wb", mtime=0) as gz:
-        gz.write(data)
+    # filename="" + mtime=0 keep the gzip header path- and time-independent, so
+    # the same payload yields the same bytes (and sha256) regardless of output path.
+    with output_path.open("wb") as fh:
+        with gzip.GzipFile(fileobj=fh, filename="", mode="wb", mtime=0) as gz:
+            gz.write(data)
     return hashlib.sha256(output_path.read_bytes()).hexdigest()
 
 

--- a/backend/app/services/ibd_classification_service.py
+++ b/backend/app/services/ibd_classification_service.py
@@ -1,0 +1,319 @@
+"""Hybrid IBD industry-group classifier.
+
+Assigns an IBD industry group to every active universe symbol that lacks an
+authoritative one, using a free-first cascade that mirrors the theme matcher:
+
+1. **skip** symbols already carrying an authoritative group (``csv``/``manual``);
+2. **crosswalk** — deterministic GICS/sector → IBD group (free, high confidence);
+3. **embedding** — local ``all-MiniLM-L6-v2`` nearest group centroid (free);
+4. **llm** — closed-set shortlist tiebreaker for the residual (paid, optional).
+
+All markets classify into the *same* canonical IBD taxonomy (the groups the
+curated US CSV defines) so ``IBDGroupRankService`` works unchanged and groups are
+cross-market comparable. The embedding engine and LLM client are injected so the
+cascade is unit-testable without loading models or calling APIs.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, Optional, Protocol
+
+from sqlalchemy.orm import Session
+
+if TYPE_CHECKING:
+    import numpy as np
+
+from ..models.industry import IBDIndustryGroup
+from ..models.stock import StockIndustry
+from ..models.stock_universe import StockUniverse
+from .ibd_crosswalk import IBDCrosswalk
+from .ibd_industry_service import IBDIndustryService
+
+logger = logging.getLogger(__name__)
+
+# Source tags persisted on each assignment (see IBDIndustryGroup docstring).
+SOURCE_CROSSWALK = "crosswalk"
+SOURCE_EMBEDDING = "embedding"
+SOURCE_LLM = "llm"
+
+
+@dataclass
+class StockContext:
+    symbol: str
+    market: str
+    name: str = ""
+    sector: str = ""
+    industry: str = ""
+    sub_industry: str = ""
+
+    def text(self) -> str:
+        """Descriptive text used for embedding / LLM input."""
+        parts = [self.name, self.sector, self.industry, self.sub_industry]
+        return " ".join(p for p in (s.strip() for s in parts) if p)
+
+
+@dataclass
+class Assignment:
+    symbol: str
+    market: str
+    industry_group: str
+    source: str
+    confidence: Optional[float]
+    method: str
+    model_id: Optional[str] = None
+
+
+@dataclass
+class ClassificationResult:
+    market: str
+    assignments: list[Assignment] = field(default_factory=list)
+    skipped_authoritative: int = 0
+    unresolved: list[str] = field(default_factory=list)
+    candidates: int = 0
+
+    def summary(self) -> dict:
+        by_method: dict[str, int] = {}
+        for a in self.assignments:
+            by_method[a.source] = by_method.get(a.source, 0) + 1
+        total_active = self.candidates + self.skipped_authoritative
+        classified = len(self.assignments) + self.skipped_authoritative
+        return {
+            "market": self.market,
+            "active_total": total_active,
+            "candidates": self.candidates,
+            "skipped_authoritative": self.skipped_authoritative,
+            "newly_classified": len(self.assignments),
+            "unresolved": len(self.unresolved),
+            "by_source": by_method,
+            "coverage_pct": round(100.0 * classified / total_active, 2) if total_active else 0.0,
+        }
+
+
+class EmbeddingEngine(Protocol):
+    def encode(self, text: str): ...  # returns vector or None
+
+    @staticmethod
+    def cosine_similarity(left, right) -> float: ...
+
+
+# LLM tiebreaker contract: given a stock's text and a shortlist of candidate
+# group names, return the chosen group (must be one of the shortlist) or None.
+LLMTiebreaker = Callable[[str, list[str]], Optional[str]]
+
+
+def _clean_group_name_for_embedding(group: str) -> str:
+    """Turn an IBD group code into descriptive text, e.g.
+    'Oil&Gas-Refining/Mktg' -> 'Oil Gas Refining Mktg'."""
+    return re.sub(r"[-/&]+", " ", group).strip()
+
+
+class IBDClassificationService:
+    """Classify universe symbols into the canonical IBD taxonomy."""
+
+    # Embedding cosine above which we auto-attach without the LLM.
+    EMBEDDING_ATTACH_THRESHOLD = 0.55
+    # Number of nearest group centroids handed to the LLM tiebreaker.
+    LLM_SHORTLIST_SIZE = 6
+    # Representative member texts blended into each group centroid (when present).
+    MAX_MEMBERS_PER_CENTROID = 25
+
+    def __init__(
+        self,
+        *,
+        crosswalk: IBDCrosswalk | None,
+        embedding_engine: EmbeddingEngine | None = None,
+        llm_tiebreaker: LLMTiebreaker | None = None,
+        llm_model_id: str | None = None,
+        group_taxonomy: list[str] | None = None,
+        attach_threshold: float | None = None,
+    ):
+        self.crosswalk = crosswalk
+        self.engine = embedding_engine
+        self.llm_tiebreaker = llm_tiebreaker
+        self.llm_model_id = llm_model_id
+        self._taxonomy = group_taxonomy
+        self.attach_threshold = (
+            attach_threshold if attach_threshold is not None else self.EMBEDDING_ATTACH_THRESHOLD
+        )
+        self._centroids: dict[str, "np.ndarray"] | None = None
+
+    # ---- taxonomy & centroids ------------------------------------------------
+
+    def canonical_taxonomy(self, db: Session) -> list[str]:
+        """The canonical IBD group list (distinct US CSV/manual groups)."""
+        if self._taxonomy is None:
+            rows = (
+                db.query(IBDIndustryGroup.industry_group)
+                .filter(IBDIndustryGroup.industry_group.isnot(None))
+                .distinct()
+                .all()
+            )
+            self._taxonomy = sorted({r.industry_group for r in rows if r.industry_group})
+        return self._taxonomy
+
+    def _build_centroids(self, db: Session, taxonomy: list[str]) -> dict[str, "np.ndarray"]:
+        """Centroid embedding per group: the cleaned group name, blended with a
+        sample of labelled members' text when those rows are available locally."""
+        if self.engine is None:
+            return {}
+        import numpy as np
+
+        # Gather sample member texts per group (only works where the labelled
+        # universe is loaded; degrades to name-only otherwise).
+        member_texts: dict[str, list[str]] = {g: [] for g in taxonomy}
+        rows = (
+            db.query(
+                IBDIndustryGroup.industry_group,
+                StockUniverse.name,
+                StockUniverse.sector,
+                StockUniverse.industry,
+            )
+            .join(StockUniverse, StockUniverse.symbol == IBDIndustryGroup.symbol)
+            .filter(IBDIndustryGroup.source.in_(IBDIndustryService.AUTHORITATIVE_SOURCES))
+            .all()
+        )
+        for group, name, sector, industry in rows:
+            bucket = member_texts.get(group)
+            if bucket is None or len(bucket) >= self.MAX_MEMBERS_PER_CENTROID:
+                continue
+            txt = " ".join(p for p in (name, sector, industry) if p)
+            if txt:
+                bucket.append(txt)
+
+        centroids: dict[str, object] = {}
+        for group in taxonomy:
+            texts = [_clean_group_name_for_embedding(group)] + member_texts.get(group, [])
+            vectors = [v for v in (self.engine.encode(t) for t in texts) if v is not None]
+            if not vectors:
+                continue
+            # Mean of unit vectors → centroid direction.
+            centroids[group] = np.mean(np.stack(vectors), axis=0)
+        return centroids
+
+    def _centroids_for(self, db: Session, taxonomy: list[str]) -> dict[str, "np.ndarray"]:
+        if self._centroids is None:
+            self._centroids = self._build_centroids(db, taxonomy)
+        return self._centroids
+
+    # ---- candidate selection -------------------------------------------------
+
+    def _authoritative_symbols(self, db: Session) -> set[str]:
+        rows = (
+            db.query(IBDIndustryGroup.symbol)
+            .filter(IBDIndustryGroup.source.in_(IBDIndustryService.AUTHORITATIVE_SOURCES))
+            .all()
+        )
+        return {r.symbol for r in rows}
+
+    def _candidate_contexts(self, db: Session, market: str) -> tuple[list[StockContext], int]:
+        """Return ``(contexts_to_classify, skipped_authoritative_count)`` from a
+        single active-universe fetch, so the skip count can never drift from the
+        skip logic that produced it."""
+        authoritative = self._authoritative_symbols(db)
+        universe = (
+            db.query(StockUniverse)
+            .filter(StockUniverse.market == market, StockUniverse.is_active.is_(True))
+            .all()
+        )
+        symbols = [u.symbol for u in universe]
+        sub_by_symbol: dict[str, str] = {}
+        for start in range(0, len(symbols), 500):
+            chunk = symbols[start:start + 500]
+            for sym, sub in (
+                db.query(StockIndustry.symbol, StockIndustry.sub_industry)
+                .filter(StockIndustry.symbol.in_(chunk))
+                .all()
+            ):
+                if sub:
+                    sub_by_symbol[sym] = sub
+
+        contexts: list[StockContext] = []
+        skipped = 0
+        for u in universe:
+            if u.symbol in authoritative:
+                skipped += 1
+                continue
+            contexts.append(StockContext(
+                symbol=u.symbol,
+                market=market,
+                name=u.name or "",
+                sector=u.sector or "",
+                industry=u.industry or "",
+                sub_industry=sub_by_symbol.get(u.symbol, ""),
+            ))
+        return contexts, skipped
+
+    # ---- the cascade ---------------------------------------------------------
+
+    def _embedding_ranking(self, ctx: StockContext, centroids: dict[str, "np.ndarray"]) -> list[tuple[str, float]]:
+        if self.engine is None or not centroids:
+            return []
+        vec = self.engine.encode(ctx.text())
+        if vec is None:
+            return []
+        scored = [
+            (group, self.engine.cosine_similarity(vec, centroid))
+            for group, centroid in centroids.items()
+        ]
+        scored.sort(key=lambda gs: (-gs[1], gs[0]))
+        return scored
+
+    def classify_one(self, ctx: StockContext, centroids: dict[str, "np.ndarray"]) -> Optional[Assignment]:
+        # Tier 2: deterministic crosswalk.
+        if self.crosswalk is not None:
+            hit = self.crosswalk.lookup(
+                sub_industry=ctx.sub_industry, sector=ctx.sector, industry=ctx.industry
+            )
+            if hit is not None:
+                return Assignment(
+                    symbol=ctx.symbol, market=ctx.market, industry_group=hit.group,
+                    source=SOURCE_CROSSWALK, confidence=hit.confidence, method=hit.method,
+                )
+
+        # Tier 3/4: rank against group centroids; attach the nearest if confident,
+        # otherwise let the LLM tiebreaker pick from that shortlist.
+        ranking = self._embedding_ranking(ctx, centroids)
+        if not ranking:
+            return None
+
+        best_group, best_score = ranking[0]
+        if best_score >= self.attach_threshold:
+            return Assignment(
+                symbol=ctx.symbol, market=ctx.market, industry_group=best_group,
+                source=SOURCE_EMBEDDING, confidence=round(float(best_score), 4),
+                method="centroid_nn",
+            )
+
+        if self.llm_tiebreaker is not None:
+            shortlist = [g for g, _ in ranking[: self.LLM_SHORTLIST_SIZE]]
+            chosen = self.llm_tiebreaker(ctx.text(), shortlist)
+            if chosen and chosen in shortlist:
+                return Assignment(
+                    symbol=ctx.symbol, market=ctx.market, industry_group=chosen,
+                    source=SOURCE_LLM, confidence=None, method="llm_shortlist",
+                    model_id=self.llm_model_id,
+                )
+        return None
+
+    def classify_market(self, db: Session, market: str) -> ClassificationResult:
+        market = (market or "US").upper()
+        taxonomy = self.canonical_taxonomy(db)
+        if not taxonomy:
+            logger.warning("No canonical IBD taxonomy available; load the CSV first")
+        centroids = self._centroids_for(db, taxonomy)
+
+        contexts, skipped_authoritative = self._candidate_contexts(db, market)
+        result = ClassificationResult(
+            market=market, candidates=len(contexts), skipped_authoritative=skipped_authoritative
+        )
+        for ctx in contexts:
+            assignment = self.classify_one(ctx, centroids)
+            if assignment is not None:
+                result.assignments.append(assignment)
+            else:
+                result.unresolved.append(ctx.symbol)
+
+        logger.info("IBD classification %s: %s", market, result.summary())
+        return result

--- a/backend/app/services/ibd_classification_service.py
+++ b/backend/app/services/ibd_classification_service.py
@@ -144,9 +144,15 @@ class IBDClassificationService:
     def canonical_taxonomy(self, db: Session) -> list[str]:
         """The canonical IBD group list (distinct US CSV/manual groups)."""
         if self._taxonomy is None:
+            # Authoritative US rows only — never let a derived (crosswalk/embedding/
+            # llm) or non-US assignment widen the canonical taxonomy on a later run.
             rows = (
                 db.query(IBDIndustryGroup.industry_group)
-                .filter(IBDIndustryGroup.industry_group.isnot(None))
+                .filter(
+                    IBDIndustryGroup.industry_group.isnot(None),
+                    IBDIndustryGroup.market == "US",
+                    IBDIndustryGroup.source.in_(IBDIndustryService.AUTHORITATIVE_SOURCES),
+                )
                 .distinct()
                 .all()
             )

--- a/backend/app/services/ibd_crosswalk.py
+++ b/backend/app/services/ibd_crosswalk.py
@@ -1,0 +1,165 @@
+"""Data-derived GICS/sector → IBD industry-group crosswalk.
+
+The curated ``data/IBD_industry_group.csv`` gives ``symbol → IBD group`` for ~10k
+US names. Those same symbols carry GICS classification (``stock_industry``) and
+source sector/industry (``stock_universe``). By majority-voting the IBD group
+within each GICS sub-industry (and, as a fallback, each ``sector||industry`` and
+each ``sector``), we learn a deterministic mapping that generalises for free to
+any stock — new US names and foreign markets — that shares those attributes.
+
+The vote logic here is pure and unit-tested; ``scripts/build_ibd_crosswalk.py``
+feeds it from the database and writes ``data/ibd_crosswalk.json``. At runtime the
+classifier loads that JSON via :class:`IBDCrosswalk` and consults it as the first,
+free tier of the classification cascade.
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+CROSSWALK_SCHEMA_VERSION = 1
+
+# Keys for the three lookup tiers, most specific first.
+TIER_SUBINDUSTRY = "gics_subindustry"
+TIER_SECTOR_INDUSTRY = "sector_industry"
+TIER_SECTOR = "sector"
+
+_SECTOR_INDUSTRY_SEP = "||"
+
+
+def _norm(value: Optional[str]) -> str:
+    return (value or "").strip()
+
+
+def _pick_majority(votes: dict[str, int]) -> tuple[str, int, int]:
+    """Return (group, group_votes, total_votes) for the winning group.
+
+    Ties broken by highest votes then lexicographically smallest group name, so
+    the crosswalk is fully deterministic regardless of insertion order.
+    """
+    total = sum(votes.values())
+    group = min(votes.items(), key=lambda kv: (-kv[1], kv[0]))[0]
+    return group, votes[group], total
+
+
+def build_crosswalk(
+    *,
+    symbol_to_group: dict[str, str],
+    symbol_to_subindustry: dict[str, str] | None = None,
+    symbol_to_sector_industry: dict[str, tuple[str, str]] | None = None,
+    generated_at: str | None = None,
+) -> dict:
+    """Build the crosswalk dict from ground-truth symbol→group labels.
+
+    Args:
+        symbol_to_group: authoritative IBD group per symbol (from the curated CSV).
+        symbol_to_subindustry: GICS sub-industry per symbol (``stock_industry``).
+        symbol_to_sector_industry: ``(sector, industry)`` per symbol (``stock_universe``).
+        generated_at: ISO timestamp stamped into the artifact (caller-supplied so
+            the build stays deterministic / replayable).
+    """
+    symbol_to_subindustry = symbol_to_subindustry or {}
+    symbol_to_sector_industry = symbol_to_sector_industry or {}
+
+    sub_votes: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    sec_ind_votes: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    sec_votes: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+    for symbol, group in symbol_to_group.items():
+        group = _norm(group)
+        if not group:
+            continue
+
+        sub = _norm(symbol_to_subindustry.get(symbol))
+        if sub:
+            sub_votes[sub][group] += 1
+
+        sector, industry = symbol_to_sector_industry.get(symbol, ("", ""))
+        sector, industry = _norm(sector), _norm(industry)
+        if sector and industry:
+            sec_ind_votes[f"{sector}{_SECTOR_INDUSTRY_SEP}{industry}"][group] += 1
+        if sector:
+            sec_votes[sector][group] += 1
+
+    def _resolve(table: dict[str, dict[str, int]]) -> dict[str, dict]:
+        resolved: dict[str, dict] = {}
+        for key in sorted(table):
+            group, votes, total = _pick_majority(table[key])
+            resolved[key] = {
+                "group": group,
+                "votes": votes,
+                "total": total,
+                "share": round(votes / total, 4) if total else 0.0,
+            }
+        return resolved
+
+    return {
+        "schema_version": CROSSWALK_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        TIER_SUBINDUSTRY: _resolve(sub_votes),
+        TIER_SECTOR_INDUSTRY: _resolve(sec_ind_votes),
+        TIER_SECTOR: _resolve(sec_votes),
+    }
+
+
+@dataclass
+class CrosswalkHit:
+    group: str
+    confidence: float
+    method: str  # one of TIER_* constants
+
+
+class IBDCrosswalk:
+    """Loads a crosswalk artifact and resolves stocks to IBD groups."""
+
+    def __init__(self, data: dict):
+        self._sub = data.get(TIER_SUBINDUSTRY, {})
+        self._sec_ind = data.get(TIER_SECTOR_INDUSTRY, {})
+        self._sec = data.get(TIER_SECTOR, {})
+
+    @classmethod
+    def load(cls, path: str | Path) -> "IBDCrosswalk":
+        with open(path, "r", encoding="utf-8") as f:
+            return cls(json.load(f))
+
+    def lookup(
+        self,
+        *,
+        sub_industry: Optional[str] = None,
+        sector: Optional[str] = None,
+        industry: Optional[str] = None,
+        min_share: float = 0.6,
+        min_votes: int = 3,
+    ) -> Optional[CrosswalkHit]:
+        """Resolve a stock to an IBD group, most-specific tier first.
+
+        Returns the first tier whose winning group clears ``min_share`` and
+        ``min_votes``; ``None`` if no tier qualifies (defers to the next cascade
+        stage). ``confidence`` is the winning group's vote share.
+        """
+        sub = _norm(sub_industry)
+        sector = _norm(sector)
+        industry = _norm(industry)
+
+        candidates: list[tuple[dict, str, str]] = []
+        if sub:
+            candidates.append((self._sub, sub, TIER_SUBINDUSTRY))
+        if sector and industry:
+            candidates.append(
+                (self._sec_ind, f"{sector}{_SECTOR_INDUSTRY_SEP}{industry}", TIER_SECTOR_INDUSTRY)
+            )
+        if sector:
+            candidates.append((self._sec, sector, TIER_SECTOR))
+
+        for table, key, method in candidates:
+            entry = table.get(key)
+            if not entry:
+                continue
+            if entry["share"] >= min_share and entry["votes"] >= min_votes:
+                return CrosswalkHit(
+                    group=entry["group"], confidence=entry["share"], method=method
+                )
+        return None

--- a/backend/app/services/ibd_industry_service.py
+++ b/backend/app/services/ibd_industry_service.py
@@ -59,10 +59,20 @@ class IBDIndustryService:
 
         return configured_path
 
+    # Provenance values that are authoritative and must not be clobbered by the
+    # hybrid classifier or its bundle import.
+    AUTHORITATIVE_SOURCES = ("csv", "manual")
+
     @staticmethod
     def load_from_csv(db: Session, csv_path: str = None) -> int:
         """
-        Load IBD industry groups from CSV file.
+        Load IBD industry groups from the curated CSV (US, ``source='csv'``).
+
+        The CSV is the authoritative seed layer. To preserve classifier-derived
+        rows (``source in {crosswalk, embedding, llm}``) and human overrides
+        (``source='manual'``) across reloads, this only clears ``csv`` rows rather
+        than the whole table, and drops classifier rows for any symbol the CSV now
+        claims (CSV wins) while leaving ``manual`` rows untouched.
 
         Args:
             db: Database session
@@ -77,47 +87,79 @@ class IBDIndustryService:
 
         logger.info(f"Loading IBD industry groups from {csv_path}")
 
-        # Clear existing data
-        db.execute(delete(IBDIndustryGroup))
-        db.commit()
-        logger.info("Cleared existing IBD industry data")
+        # Parse the full CSV up front so we know which symbols the curated file
+        # claims before we mutate the table.
+        parsed: dict[str, str] = {}
+        with open(csv_path, 'r', encoding='utf-8') as f:
+            for row in csv.reader(f):
+                if len(row) != 2:
+                    continue
+                symbol, industry_group = row
+                symbol = symbol.strip().upper()
+                industry_group = industry_group.strip()
+                if not symbol or not industry_group:
+                    continue
+                parsed[symbol] = industry_group  # last write wins on dup symbol
 
-        loaded = 0
-        batch = []
+        csv_symbols = list(parsed.keys())
 
         try:
-            with open(csv_path, 'r', encoding='utf-8') as f:
-                reader = csv.reader(f)
+            # 1. Clear previously-loaded CSV rows (not classifier/manual rows).
+            db.execute(
+                delete(IBDIndustryGroup).where(IBDIndustryGroup.source == "csv")
+            )
 
-                for row in reader:
-                    if len(row) != 2:
-                        continue
+            # 2. Drop classifier rows for symbols the CSV now claims (CSV is
+            #    authoritative); keep human ``manual`` rows. Chunked to respect
+            #    SQLite's bound-parameter limit.
+            for start in range(0, len(csv_symbols), 500):
+                chunk = csv_symbols[start:start + 500]
+                db.execute(
+                    delete(IBDIndustryGroup).where(
+                        IBDIndustryGroup.symbol.in_(chunk),
+                        IBDIndustryGroup.source.notin_(
+                            IBDIndustryService.AUTHORITATIVE_SOURCES
+                        ),
+                    )
+                )
+            db.commit()
+            logger.info("Cleared existing CSV-sourced IBD industry data")
 
-                    symbol, industry_group = row
-                    symbol = symbol.strip().upper()
-                    industry_group = industry_group.strip()
+            # 3. Symbols still present are ``manual`` overrides — never replace them.
+            protected: set[str] = set()
+            for start in range(0, len(csv_symbols), 500):
+                chunk = csv_symbols[start:start + 500]
+                rows = db.query(IBDIndustryGroup.symbol).filter(
+                    IBDIndustryGroup.symbol.in_(chunk)
+                ).all()
+                protected.update(r.symbol for r in rows)
+            if protected:
+                logger.info(
+                    "Preserving %d manual IBD overrides over CSV values", len(protected)
+                )
 
-                    if not symbol or not industry_group:
-                        continue
-
-                    batch.append({
-                        'symbol': symbol,
-                        'industry_group': industry_group
-                    })
-
-                    # Batch insert every 500 records
-                    if len(batch) >= 500:
-                        db.bulk_insert_mappings(IBDIndustryGroup, batch)
-                        db.commit()
-                        loaded += len(batch)
-                        logger.info(f"Loaded {loaded} IBD industry mappings...")
-                        batch = []
-
-                # Insert remaining records
-                if batch:
+            loaded = 0
+            batch = []
+            for symbol, industry_group in parsed.items():
+                if symbol in protected:
+                    continue
+                batch.append({
+                    'symbol': symbol,
+                    'industry_group': industry_group,
+                    'market': 'US',
+                    'source': 'csv',
+                })
+                if len(batch) >= 500:
                     db.bulk_insert_mappings(IBDIndustryGroup, batch)
                     db.commit()
                     loaded += len(batch)
+                    logger.info(f"Loaded {loaded} IBD industry mappings...")
+                    batch = []
+
+            if batch:
+                db.bulk_insert_mappings(IBDIndustryGroup, batch)
+                db.commit()
+                loaded += len(batch)
 
             logger.info(f"Successfully loaded {loaded} IBD industry group mappings")
             return loaded

--- a/backend/app/services/ibd_industry_service.py
+++ b/backend/app/services/ibd_industry_service.py
@@ -165,8 +165,10 @@ class IBDIndustryService:
                     'source': 'csv',
                 })
                 if len(batch) >= 500:
+                    # bulk_insert_mappings emits the INSERT immediately within the
+                    # open transaction; the single commit below makes the whole
+                    # delete+reload atomic.
                     db.bulk_insert_mappings(IBDIndustryGroup, batch)
-                    db.flush()
                     loaded += len(batch)
                     logger.info(f"Loaded {loaded} IBD industry mappings...")
                     batch = []

--- a/backend/app/services/ibd_industry_service.py
+++ b/backend/app/services/ibd_industry_service.py
@@ -29,6 +29,18 @@ def _market_taxonomy_service():
 _TAXONOMY_SINGLETON = None
 
 
+def _market_has_curated_taxonomy(market: str) -> bool:
+    """True when ``market`` ships a committed classification taxonomy (HK/JP/TW/IN).
+
+    CA/DE/SG/MY register empty taxonomy buckets, so they fall through to the
+    classifier-populated ``ibd_industry_groups`` table instead.
+    """
+    try:
+        return bool(_market_taxonomy_service().groups_for_market(market))
+    except Exception:  # noqa: BLE001 — fail toward the DB path
+        return False
+
+
 class IBDIndustryService:
     """Manage IBD Industry Group data"""
 
@@ -122,7 +134,10 @@ class IBDIndustryService:
                         ),
                     )
                 )
-            db.commit()
+            # No intermediate commit: the whole delete-and-reload runs in one
+            # transaction so a failure rolls back to the prior consistent state
+            # rather than leaving the table partially emptied. The protected
+            # query below still sees the deletes via the session's autoflush.
             logger.info("Cleared existing CSV-sourced IBD industry data")
 
             # 3. Symbols still present are ``manual`` overrides — never replace them.
@@ -151,16 +166,16 @@ class IBDIndustryService:
                 })
                 if len(batch) >= 500:
                     db.bulk_insert_mappings(IBDIndustryGroup, batch)
-                    db.commit()
+                    db.flush()
                     loaded += len(batch)
                     logger.info(f"Loaded {loaded} IBD industry mappings...")
                     batch = []
 
             if batch:
                 db.bulk_insert_mappings(IBDIndustryGroup, batch)
-                db.commit()
                 loaded += len(batch)
 
+            db.commit()  # single commit → delete+reload is atomic
             logger.info(f"Successfully loaded {loaded} IBD industry group mappings")
             return loaded
 
@@ -225,12 +240,14 @@ class IBDIndustryService:
     def get_group_symbols(db: Session, industry_group: str, *, market: str | None = None) -> list:
         """Get all symbols in an industry group.
 
-        For ``market='US'`` (default) reads the persisted ``ibd_industry_groups``
-        table. For HK/JP/TW/IN, delegates to ``MarketTaxonomyService`` which
-        loads classification CSVs from ``data/`` at runtime.
+        Markets with a committed taxonomy (HK/JP/TW/IN) delegate to
+        ``MarketTaxonomyService``. US and taxonomy-less markets (CA/DE/SG/MY,
+        populated by the hybrid classifier) read the ``ibd_industry_groups``
+        table — always filtered by ``market`` so a group's membership never
+        leaks symbols across markets.
         """
         normalized = (market or "US").upper()
-        if normalized != "US":
+        if normalized != "US" and _market_has_curated_taxonomy(normalized):
             try:
                 return _market_taxonomy_service().symbols_for_group(normalized, industry_group)
             except Exception as e:
@@ -241,7 +258,8 @@ class IBDIndustryService:
                 return []
         try:
             records = db.query(IBDIndustryGroup.symbol).filter(
-                IBDIndustryGroup.industry_group == industry_group
+                IBDIndustryGroup.industry_group == industry_group,
+                IBDIndustryGroup.market == normalized,
             ).all()
             return [r.symbol for r in records]
         except Exception as e:
@@ -252,11 +270,13 @@ class IBDIndustryService:
     def get_all_groups(db: Session, *, market: str | None = None) -> list:
         """Get list of all unique industry groups for a market.
 
-        For ``market='US'`` (default) reads the persisted ``ibd_industry_groups``
-        table. For HK/JP/TW/IN, delegates to ``MarketTaxonomyService``.
+        Markets with a committed taxonomy (HK/JP/TW/IN) delegate to
+        ``MarketTaxonomyService``. US and taxonomy-less markets (CA/DE/SG/MY)
+        read the classifier-populated ``ibd_industry_groups`` table, scoped to
+        ``market``.
         """
         normalized = (market or "US").upper()
-        if normalized != "US":
+        if normalized != "US" and _market_has_curated_taxonomy(normalized):
             try:
                 return _market_taxonomy_service().groups_for_market(normalized)
             except Exception as e:
@@ -266,7 +286,12 @@ class IBDIndustryService:
                 )
                 raise
         try:
-            records = db.query(IBDIndustryGroup.industry_group).distinct().all()
+            records = (
+                db.query(IBDIndustryGroup.industry_group)
+                .filter(IBDIndustryGroup.market == normalized)
+                .distinct()
+                .all()
+            )
             return [r.industry_group for r in records]
         except Exception as e:
             logger.error(f"Error getting all industry groups: {e}", exc_info=True)

--- a/backend/app/services/llm/config.py
+++ b/backend/app/services/llm/config.py
@@ -89,6 +89,24 @@ COMPRESSION_PRESET = ModelPreset(
     fallbacks=[GROQ_LLAMA_8B],
 )
 
+# IBD industry-group classification (closed-set tiebreaker). Low temperature for
+# deterministic single-label selection. This is the *sanctioned* fallback used
+# when the env-driven OpenAI-compatible path (IBD_LLM_*) is not configured.
+IBD_CLASSIFICATION_MINIMAX = ModelConfig(
+    model_id="minimax/MiniMax-M2.7",
+    temperature=0.1,
+    max_tokens=200,
+)
+IBD_CLASSIFICATION_ZAI = ModelConfig(
+    model_id="openai/glm-4.7-flash",
+    temperature=0.1,
+    max_tokens=200,
+)
+IBD_CLASSIFICATION_PRESET = ModelPreset(
+    primary=IBD_CLASSIFICATION_MINIMAX,
+    fallbacks=[IBD_CLASSIFICATION_ZAI],
+)
+
 
 PROVIDER_ENV_VARS = {
     "groq": "GROQ_API_KEY",
@@ -125,6 +143,10 @@ SUPPORTED_MODELS_BY_USE_CASE: dict[str, set[str]] = {
         "minimax/MiniMax-M2.7",
         "openai/glm-4.7-flash",
     },
+    "ibd_classification": {
+        "minimax/MiniMax-M2.7",
+        "openai/glm-4.7-flash",
+    },
 }
 
 
@@ -133,6 +155,7 @@ DEFAULT_MODEL_BY_USE_CASE: dict[str, str] = {
     "research": "groq/qwen/qwen3-32b",
     "extraction": "minimax/MiniMax-M2.7",
     "merge": "minimax/MiniMax-M2.7",
+    "ibd_classification": "minimax/MiniMax-M2.7",
 }
 
 
@@ -163,6 +186,7 @@ def get_preset_for_use_case(use_case: str) -> ModelPreset:
         "merge": MERGE_PRESET,
         "report": REPORT_PRESET,
         "compression": COMPRESSION_PRESET,
+        "ibd_classification": IBD_CLASSIFICATION_PRESET,
     }
     return presets.get(use_case, CHATBOT_PRESET)
 

--- a/backend/app/services/llm/openai_compatible_client.py
+++ b/backend/app/services/llm/openai_compatible_client.py
@@ -1,0 +1,222 @@
+"""Env-driven, provider-agnostic LLM tiebreaker for IBD classification.
+
+The IBD classifier is delivered as a GitHub Action where the operator wants to
+point at *any* OpenAI-compatible LLM by setting environment variables — exactly
+the pattern in ZhuLinsen/daily_stock_analysis (OPENAI_BASE_URL/MODEL/API_KEY).
+Switching providers is therefore an env-var edit, not a code change:
+
+    IBD_LLM_API_BASE   e.g. https://api.deepseek.com/v1
+    IBD_LLM_API_KEY    the provider key
+    IBD_LLM_MODEL      e.g. deepseek-chat  (or a provider-prefixed id like minimax/MiniMax-M2.7)
+    IBD_LLM_TEMPERATURE / IBD_LLM_MAX_TOKENS  (optional)
+
+LiteLLM routes any OpenAI-compatible endpoint via ``model="openai/<name>" +
+api_base + api_key`` — the same mechanism the repo already uses for Z.AI.
+
+When ``IBD_LLM_*`` is unset, this falls back to the sanctioned in-repo path
+(``LLMService(use_case="ibd_classification")``), so governance is preserved for
+default deployments while the GitHub Action stays freely swappable. The generic
+override is scoped to this classifier and does not touch the allowlist used by
+chatbot/extraction/etc.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = (
+    "You are an IBD industry-group classifier. Given a company's descriptive text "
+    "and a list of candidate industry groups, choose the single group that best "
+    "fits the company. Respond with ONLY the exact group name from the list, with "
+    "no explanation, punctuation, or extra words."
+)
+
+
+def _render_prompt(text: str, shortlist: list[str]) -> str:
+    listing = "\n".join(f"- {g}" for g in shortlist)
+    return (
+        f"Company: {text}\n\n"
+        f"Candidate industry groups:\n{listing}\n\n"
+        "Answer with exactly one group name from the list above."
+    )
+
+
+def _env(name: str) -> Optional[str]:
+    value = os.environ.get(name)
+    return value.strip() if value and value.strip() else None
+
+
+def env_model_id() -> Optional[str]:
+    return _env("IBD_LLM_MODEL")
+
+
+def _resolve_litellm_model(model: str) -> str:
+    """Provider-prefix the model for LiteLLM. A bare name (``deepseek-chat``) is
+    treated as OpenAI-compatible; an already-prefixed id (``minimax/...``,
+    ``openai/...``, ``groq/...``) passes through untouched."""
+    return model if "/" in model else f"openai/{model}"
+
+
+def match_choice(response_text: str, shortlist: list[str]) -> Optional[str]:
+    """Map a model response to one of the shortlisted group names.
+
+    Tolerates models that echo extra text: exact (case-insensitive) match first,
+    then the longest shortlist entry contained in the response (longest-first so
+    'Computers-Software' wins over a substring 'Computers')."""
+    if not response_text:
+        return None
+    text = response_text.strip()
+    lowered = text.lower()
+    by_lower = {g.lower(): g for g in shortlist}
+    if lowered in by_lower:
+        return by_lower[lowered]
+    for group in sorted(shortlist, key=len, reverse=True):
+        if group.lower() in lowered:
+            return group
+    return None
+
+
+class OpenAICompatibleTiebreaker:
+    """Calls an OpenAI-compatible endpoint to pick one group from a shortlist."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        temperature: float = 0.1,
+        max_tokens: int = 200,
+        complete_fn: Optional[Callable[..., str]] = None,
+    ):
+        self.model = model
+        self.litellm_model = _resolve_litellm_model(model)
+        self.api_base = api_base
+        self.api_key = api_key
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self._complete_fn = complete_fn  # injectable for tests
+
+    @property
+    def model_id(self) -> str:
+        return self.model
+
+    def _complete(self, user_prompt: str) -> str:
+        if self._complete_fn is not None:
+            return self._complete_fn(user_prompt)
+        import litellm
+
+        params = {
+            "model": self.litellm_model,
+            "messages": [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+        if self.api_base:
+            params["api_base"] = self.api_base
+        if self.api_key:
+            params["api_key"] = self.api_key
+        response = litellm.completion(**params)
+        return response["choices"][0]["message"]["content"] or ""
+
+    def __call__(self, text: str, shortlist: list[str]) -> Optional[str]:
+        if not shortlist:
+            return None
+        try:
+            raw = self._complete(_render_prompt(text, shortlist))
+        except Exception as exc:  # noqa: BLE001 — never let a bad call break the batch
+            logger.warning("IBD LLM tiebreaker call failed: %s", exc)
+            return None
+        return match_choice(raw, shortlist)
+
+
+def build_ibd_tiebreaker() -> tuple[Optional[Callable[[str, list[str]], Optional[str]]], Optional[str]]:
+    """Return ``(tiebreaker, model_id)`` for the IBD classifier.
+
+    Precedence:
+    1. Env-driven OpenAI-compatible path when ``IBD_LLM_MODEL`` is set.
+    2. Sanctioned ``LLMService(use_case="ibd_classification")`` when a provider key
+       is configured.
+    3. ``(None, None)`` — the classifier then runs free-only (crosswalk + embedding).
+    """
+    model = env_model_id()
+    if model:
+        temperature = float(_env("IBD_LLM_TEMPERATURE") or 0.1)
+        max_tokens = int(_env("IBD_LLM_MAX_TOKENS") or 200)
+        tb = OpenAICompatibleTiebreaker(
+            model=model,
+            api_base=_env("IBD_LLM_API_BASE"),
+            api_key=_env("IBD_LLM_API_KEY"),
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        logger.info("IBD tiebreaker: env-driven OpenAI-compatible model %s", model)
+        return tb, tb.model_id
+
+    sanctioned = _build_sanctioned_tiebreaker()
+    if sanctioned is not None:
+        return sanctioned
+    logger.info("IBD tiebreaker: none configured; classifier runs free-only")
+    return None, None
+
+
+def _sanctioned_key_available() -> bool:
+    """True when a key for the ibd_classification preset (Minimax/Z.AI) exists.
+
+    Guards against returning a tiebreaker that would fail one API call per residual
+    stock when no provider is configured — in that case the classifier should run
+    free-only (crosswalk + embedding) instead.
+    """
+    try:
+        from ...config import settings
+    except Exception:  # noqa: BLE001
+        return False
+    if (getattr(settings, "minimax_api_key", "") or "").strip():
+        return True
+    try:
+        if settings.zai_api_keys_list:
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    return bool((getattr(settings, "zai_api_key", "") or "").strip())
+
+
+def _build_sanctioned_tiebreaker():
+    """Wrap the in-repo LLMService preset as a tiebreaker, if a key is available."""
+    if not _sanctioned_key_available():
+        return None
+    try:
+        from .llm_service import LLMService
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Sanctioned LLMService unavailable: %s", exc)
+        return None
+    try:
+        service = LLMService(use_case="ibd_classification")
+    except Exception as exc:  # noqa: BLE001
+        logger.info("No sanctioned LLM provider for IBD classification: %s", exc)
+        return None
+
+    model_id = service.preset.primary.model_id
+
+    # Reuse the single tiebreaker implementation; only the transport differs.
+    def _complete(prompt: str) -> str:
+        response = service.completion_sync(
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.1,
+            max_tokens=200,
+        )
+        return LLMService.extract_content(response)
+
+    tiebreaker = OpenAICompatibleTiebreaker(
+        model=model_id, api_base=None, api_key=None, complete_fn=_complete
+    )
+    return tiebreaker, model_id

--- a/backend/app/services/llm/openai_compatible_client.py
+++ b/backend/app/services/llm/openai_compatible_client.py
@@ -53,10 +53,23 @@ def env_model_id() -> Optional[str]:
     return _env("IBD_LLM_MODEL")
 
 
-def _resolve_litellm_model(model: str) -> str:
-    """Provider-prefix the model for LiteLLM. A bare name (``deepseek-chat``) is
-    treated as OpenAI-compatible; an already-prefixed id (``minimax/...``,
-    ``openai/...``, ``groq/...``) passes through untouched."""
+def _resolve_litellm_model(model: str, *, has_api_base: bool) -> str:
+    """Provider-prefix the model for LiteLLM.
+
+    The deciding signal is whether a custom ``api_base`` is configured, not
+    whether the id contains a slash:
+    - already ``openai/``-prefixed → unchanged;
+    - custom OpenAI-compatible endpoint (``has_api_base``) → force the ``openai/``
+      prefix so a slashed gateway model id like ``org/model`` (vLLM/LM Studio/HF
+      names) routes through ``api_base`` instead of being misread as a
+      ``<provider>/...`` route;
+    - otherwise a slashed id is a native LiteLLM provider route (e.g.
+      ``groq/llama-3.3-70b``) and a bare name gets the ``openai/`` prefix.
+    """
+    if model.startswith("openai/"):
+        return model
+    if has_api_base:
+        return f"openai/{model}"
     return model if "/" in model else f"openai/{model}"
 
 
@@ -93,7 +106,7 @@ class OpenAICompatibleTiebreaker:
         complete_fn: Optional[Callable[..., str]] = None,
     ):
         self.model = model
-        self.litellm_model = _resolve_litellm_model(model)
+        self.litellm_model = _resolve_litellm_model(model, has_api_base=bool(api_base))
         self.api_base = api_base
         self.api_key = api_key
         self.temperature = temperature

--- a/backend/tests/unit/test_ibd_classification_bundle.py
+++ b/backend/tests/unit/test_ibd_classification_bundle.py
@@ -1,0 +1,96 @@
+"""Unit tests for the IBD classification bundle format + import upsert."""
+import hashlib
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.industry import IBDIndustryGroup
+from app.services.ibd_classification_bundle import (
+    IBD_CLASSIFICATION_BUNDLE_SCHEMA_VERSION,
+    bundle_asset_name,
+    build_manifest,
+    build_payload,
+    import_classifications,
+    latest_manifest_name,
+    read_bundle,
+    write_bundle,
+    write_manifest,
+)
+from app.services.ibd_classification_service import Assignment
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _assignments():
+    return [
+        Assignment("0700.HK", "HK", "Internet-Content", "embedding", 0.91, "centroid_nn", None),
+        Assignment("9988.HK", "HK", "Retail-Internet", "crosswalk", 0.8, "sector_industry", None),
+        Assignment("1810.HK", "HK", "Telecom-Equipment", "llm", None, "llm_shortlist", "deepseek-chat"),
+    ]
+
+
+def test_asset_names():
+    assert bundle_asset_name("HK", "20260601", "ibd:20260601120000") == (
+        "ibd-classification-hk-20260601-ibd-20260601120000.json.gz"
+    )
+    assert latest_manifest_name("SG") == "ibd-classification-latest-sg.json"
+
+
+def test_bundle_roundtrip_and_manifest_sha(tmp_path):
+    payload = build_payload(
+        market="HK", as_of_date="2026-06-01", source_revision="ibd:1",
+        generated_at="2026-06-01T00:00:00Z", model_id="deepseek-chat",
+        assignments=_assignments(), summary={"newly_classified": 3},
+    )
+    bundle_path = tmp_path / "bundle.json.gz"
+    sha = write_bundle(bundle_path, payload)
+
+    # sha matches the file on disk.
+    assert sha == hashlib.sha256(bundle_path.read_bytes()).hexdigest()
+    # round-trips losslessly.
+    loaded = read_bundle(bundle_path)
+    assert loaded["schema_version"] == IBD_CLASSIFICATION_BUNDLE_SCHEMA_VERSION
+    assert loaded["market"] == "HK"
+    assert len(loaded["classifications"]) == 3
+    assert loaded["classifications"][0]["symbol"] == "0700.HK"
+
+    manifest = build_manifest(payload=payload, bundle_name="bundle.json.gz", sha256=sha)
+    manifest_path = tmp_path / latest_manifest_name("HK")
+    write_manifest(manifest_path, manifest)
+    assert manifest["sha256"] == sha
+    assert manifest["bundle_asset_name"] == "bundle.json.gz"
+    assert manifest_path.read_text().endswith("\n")
+
+
+def test_import_inserts_updates_and_skips_authoritative():
+    session = _make_session()
+    # Pre-existing rows: one authoritative (csv), one stale classifier (embedding).
+    session.add(IBDIndustryGroup(symbol="0700.HK", industry_group="Old-Group",
+                                 market="HK", source="csv"))
+    session.add(IBDIndustryGroup(symbol="9988.HK", industry_group="Stale-Guess",
+                                 market="HK", source="embedding", confidence=0.5))
+    session.commit()
+
+    payload = build_payload(
+        market="HK", as_of_date="2026-06-01", source_revision="ibd:1",
+        generated_at=None, model_id="deepseek-chat",
+        assignments=_assignments(), summary={},
+    )
+    stats = import_classifications(session, payload)
+
+    assert stats["skipped_authoritative"] == 1  # 0700.HK (csv) untouched
+    assert stats["updated"] == 1                 # 9988.HK refreshed
+    assert stats["inserted"] == 1                # 1810.HK new
+
+    rows = {r.symbol: r for r in session.query(IBDIndustryGroup).all()}
+    assert rows["0700.HK"].industry_group == "Old-Group"  # csv preserved
+    assert rows["0700.HK"].source == "csv"
+    assert rows["9988.HK"].industry_group == "Retail-Internet"  # updated
+    assert rows["9988.HK"].source == "crosswalk"
+    assert rows["1810.HK"].source == "llm"
+    assert rows["1810.HK"].model_version == "deepseek-chat"

--- a/backend/tests/unit/test_ibd_classification_service.py
+++ b/backend/tests/unit/test_ibd_classification_service.py
@@ -1,0 +1,163 @@
+"""Unit tests for the hybrid IBD classifier cascade.
+
+Uses a deterministic fake embedding engine (orthogonal one-hot vectors keyed off
+group keywords) so the crosswalk → embedding → LLM tiers can be exercised without
+loading sentence-transformers or calling an API.
+"""
+import numpy as np
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.industry import IBDIndustryGroup
+from app.models.stock_universe import StockUniverse
+from app.services.ibd_classification_service import (
+    SOURCE_CROSSWALK,
+    SOURCE_EMBEDDING,
+    SOURCE_LLM,
+    IBDClassificationService,
+)
+from app.services.ibd_crosswalk import IBDCrosswalk, build_crosswalk
+
+DIM = 3
+_KEYWORDS = {"software": 0, "drug": 1, "energy": 2}
+_NEUTRAL = np.ones(DIM) / np.sqrt(DIM)
+
+
+class FakeEngine:
+    """encode() → one-hot for a recognised keyword, neutral vector otherwise,
+    or None for the sentinel 'NOVEC' (simulates an un-embeddable stock)."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def encode(self, text: str):
+        self.calls += 1
+        lowered = (text or "").lower()
+        if "novec" in lowered:
+            return None
+        for kw, idx in _KEYWORDS.items():
+            if kw in lowered:
+                v = np.zeros(DIM)
+                v[idx] = 1.0
+                return v
+        return _NEUTRAL.copy()
+
+    @staticmethod
+    def cosine_similarity(left, right) -> float:
+        denom = np.linalg.norm(left) * np.linalg.norm(right)
+        return float(np.dot(left, right) / denom) if denom else 0.0
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _seed_taxonomy(session):
+    # Curated US groups (centroids derive from these names; no US universe rows,
+    # so centroids are name-only — the foreign-market scenario).
+    for sym, grp in [
+        ("AAPL", "Computers-Software"),
+        ("JNJ", "Medical-Drugs"),
+        ("XOM", "Energy-Oil"),
+    ]:
+        session.add(IBDIndustryGroup(symbol=sym, industry_group=grp, market="US", source="csv"))
+    session.commit()
+
+
+def _add_universe(session, symbol, market, name="", sector="", industry=""):
+    session.add(StockUniverse(
+        symbol=symbol, name=name, market=market, sector=sector, industry=industry, is_active=True
+    ))
+    session.commit()
+
+
+def test_crosswalk_tier_short_circuits():
+    session = _make_session()
+    _seed_taxonomy(session)
+    _add_universe(session, "D05.SG", "SG", name="DBS", sector="Financials", industry="Banks")
+    crosswalk = IBDCrosswalk(build_crosswalk(
+        symbol_to_group={f"B{i}": "Banks-Money Center" for i in range(5)},
+        symbol_to_sector_industry={f"B{i}": ("Financials", "Banks") for i in range(5)},
+    ))
+    svc = IBDClassificationService(crosswalk=crosswalk, embedding_engine=FakeEngine())
+
+    result = svc.classify_market(session, "SG")
+
+    assert len(result.assignments) == 1
+    a = result.assignments[0]
+    assert a.source == SOURCE_CROSSWALK
+    assert a.industry_group == "Banks-Money Center"
+    assert a.confidence == 1.0
+
+
+def test_embedding_tier_attaches_above_threshold():
+    session = _make_session()
+    _seed_taxonomy(session)
+    _add_universe(session, "0700.HK", "HK", name="Tencent", sector="Tech", industry="Software")
+    svc = IBDClassificationService(crosswalk=None, embedding_engine=FakeEngine())
+
+    result = svc.classify_market(session, "HK")
+
+    a = result.assignments[0]
+    assert a.source == SOURCE_EMBEDDING
+    assert a.industry_group == "Computers-Software"
+    assert a.confidence is not None and a.confidence > 0.99
+
+
+def test_llm_tiebreaker_invoked_below_threshold():
+    session = _make_session()
+    _seed_taxonomy(session)
+    # Neutral text → best cosine ~0.577; high attach threshold forces the LLM.
+    _add_universe(session, "MIXED.SG", "SG", name="Conglomerate Holdings")
+    captured = {}
+
+    def fake_llm(text, shortlist):
+        captured["shortlist"] = shortlist
+        return shortlist[-1]  # pick a deterministic, non-top candidate
+
+    svc = IBDClassificationService(
+        crosswalk=None, embedding_engine=FakeEngine(),
+        llm_tiebreaker=fake_llm, llm_model_id="test/model", attach_threshold=0.9,
+    )
+
+    result = svc.classify_market(session, "SG")
+
+    a = result.assignments[0]
+    assert a.source == SOURCE_LLM
+    assert a.model_id == "test/model"
+    assert a.industry_group == captured["shortlist"][-1]
+    assert a.industry_group in {"Computers-Software", "Medical-Drugs", "Energy-Oil"}
+
+
+def test_authoritative_symbols_are_skipped():
+    session = _make_session()
+    _seed_taxonomy(session)
+    _add_universe(session, "RELIANCE.NS", "IN", name="Reliance", sector="Energy", industry="Oil")
+    # Human override for the same symbol → must be skipped, counted authoritative.
+    session.add(IBDIndustryGroup(
+        symbol="RELIANCE.NS", industry_group="Energy-Oil", market="IN", source="manual"
+    ))
+    session.commit()
+    svc = IBDClassificationService(crosswalk=None, embedding_engine=FakeEngine())
+
+    result = svc.classify_market(session, "IN")
+
+    assert result.assignments == []
+    assert result.candidates == 0
+    assert result.skipped_authoritative == 1
+
+
+def test_unresolved_when_no_match_and_no_llm():
+    session = _make_session()
+    _seed_taxonomy(session)
+    _add_universe(session, "NOVEC.SG", "SG", name="NOVEC unembeddable")
+    svc = IBDClassificationService(crosswalk=None, embedding_engine=FakeEngine())
+
+    result = svc.classify_market(session, "SG")
+
+    assert result.assignments == []
+    assert result.unresolved == ["NOVEC.SG"]
+    assert result.summary()["coverage_pct"] == 0.0

--- a/backend/tests/unit/test_ibd_classification_service.py
+++ b/backend/tests/unit/test_ibd_classification_service.py
@@ -161,3 +161,20 @@ def test_unresolved_when_no_match_and_no_llm():
     assert result.assignments == []
     assert result.unresolved == ["NOVEC.SG"]
     assert result.summary()["coverage_pct"] == 0.0
+
+
+def test_canonical_taxonomy_ignores_non_us_and_derived_rows():
+    session = _make_session()
+    _seed_taxonomy(session)  # US csv groups
+    # A derived non-US row with a novel group must NOT widen the taxonomy.
+    session.add(IBDIndustryGroup(
+        symbol="X.SG", industry_group="Bogus-Derived-Group",
+        market="SG", source="embedding", confidence=0.3,
+    ))
+    session.commit()
+
+    svc = IBDClassificationService(crosswalk=None, embedding_engine=None)
+    taxonomy = svc.canonical_taxonomy(session)
+
+    assert "Bogus-Derived-Group" not in taxonomy
+    assert set(taxonomy) == {"Computers-Software", "Medical-Drugs", "Energy-Oil"}

--- a/backend/tests/unit/test_ibd_crosswalk.py
+++ b/backend/tests/unit/test_ibd_crosswalk.py
@@ -1,0 +1,74 @@
+"""Unit tests for the data-derived GICS/sector → IBD crosswalk (pure vote logic)."""
+from app.services.ibd_crosswalk import (
+    TIER_SECTOR,
+    TIER_SECTOR_INDUSTRY,
+    TIER_SUBINDUSTRY,
+    IBDCrosswalk,
+    build_crosswalk,
+)
+
+
+def _build(**kwargs):
+    return build_crosswalk(**kwargs)
+
+
+def test_majority_vote_per_subindustry():
+    cw = _build(
+        symbol_to_group={"A": "Computers-Large", "B": "Computers-Large", "C": "Computers-Small"},
+        symbol_to_subindustry={"A": "Hardware", "B": "Hardware", "C": "Hardware"},
+    )
+    entry = cw[TIER_SUBINDUSTRY]["Hardware"]
+    assert entry["group"] == "Computers-Large"
+    assert entry["votes"] == 2
+    assert entry["total"] == 3
+    assert entry["share"] == round(2 / 3, 4)
+
+
+def test_tie_break_is_deterministic_alphabetical():
+    # 1 vote each → tie broken by lexicographically smallest group name.
+    cw = _build(
+        symbol_to_group={"A": "Zeta-Group", "B": "Alpha-Group"},
+        symbol_to_subindustry={"A": "X", "B": "X"},
+    )
+    assert cw[TIER_SUBINDUSTRY]["X"]["group"] == "Alpha-Group"
+
+
+def test_lookup_prefers_subindustry_then_sector_industry_then_sector():
+    cw = IBDCrosswalk(_build(
+        symbol_to_group={f"S{i}": "Specific-Group" for i in range(5)},
+        symbol_to_subindustry={f"S{i}": "SubX" for i in range(5)},
+        symbol_to_sector_industry={f"S{i}": ("Tech", "Software") for i in range(5)},
+    ))
+    # Sub-industry tier wins when present.
+    hit = cw.lookup(sub_industry="SubX", sector="Tech", industry="Software")
+    assert hit is not None
+    assert hit.method == TIER_SUBINDUSTRY
+    assert hit.group == "Specific-Group"
+
+    # Falls back to sector+industry when sub-industry unknown.
+    hit2 = cw.lookup(sub_industry="Unknown", sector="Tech", industry="Software")
+    assert hit2.method == TIER_SECTOR_INDUSTRY
+
+    # Falls back to sector alone when industry unknown.
+    hit3 = cw.lookup(sector="Tech")
+    assert hit3.method == TIER_SECTOR
+
+
+def test_lookup_returns_none_below_thresholds():
+    cw = IBDCrosswalk(_build(
+        symbol_to_group={"A": "G1", "B": "G2", "C": "G3"},  # 1 vote each, share 1/3
+        symbol_to_subindustry={"A": "Mixed", "B": "Mixed", "C": "Mixed"},
+    ))
+    # share 0.33 < default 0.6 → no confident hit.
+    assert cw.lookup(sub_industry="Mixed") is None
+    # Even with low share threshold, min_votes=3 not met for the winning group (1).
+    assert cw.lookup(sub_industry="Mixed", min_share=0.1, min_votes=3) is None
+    # Relaxing both yields the deterministic winner.
+    hit = cw.lookup(sub_industry="Mixed", min_share=0.1, min_votes=1)
+    assert hit is not None and hit.group == "G1"
+
+
+def test_unknown_key_returns_none():
+    cw = IBDCrosswalk(_build(symbol_to_group={"A": "G"}, symbol_to_subindustry={"A": "K"}))
+    assert cw.lookup(sub_industry="DOES-NOT-EXIST") is None
+    assert cw.lookup() is None  # no attributes → nothing to resolve

--- a/backend/tests/unit/test_ibd_industry_service.py
+++ b/backend/tests/unit/test_ibd_industry_service.py
@@ -1,0 +1,91 @@
+"""Unit tests for IBDIndustryService CSV loading and the seed+override invariant.
+
+The curated CSV is the authoritative seed layer. ``load_from_csv`` must:
+- tag loaded rows ``source='csv'`` / ``market='US'``;
+- preserve classifier-derived rows for symbols the CSV does NOT claim;
+- let the CSV win (replace classifier rows) for symbols it DOES claim;
+- never clobber human ``manual`` overrides, even for symbols in the CSV.
+"""
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.industry import IBDIndustryGroup
+from app.services.ibd_industry_service import IBDIndustryService
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _write_csv(tmp_path, rows):
+    path = tmp_path / "ibd.csv"
+    path.write_text("".join(f"{sym},{grp}\n" for sym, grp in rows), encoding="utf-8")
+    return str(path)
+
+
+def test_load_tags_provenance(tmp_path):
+    session = _make_session()
+    csv_path = _write_csv(tmp_path, [("AAPL", "Computers-Large"), ("MSFT", "Computers-Software")])
+
+    loaded = IBDIndustryService.load_from_csv(session, csv_path)
+
+    assert loaded == 2
+    rows = {r.symbol: r for r in session.query(IBDIndustryGroup).all()}
+    assert rows["AAPL"].source == "csv"
+    assert rows["AAPL"].market == "US"
+    assert rows["AAPL"].industry_group == "Computers-Large"
+
+
+def test_reload_preserves_classifier_row_not_in_csv(tmp_path):
+    session = _make_session()
+    # A classifier-assigned symbol that the CSV never mentions.
+    session.add(IBDIndustryGroup(
+        symbol="0700.HK", industry_group="Internet-Content",
+        market="HK", source="embedding", confidence=0.91, method="centroid_nn",
+    ))
+    session.commit()
+
+    csv_path = _write_csv(tmp_path, [("AAPL", "Computers-Large")])
+    IBDIndustryService.load_from_csv(session, csv_path)
+
+    hk = session.query(IBDIndustryGroup).filter_by(symbol="0700.HK").one()
+    assert hk.source == "embedding"  # survived the CSV reload
+    assert session.query(IBDIndustryGroup).filter_by(symbol="AAPL").one().source == "csv"
+
+
+def test_reload_csv_wins_over_classifier_for_claimed_symbol(tmp_path):
+    session = _make_session()
+    # Classifier guessed a group for AAPL before it was hand-curated.
+    session.add(IBDIndustryGroup(
+        symbol="AAPL", industry_group="Wrong-Guess",
+        market="US", source="llm", confidence=0.4, method="llm_shortlist",
+    ))
+    session.commit()
+
+    csv_path = _write_csv(tmp_path, [("AAPL", "Computers-Large")])
+    IBDIndustryService.load_from_csv(session, csv_path)
+
+    aapl = session.query(IBDIndustryGroup).filter_by(symbol="AAPL").one()
+    assert aapl.source == "csv"
+    assert aapl.industry_group == "Computers-Large"  # CSV is authoritative
+
+
+def test_reload_preserves_manual_override_over_csv(tmp_path):
+    session = _make_session()
+    # A human deliberately overrode AAPL's group.
+    session.add(IBDIndustryGroup(
+        symbol="AAPL", industry_group="Human-Choice",
+        market="US", source="manual",
+    ))
+    session.commit()
+
+    csv_path = _write_csv(tmp_path, [("AAPL", "Computers-Large")])
+    IBDIndustryService.load_from_csv(session, csv_path)
+
+    rows = session.query(IBDIndustryGroup).filter_by(symbol="AAPL").all()
+    assert len(rows) == 1
+    assert rows[0].source == "manual"
+    assert rows[0].industry_group == "Human-Choice"  # manual wins, CSV skipped

--- a/backend/tests/unit/test_ibd_industry_service.py
+++ b/backend/tests/unit/test_ibd_industry_service.py
@@ -89,3 +89,59 @@ def test_reload_preserves_manual_override_over_csv(tmp_path):
     assert len(rows) == 1
     assert rows[0].source == "manual"
     assert rows[0].industry_group == "Human-Choice"  # manual wins, CSV skipped
+
+
+# --- F3: market-scoped group lookups (DB fallback for taxonomy-less markets) ---
+
+import app.services.ibd_industry_service as ibd_module
+
+
+def _add(session, symbol, group, market, source="csv"):
+    session.add(IBDIndustryGroup(
+        symbol=symbol, industry_group=group, market=market, source=source
+    ))
+    session.commit()
+
+
+def test_get_group_symbols_us_does_not_leak_foreign_symbols():
+    session = _make_session()
+    _add(session, "AAPL", "Computers-Software", "US")
+    _add(session, "0700.HK", "Computers-Software", "HK", source="embedding")
+    _add(session, "D05.SG", "Computers-Software", "SG", source="crosswalk")
+
+    us = IBDIndustryService.get_group_symbols(session, "Computers-Software", market="US")
+    assert us == ["AAPL"]  # foreign rows with the same group name are excluded
+
+
+def test_taxonomyless_market_falls_back_to_db(monkeypatch):
+    # SG has no curated taxonomy → group lookups read the classifier-populated table.
+    session = _make_session()
+    _add(session, "D05.SG", "Banks-Money Center", "SG", source="crosswalk")
+    _add(session, "O39.SG", "Banks-Money Center", "SG", source="embedding")
+    _add(session, "AAPL", "Computers-Software", "US")
+
+    groups = IBDIndustryService.get_all_groups(session, market="SG")
+    assert groups == ["Banks-Money Center"]  # DB groups, scoped to SG
+    symbols = sorted(IBDIndustryService.get_group_symbols(
+        session, "Banks-Money Center", market="SG"))
+    assert symbols == ["D05.SG", "O39.SG"]
+
+
+def test_curated_market_still_delegates_to_taxonomy(monkeypatch):
+    # Markets with a committed taxonomy keep using MarketTaxonomyService, never
+    # the DB — even if classifier rows happen to exist for them.
+    session = _make_session()
+    _add(session, "0700.HK", "DB-Only-Group", "HK", source="embedding")
+
+    class _FakeTaxonomy:
+        def groups_for_market(self, m):
+            return ["Curated-Group"]
+
+        def symbols_for_group(self, m, g):
+            return ["CURATED.HK"]
+
+    monkeypatch.setattr(ibd_module, "_market_taxonomy_service", lambda: _FakeTaxonomy())
+
+    assert IBDIndustryService.get_all_groups(session, market="HK") == ["Curated-Group"]
+    assert IBDIndustryService.get_group_symbols(
+        session, "Curated-Group", market="HK") == ["CURATED.HK"]

--- a/backend/tests/unit/test_ibd_openai_compatible_client.py
+++ b/backend/tests/unit/test_ibd_openai_compatible_client.py
@@ -1,0 +1,92 @@
+"""Unit tests for the env-driven OpenAI-compatible IBD tiebreaker."""
+import pytest
+
+from app.services.llm.openai_compatible_client import (
+    OpenAICompatibleTiebreaker,
+    _resolve_litellm_model,
+    build_ibd_tiebreaker,
+    match_choice,
+)
+
+SHORTLIST = ["Computers-Software", "Computers-Hardware", "Medical-Drugs"]
+
+
+def test_match_choice_exact_case_insensitive():
+    assert match_choice("computers-software", SHORTLIST) == "Computers-Software"
+    assert match_choice("  Medical-Drugs  ", SHORTLIST) == "Medical-Drugs"
+
+
+def test_match_choice_substring_longest_first():
+    # Response embeds the answer in prose; longest matching group wins.
+    txt = "The best fit is Computers-Software for this company."
+    assert match_choice(txt, SHORTLIST) == "Computers-Software"
+
+
+def test_match_choice_none_when_unmatched():
+    assert match_choice("Energy-Oil", SHORTLIST) is None
+    assert match_choice("", SHORTLIST) is None
+
+
+def test_resolve_litellm_model_prefixing():
+    assert _resolve_litellm_model("deepseek-chat") == "openai/deepseek-chat"
+    assert _resolve_litellm_model("minimax/MiniMax-M2.7") == "minimax/MiniMax-M2.7"
+    assert _resolve_litellm_model("openai/gpt-4o") == "openai/gpt-4o"
+
+
+def test_tiebreaker_call_uses_injected_completion():
+    captured = {}
+
+    def fake_complete(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "Computers-Hardware"
+
+    tb = OpenAICompatibleTiebreaker(
+        model="deepseek-chat", api_base="https://x/v1", api_key="k",
+        complete_fn=fake_complete,
+    )
+    assert tb.model_id == "deepseek-chat"
+    assert tb("A chip maker", SHORTLIST) == "Computers-Hardware"
+    assert "A chip maker" in captured["prompt"]
+    assert "Computers-Software" in captured["prompt"]  # shortlist rendered
+
+
+def test_tiebreaker_call_swallows_errors():
+    def boom(prompt: str) -> str:
+        raise RuntimeError("network down")
+
+    tb = OpenAICompatibleTiebreaker(model="x", api_base=None, api_key=None, complete_fn=boom)
+    assert tb("text", SHORTLIST) is None  # never propagates
+
+
+def test_build_tiebreaker_env_driven(monkeypatch):
+    monkeypatch.setenv("IBD_LLM_MODEL", "deepseek-chat")
+    monkeypatch.setenv("IBD_LLM_API_BASE", "https://api.deepseek.com/v1")
+    monkeypatch.setenv("IBD_LLM_API_KEY", "sk-test")
+    tb, model_id = build_ibd_tiebreaker()
+    assert model_id == "deepseek-chat"
+    assert isinstance(tb, OpenAICompatibleTiebreaker)
+    assert tb.api_base == "https://api.deepseek.com/v1"
+
+
+def test_build_tiebreaker_none_when_unconfigured(monkeypatch):
+    # No env-driven model, and no sanctioned provider key available → free-only.
+    monkeypatch.delenv("IBD_LLM_MODEL", raising=False)
+    monkeypatch.setattr(
+        "app.services.llm.openai_compatible_client._sanctioned_key_available",
+        lambda: False,
+    )
+    tb, model_id = build_ibd_tiebreaker()
+    assert tb is None
+    assert model_id is None
+
+
+def test_build_tiebreaker_sanctioned_when_key_present(monkeypatch):
+    # No env model but a sanctioned key exists → returns the in-repo tiebreaker.
+    monkeypatch.delenv("IBD_LLM_MODEL", raising=False)
+    monkeypatch.setattr(
+        "app.services.llm.openai_compatible_client._sanctioned_key_available",
+        lambda: True,
+    )
+    tb, model_id = build_ibd_tiebreaker()
+    assert tb is not None
+    assert model_id == "minimax/MiniMax-M2.7"  # ibd_classification preset primary

--- a/backend/tests/unit/test_ibd_openai_compatible_client.py
+++ b/backend/tests/unit/test_ibd_openai_compatible_client.py
@@ -28,9 +28,15 @@ def test_match_choice_none_when_unmatched():
 
 
 def test_resolve_litellm_model_prefixing():
-    assert _resolve_litellm_model("deepseek-chat") == "openai/deepseek-chat"
-    assert _resolve_litellm_model("minimax/MiniMax-M2.7") == "minimax/MiniMax-M2.7"
-    assert _resolve_litellm_model("openai/gpt-4o") == "openai/gpt-4o"
+    # Custom OpenAI-compatible endpoint (api_base set): always openai/-prefixed,
+    # including slashed gateway model ids that aren't LiteLLM provider routes.
+    assert _resolve_litellm_model("deepseek-chat", has_api_base=True) == "openai/deepseek-chat"
+    assert _resolve_litellm_model("org/model", has_api_base=True) == "openai/org/model"
+    assert _resolve_litellm_model("openai/gpt-4o", has_api_base=True) == "openai/gpt-4o"
+    # No custom endpoint: slashed ids are native provider routes; bare names get openai/.
+    assert _resolve_litellm_model("minimax/MiniMax-M2.7", has_api_base=False) == "minimax/MiniMax-M2.7"
+    assert _resolve_litellm_model("groq/llama-3.3-70b", has_api_base=False) == "groq/llama-3.3-70b"
+    assert _resolve_litellm_model("deepseek-chat", has_api_base=False) == "openai/deepseek-chat"
 
 
 def test_tiebreaker_call_uses_injected_completion():

--- a/backend/tests/unit/test_settings_llm_keys.py
+++ b/backend/tests/unit/test_settings_llm_keys.py
@@ -141,6 +141,16 @@ def test_ibd_industry_loader_falls_back_to_project_data_when_override_is_missing
             assert model is IBDIndustryGroup
             self.inserted.extend(rows)
 
+        def query(self, *args):
+            class _Q:
+                def filter(self, *a, **k):
+                    return self
+
+                def all(self):
+                    return []
+
+            return _Q()
+
         def rollback(self) -> None:
             self.rollback_calls += 1
 
@@ -155,12 +165,14 @@ def test_ibd_industry_loader_falls_back_to_project_data_when_override_is_missing
     loaded = ibd_industry_service.IBDIndustryService.load_from_csv(fake_db)
 
     assert loaded == 2
-    assert fake_db.execute_calls == 1
+    # Two deletes (csv-sourced rows, then classifier rows for claimed symbols).
+    assert fake_db.execute_calls == 2
     assert fake_db.commit_calls == 2
     assert fake_db.rollback_calls == 0
+    # Rows now carry provenance (source='csv', market='US').
     assert fake_db.inserted == [
-        {"symbol": "AAPL", "industry_group": "Software"},
-        {"symbol": "MSFT", "industry_group": "Software"},
+        {"symbol": "AAPL", "industry_group": "Software", "market": "US", "source": "csv"},
+        {"symbol": "MSFT", "industry_group": "Software", "market": "US", "source": "csv"},
     ]
 
 
@@ -250,6 +262,16 @@ def test_ibd_industry_loader_treats_empty_csv_path_as_unset(
             assert model is IBDIndustryGroup
             self.inserted.extend(rows)
 
+        def query(self, *args):
+            class _Q:
+                def filter(self, *a, **k):
+                    return self
+
+                def all(self):
+                    return []
+
+            return _Q()
+
         def rollback(self) -> None:
             self.rollback_calls += 1
 
@@ -266,12 +288,14 @@ def test_ibd_industry_loader_treats_empty_csv_path_as_unset(
     loaded = ibd_industry_service.IBDIndustryService.load_from_csv(fake_db, csv_path="")
 
     assert loaded == 2
-    assert fake_db.execute_calls == 1
+    # Two deletes (csv-sourced rows, then classifier rows for claimed symbols).
+    assert fake_db.execute_calls == 2
     assert fake_db.commit_calls == 2
     assert fake_db.rollback_calls == 0
+    # Rows now carry provenance (source='csv', market='US').
     assert fake_db.inserted == [
-        {"symbol": "AAPL", "industry_group": "Software"},
-        {"symbol": "MSFT", "industry_group": "Software"},
+        {"symbol": "AAPL", "industry_group": "Software", "market": "US", "source": "csv"},
+        {"symbol": "MSFT", "industry_group": "Software", "market": "US", "source": "csv"},
     ]
 
 

--- a/backend/tests/unit/test_settings_llm_keys.py
+++ b/backend/tests/unit/test_settings_llm_keys.py
@@ -151,9 +151,6 @@ def test_ibd_industry_loader_falls_back_to_project_data_when_override_is_missing
 
             return _Q()
 
-        def flush(self) -> None:
-            pass
-
         def rollback(self) -> None:
             self.rollback_calls += 1
 
@@ -204,9 +201,6 @@ def test_ibd_industry_loader_does_not_fallback_for_explicit_missing_path(
 
         def bulk_insert_mappings(self, model, rows) -> None:
             raise AssertionError(f"Unexpected bulk insert for {model}: {rows}")
-
-        def flush(self) -> None:
-            pass
 
         def rollback(self) -> None:
             self.rollback_calls += 1
@@ -278,9 +272,6 @@ def test_ibd_industry_loader_treats_empty_csv_path_as_unset(
                     return []
 
             return _Q()
-
-        def flush(self) -> None:
-            pass
 
         def rollback(self) -> None:
             self.rollback_calls += 1

--- a/backend/tests/unit/test_settings_llm_keys.py
+++ b/backend/tests/unit/test_settings_llm_keys.py
@@ -151,6 +151,9 @@ def test_ibd_industry_loader_falls_back_to_project_data_when_override_is_missing
 
             return _Q()
 
+        def flush(self) -> None:
+            pass
+
         def rollback(self) -> None:
             self.rollback_calls += 1
 
@@ -167,7 +170,8 @@ def test_ibd_industry_loader_falls_back_to_project_data_when_override_is_missing
     assert loaded == 2
     # Two deletes (csv-sourced rows, then classifier rows for claimed symbols).
     assert fake_db.execute_calls == 2
-    assert fake_db.commit_calls == 2
+    # Single atomic commit at the end (delete + reload in one transaction).
+    assert fake_db.commit_calls == 1
     assert fake_db.rollback_calls == 0
     # Rows now carry provenance (source='csv', market='US').
     assert fake_db.inserted == [
@@ -200,6 +204,9 @@ def test_ibd_industry_loader_does_not_fallback_for_explicit_missing_path(
 
         def bulk_insert_mappings(self, model, rows) -> None:
             raise AssertionError(f"Unexpected bulk insert for {model}: {rows}")
+
+        def flush(self) -> None:
+            pass
 
         def rollback(self) -> None:
             self.rollback_calls += 1
@@ -272,6 +279,9 @@ def test_ibd_industry_loader_treats_empty_csv_path_as_unset(
 
             return _Q()
 
+        def flush(self) -> None:
+            pass
+
         def rollback(self) -> None:
             self.rollback_calls += 1
 
@@ -290,7 +300,8 @@ def test_ibd_industry_loader_treats_empty_csv_path_as_unset(
     assert loaded == 2
     # Two deletes (csv-sourced rows, then classifier rows for claimed symbols).
     assert fake_db.execute_calls == 2
-    assert fake_db.commit_calls == 2
+    # Single atomic commit at the end (delete + reload in one transaction).
+    assert fake_db.commit_calls == 1
     assert fake_db.rollback_calls == 0
     # Rows now carry provenance (source='csv', market='US').
     assert fake_db.inserted == [


### PR DESCRIPTION
## Summary

Automated, weekly **IBD industry-group classification** for the whole universe — including the four markets (CA/DE/SG/MY) that have **no curated taxonomy** and were producing empty group rankings. Classification runs as a **GitHub Action** that publishes an `ibd-classification-data` release artifact, which the **daily static-site build** consumes — so group rankings finally cover new listings and foreign markets, not just the ~10k hand-mapped US rows in `data/IBD_industry_group.csv`.

### The cascade (free-first)
For every active universe symbol lacking an authoritative group:
1. **skip** `csv`/`manual` rows (the curated CSV stays authoritative);
2. **crosswalk** — deterministic GICS sub-industry / sector+industry → IBD group, majority-voted from the CSV ∩ `stock_industry` (free);
3. **embedding** — nearest group centroid via the local `all-MiniLM-L6-v2` (free);
4. **LLM tiebreaker** — closed-set pick over the embedding shortlist (paid, optional).

### Delivery
- `ibd-classification.yml` — triggered `workflow_run` after **Weekly Reference Data**, per-market matrix; publishes `bundle.json.gz` + `latest` manifest + sha256 to the `ibd-classification-data` release (mirrors weekly-reference / daily-price conventions).
- `static-site.yml` — additive, `continue-on-error` consumption step after the CSV seed load; falls back to CSV-only if the artifact is absent.
- `release-asset-cleanup.yml` — retention for the new release.

### LLM provider swapping
Set `IBD_LLM_API_BASE` / `IBD_LLM_MODEL` (repo vars) + `IBD_LLM_API_KEY` (secret) — any OpenAI-compatible provider, no code change. Falls back to the sanctioned Minimax/Z.AI preset; runs free-only when unset.

### Data model
Provenance columns (`source`, `confidence`, `method`, `model_version`, `market`) on `ibd_industry_groups`. The classifier fills gaps and **never overwrites `csv`/`manual` rows**. Migration `20260601_0020` chains off the current head `20260529_0020`.

## Before first run (operator steps)
1. Generate the crosswalk once against a populated DB: `python -m app.scripts.build_ibd_crosswalk` → commit `data/ibd_crosswalk.json`. (Cascade degrades gracefully — embedding+LLM — if absent.)
2. Set the GitHub Environment vars/secret above (optional; omit for free-only).
3. `alembic upgrade head` on Postgres.

## Tests
42 unit tests covering the crosswalk vote logic, cascade tiering, bundle round-trip + sha256, the CSV seed/override invariant, and env-driven vs sanctioned LLM selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated daily IBD industry-group classification with per‑market release bundles and site sync.
  * Hybrid classifier with deterministic lookup, embedding-based assignment, and optional LLM tiebreaker; provenance and confidence tracked per classification.
  * CLI sync/build/import tools for producing and applying classification bundles.

* **Tests**
  * Comprehensive unit tests covering crosswalks, classifier tiers, bundle format, and import/upsert behavior.

* **Chores**
  * New CI workflows and release-asset cleanup policy; updated model selection presets for classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->