### PR TITLE
fix(ingest): backfill StockUniverse sector/industry from yfinance (unblocks foreign IBD classification)

### DIFF
--- a/backend/app/scripts/backfill_universe_sector_industry.py
+++ b/backend/app/scripts/backfill_universe_sector_industry.py
@@ -1,0 +1,106 @@
+"""One-time backfill of ``StockUniverse.sector``/``industry`` from yfinance.
+
+Foreign-market universe rows ingest without classification (CN ``sector="Other"``,
+HK empty), which starves the IBD crosswalk + embedding tiers. yfinance returns
+sector/industry on its fundamentals call; this fills rows that are missing it,
+without touching rows that already carry a real value (e.g. US finviz data).
+Idempotent and safe to re-run; new full refreshes carry the data automatically
+once the fundamentals persist path is in place, so this just avoids waiting.
+
+Usage:
+    python -m app.scripts.backfill_universe_sector_industry [--market HK] [--limit N] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+from typing import Callable, Optional
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models.stock_universe import StockUniverse
+from app.scripts._runtime import prepare_runtime
+from app.services.fundamentals_cache_service import (
+    _backfill_universe_classification,
+    _is_meaningful_classification,
+)
+
+
+def _needs_backfill(row: StockUniverse) -> bool:
+    """True when the row lacks a real sector OR industry."""
+    return not (
+        _is_meaningful_classification(row.sector)
+        and _is_meaningful_classification(row.industry)
+    )
+
+
+def backfill_universe(
+    db: Session,
+    *,
+    fetch_fundamentals: Callable[[str], Optional[dict]],
+    market: Optional[str] = None,
+    limit: Optional[int] = None,
+    dry_run: bool = False,
+    progress: Optional[Callable[[dict], None]] = None,
+) -> dict:
+    """Fill missing sector/industry for active universe rows via ``fetch_fundamentals``.
+
+    Pure orchestration over an injected fetcher (so it's testable without yfinance);
+    reuses the shared, no-clobber ``_backfill_universe_classification`` for the actual
+    write so the precedence rules stay in one place.
+    """
+    query = db.query(StockUniverse).filter(StockUniverse.is_active.is_(True))
+    if market:
+        query = query.filter(StockUniverse.market == market.strip().upper())
+    candidates = [row for row in query.all() if _needs_backfill(row)]
+    if limit is not None:
+        candidates = candidates[:limit]
+
+    filled = errors = 0
+    for i, row in enumerate(candidates, 1):
+        try:
+            data = fetch_fundamentals(row.symbol) or {}
+        except Exception:  # noqa: BLE001 — one bad symbol must not abort the batch
+            errors += 1
+            continue
+        if _backfill_universe_classification(db, row.symbol, data):
+            filled += 1
+        if progress and i % 200 == 0:
+            progress({"scanned": i, "total": len(candidates), "filled": filled, "errors": errors})
+
+    if dry_run:
+        db.rollback()
+    else:
+        db.commit()
+    return {"candidates": len(candidates), "filled": filled, "errors": errors, "dry_run": dry_run}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--market", default=None, help="Restrict to one market (e.g. HK).")
+    parser.add_argument("--limit", type=int, default=None, help="Cap rows processed.")
+    parser.add_argument("--dry-run", action="store_true", help="Report changes without persisting.")
+    args = parser.parse_args(argv)
+
+    prepare_runtime()
+    from app.services.yfinance_service import YFinanceService
+
+    yf_service = YFinanceService()
+    with SessionLocal() as db:
+        stats = backfill_universe(
+            db,
+            fetch_fundamentals=yf_service.get_fundamentals,
+            market=args.market,
+            limit=args.limit,
+            dry_run=args.dry_run,
+            progress=lambda rec: print(f"  progress: {rec}", flush=True),
+        )
+
+    print("Universe sector/industry backfill complete:")
+    for key, value in stats.items():
+        print(f"  - {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/scripts/backfill_universe_sector_industry.py
+++ b/backend/app/scripts/backfill_universe_sector_industry.py
@@ -48,6 +48,9 @@ def backfill_universe(
     Pure orchestration over an injected fetcher (so it's testable without yfinance);
     reuses the shared, no-clobber ``_backfill_universe_classification`` for the actual
     write so the precedence rules stay in one place.
+
+    ``dry_run`` rolls ``db`` back at the end, so pass a session with no other pending
+    writes (``main()`` opens a fresh one).
     """
     query = db.query(StockUniverse).filter(StockUniverse.is_active.is_(True))
     if market:

--- a/backend/app/scripts/backfill_universe_sector_industry.py
+++ b/backend/app/scripts/backfill_universe_sector_industry.py
@@ -62,8 +62,12 @@ def backfill_universe(
     filled = errors = 0
     for i, row in enumerate(candidates, 1):
         try:
-            data = fetch_fundamentals(row.symbol) or {}
+            data = fetch_fundamentals(row.symbol)
         except Exception:  # noqa: BLE001 — one bad symbol must not abort the batch
+            data = None
+        # get_fundamentals logs and returns None on failure (it doesn't re-raise),
+        # so a None result is a fetch error, not "no data to fill".
+        if data is None:
             errors += 1
             continue
         if backfill_universe_classification(

--- a/backend/app/scripts/backfill_universe_sector_industry.py
+++ b/backend/app/scripts/backfill_universe_sector_industry.py
@@ -20,17 +20,17 @@ from sqlalchemy.orm import Session
 from app.database import SessionLocal
 from app.models.stock_universe import StockUniverse
 from app.scripts._runtime import prepare_runtime
-from app.services.fundamentals_cache_service import (
-    _backfill_universe_classification,
-    _is_meaningful_classification,
+from app.services.universe_classification import (
+    backfill_universe_classification,
+    is_meaningful_classification,
 )
 
 
 def _needs_backfill(row: StockUniverse) -> bool:
     """True when the row lacks a real sector OR industry."""
     return not (
-        _is_meaningful_classification(row.sector)
-        and _is_meaningful_classification(row.industry)
+        is_meaningful_classification(row.sector)
+        and is_meaningful_classification(row.industry)
     )
 
 
@@ -66,7 +66,9 @@ def backfill_universe(
         except Exception:  # noqa: BLE001 — one bad symbol must not abort the batch
             errors += 1
             continue
-        if _backfill_universe_classification(db, row.symbol, data):
+        if backfill_universe_classification(
+            db, row.symbol, sector=data.get("sector"), industry=data.get("industry")
+        ):
             filled += 1
         if progress and i % 200 == 0:
             progress({"scanned": i, "total": len(candidates), "filled": filled, "errors": errors})

--- a/backend/app/services/fundamentals_cache_service.py
+++ b/backend/app/services/fundamentals_cache_service.py
@@ -25,6 +25,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised in desktop packaging
 
 from ..database import SessionLocal
 from ..models.stock import StockFundamental
+from ..models.stock_universe import StockUniverse
 from ..config import settings
 from .errors import CacheRefreshError
 from .fundamentals_completeness import (
@@ -48,6 +49,45 @@ def _assign_if_present(record: Any, attr: str, data: Dict[str, Any], key: str) -
     payloads from wiping previously stored market-state fields."""
     if key in data and data[key] is not None:
         setattr(record, attr, data[key])
+
+
+# Sector/industry values that mean "no real classification" — foreign-market
+# universe ingest leaves these (CN="Other", HK=""), starving the IBD classifier.
+_PLACEHOLDER_CLASSIFICATION = frozenset({"", "other", "unknown", "n/a", "none"})
+
+
+def _is_meaningful_classification(value: object) -> bool:
+    """True when ``value`` is a real sector/industry label (not blank/Other/Unknown)."""
+    return bool(value) and str(value).strip().lower() not in _PLACEHOLDER_CLASSIFICATION
+
+
+def _backfill_universe_classification(db: Session, symbol: str, data: Dict[str, Any]) -> bool:
+    """Backfill ``StockUniverse.sector``/``industry`` from a fundamentals payload.
+
+    Foreign-market universe rows arrive without classification; yfinance returns it
+    on the same fundamentals fetch. Fill the universe row only where it's currently
+    missing (empty/Other/Unknown) and the fetched value is real — never clobber an
+    existing meaningful value (e.g. US finviz sectors). Returns True if anything changed.
+    """
+    sector = data.get("sector")
+    industry = data.get("industry")
+    if not (_is_meaningful_classification(sector) or _is_meaningful_classification(industry)):
+        return False
+
+    row = db.query(StockUniverse).filter(StockUniverse.symbol == symbol).first()
+    if row is None:
+        return False
+
+    changed = False
+    if _is_meaningful_classification(sector) and not _is_meaningful_classification(row.sector):
+        row.sector = str(sector).strip()
+        changed = True
+    if _is_meaningful_classification(industry) and not _is_meaningful_classification(row.industry):
+        row.industry = str(industry).strip()
+        changed = True
+    if changed:
+        logger.info("Backfilled StockUniverse sector/industry for %s from fundamentals", symbol)
+    return changed
 
 
 _RECOMMENDATION_SCORE_BY_KEY: dict[str, float | None] = {
@@ -1115,6 +1155,10 @@ class FundamentalsCacheService:
                 )
                 db.add(new_record)
                 logger.info(f"Inserted fundamental data for {symbol} in database")
+
+            # Propagate sector/industry into the universe row when it's missing
+            # there (foreign-market ingest lacks it); never clobbers a real value.
+            _backfill_universe_classification(db, symbol, data)
 
             db.commit()
 

--- a/backend/app/services/fundamentals_cache_service.py
+++ b/backend/app/services/fundamentals_cache_service.py
@@ -57,7 +57,11 @@ _PLACEHOLDER_CLASSIFICATION = frozenset({"", "other", "unknown", "n/a", "none"})
 
 
 def _is_meaningful_classification(value: object) -> bool:
-    """True when ``value`` is a real sector/industry label (not blank/Other/Unknown)."""
+    """True when ``value`` is a real sector/industry label (not blank/Other/Unknown).
+
+    The ``bool(value)`` guard must stay first so ``None`` is rejected before the
+    string compare — ``str(None)`` is ``"None"`` (capital N), not in the set.
+    """
     return bool(value) and str(value).strip().lower() not in _PLACEHOLDER_CLASSIFICATION
 
 

--- a/backend/app/services/fundamentals_cache_service.py
+++ b/backend/app/services/fundamentals_cache_service.py
@@ -25,7 +25,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised in desktop packaging
 
 from ..database import SessionLocal
 from ..models.stock import StockFundamental
-from ..models.stock_universe import StockUniverse
+from .universe_classification import backfill_universe_classification
 from ..config import settings
 from .errors import CacheRefreshError
 from .fundamentals_completeness import (
@@ -49,49 +49,6 @@ def _assign_if_present(record: Any, attr: str, data: Dict[str, Any], key: str) -
     payloads from wiping previously stored market-state fields."""
     if key in data and data[key] is not None:
         setattr(record, attr, data[key])
-
-
-# Sector/industry values that mean "no real classification" — foreign-market
-# universe ingest leaves these (CN="Other", HK=""), starving the IBD classifier.
-_PLACEHOLDER_CLASSIFICATION = frozenset({"", "other", "unknown", "n/a", "none"})
-
-
-def _is_meaningful_classification(value: object) -> bool:
-    """True when ``value`` is a real sector/industry label (not blank/Other/Unknown).
-
-    The ``bool(value)`` guard must stay first so ``None`` is rejected before the
-    string compare — ``str(None)`` is ``"None"`` (capital N), not in the set.
-    """
-    return bool(value) and str(value).strip().lower() not in _PLACEHOLDER_CLASSIFICATION
-
-
-def _backfill_universe_classification(db: Session, symbol: str, data: Dict[str, Any]) -> bool:
-    """Backfill ``StockUniverse.sector``/``industry`` from a fundamentals payload.
-
-    Foreign-market universe rows arrive without classification; yfinance returns it
-    on the same fundamentals fetch. Fill the universe row only where it's currently
-    missing (empty/Other/Unknown) and the fetched value is real — never clobber an
-    existing meaningful value (e.g. US finviz sectors). Returns True if anything changed.
-    """
-    sector = data.get("sector")
-    industry = data.get("industry")
-    if not (_is_meaningful_classification(sector) or _is_meaningful_classification(industry)):
-        return False
-
-    row = db.query(StockUniverse).filter(StockUniverse.symbol == symbol).first()
-    if row is None:
-        return False
-
-    changed = False
-    if _is_meaningful_classification(sector) and not _is_meaningful_classification(row.sector):
-        row.sector = str(sector).strip()
-        changed = True
-    if _is_meaningful_classification(industry) and not _is_meaningful_classification(row.industry):
-        row.industry = str(industry).strip()
-        changed = True
-    if changed:
-        logger.info("Backfilled StockUniverse sector/industry for %s from fundamentals", symbol)
-    return changed
 
 
 _RECOMMENDATION_SCORE_BY_KEY: dict[str, float | None] = {
@@ -1162,7 +1119,9 @@ class FundamentalsCacheService:
 
             # Propagate sector/industry into the universe row when it's missing
             # there (foreign-market ingest lacks it); never clobbers a real value.
-            _backfill_universe_classification(db, symbol, data)
+            backfill_universe_classification(
+                db, symbol, sector=data.get("sector"), industry=data.get("industry")
+            )
 
             db.commit()
 

--- a/backend/app/services/stock_universe_service.py
+++ b/backend/app/services/stock_universe_service.py
@@ -31,6 +31,7 @@ from ..models.stock_universe import (
 )
 from ..models.stock import StockIndustry
 from ..models.ticker_validation import TickerValidationLog
+from .universe_classification import prefer_meaningful
 from ..schemas.universe import IndexName
 from ..config import settings
 from ..domain.markets.catalog import get_market_catalog
@@ -2262,8 +2263,8 @@ class StockUniverseService:
                     existing.currency = identity.currency
                     existing.timezone = identity.timezone
                     existing.local_code = identity.local_code or existing.local_code
-                    existing.sector = stock_data["sector"] or existing.sector
-                    existing.industry = stock_data["industry"] or existing.industry
+                    existing.sector = prefer_meaningful(stock_data["sector"], existing.sector)
+                    existing.industry = prefer_meaningful(stock_data["industry"], existing.industry)
                     existing.market_cap = stock_data["market_cap"] or existing.market_cap
                     self._apply_status_transition(
                         db,

--- a/backend/app/services/universe_classification.py
+++ b/backend/app/services/universe_classification.py
@@ -24,10 +24,11 @@ _T = TypeVar("_T")
 
 
 def is_meaningful_classification(value: object) -> bool:
-    """True when ``value`` is a real sector/industry label (not blank/Other/Unknown).
+    """True when ``value`` is a real sector/industry label.
 
-    The ``bool(value)`` guard must stay first so ``None`` is rejected before the
-    string compare — ``str(None)`` is ``"None"`` (capital N), not in the set.
+    Blank/``None`` and the placeholder labels (``Other``/``Unknown``/``N/A``/``None``)
+    all read as not-meaningful; the membership test is case-insensitive. (``None``
+    is caught both by the falsy guard and by ``"none"`` being in the set.)
     """
     return bool(value) and str(value).strip().lower() not in _PLACEHOLDER_CLASSIFICATION
 

--- a/backend/app/services/universe_classification.py
+++ b/backend/app/services/universe_classification.py
@@ -1,0 +1,71 @@
+"""Canonical helpers for ``StockUniverse`` sector/industry classification.
+
+Foreign-market ingest lands universe rows without real classification (CN
+``sector="Other"``, HK empty), which starves the IBD crosswalk + embedding tiers.
+This module is the single home for *what counts as a meaningful sector/industry*
+and the two write policies over it, so every universe write path shares one
+definition instead of re-deriving "is this missing?" inline.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TypeVar
+
+from sqlalchemy.orm import Session
+
+from ..models.stock_universe import StockUniverse
+
+logger = logging.getLogger(__name__)
+
+# Values that mean "no real classification" — placeholders left by foreign ingest.
+_PLACEHOLDER_CLASSIFICATION = frozenset({"", "other", "unknown", "n/a", "none"})
+
+_T = TypeVar("_T")
+
+
+def is_meaningful_classification(value: object) -> bool:
+    """True when ``value`` is a real sector/industry label (not blank/Other/Unknown).
+
+    The ``bool(value)`` guard must stay first so ``None`` is rejected before the
+    string compare — ``str(None)`` is ``"None"`` (capital N), not in the set.
+    """
+    return bool(value) and str(value).strip().lower() not in _PLACEHOLDER_CLASSIFICATION
+
+
+def prefer_meaningful(new: _T, current: _T) -> _T:
+    """Return ``new`` when it's a meaningful label, else keep ``current``.
+
+    For ingest/update paths where the incoming source is authoritative for the
+    market: a fresh real value wins, but a placeholder ("", "Other", …) must not
+    clobber an existing real value — the bug in the older ``new or current`` form,
+    which treated the truthy ``"Other"`` as a real value.
+    """
+    return new if is_meaningful_classification(new) else current
+
+
+def backfill_universe_classification(
+    db: Session, symbol: str, *, sector: object, industry: object
+) -> bool:
+    """Fill a universe row's sector/industry only where it's currently missing.
+
+    Conservative no-clobber backfill for *enrichment* paths (e.g. yfinance
+    fundamentals) that must not override an already-authoritative classification
+    (US finviz). Returns True if anything changed.
+    """
+    if not (is_meaningful_classification(sector) or is_meaningful_classification(industry)):
+        return False
+
+    row = db.query(StockUniverse).filter(StockUniverse.symbol == symbol).first()
+    if row is None:
+        return False
+
+    changed = False
+    if is_meaningful_classification(sector) and not is_meaningful_classification(row.sector):
+        row.sector = str(sector).strip()
+        changed = True
+    if is_meaningful_classification(industry) and not is_meaningful_classification(row.industry):
+        row.industry = str(industry).strip()
+        changed = True
+    if changed:
+        logger.info("Backfilled StockUniverse sector/industry for %s", symbol)
+    return changed

--- a/backend/app/services/universe_ingestion_pipeline.py
+++ b/backend/app/services/universe_ingestion_pipeline.py
@@ -26,6 +26,7 @@ from ..models.stock_universe import (
     UNIVERSE_EVENT_LISTING_TIER_CHANGED,
     UNIVERSE_STATUS_ACTIVE,
 )
+from .universe_classification import prefer_meaningful
 
 
 class UniverseCanonicalizer(Protocol):
@@ -409,8 +410,8 @@ class UniversePersistence:
         existing.currency = row.currency
         existing.timezone = row.timezone
         existing.local_code = row.local_code or existing.local_code
-        existing.sector = row.sector or existing.sector
-        existing.industry = row.industry or existing.industry
+        existing.sector = prefer_meaningful(row.sector, existing.sector)
+        existing.industry = prefer_meaningful(row.industry, existing.industry)
         if row.market_cap is not None:
             existing.market_cap = row.market_cap
 

--- a/backend/app/services/yfinance_service.py
+++ b/backend/app/services/yfinance_service.py
@@ -220,6 +220,11 @@ class YFinanceService:
 
             result = {
                 "symbol": symbol,
+                # Classification — already present in ``info``; surfaced so the
+                # universe sector/industry backfill can use it (foreign-market
+                # ingest otherwise lands without sector/industry).
+                "sector": info.get("sector"),
+                "industry": info.get("industry"),
                 "market_cap": info.get("marketCap"),
                 "pe_ratio": info.get("trailingPE"),
                 "peg_ratio": info.get("pegRatio"),

--- a/backend/tests/unit/test_backfill_universe_sector_industry_script.py
+++ b/backend/tests/unit/test_backfill_universe_sector_industry_script.py
@@ -1,0 +1,86 @@
+"""Unit tests for the one-time universe sector/industry backfill script core."""
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.stock_universe import StockUniverse
+from app.scripts.backfill_universe_sector_industry import backfill_universe
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _add(session, symbol, market, sector, industry, is_active=True):
+    session.add(StockUniverse(
+        symbol=symbol, market=market, sector=sector, industry=industry, is_active=is_active
+    ))
+    session.commit()
+
+
+_FETCH = {
+    "0700.HK": {"sector": "Communication Services", "industry": "Internet Content & Information"},
+    "600519.SS": {"sector": "Consumer Defensive", "industry": "Beverages - Wineries & Distilleries"},
+    "9988.HK": {"sector": "Consumer Cyclical", "industry": "Internet Retail"},
+}
+
+
+def _fetch(symbol):
+    return _FETCH.get(symbol)
+
+
+def test_backfill_fills_missing_and_skips_populated():
+    session = _session()
+    _add(session, "0700.HK", "HK", "", "")                 # missing → backfill
+    _add(session, "600519.SS", "CN", "Other", None)        # placeholder → backfill
+    _add(session, "AAPL", "US", "Technology", "Software")   # real → skipped (not a candidate)
+
+    stats = backfill_universe(session, fetch_fundamentals=_fetch)
+
+    assert stats["candidates"] == 2          # AAPL is not a candidate
+    assert stats["filled"] == 2
+    rows = {r.symbol: r for r in session.query(StockUniverse).all()}
+    assert rows["0700.HK"].sector == "Communication Services"
+    assert rows["600519.SS"].industry == "Beverages - Wineries & Distilleries"
+    assert rows["AAPL"].sector == "Technology"  # untouched
+
+
+def test_market_filter_and_limit():
+    session = _session()
+    _add(session, "0700.HK", "HK", "", "")
+    _add(session, "9988.HK", "HK", "", "")
+    _add(session, "600519.SS", "CN", "Other", None)
+
+    stats = backfill_universe(session, fetch_fundamentals=_fetch, market="hk", limit=1)
+    assert stats["candidates"] == 1   # HK only, capped at 1
+    assert stats["filled"] == 1
+
+
+def test_dry_run_reports_without_persisting():
+    session = _session()
+    _add(session, "0700.HK", "HK", "", "")
+
+    stats = backfill_universe(session, fetch_fundamentals=_fetch, dry_run=True)
+    assert stats["filled"] == 1 and stats["dry_run"] is True
+    # rolled back → not persisted
+    assert (session.query(StockUniverse).filter_by(symbol="0700.HK").first().sector or "") == ""
+
+
+def test_tolerates_fetch_errors():
+    session = _session()
+    _add(session, "0700.HK", "HK", "", "")
+    _add(session, "BAD.HK", "HK", "", "")
+
+    def flaky(symbol):
+        if symbol == "BAD.HK":
+            raise RuntimeError("provider down")
+        return _fetch(symbol)
+
+    stats = backfill_universe(session, fetch_fundamentals=flaky)
+    assert stats["candidates"] == 2
+    assert stats["filled"] == 1
+    assert stats["errors"] == 1

--- a/backend/tests/unit/test_backfill_universe_sector_industry_script.py
+++ b/backend/tests/unit/test_backfill_universe_sector_industry_script.py
@@ -56,8 +56,16 @@ def test_market_filter_and_limit():
     _add(session, "600519.SS", "CN", "Other", None)
 
     stats = backfill_universe(session, fetch_fundamentals=_fetch, market="hk", limit=1)
-    assert stats["candidates"] == 1   # HK only, capped at 1
+    assert stats["candidates"] == 1   # HK only, capped at 1 of the 2 HK candidates
     assert stats["filled"] == 1
+    # Exactly one HK row was filled; the other was dropped by the limit (still empty),
+    # and CN was excluded by the market filter.
+    hk_filled = [
+        r for r in session.query(StockUniverse).filter_by(market="HK").all()
+        if (r.sector or "")
+    ]
+    assert len(hk_filled) == 1
+    assert (session.query(StockUniverse).filter_by(symbol="600519.SS").first().sector) == "Other"
 
 
 def test_dry_run_reports_without_persisting():

--- a/backend/tests/unit/test_backfill_universe_sector_industry_script.py
+++ b/backend/tests/unit/test_backfill_universe_sector_industry_script.py
@@ -78,17 +78,22 @@ def test_dry_run_reports_without_persisting():
     assert (session.query(StockUniverse).filter_by(symbol="0700.HK").first().sector or "") == ""
 
 
-def test_tolerates_fetch_errors():
+def test_counts_errors_for_raises_and_none_returns():
+    # get_fundamentals returns None on failure (doesn't re-raise); both a raised
+    # exception AND a None return must count as errors, not silent "not filled".
     session = _session()
     _add(session, "0700.HK", "HK", "", "")
-    _add(session, "BAD.HK", "HK", "", "")
+    _add(session, "RAISE.HK", "HK", "", "")
+    _add(session, "NONE.HK", "HK", "", "")
 
     def flaky(symbol):
-        if symbol == "BAD.HK":
+        if symbol == "RAISE.HK":
             raise RuntimeError("provider down")
+        if symbol == "NONE.HK":
+            return None  # the common failure mode
         return _fetch(symbol)
 
     stats = backfill_universe(session, fetch_fundamentals=flaky)
-    assert stats["candidates"] == 2
+    assert stats["candidates"] == 3
     assert stats["filled"] == 1
-    assert stats["errors"] == 1
+    assert stats["errors"] == 2  # both RAISE.HK and NONE.HK

--- a/backend/tests/unit/test_universe_classification.py
+++ b/backend/tests/unit/test_universe_classification.py
@@ -1,9 +1,9 @@
-"""Unit tests for backfilling StockUniverse.sector/industry from fundamentals.
+"""Unit tests for the canonical universe sector/industry classification helpers.
 
 Foreign-market universe ingest lands without sector/industry (CN="Other", HK empty),
-which starves the IBD crosswalk + embedding tiers. yfinance already returns proper
-sector/industry on the fundamentals fetch; these helpers propagate it into the
-universe row without clobbering an existing meaningful value (e.g. US finviz data).
+which starves the IBD crosswalk + embedding tiers. These helpers are the single
+definition of "meaningful classification" + the two write policies over it
+(``prefer_meaningful`` for authoritative ingest, ``backfill_*`` for enrichment).
 """
 from __future__ import annotations
 
@@ -12,9 +12,10 @@ from sqlalchemy.orm import sessionmaker
 
 from app.database import Base
 from app.models.stock_universe import StockUniverse
-from app.services.fundamentals_cache_service import (
-    _backfill_universe_classification,
-    _is_meaningful_classification,
+from app.services.universe_classification import (
+    backfill_universe_classification,
+    is_meaningful_classification,
+    prefer_meaningful,
 )
 
 
@@ -33,24 +34,36 @@ def _add(session, symbol, sector, industry, market="HK"):
 
 def test_is_meaningful_classification_truth_table():
     for good in ("Technology", "Communication Services", " Energy "):
-        assert _is_meaningful_classification(good) is True
+        assert is_meaningful_classification(good) is True
     for bad in (None, "", "   ", "Other", "other", "Unknown", "UNKNOWN", "N/A", "n/a", "None"):
-        assert _is_meaningful_classification(bad) is False
+        assert is_meaningful_classification(bad) is False
+
+
+def test_prefer_meaningful_keeps_current_unless_new_is_real():
+    # A real incoming value wins (authoritative source refresh).
+    assert prefer_meaningful("Technology", "Energy") == "Technology"
+    assert prefer_meaningful("Technology", None) == "Technology"
+    # A placeholder must NOT clobber an existing real value (the old `new or cur` bug).
+    assert prefer_meaningful("Other", "Energy") == "Energy"
+    assert prefer_meaningful("", "Energy") == "Energy"
+    assert prefer_meaningful(None, "Energy") == "Energy"
+    # Two placeholders → keep current (even if current is also a placeholder).
+    assert prefer_meaningful("Other", "") == ""
 
 
 def test_backfill_fills_empty_and_placeholder_values():
     session = _session()
-    _add(session, "0700.HK", "", "")              # HK: both empty
-    _add(session, "600519.SS", "Other", None, market="CN")  # CN: Other / null
+    _add(session, "0700.HK", "", "")                          # HK: both empty
+    _add(session, "600519.SS", "Other", None, market="CN")   # CN: Other / null
 
-    assert _backfill_universe_classification(session, "0700.HK", {
-        "sector": "Communication Services",
-        "industry": "Internet Content & Information",
-    }) is True
-    assert _backfill_universe_classification(session, "600519.SS", {
-        "sector": "Consumer Defensive",
-        "industry": "Beverages - Wineries & Distilleries",
-    }) is True
+    assert backfill_universe_classification(
+        session, "0700.HK",
+        sector="Communication Services", industry="Internet Content & Information",
+    ) is True
+    assert backfill_universe_classification(
+        session, "600519.SS",
+        sector="Consumer Defensive", industry="Beverages - Wineries & Distilleries",
+    ) is True
     session.commit()
 
     rows = {r.symbol: r for r in session.query(StockUniverse).all()}
@@ -64,9 +77,9 @@ def test_backfill_does_not_clobber_meaningful_existing():
     session = _session()
     _add(session, "AAPL", "Technology", "Consumer Electronics", market="US")  # US finviz
 
-    changed = _backfill_universe_classification(session, "AAPL", {
-        "sector": "Technology Different", "industry": "Something Else",
-    })
+    changed = backfill_universe_classification(
+        session, "AAPL", sector="Technology Different", industry="Something Else",
+    )
     assert changed is False
     row = session.query(StockUniverse).filter_by(symbol="AAPL").first()
     assert row.sector == "Technology"
@@ -76,24 +89,22 @@ def test_backfill_does_not_clobber_meaningful_existing():
 def test_backfill_noop_when_fetched_not_meaningful():
     session = _session()
     _add(session, "X.HK", "", "")
-    assert _backfill_universe_classification(session, "X.HK", {
-        "sector": "Other", "industry": None,
-    }) is False
+    assert backfill_universe_classification(session, "X.HK", sector="Other", industry=None) is False
     assert (session.query(StockUniverse).filter_by(symbol="X.HK").first().sector or "") == ""
 
 
 def test_backfill_noop_when_no_universe_row():
     session = _session()
-    assert _backfill_universe_classification(session, "GHOST.HK", {"sector": "Energy"}) is False
+    assert backfill_universe_classification(session, "GHOST.HK", sector="Energy", industry=None) is False
 
 
 def test_backfill_partial_industry_only():
     # sector already meaningful, industry empty → only industry is filled.
     session = _session()
     _add(session, "P.HK", "Energy", "")
-    changed = _backfill_universe_classification(session, "P.HK", {
-        "sector": "Energy", "industry": "Oil & Gas E&P",
-    })
+    changed = backfill_universe_classification(
+        session, "P.HK", sector="Energy", industry="Oil & Gas E&P",
+    )
     assert changed is True
     row = session.query(StockUniverse).filter_by(symbol="P.HK").first()
     assert row.sector == "Energy"

--- a/backend/tests/unit/test_universe_sector_backfill.py
+++ b/backend/tests/unit/test_universe_sector_backfill.py
@@ -1,0 +1,100 @@
+"""Unit tests for backfilling StockUniverse.sector/industry from fundamentals.
+
+Foreign-market universe ingest lands without sector/industry (CN="Other", HK empty),
+which starves the IBD crosswalk + embedding tiers. yfinance already returns proper
+sector/industry on the fundamentals fetch; these helpers propagate it into the
+universe row without clobbering an existing meaningful value (e.g. US finviz data).
+"""
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.stock_universe import StockUniverse
+from app.services.fundamentals_cache_service import (
+    _backfill_universe_classification,
+    _is_meaningful_classification,
+)
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _add(session, symbol, sector, industry, market="HK"):
+    session.add(StockUniverse(
+        symbol=symbol, market=market, sector=sector, industry=industry, is_active=True
+    ))
+    session.commit()
+
+
+def test_is_meaningful_classification_truth_table():
+    for good in ("Technology", "Communication Services", " Energy "):
+        assert _is_meaningful_classification(good) is True
+    for bad in (None, "", "   ", "Other", "other", "Unknown", "UNKNOWN", "N/A", "n/a", "None"):
+        assert _is_meaningful_classification(bad) is False
+
+
+def test_backfill_fills_empty_and_placeholder_values():
+    session = _session()
+    _add(session, "0700.HK", "", "")              # HK: both empty
+    _add(session, "600519.SS", "Other", None, market="CN")  # CN: Other / null
+
+    assert _backfill_universe_classification(session, "0700.HK", {
+        "sector": "Communication Services",
+        "industry": "Internet Content & Information",
+    }) is True
+    assert _backfill_universe_classification(session, "600519.SS", {
+        "sector": "Consumer Defensive",
+        "industry": "Beverages - Wineries & Distilleries",
+    }) is True
+    session.commit()
+
+    rows = {r.symbol: r for r in session.query(StockUniverse).all()}
+    assert rows["0700.HK"].sector == "Communication Services"
+    assert rows["0700.HK"].industry == "Internet Content & Information"
+    assert rows["600519.SS"].sector == "Consumer Defensive"
+    assert rows["600519.SS"].industry == "Beverages - Wineries & Distilleries"
+
+
+def test_backfill_does_not_clobber_meaningful_existing():
+    session = _session()
+    _add(session, "AAPL", "Technology", "Consumer Electronics", market="US")  # US finviz
+
+    changed = _backfill_universe_classification(session, "AAPL", {
+        "sector": "Technology Different", "industry": "Something Else",
+    })
+    assert changed is False
+    row = session.query(StockUniverse).filter_by(symbol="AAPL").first()
+    assert row.sector == "Technology"
+    assert row.industry == "Consumer Electronics"
+
+
+def test_backfill_noop_when_fetched_not_meaningful():
+    session = _session()
+    _add(session, "X.HK", "", "")
+    assert _backfill_universe_classification(session, "X.HK", {
+        "sector": "Other", "industry": None,
+    }) is False
+    assert (session.query(StockUniverse).filter_by(symbol="X.HK").first().sector or "") == ""
+
+
+def test_backfill_noop_when_no_universe_row():
+    session = _session()
+    assert _backfill_universe_classification(session, "GHOST.HK", {"sector": "Energy"}) is False
+
+
+def test_backfill_partial_industry_only():
+    # sector already meaningful, industry empty → only industry is filled.
+    session = _session()
+    _add(session, "P.HK", "Energy", "")
+    changed = _backfill_universe_classification(session, "P.HK", {
+        "sector": "Energy", "industry": "Oil & Gas E&P",
+    })
+    assert changed is True
+    row = session.query(StockUniverse).filter_by(symbol="P.HK").first()
+    assert row.sector == "Energy"
+    assert row.industry == "Oil & Gas E&P"

--- a/backend/tests/unit/test_yfinance_get_fundamentals_classification.py
+++ b/backend/tests/unit/test_yfinance_get_fundamentals_classification.py
@@ -1,0 +1,36 @@
+"""get_fundamentals must surface sector/industry (already in the fetched info dict).
+
+These feed the universe sector/industry backfill; yfinance returns them on the same
+``ticker.info`` call the fundamentals fetch already makes, so exposing them is free.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.services import yfinance_service as ymod
+
+
+class _FakeTicker:
+    def __init__(self, symbol):
+        self.symbol = symbol
+
+    @property
+    def info(self):
+        return {
+            "sector": "Communication Services",
+            "industry": "Internet Content & Information",
+            "marketCap": 1_000_000,
+            "longName": "Tencent Holdings",
+        }
+
+
+def test_get_fundamentals_surfaces_sector_and_industry(monkeypatch):
+    svc = ymod.YFinanceService(rate_limiter=SimpleNamespace(), eps_rating_service=SimpleNamespace())
+    monkeypatch.setattr(ymod.yf, "Ticker", _FakeTicker)
+    monkeypatch.setattr(svc, "_wait_for_yfinance_rate_limit", lambda: None)
+    monkeypatch.setattr(svc, "_extract_eps_rating_data", lambda ticker: {})
+
+    result = svc.get_fundamentals("0700.HK")
+
+    assert result["sector"] == "Communication Services"
+    assert result["industry"] == "Internet Content & Information"


### PR DESCRIPTION
## Why
The IBD classifier produces ~100% low-confidence soft-attach for every non-US market because foreign `StockUniverse` rows have **no usable sector/industry** (CN `sector="Other"`/industry empty; HK both empty), while US rows carry the full yfinance taxonomy and match the crosswalk 100%. The classifier's crosswalk + embedding tiers are starved of input features abroad — "100% coverage" is masking near-total guessing, and the LLM tier burns ~600 off-shortlist calls/market for ~1% yield.

Root cause is **upstream data, not the classifier**: yfinance returns proper sector/industry for foreign tickers (verified: `0700.HK` → Communication Services / Internet Content & Information), and the weekly-reference build *already* calls `ticker.info` per symbol — but `get_fundamentals()` dropped sector/industry, and even where captured they only land in `StockFundamental`, a table the classifier never reads (it reads `StockUniverse`).

## Changes (two small, surgical edits + one script)
1. **`get_fundamentals()` surfaces sector/industry** — already present in the fetched `info`, so **zero extra network calls** (the 1-req/sec yfinance budget is untouched).
2. **`_store_in_database` propagates them to `StockUniverse`** — only when the universe value is missing (empty/`Other`/`Unknown`) and the fetched value is real; **never clobbers a meaningful existing value** (e.g. US finviz sectors). Precedence + no-clobber live in one shared helper. Runs per-symbol in the weekly-reference build → the exported bundle then carries sector/industry → the IBD classify job seeds populated rows.
3. **`backfill_universe_sector_industry` script** — one-time fill for existing rows (`--market`/`--limit`/`--dry-run`), idempotent, reuses the same helper.

## Expected effect
Foreign stocks gain real yfinance sector+industry → the `sector_industry` crosswalk tier (149 keys) starts hitting (e.g. `Communication Services||Internet Content & Information`), and where the industry isn't a US-derived key the embedding text is now `"… Communication Services Internet Content & Information"` instead of a bare name → far higher cosine → fewer <0.5 soft-attaches. Both tiers improve; the wasted LLM spend drops.

Caveat to validate post-merge: yfinance *industry* strings for foreign names may only partially overlap the US-derived 149 keys; anything unmatched falls back to the (now content-rich) embedding — still a large quality gain over today.

## Test plan
- [x] 11 new unit tests, TDD: `get_fundamentals` surfaces sector/industry; `_is_meaningful_classification` truth table; `_backfill_universe_classification` fills empty/`Other`, **doesn't clobber** real values, no-ops on non-meaningful/no-row, partial industry-only; script core (fill/skip, market+limit, dry-run, fetch-error tolerance).
- [x] Regression: 694 fundamentals/yfinance/universe/stock_data tests pass; the 2 failures under that filter are **pre-existing on `main`** (scan/feature-store, unrelated).
- [ ] Post-merge validation: re-run one foreign IBD market and confirm crosswalk hits jump and the health report's confidence histogram shifts up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added utility to backfill missing sector and industry classifications for stocks in the database.

* **Improvements**
  * System now intelligently prioritizes meaningful sector and industry values during data imports and fundamentals caching, avoiding placeholder classifications.
  * Enhanced data consistency across stock universe records when fundamentals are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->