### PR TITLE
fix(ibd): bound classifier runtime + raise foreign-market coverage (A + D)

### DIFF
--- a/.github/workflows/ibd-classification.yml
+++ b/.github/workflows/ibd-classification.yml
@@ -304,6 +304,11 @@ jobs:
         env:
           MARKET: ${{ matrix.market }}
           PREV_BUNDLE: ${{ steps.prev.outputs.prev_bundle }}
+          # Bound the paid LLM tier so a large foreign universe finishes under the
+          # 120-min job cap: once the deadline or call budget trips, remaining
+          # symbols use the free deterministic fallback (soft attach, on by default).
+          MAX_RUNTIME_MINUTES: ${{ vars.IBD_MAX_RUNTIME_MINUTES || '100' }}
+          MAX_LLM_CALLS: ${{ vars.IBD_MAX_LLM_CALLS || '600' }}
         run: |
           cd backend
           PREV_ARG=()
@@ -313,6 +318,8 @@ jobs:
           python -m app.scripts.build_ibd_classification_bundle \
             --market "$MARKET" \
             --output-dir /tmp/ibd-classification \
+            --max-runtime-minutes "$MAX_RUNTIME_MINUTES" \
+            --max-llm-calls "$MAX_LLM_CALLS" \
             "${PREV_ARG[@]}"
 
       - name: Upload IBD health report

--- a/.github/workflows/ibd-classification.yml
+++ b/.github/workflows/ibd-classification.yml
@@ -193,6 +193,9 @@ jobs:
       IBD_LLM_API_BASE: ${{ vars.IBD_LLM_API_BASE }}
       IBD_LLM_MODEL: ${{ vars.IBD_LLM_MODEL }}
       IBD_LLM_API_KEY: ${{ secrets.IBD_LLM_API_KEY }}
+      # Per-call timeout (seconds) so a hung request can't exceed the job cap;
+      # unset → 30s default in build_ibd_tiebreaker.
+      IBD_LLM_TIMEOUT: ${{ vars.IBD_LLM_TIMEOUT }}
 
     steps:
       - uses: actions/checkout@v4

--- a/backend/app/scripts/build_ibd_classification_bundle.py
+++ b/backend/app/scripts/build_ibd_classification_bundle.py
@@ -88,6 +88,30 @@ def main() -> int:
         help="Path to the previous week's bundle (.json.gz) for the churn diff. "
         "When omitted, the health report's diff is null (e.g. first run).",
     )
+    parser.add_argument(
+        "--max-runtime-minutes",
+        type=float,
+        default=0.0,
+        help="Soft deadline for the classification loop. Once reached, the paid LLM "
+        "tier is disabled and remaining symbols use the free deterministic "
+        "fallback so the job finishes under the CI cap. 0 = unbounded.",
+    )
+    parser.add_argument(
+        "--max-llm-calls",
+        type=int,
+        default=0,
+        help="Cap on paid LLM tiebreaker calls per run; remaining low-confidence "
+        "symbols use the free deterministic fallback. 0 = unbounded.",
+    )
+    parser.add_argument(
+        "--soft-attach",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="When the crosswalk/embedding/LLM tiers don't produce a confident "
+        "match, attach the nearest deterministic guess (relaxed crosswalk "
+        "plurality, then nearest centroid) instead of leaving the symbol "
+        "unresolved. Keeps foreign-market coverage high off the paid tier.",
+    )
     args = parser.parse_args()
 
     prepare_runtime()
@@ -108,6 +132,12 @@ def main() -> int:
     as_of_compact = as_of_date.replace("-", "")
     source_revision = f"ibd:{now.strftime('%Y%m%d%H%M%S')}"
 
+    deadline_seconds = args.max_runtime_minutes * 60 if args.max_runtime_minutes > 0 else None
+    max_llm_calls = args.max_llm_calls if args.max_llm_calls > 0 else None
+
+    def _print_progress(record: dict) -> None:
+        print(f"  progress: {record}", flush=True)
+
     with SessionLocal() as db:
         service = IBDClassificationService(
             crosswalk=crosswalk,
@@ -115,7 +145,13 @@ def main() -> int:
             llm_tiebreaker=tiebreaker,
             llm_model_id=model_id,
         )
