### PR TITLE
fix(snapshot): stop TW .TWO/.TW canonical collision crashing weekly market build

### DIFF
--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -557,9 +557,16 @@ class ProviderSnapshotService:
                 ]
             )
 
-        run.symbols_total = int(coverage_stats.get("snapshot_symbols", len(materialized_rows)) or 0)
-        run.symbols_published = int(
-            coverage_stats.get("covered_active_symbols", len(materialized_rows)) or 0
+        # ``coverage_stats`` is computed by the caller before this method dedups, so
+        # clamp the persisted counts to the actual number of rows written — the run
+        # metadata must never claim more symbols than exist in provider_snapshot_row.
+        persisted_count = len(materialized_rows)
+        run.symbols_total = min(
+            int(coverage_stats.get("snapshot_symbols", persisted_count) or 0), persisted_count
+        )
+        run.symbols_published = min(
+            int(coverage_stats.get("covered_active_symbols", persisted_count) or 0),
+            persisted_count,
         )
         run.coverage_stats_json = json.dumps(coverage_stats, sort_keys=True)
         run.parity_stats_json = json.dumps(parity_stats, sort_keys=True)

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -520,10 +520,13 @@ class ProviderSnapshotService:
         db.add(run)
         db.flush()
 
-        # Dedup by canonical symbol before insert. Two universe rows can resolve to
-        # the same canonical symbol (e.g. a drifted TW .TWO/.TW pair); without this
-        # the (run_id, symbol) unique constraint would abort the entire market build.
-        # Last write wins; collisions are logged rather than silently dropped.
+        # Defense-in-depth for the (run_id, symbol) unique constraint: collapse any
+        # rows that share a symbol before insert, so a collision can never abort the
+        # whole market build. build_market_snapshot_row now trusts the already-unique
+        # StockUniverse.symbol, so the primary collision source (re-canonicalizing a
+        # drifted TW .TWO/.TW pair) is gone; this guards only the residual case where
+        # light normalization maps two stored symbols together. Mirrors the US path,
+        # which already dedups via a symbol-keyed dict. Last write wins; logged.
         deduped_by_symbol: Dict[str, Dict[str, Any]] = {}
         for row in rows:
             symbol = row["symbol"]
@@ -561,13 +564,12 @@ class ProviderSnapshotService:
         # clamp the persisted counts to the actual number of rows written — the run
         # metadata must never claim more symbols than exist in provider_snapshot_row.
         persisted_count = len(materialized_rows)
-        run.symbols_total = min(
-            int(coverage_stats.get("snapshot_symbols", persisted_count) or 0), persisted_count
-        )
-        run.symbols_published = min(
-            int(coverage_stats.get("covered_active_symbols", persisted_count) or 0),
-            persisted_count,
-        )
+
+        def _count(key: str) -> int:
+            return min(int(coverage_stats.get(key, persisted_count) or 0), persisted_count)
+
+        run.symbols_total = _count("snapshot_symbols")
+        run.symbols_published = _count("covered_active_symbols")
         run.coverage_stats_json = json.dumps(coverage_stats, sort_keys=True)
         run.parity_stats_json = json.dumps(parity_stats, sort_keys=True)
         run.warnings_json = json.dumps(all_warnings, sort_keys=True) if all_warnings else None

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -326,7 +326,18 @@ class ProviderSnapshotService:
         normalized_payload: Dict[str, Any],
         raw_payload: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
-        """Return a ProviderSnapshotRow-ready payload for a market-scoped bundle."""
+        """Return a ProviderSnapshotRow-ready payload for a market-scoped bundle.
+
+        The incoming ``symbol`` is already the canonical symbol (it is read from
+        ``StockUniverse.symbol``, which was canonicalized at ingest). We therefore
+        trust it as-is — applying only light normalization — and must NOT re-derive
+        it from ``(symbol, exchange)``. Re-canonicalizing here is unsafe: if a row's
+        stored exchange has drifted away from its explicit suffix (e.g. a TPEx
+        ``8906.TWO`` row carrying ``exchange="TWSE"``), ``resolve_identity`` would
+        rewrite it to ``8906.TW`` and collide with the genuine TWSE sibling, crashing
+        the whole market build on ``uq_provider_snapshot_row_run_symbol``. ``identity``
+        is still resolved, but only to fill missing payload metadata defaults.
+        """
         identity = security_master_resolver.resolve_identity(
             symbol=str(symbol or ""),
             market=market,
@@ -335,8 +346,9 @@ class ProviderSnapshotService:
             timezone=normalized_payload.get("timezone"),
             local_code=normalized_payload.get("local_code"),
         )
+        canonical_symbol = identity.normalized_symbol
         payload = dict(normalized_payload)
-        payload.setdefault("symbol", identity.canonical_symbol)
+        payload.setdefault("symbol", canonical_symbol)
         payload.setdefault("market", identity.market)
         payload.setdefault("exchange", identity.exchange)
         payload.setdefault("currency", identity.currency)
@@ -344,7 +356,7 @@ class ProviderSnapshotService:
         payload.setdefault("local_code", identity.local_code)
         payload_json = json.dumps(payload, sort_keys=True, default=str)
         return {
-            "symbol": identity.canonical_symbol,
+            "symbol": canonical_symbol,
             "exchange": identity.exchange,
             "row_hash": hashlib.sha256(payload_json.encode("utf-8")).hexdigest(),
             "normalized_payload": payload,
@@ -508,7 +520,22 @@ class ProviderSnapshotService:
         db.add(run)
         db.flush()
 
-        materialized_rows = list(rows)
+        # Dedup by canonical symbol before insert. Two universe rows can resolve to
+        # the same canonical symbol (e.g. a drifted TW .TWO/.TW pair); without this
+        # the (run_id, symbol) unique constraint would abort the entire market build.
+        # Last write wins; collisions are logged rather than silently dropped.
+        deduped_by_symbol: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            symbol = row["symbol"]
+            if symbol in deduped_by_symbol:
+                logger.warning(
+                    "Collapsing duplicate snapshot row for %s in %s run (canonical "
+                    "symbol collision); keeping last occurrence.",
+                    symbol,
+                    normalized_market,
+                )
+            deduped_by_symbol[symbol] = row
+        materialized_rows = list(deduped_by_symbol.values())
         if materialized_rows:
             db.bulk_save_objects(
                 [

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -1668,10 +1668,13 @@ def test_publish_market_snapshot_run_dedups_colliding_canonical_symbols():
         }
 
     rows = [_row("8906.TW", "first"), _row("8906.TW", "second")]
+    # coverage_stats reflects the PRE-dedup count, exactly as the weekly builder
+    # computes it (len(snapshot_rows) before this method dedups). Persisted run
+    # metadata must not claim more symbols than rows actually written.
     coverage_stats = {
-        "active_symbols": 1,
-        "snapshot_symbols": 1,
-        "covered_active_symbols": 1,
+        "active_symbols": 2,
+        "snapshot_symbols": 2,
+        "covered_active_symbols": 2,
         "missing_active_symbols": 0,
     }
 
@@ -1692,4 +1695,8 @@ def test_publish_market_snapshot_run_dedups_colliding_canonical_symbols():
     )
     assert len(persisted) == 1
     assert persisted[0].symbol == "8906.TW"
+
+    run = db.query(ProviderSnapshotRun).filter(ProviderSnapshotRun.id == result["run_id"]).one()
+    assert run.symbols_total == 1  # clamped to actual persisted rows, not pre-dedup 2
+    assert run.symbols_published == 1
     db.close()

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -1621,3 +1621,75 @@ def test_deserialize_universe_row_normalizes_tpex_symbol_to_two_suffix():
     assert row["symbol"] == "3008.TWO"
     assert row["exchange"] == "TPEX"
     assert row["market"] == "TW"
+
+
+def test_build_market_snapshot_row_trusts_already_canonical_symbol():
+    # StockUniverse.symbol is already canonical at ingest time. The weekly build
+    # must NOT re-derive it from (symbol, exchange): a TPEx row whose stored
+    # exchange drifted to a non-TPEX value (e.g. "TWSE") would otherwise be
+    # rewritten 8906.TWO -> 8906.TW, colliding with the genuine TWSE 8906.TW row
+    # and crashing the whole TW build on uq_provider_snapshot_row_run_symbol.
+    service = _make_provider_snapshot_service()
+
+    row = service.build_market_snapshot_row(
+        market="TW",
+        symbol="8906.TWO",
+        exchange="TWSE",  # drifted/wrong exchange on an explicit .TWO symbol
+        normalized_payload={"symbol": "8906.TWO"},
+    )
+
+    assert row["symbol"] == "8906.TWO"  # explicit suffix preserved, not collapsed
+    # The genuine TWSE sibling stays distinct.
+    sibling = service.build_market_snapshot_row(
+        market="TW",
+        symbol="8906.TW",
+        exchange="TWSE",
+        normalized_payload={"symbol": "8906.TW"},
+    )
+    assert sibling["symbol"] == "8906.TW"
+    assert row["symbol"] != sibling["symbol"]
+
+
+def test_publish_market_snapshot_run_dedups_colliding_canonical_symbols():
+    # Defensive: even if two universe rows resolve to the same canonical symbol,
+    # the publisher must not crash the market build on the (run_id, symbol)
+    # unique constraint. It should collapse them to a single snapshot row.
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    service = _make_provider_snapshot_service()
+
+    def _row(symbol, marker):
+        return {
+            "symbol": symbol,
+            "exchange": "TWSE",
+            "row_hash": f"hash-{marker}",
+            "normalized_payload": {"symbol": symbol, "marker": marker},
+            "raw_payload": None,
+        }
+
+    rows = [_row("8906.TW", "first"), _row("8906.TW", "second")]
+    coverage_stats = {
+        "active_symbols": 1,
+        "snapshot_symbols": 1,
+        "covered_active_symbols": 1,
+        "missing_active_symbols": 0,
+    }
+
+    result = service.publish_market_snapshot_run(
+        db,
+        snapshot_key="tw_weekly_reference",
+        market="TW",
+        source_revision="tw:test",
+        rows=rows,
+        coverage_stats=coverage_stats,
+        publish=False,
+    )
+
+    persisted = (
+        db.query(ProviderSnapshotRow)
+        .filter(ProviderSnapshotRow.run_id == result["run_id"])
+        .all()
+    )
+    assert len(persisted) == 1
+    assert persisted[0].symbol == "8906.TW"
+    db.close()


### PR DESCRIPTION
## Problem

The weekly-reference **TW (Taiwan)** market build crashed the entire job (run [26867289727](https://github.com/xang1234/stock-screener/actions/runs/26867289727)) — *after* a fully successful fundamentals refresh (`persisted=2857 failed=0`) — while persisting snapshot rows:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint
"uq_provider_snapshot_row_run_symbol"   (run_id, symbol)
```

## Root cause (verified)

`ProviderSnapshotService.build_market_snapshot_row` re-derived the canonical symbol from `(symbol, exchange)` via `resolve_identity`, even though `StockUniverse.symbol` is **already canonical** (set at ingest). Taiwan lists on two boards — `.TW` (TWSE) and `.TWO` (TPEx). When a TPEx `.TWO` row's stored `exchange` had drifted to a non-TPEX value, the resolver rewrote `8906.TWO` → `8906.TW`, colliding with the genuine TWSE `8906.TW` row. `publish_market_snapshot_run` then bulk-inserted both under one `run_id` → constraint violation → the whole market build aborted.

Reproduced against the live resolver:

| input symbol | exchange | → canonical |
|---|---|---|
| `8906.TWO` | `TPEX` | `8906.TWO` ✓ |
| `8906.TWO` | `TWSE`/`XTAI`/other | **`8906.TW`** ✗ collapses |

## Fix

1. **`build_market_snapshot_row` trusts the already-canonical incoming symbol** (light normalization only via `identity.normalized_symbol`) instead of re-applying the exchange-driven suffix rewrite. `identity` is still resolved for payload metadata defaults.
2. **`publish_market_snapshot_run` dedups rows by symbol before insert** (last-wins, logged) — defense-in-depth so no canonicalization collision can ever crash a market build again. This brings the Asia path to parity with the US path, which already dedups via a symbol-keyed dict.
3. **Clamp `symbols_total`/`symbols_published`** to the actual deduped row count, since `coverage_stats` is computed pre-dedup — run metadata must never claim more symbols than rows written.

Both helpers have exactly one caller each (the Asia weekly-build path); the US path uses `create_snapshot_run` and is unaffected.

## Tests (TDD)

- `test_build_market_snapshot_row_trusts_already_canonical_symbol` — `.TWO` symbol preserved even with a drifted `TWSE` exchange; TWSE sibling stays distinct.
- `test_publish_market_snapshot_run_dedups_colliding_canonical_symbols` — reproduces the exact `UNIQUE constraint failed: run_id, symbol`; asserts one persisted row and clamped run counts.

Each test was written first and watched fail for the right reason. 142 tests pass across all affected modules (`provider_snapshot_service`, `security_master_service`, `weekly_reference_scripts`, `stock_universe_service`, `universe_ingestion_pipeline`, `provider_snapshot_finite_guard`).

## Deploy note

The IBD classification job is a pure consumer of the weekly-reference bundle. To realize the fix, merge → re-run **weekly-reference** (rebuilds bundles) → then IBD classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced market snapshot processing to properly deduplicate symbols and prevent constraint failures during bulk inserts.
  * Improved symbol counter accuracy in snapshot runs by aligning reported counts with actual persisted data.
  * Strengthened symbol validation to preserve user-provided symbol information during snapshot processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->