-        result = service.classify_market(db, market)
+        result = service.classify_market(
+            db, market,
+            deadline_seconds=deadline_seconds,
+            max_llm_calls=max_llm_calls,
+            soft_attach=args.soft_attach,
+            progress_callback=_print_progress,
+        )
 
     summary = result.summary()
     payload = build_payload(
@@ -166,6 +202,12 @@ def main() -> int:
     print(f"  - health:   {health_path}")
     if health.get("diff") is not None:
         print(f"  - churn:    {health['diff']['churn_pct']}%")
+    if result.deadline_hit:
+        print(
+            f"  - NOTE: runtime deadline reached after {result.processed}/{result.candidates} "
+            f"symbols; remainder classified via free deterministic fallback (partial-quality run)",
+            flush=True,
+        )
     return 0
 
 

--- a/backend/app/services/ibd_classification_service.py
+++ b/backend/app/services/ibd_classification_service.py
@@ -167,15 +167,21 @@ class IBDClassificationService:
     # ---- taxonomy & centroids ------------------------------------------------
 
     def canonical_taxonomy(self, db: Session) -> list[str]:
-        """The canonical IBD group list (distinct US CSV/manual groups)."""
+        """The canonical IBD group list — one shared namespace across all markets.
+
+        Includes only *authoritative* rows (``csv``/``manual``), so a machine-derived
+        assignment (crosswalk/embedding/llm) can never widen the taxonomy on a later
+        run and grow a centroid for its own guess. Crucially this is **not** scoped to
+        ``market == "US"``: a human ``manual`` curation in *any* market extends the
+        shared namespace (the escape hatch for industries the US CSV doesn't cover,
+        e.g. a CN-specific group), keeping groups cross-market comparable for
+        ``IBDGroupRankService`` rather than forking a per-market taxonomy.
+        """
         if self._taxonomy is None:
-            # Authoritative US rows only — never let a derived (crosswalk/embedding/
-            # llm) or non-US assignment widen the canonical taxonomy on a later run.
             rows = (
                 db.query(IBDIndustryGroup.industry_group)
                 .filter(
                     IBDIndustryGroup.industry_group.isnot(None),
-                    IBDIndustryGroup.market == "US",
                     IBDIndustryGroup.source.in_(IBDIndustryService.AUTHORITATIVE_SOURCES),
                 )
                 .distinct()

--- a/backend/app/services/ibd_classification_service.py
+++ b/backend/app/services/ibd_classification_service.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Optional, Protocol
 
@@ -72,6 +73,13 @@ class ClassificationResult:
     skipped_authoritative: int = 0
     unresolved: list[str] = field(default_factory=list)
     candidates: int = 0
+    # Operational fields (populated by classify_market): how many candidates were
+    # processed, how many paid LLM calls were made, and whether a runtime deadline
+    # cut the expensive tier short (a "partial-quality" run, not a partial set —
+    # soft-attach keeps coverage high even after the deadline).
+    processed: int = 0
+    llm_calls: int = 0
+    deadline_hit: bool = False
 
     def summary(self) -> dict:
         by_method: dict[str, int] = {}
@@ -88,6 +96,9 @@ class ClassificationResult:
             "unresolved": len(self.unresolved),
             "by_source": by_method,
             "coverage_pct": round(100.0 * classified / total_active, 2) if total_active else 0.0,
+            "processed": self.processed,
+            "llm_calls": self.llm_calls,
+            "partial": self.deadline_hit,
         }
 
 
@@ -118,6 +129,14 @@ class IBDClassificationService:
     LLM_SHORTLIST_SIZE = 6
     # Representative member texts blended into each group centroid (when present).
     MAX_MEMBERS_PER_CENTROID = 25
+    # Relaxed thresholds for the soft (plurality) crosswalk fallback: any tier with
+    # at least one vote wins. Foreign markets carry English/global sector+industry
+    # strings even when GICS sub-industry and US-name-biased embeddings fail, so
+    # this is a free, deterministic way to keep coverage off the paid LLM tier.
+    SOFT_CROSSWALK_MIN_SHARE = 0.0
+    SOFT_CROSSWALK_MIN_VOTES = 1
+    # How often classify_market emits a progress record.
+    PROGRESS_EVERY = 500
 
     def __init__(
         self,
@@ -266,8 +285,23 @@ class IBDClassificationService:
         scored.sort(key=lambda gs: (-gs[1], gs[0]))
         return scored
 
-    def classify_one(self, ctx: StockContext, centroids: dict[str, "np.ndarray"]) -> Optional[Assignment]:
-        # Tier 2: deterministic crosswalk.
+    def classify_one(
+        self,
+        ctx: StockContext,
+        centroids: dict[str, "np.ndarray"],
+        *,
+        allow_llm: bool = True,
+        soft_attach: bool = False,
+    ) -> tuple[Optional[Assignment], bool]:
+        """Classify one stock. Returns ``(assignment_or_none, llm_called)``.
+
+        The cascade: strict crosswalk → confident embedding → (paid LLM, only when
+        ``allow_llm``) → free deterministic fallbacks when ``soft_attach`` is set
+        (relaxed crosswalk plurality, then nearest embedding centroid). The
+        ``llm_called`` flag lets the caller meter a paid-call budget even when the
+        call returns no usable answer.
+        """
+        # Tier 2: strict deterministic crosswalk.
         if self.crosswalk is not None:
             hit = self.crosswalk.lookup(
                 sub_industry=ctx.sub_industry, sector=ctx.sector, industry=ctx.industry
@@ -276,35 +310,80 @@ class IBDClassificationService:
                 return Assignment(
                     symbol=ctx.symbol, market=ctx.market, industry_group=hit.group,
                     source=SOURCE_CROSSWALK, confidence=hit.confidence, method=hit.method,
-                )
+                ), False
 
-        # Tier 3/4: rank against group centroids; attach the nearest if confident,
-        # otherwise let the LLM tiebreaker pick from that shortlist.
+        # Tier 3: rank against group centroids; attach the nearest if confident.
         ranking = self._embedding_ranking(ctx, centroids)
-        if not ranking:
-            return None
+        if ranking:
+            best_group, best_score = ranking[0]
+            if best_score >= self.attach_threshold:
+                return Assignment(
+                    symbol=ctx.symbol, market=ctx.market, industry_group=best_group,
+                    source=SOURCE_EMBEDDING, confidence=round(float(best_score), 4),
+                    method="centroid_nn",
+                ), False
 
-        best_group, best_score = ranking[0]
-        if best_score >= self.attach_threshold:
-            return Assignment(
-                symbol=ctx.symbol, market=ctx.market, industry_group=best_group,
-                source=SOURCE_EMBEDDING, confidence=round(float(best_score), 4),
-                method="centroid_nn",
-            )
-
-        if self.llm_tiebreaker is not None:
+        # Tier 4: paid LLM tiebreaker over the embedding shortlist (budget/deadline
+        # gated by the caller via allow_llm).
+        llm_called = False
+        if allow_llm and self.llm_tiebreaker is not None and ranking:
             shortlist = [g for g, _ in ranking[: self.LLM_SHORTLIST_SIZE]]
             chosen = self.llm_tiebreaker(ctx.text(), shortlist)
+            llm_called = True
             if chosen and chosen in shortlist:
                 return Assignment(
                     symbol=ctx.symbol, market=ctx.market, industry_group=chosen,
                     source=SOURCE_LLM, confidence=None, method="llm_shortlist",
                     model_id=self.llm_model_id,
-                )
-        return None
+                ), True
 
-    def classify_market(self, db: Session, market: str) -> ClassificationResult:
+        # Free deterministic fallbacks — keep coverage high (without the LLM) when
+        # the LLM is unavailable, over budget, past the deadline, or unhelpful.
+        if soft_attach:
+            if self.crosswalk is not None:
+                soft = self.crosswalk.lookup(
+                    sub_industry=ctx.sub_industry, sector=ctx.sector, industry=ctx.industry,
+                    min_share=self.SOFT_CROSSWALK_MIN_SHARE, min_votes=self.SOFT_CROSSWALK_MIN_VOTES,
+                )
+                if soft is not None:
+                    return Assignment(
+                        symbol=ctx.symbol, market=ctx.market, industry_group=soft.group,
+                        source=SOURCE_CROSSWALK, confidence=soft.confidence,
+                        method=f"{soft.method}_plurality",
+                    ), llm_called
+            if ranking:
+                best_group, best_score = ranking[0]
+                return Assignment(
+                    symbol=ctx.symbol, market=ctx.market, industry_group=best_group,
+                    source=SOURCE_EMBEDDING, confidence=round(float(best_score), 4),
+                    method="centroid_nn_soft",
+                ), llm_called
+
+        return None, llm_called
+
+    def classify_market(
+        self,
+        db: Session,
+        market: str,
+        *,
+        deadline_seconds: float | None = None,
+        clock: Callable[[], float] | None = None,
+        max_llm_calls: int | None = None,
+        soft_attach: bool = False,
+        progress_every: int | None = None,
+        progress_callback: Callable[[dict], None] | None = None,
+    ) -> ClassificationResult:
+        """Classify a market's residual universe.
+
+        ``deadline_seconds`` and ``max_llm_calls`` bound the expensive LLM tier so a
+        large foreign universe can't run past the CI job cap or an unbounded paid
+        bill; once either trips, remaining symbols use the free deterministic
+        fallbacks (when ``soft_attach``). ``clock`` is injectable for tests.
+        """
         market = (market or "US").upper()
+        clock = clock or time.monotonic
+        progress_every = self.PROGRESS_EVERY if progress_every is None else progress_every
+
         taxonomy = self.canonical_taxonomy(db)
         if not taxonomy:
             logger.warning("No canonical IBD taxonomy available; load the CSV first")
@@ -314,12 +393,49 @@ class IBDClassificationService:
         result = ClassificationResult(
             market=market, candidates=len(contexts), skipped_authoritative=skipped_authoritative
         )
-        for ctx in contexts:
-            assignment = self.classify_one(ctx, centroids)
+
+        total = len(contexts)
+        start = clock()
+        for i, ctx in enumerate(contexts, 1):
+            past_deadline = (
+                deadline_seconds is not None and (clock() - start) >= deadline_seconds
+            )
+            if past_deadline and not result.deadline_hit:
+                result.deadline_hit = True
+                logger.warning(
+                    "IBD %s: deadline (%ss) reached after %d/%d symbols; disabling the "
+                    "LLM tier for the remainder (deterministic fallback only)",
+                    market, deadline_seconds, i - 1, total,
+                )
+            budget_ok = max_llm_calls is None or result.llm_calls < max_llm_calls
+            allow_llm = (
+                self.llm_tiebreaker is not None and not past_deadline and budget_ok
+            )
+
+            assignment, llm_called = self.classify_one(
+                ctx, centroids, allow_llm=allow_llm, soft_attach=soft_attach
+            )
+            if llm_called:
+                result.llm_calls += 1
             if assignment is not None:
                 result.assignments.append(assignment)
             else:
                 result.unresolved.append(ctx.symbol)
+            result.processed = i
+
+            if progress_every and (i % progress_every == 0 or i == total):
+                by_source: dict[str, int] = {}
+                for a in result.assignments:
+                    by_source[a.source] = by_source.get(a.source, 0) + 1
+                record = {
+                    "market": market, "processed": i, "total": total,
+                    "assigned": len(result.assignments), "unresolved": len(result.unresolved),
+                    "llm_calls": result.llm_calls, "by_source": by_source,
+                    "elapsed_sec": round(clock() - start, 1),
+                }
+                logger.info("IBD %s progress: %s", market, record)
+                if progress_callback is not None:
+                    progress_callback(record)
 
         logger.info("IBD classification %s: %s", market, result.summary())
         return result

--- a/backend/app/services/ibd_classification_service.py
+++ b/backend/app/services/ibd_classification_service.py
@@ -80,6 +80,7 @@ class ClassificationResult:
     processed: int = 0
     llm_calls: int = 0
     deadline_hit: bool = False
+    llm_budget_exhausted: bool = False
 
     def summary(self) -> dict:
         by_method: dict[str, int] = {}
@@ -98,7 +99,12 @@ class ClassificationResult:
             "coverage_pct": round(100.0 * classified / total_active, 2) if total_active else 0.0,
             "processed": self.processed,
             "llm_calls": self.llm_calls,
+            # ``partial`` flags the *abnormal* case: the runtime deadline cut the
+            # high-quality (LLM) tier short. Hitting the LLM call budget is a
+            # by-design cost cap, reported separately so it doesn't dilute the
+            # deadline alarm.
             "partial": self.deadline_hit,
+            "llm_budget_exhausted": self.llm_budget_exhausted,
         }
 
 
@@ -384,6 +390,13 @@ class IBDClassificationService:
         clock = clock or time.monotonic
         progress_every = self.PROGRESS_EVERY if progress_every is None else progress_every
 
+        if deadline_seconds is not None and not soft_attach and self.llm_tiebreaker is not None:
+            logger.warning(
+                "IBD %s: deadline set without soft_attach — symbols reached after the "
+                "deadline will be left unresolved (pass soft_attach=True to keep coverage)",
+                market,
+            )
+
         taxonomy = self.canonical_taxonomy(db)
         if not taxonomy:
             logger.warning("No canonical IBD taxonomy available; load the CSV first")
@@ -437,5 +450,8 @@ class IBDClassificationService:
                 if progress_callback is not None:
                     progress_callback(record)
 
+        result.llm_budget_exhausted = (
+            max_llm_calls is not None and result.llm_calls >= max_llm_calls
+        )
         logger.info("IBD classification %s: %s", market, result.summary())
         return result

--- a/backend/app/services/llm/openai_compatible_client.py
+++ b/backend/app/services/llm/openai_compatible_client.py
@@ -103,6 +103,7 @@ class OpenAICompatibleTiebreaker:
         api_key: Optional[str],
         temperature: float = 0.1,
         max_tokens: int = 200,
+        timeout: float = 30.0,
         complete_fn: Optional[Callable[..., str]] = None,
     ):
         self.model = model
@@ -111,17 +112,14 @@ class OpenAICompatibleTiebreaker:
         self.api_key = api_key
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.timeout = timeout
         self._complete_fn = complete_fn  # injectable for tests
 
     @property
     def model_id(self) -> str:
         return self.model
 
-    def _complete(self, user_prompt: str) -> str:
-        if self._complete_fn is not None:
-            return self._complete_fn(user_prompt)
-        import litellm
-
+    def _litellm_params(self, user_prompt: str) -> dict:
         params = {
             "model": self.litellm_model,
             "messages": [
@@ -130,12 +128,23 @@ class OpenAICompatibleTiebreaker:
             ],
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
+            # Bound every call: the classifier's runtime deadline is only checked
+            # between symbols, so without this a single hung request could run past
+            # the job cap. Worst-case overrun is one timeout, not unbounded.
+            "timeout": self.timeout,
         }
         if self.api_base:
             params["api_base"] = self.api_base
         if self.api_key:
             params["api_key"] = self.api_key
-        response = litellm.completion(**params)
+        return params
+
+    def _complete(self, user_prompt: str) -> str:
+        if self._complete_fn is not None:
+            return self._complete_fn(user_prompt)
+        import litellm
+
+        response = litellm.completion(**self._litellm_params(user_prompt))
         return response["choices"][0]["message"]["content"] or ""
 
     def __call__(self, text: str, shortlist: list[str]) -> Optional[str]:
@@ -162,12 +171,14 @@ def build_ibd_tiebreaker() -> tuple[Optional[Callable[[str, list[str]], Optional
     if model:
         temperature = float(_env("IBD_LLM_TEMPERATURE") or 0.1)
         max_tokens = int(_env("IBD_LLM_MAX_TOKENS") or 200)
+        timeout = float(_env("IBD_LLM_TIMEOUT") or 30.0)
         tb = OpenAICompatibleTiebreaker(
             model=model,
             api_base=_env("IBD_LLM_API_BASE"),
             api_key=_env("IBD_LLM_API_KEY"),
             temperature=temperature,
             max_tokens=max_tokens,
+            timeout=timeout,
         )
         logger.info("IBD tiebreaker: env-driven OpenAI-compatible model %s", model)
         return tb, tb.model_id

--- a/backend/tests/unit/test_ibd_classification_service.py
+++ b/backend/tests/unit/test_ibd_classification_service.py
@@ -163,6 +163,150 @@ def test_unresolved_when_no_match_and_no_llm():
     assert result.summary()["coverage_pct"] == 0.0
 
 
+class FakeClock:
+    """Deterministic monotonic clock: returns each value in ``seq`` per call,
+    then repeats the last one (so a deadline can be tripped on a chosen iteration)."""
+
+    def __init__(self, seq):
+        self.seq = list(seq)
+        self.i = 0
+
+    def __call__(self) -> float:
+        value = self.seq[min(self.i, len(self.seq) - 1)]
+        self.i += 1
+        return value
+
+
+def _counting_llm(return_value=None):
+    calls = {"n": 0}
+
+    def _llm(text, shortlist):
+        calls["n"] += 1
+        return shortlist[-1] if return_value is None else return_value
+
+    return _llm, calls
+
+
+def test_deadline_disables_llm_and_falls_back_to_deterministic():
+    session = _make_session()
+    _seed_taxonomy(session)
+    # Two neutral SG stocks → both would hit the LLM (threshold 0.9), but the
+    # deadline trips before the 2nd, so it must fall back to a free soft attach.
+    _add_universe(session, "AAA.SG", "SG", name="Alpha Holdings")
+    _add_universe(session, "BBB.SG", "SG", name="Beta Holdings")
+    llm, calls = _counting_llm()
+    svc = IBDClassificationService(
+        crosswalk=None, embedding_engine=FakeEngine(),
+        llm_tiebreaker=llm, llm_model_id="test/model", attach_threshold=0.9,
+    )
+
+    # start=0, iter1 clock=0 (<10 → LLM ok), iter2 clock=100 (>=10 → deadline).
+    result = svc.classify_market(
+        session, "SG", deadline_seconds=10, clock=FakeClock([0, 0, 100]),
+        soft_attach=True,
+    )
+
+    assert calls["n"] == 1                      # only the first symbol reached the LLM
+    assert result.deadline_hit is True
+    assert result.llm_calls == 1
+    assert len(result.assignments) == 2         # both still classified (coverage kept)
+    sources = sorted(a.source for a in result.assignments)
+    assert SOURCE_LLM in sources
+    assert any(a.method == "centroid_nn_soft" for a in result.assignments)
+    assert result.summary()["partial"] is True
+    assert result.summary()["processed"] == 2
+
+
+def test_max_llm_calls_budget_caps_calls():
+    session = _make_session()
+    _seed_taxonomy(session)
+    for sym in ("AAA.SG", "BBB.SG", "CCC.SG"):
+        _add_universe(session, sym, "SG", name=f"{sym} Holdings")
+    llm, calls = _counting_llm()
+    svc = IBDClassificationService(
+        crosswalk=None, embedding_engine=FakeEngine(),
+        llm_tiebreaker=llm, llm_model_id="test/model", attach_threshold=0.9,
+    )
+
+    result = svc.classify_market(session, "SG", max_llm_calls=1, soft_attach=True)
+
+    assert calls["n"] == 1                      # budget capped the paid tier
+    assert result.llm_calls == 1
+    assert len(result.assignments) == 3         # the other two soft-attached for free
+    assert sum(1 for a in result.assignments if a.method == "centroid_nn_soft") == 2
+
+
+def test_soft_attach_uses_relaxed_crosswalk_plurality():
+    session = _make_session()
+    _seed_taxonomy(session)
+    _add_universe(session, "D05.SG", "SG", name="DBS", sector="Financials", industry="Banks")
+    # A 1–1 split → strict lookup (0.6/3) fails, but the relaxed plurality wins.
+    crosswalk = IBDCrosswalk(build_crosswalk(
+        symbol_to_group={"B0": "Banks-Money Center", "B1": "Banks-Regional"},
+        symbol_to_sector_industry={
+            "B0": ("Financials", "Banks"), "B1": ("Financials", "Banks"),
+        },
+    ))
+    svc = IBDClassificationService(
+        crosswalk=crosswalk, embedding_engine=FakeEngine(), attach_threshold=0.9,
+    )
+
+    result = svc.classify_market(session, "SG", soft_attach=True)
+
+    a = result.assignments[0]
+    assert a.source == SOURCE_CROSSWALK
+    assert a.industry_group == "Banks-Money Center"   # deterministic tie-break
+    assert a.confidence == 0.5                          # actual vote share
+    assert a.method == "sector_industry_plurality"
+
+
+def test_soft_attach_falls_back_to_embedding_top1():
+    session = _make_session()
+    _seed_taxonomy(session)
+    # Neutral name (no keyword) → best cosine ~0.577, below the 0.9 threshold, no
+    # crosswalk and no LLM → soft attach to the nearest centroid (lexicographic
+    # tie-break across the equal-distance one-hot centroids → Computers-Software).
+    _add_universe(session, "0700.HK", "HK", name="Generic Holdings")
+    svc = IBDClassificationService(
+        crosswalk=None, embedding_engine=FakeEngine(), attach_threshold=0.9,
+    )
+
+    result = svc.classify_market(session, "HK", soft_attach=True)
+
+    a = result.assignments[0]
+    assert a.source == SOURCE_EMBEDDING
+    assert a.method == "centroid_nn_soft"
+    assert a.industry_group == "Computers-Software"
+
+
+def test_soft_attach_off_preserves_unresolved():
+    session = _make_session()
+    _seed_taxonomy(session)
+    _add_universe(session, "MIXED.SG", "SG", name="Conglomerate Holdings")
+    svc = IBDClassificationService(
+        crosswalk=None, embedding_engine=FakeEngine(), attach_threshold=0.9,
+    )
+
+    result = svc.classify_market(session, "SG")  # soft_attach defaults False
+
+    assert result.assignments == []
+    assert result.unresolved == ["MIXED.SG"]
+
+
+def test_progress_callback_receives_counts():
+    session = _make_session()
+    _seed_taxonomy(session)
+    _add_universe(session, "0700.HK", "HK", name="Tencent Software")
+    seen = []
+    svc = IBDClassificationService(crosswalk=None, embedding_engine=FakeEngine())
+
+    svc.classify_market(session, "HK", progress_every=1, progress_callback=seen.append)
+
+    assert seen and seen[-1]["processed"] == 1
+    assert seen[-1]["market"] == "HK"
+    assert "by_source" in seen[-1]
+
+
 def test_canonical_taxonomy_ignores_non_us_and_derived_rows():
     session = _make_session()
     _seed_taxonomy(session)  # US csv groups

--- a/backend/tests/unit/test_ibd_classification_service.py
+++ b/backend/tests/unit/test_ibd_classification_service.py
@@ -311,18 +311,44 @@ def test_progress_callback_receives_counts():
     assert "by_source" in seen[-1]
 
 
-def test_canonical_taxonomy_ignores_non_us_and_derived_rows():
+def test_canonical_taxonomy_excludes_machine_derived_rows():
     session = _make_session()
     _seed_taxonomy(session)  # US csv groups
-    # A derived non-US row with a novel group must NOT widen the taxonomy.
+    # Machine-derived rows (any market) must NOT widen the taxonomy — otherwise a
+    # bad guess becomes a "real" group and grows its own centroid (feedback loop).
     session.add(IBDIndustryGroup(
-        symbol="X.SG", industry_group="Bogus-Derived-Group",
+        symbol="X.SG", industry_group="Bogus-Embedding-Group",
         market="SG", source="embedding", confidence=0.3,
+    ))
+    session.add(IBDIndustryGroup(
+        symbol="Y.SG", industry_group="Bogus-LLM-Group", market="SG", source="llm",
     ))
     session.commit()
 
     svc = IBDClassificationService(crosswalk=None, embedding_engine=None)
     taxonomy = svc.canonical_taxonomy(session)
 
-    assert "Bogus-Derived-Group" not in taxonomy
+    assert "Bogus-Embedding-Group" not in taxonomy
+    assert "Bogus-LLM-Group" not in taxonomy
     assert set(taxonomy) == {"Computers-Software", "Medical-Drugs", "Energy-Oil"}
+
+
+def test_canonical_taxonomy_includes_manual_foreign_group():
+    session = _make_session()
+    _seed_taxonomy(session)  # US csv groups
+    # A human-curated (manual) row for a genuinely foreign industry extends the
+    # ONE shared namespace, regardless of market — the escape hatch for industries
+    # the US CSV doesn't cover (e.g. a CN-specific group).
+    session.add(IBDIndustryGroup(
+        symbol="600519.SS", industry_group="Beverages-Baijiu",
+        market="CN", source="manual",
+    ))
+    session.commit()
+
+    svc = IBDClassificationService(crosswalk=None, embedding_engine=None)
+    taxonomy = svc.canonical_taxonomy(session)
+
+    assert "Beverages-Baijiu" in taxonomy
+    assert set(taxonomy) == {
+        "Computers-Software", "Medical-Drugs", "Energy-Oil", "Beverages-Baijiu",
+    }

--- a/backend/tests/unit/test_ibd_classification_service.py
+++ b/backend/tests/unit/test_ibd_classification_service.py
@@ -234,6 +234,10 @@ def test_max_llm_calls_budget_caps_calls():
     assert result.llm_calls == 1
     assert len(result.assignments) == 3         # the other two soft-attached for free
     assert sum(1 for a in result.assignments if a.method == "centroid_nn_soft") == 2
+    # Budget exhaustion is reported distinctly from the deadline alarm.
+    assert result.llm_budget_exhausted is True
+    assert result.summary()["llm_budget_exhausted"] is True
+    assert result.summary()["partial"] is False  # budget cap is by-design, not "partial"
 
 
 def test_soft_attach_uses_relaxed_crosswalk_plurality():

--- a/backend/tests/unit/test_ibd_classification_service.py
+++ b/backend/tests/unit/test_ibd_classification_service.py
@@ -244,7 +244,7 @@ def test_soft_attach_uses_relaxed_crosswalk_plurality():
     session = _make_session()
     _seed_taxonomy(session)
     _add_universe(session, "D05.SG", "SG", name="DBS", sector="Financials", industry="Banks")
-    # A 1–1 split → strict lookup (0.6/3) fails, but the relaxed plurality wins.
+    # A 1-1 split -> strict lookup (0.6/3) fails, but the relaxed plurality wins.
     crosswalk = IBDCrosswalk(build_crosswalk(
         symbol_to_group={"B0": "Banks-Money Center", "B1": "Banks-Regional"},
         symbol_to_sector_industry={

--- a/backend/tests/unit/test_ibd_openai_compatible_client.py
+++ b/backend/tests/unit/test_ibd_openai_compatible_client.py
@@ -64,14 +64,34 @@ def test_tiebreaker_call_swallows_errors():
     assert tb("text", SHORTLIST) is None  # never propagates
 
 
+def test_litellm_params_include_timeout():
+    # Each request must carry a per-call timeout so a hung call can't run past the
+    # classifier's loop-level runtime deadline (checked only between symbols).
+    tb = OpenAICompatibleTiebreaker(
+        model="deepseek-chat", api_base="https://x/v1", api_key="k", timeout=12.5,
+    )
+    params = tb._litellm_params("a chip maker")
+    assert params["timeout"] == 12.5
+    assert params["model"] == "openai/deepseek-chat"
+    assert params["api_base"] == "https://x/v1"
+    assert any(m["role"] == "user" and "a chip maker" in m["content"] for m in params["messages"])
+
+
+def test_tiebreaker_default_timeout():
+    tb = OpenAICompatibleTiebreaker(model="x", api_base=None, api_key=None)
+    assert tb.timeout == 30.0
+
+
 def test_build_tiebreaker_env_driven(monkeypatch):
     monkeypatch.setenv("IBD_LLM_MODEL", "deepseek-chat")
     monkeypatch.setenv("IBD_LLM_API_BASE", "https://api.deepseek.com/v1")
     monkeypatch.setenv("IBD_LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("IBD_LLM_TIMEOUT", "45")
     tb, model_id = build_ibd_tiebreaker()
     assert model_id == "deepseek-chat"
     assert isinstance(tb, OpenAICompatibleTiebreaker)
     assert tb.api_base == "https://api.deepseek.com/v1"
+    assert tb.timeout == 45.0
 
 
 def test_build_tiebreaker_none_when_unconfigured(monkeypatch):


### PR DESCRIPTION
Fixes the weekly IBD Classification run where **9 of 12 non-US markets timed out at the 120-min job cap** ([run 26811119660](https://github.com/xang1234/stock-screener/actions/runs/26811119660)). Diagnosis: the cascade fell through to a **serial, per-symbol LLM network call for nearly every foreign stock** — the US-derived crosswalk and US-name-biased embeddings rarely matched, so large foreign universes couldn't drain the LLM queue in time (US finished in 5m; SG squeaked through at 1h15m with only **3.5% coverage**).

> **Note on base:** this branch is stacked on `feat/ibd-health-scorecard-v2` (PR #207), so this diff also contains those health-scorecard/regression-gate commits. Either merge #207 first, or merge this PR and close #207 as superseded.

## A — Runtime safety (stops the timeouts)
- `classify_market` gains `deadline_seconds` (+ injectable `clock`) and `max_llm_calls`. Once either trips, the **paid LLM tier is disabled** for the remainder of the run.
- Progress is now emitted every 500 symbols via a callback the build script prints — **ends the 2-hour black-box** that made the failure undiagnosable from logs.
- New result/summary signals: `processed`, `llm_calls`, `partial` (deadline alarm — abnormal), and `llm_budget_exhausted` (cost cap — by-design, kept distinct so it doesn't dilute the alarm).
- Workflow Build step binds `MAX_RUNTIME_MINUTES` (100) and `MAX_LLM_CALLS` (600) via `env:`.

## D — Foreign-market coverage (root cause)
- A free **deterministic soft-attach fallback**: relaxed crosswalk *plurality* on the **global sector/industry signal** (tagged `<tier>_plurality`), then nearest embedding centroid (`centroid_nn_soft`). Keeps coverage high *off* the paid tier — exactly the markets that were flooding the LLM.
- Grounded in IBD's actual structure (197 groups under 33 sectors): the canonical taxonomy is correct for all markets — the gap was *attachment*, and sector/industry (carried in English by foreign stocks) is the right bridge where US-name embeddings fail.
- **Shared, not forked, taxonomy** — and now globally extensible: `canonical_taxonomy()` no longer scopes to `market == "US"`, so a human `manual` curation in *any* market (e.g. a CN-specific group) extends the one shared namespace, keeping groups cross-market comparable for `IBDGroupRankService`. Machine-derived rows still never widen it (anti-feedback-loop guard intact).

**Combined effect next run:** big foreign markets spend ≤600 LLM calls (~30–40 min) then instant deterministic soft-attach → finish well under the 120-min cap, coverage **3.5% → high**, with an honest low-confidence distribution visible in the health histogram (which signals *where* to curate a manual group).

## Test plan
- [x] 74 IBD unit tests pass (`pytest tests/unit/ -k ibd`), TDD red→green throughout.
- [x] New service tests: deadline disables LLM + deterministic fallback; `max_llm_calls` hard ceiling (None-returning calls still charged); soft-attach via relaxed crosswalk plurality and via embedding top-1; `soft_attach=False` preserves old unresolved behavior; budget-exhaustion reported distinctly from `partial`; manual foreign group extends the taxonomy while derived rows don't.
- [x] Workflow YAML validated: step ordering intact, `build_crosswalk` job + `AU` market preserved, embedded heredoc Python compiles.
- [x] Back-compat verified: all new `classify_market` kwargs default to the prior cascade behavior.
- [ ] First real run: dispatch with `gate_mode=warn`, confirm foreign markets finish under the cap and coverage rises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable runtime and LLM call limits for IBD classification to control processing time and costs
  * Implemented graceful fallback to deterministic methods when limits are reached, ensuring partial results are still produced
  * Added progress reporting during classification runs with elapsed time and assignment counts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->