### PR TITLE
fix(snapshot): collapse phantom .TWO/.TW canonical collisions on bundle import

### DIFF
--- a/backend/app/scripts/prune_phantom_universe_rows.py
+++ b/backend/app/scripts/prune_phantom_universe_rows.py
@@ -1,0 +1,87 @@
+"""One-time prune of phantom ``StockUniverse`` rows that collapse on canonicalization.
+
+A row is a *phantom* when its stored symbol re-canonicalizes (via the security
+master resolver) to a *different* symbol that already exists as its own row — e.g.
+a TW ``1240.TWO`` row carrying the TWSE ``XTAI`` exchange, which canonicalizes to
+``1240.TW`` (the genuine sibling). Such duplicates are what crashed weekly-bundle
+import on the ``StockUniverse.symbol`` unique index; the import path now collapses
+them automatically, so published bundles self-heal on the next weekly cycle. This
+script is for any *persistent* universe DB (local dev, a long-running deployment)
+that won't re-import a bundle soon and should be cleaned proactively.
+
+Idempotent and safe to re-run. A genuine standalone ``.TWO`` (exchange ``TPEX``,
+no ``.TW`` sibling) canonicalizes to itself and is never pruned.
+
+Usage:
+    python -m app.scripts.prune_phantom_universe_rows [--market TW] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models.stock_universe import StockUniverse
+from app.scripts._runtime import prepare_runtime
+from app.services.security_master_service import security_master_resolver
+
+
+def _canonical_symbol(row: StockUniverse) -> str:
+    return security_master_resolver.resolve_identity(
+        symbol=str(row.symbol or ""),
+        market=row.market,
+        exchange=row.exchange,
+    ).canonical_symbol
+
+
+def prune_phantom_universe_rows(
+    db: Session,
+    *,
+    market: Optional[str] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Delete universe rows whose symbol canonicalizes onto a different existing row.
+
+    Pure DB orchestration so it's unit-testable without a live database. Returns
+    ``{"scanned", "phantoms", "deleted"}``.
+    """
+    query = db.query(StockUniverse)
+    if market:
+        query = query.filter(StockUniverse.market == market.strip().upper())
+    rows = query.all()
+
+    present = {row.symbol for row in rows}
+    phantoms = [
+        row
+        for row in rows
+        if (canonical := _canonical_symbol(row)) != row.symbol and canonical in present
+    ]
+
+    if not dry_run:
+        for row in phantoms:
+            db.delete(row)
+        db.commit()
+
+    return {"scanned": len(rows), "phantoms": len(phantoms), "deleted": 0 if dry_run else len(phantoms)}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--market", default=None, help="Restrict to one market (e.g. TW).")
+    parser.add_argument("--dry-run", action="store_true", help="Report phantoms without deleting.")
+    args = parser.parse_args(argv)
+
+    prepare_runtime()
+    with SessionLocal() as db:
+        stats = prune_phantom_universe_rows(db, market=args.market, dry_run=args.dry_run)
+
+    print("Phantom universe-row prune complete:")
+    for key, value in stats.items():
+        print(f"  - {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -455,8 +455,9 @@ class ProviderSnapshotService:
             symbol = deserialized["symbol"]
             if symbol in deduped:
                 logger.warning(
-                    "Collapsing duplicate universe row for %s on import "
-                    "(canonical symbol collision); keeping last occurrence.",
+                    "Collapsing duplicate universe row: raw=%r canonicalized to %s "
+                    "(already seen); keeping last occurrence.",
+                    row.get("symbol"),
                     symbol,
                 )
             deduped[symbol] = deserialized
@@ -1284,7 +1285,12 @@ class ProviderSnapshotService:
             db.add(run)
             db.flush()
 
-            rows = []
+            # Dedup snapshot rows by canonical symbol, same as the universe rows
+            # above: a bundle's .TWO/.TW phantom pair re-canonicalizes to one symbol
+            # and would otherwise violate uq_provider_snapshot_row_run_symbol. Keep
+            # the payload and the row in lockstep so cache hydration stays consistent.
+            deduped_rows: Dict[str, ProviderSnapshotRow] = {}
+            deduped_payloads: Dict[str, Dict[str, Any]] = {}
             for row in snapshot_rows:
                 identity = security_master_resolver.resolve_identity(
                     symbol=str(row.get("symbol") or ""),
@@ -1298,10 +1304,11 @@ class ProviderSnapshotService:
                     timezone=row.get("timezone"),
                     local_code=row.get("local_code"),
                 )
+                canonical_symbol = identity.canonical_symbol
                 normalized_payload = dict(row["normalized_payload"])
                 normalized_payload.update(
                     {
-                        "symbol": identity.canonical_symbol,
+                        "symbol": canonical_symbol,
                         "market": identity.market,
                         "exchange": identity.exchange,
                         "currency": identity.currency,
@@ -1309,21 +1316,32 @@ class ProviderSnapshotService:
                         "local_code": identity.local_code,
                     }
                 )
-                imported_payloads.append(normalized_payload)
-                rows.append(
-                    ProviderSnapshotRow(
-                        run_id=run.id,
-                        symbol=identity.canonical_symbol,
-                        exchange=identity.exchange,
-                        row_hash=row["row_hash"],
-                        normalized_payload_json=json.dumps(
-                            normalized_payload, sort_keys=True, default=str
-                        ),
-                        raw_payload_json=None,
+                if canonical_symbol in deduped_rows:
+                    logger.warning(
+                        "Collapsing duplicate snapshot row: raw=%r canonicalized to %s "
+                        "(already seen); keeping last occurrence.",
+                        row.get("symbol"),
+                        canonical_symbol,
                     )
+                deduped_payloads[canonical_symbol] = normalized_payload
+                deduped_rows[canonical_symbol] = ProviderSnapshotRow(
+                    run_id=run.id,
+                    symbol=canonical_symbol,
+                    exchange=identity.exchange,
+                    row_hash=row["row_hash"],
+                    normalized_payload_json=json.dumps(
+                        normalized_payload, sort_keys=True, default=str
+                    ),
+                    raw_payload_json=None,
                 )
+            imported_payloads.extend(deduped_payloads.values())
+            rows = list(deduped_rows.values())
             if rows:
                 db.bulk_save_objects(rows)
+            # The bundle's symbols_total/published reflect its pre-dedup row count;
+            # clamp to what was actually persisted so run metadata can't overclaim.
+            run.symbols_total = min(run.symbols_total, len(rows))
+            run.symbols_published = min(run.symbols_published, len(rows))
 
             db.add(
                 ProviderSnapshotPointer(

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -1338,8 +1338,9 @@ class ProviderSnapshotService:
             rows = list(deduped_rows.values())
             if rows:
                 db.bulk_save_objects(rows)
-            # The bundle's symbols_total/published reflect its pre-dedup row count;
-            # clamp to what was actually persisted so run metadata can't overclaim.
+            # Dedup may have reduced the snapshot-row count below what the bundle's
+            # symbols_total/published claim; clamp so run metadata never exceeds the
+            # rows actually persisted. (No-op for non-colliding bundles.)
             run.symbols_total = min(run.symbols_total, len(rows))
             run.symbols_published = min(run.symbols_published, len(rows))
 

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -481,16 +481,19 @@ class ProviderSnapshotService:
         """
         deduped: "dict[str, tuple[ProviderSnapshotRow, Dict[str, Any]]]" = {}
         for row in snapshot_rows:
+            # Snapshot rows carry currency/timezone only inside normalized_payload
+            # (the export has no top-level keys for them), so read them from there —
+            # otherwise resolve_identity falls back to the market default and the
+            # update() below silently flattens a non-default currency/timezone.
+            # local_code is intentionally left to derive from the symbol: it feeds
+            # canonicalization, and the symbol stem is the authoritative source.
+            payload = row.get("normalized_payload", {})
             identity = security_master_resolver.resolve_identity(
                 symbol=str(row.get("symbol") or ""),
-                market=(
-                    row.get("market")
-                    or row.get("normalized_payload", {}).get("market")
-                    or bundle_market
-                ),
+                market=row.get("market") or payload.get("market") or bundle_market,
                 exchange=row.get("exchange"),
-                currency=row.get("currency"),
-                timezone=row.get("timezone"),
+                currency=row.get("currency") or payload.get("currency"),
+                timezone=row.get("timezone") or payload.get("timezone"),
                 local_code=row.get("local_code"),
             )
             canonical_symbol = identity.canonical_symbol

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -464,6 +464,68 @@ class ProviderSnapshotService:
         return [StockUniverse(**row) for row in deduped.values()]
 
     @staticmethod
+    def _deserialize_snapshot_rows(
+        snapshot_rows: Iterable[Dict[str, Any]],
+        *,
+        run_id: int,
+        bundle_market: str,
+    ) -> "dict[str, tuple[ProviderSnapshotRow, Dict[str, Any]]]":
+        """Build ProviderSnapshotRow objects + their hydration payloads, collapsing
+        rows that re-canonicalize to the same symbol.
+
+        Snapshot twin of :meth:`_deserialize_universe_rows`: the same exchange-driven
+        canonicalization that collapses a phantom TW ``.TWO``/``.TW`` pair onto one
+        symbol would otherwise violate ``uq_provider_snapshot_row_run_symbol``. Keyed
+        by canonical symbol so the row and its payload stay in lockstep; last write
+        wins, collisions are logged.
+        """
+        deduped: "dict[str, tuple[ProviderSnapshotRow, Dict[str, Any]]]" = {}
+        for row in snapshot_rows:
+            identity = security_master_resolver.resolve_identity(
+                symbol=str(row.get("symbol") or ""),
+                market=(
+                    row.get("market")
+                    or row.get("normalized_payload", {}).get("market")
+                    or bundle_market
+                ),
+                exchange=row.get("exchange"),
+                currency=row.get("currency"),
+                timezone=row.get("timezone"),
+                local_code=row.get("local_code"),
+            )
+            canonical_symbol = identity.canonical_symbol
+            normalized_payload = dict(row["normalized_payload"])
+            normalized_payload.update(
+                {
+                    "symbol": canonical_symbol,
+                    "market": identity.market,
+                    "exchange": identity.exchange,
+                    "currency": identity.currency,
+                    "timezone": identity.timezone,
+                    "local_code": identity.local_code,
+                }
+            )
+            if canonical_symbol in deduped:
+                logger.warning(
+                    "Collapsing duplicate snapshot row: raw=%r canonicalized to %s "
+                    "(already seen); keeping last occurrence.",
+                    row.get("symbol"),
+                    canonical_symbol,
+                )
+            snapshot_row = ProviderSnapshotRow(
+                run_id=run_id,
+                symbol=canonical_symbol,
+                exchange=identity.exchange,
+                row_hash=row["row_hash"],
+                normalized_payload_json=json.dumps(
+                    normalized_payload, sort_keys=True, default=str
+                ),
+                raw_payload_json=None,
+            )
+            deduped[canonical_symbol] = (snapshot_row, normalized_payload)
+        return deduped
+
+    @staticmethod
     def _replace_market_universe_rows(
         db: Session,
         *,
@@ -1285,57 +1347,15 @@ class ProviderSnapshotService:
             db.add(run)
             db.flush()
 
-            # Dedup snapshot rows by canonical symbol, same as the universe rows
-            # above: a bundle's .TWO/.TW phantom pair re-canonicalizes to one symbol
-            # and would otherwise violate uq_provider_snapshot_row_run_symbol. Keep
-            # the payload and the row in lockstep so cache hydration stays consistent.
-            deduped_rows: Dict[str, ProviderSnapshotRow] = {}
-            deduped_payloads: Dict[str, Dict[str, Any]] = {}
-            for row in snapshot_rows:
-                identity = security_master_resolver.resolve_identity(
-                    symbol=str(row.get("symbol") or ""),
-                    market=(
-                        row.get("market")
-                        or row.get("normalized_payload", {}).get("market")
-                        or bundle_market
-                    ),
-                    exchange=row.get("exchange"),
-                    currency=row.get("currency"),
-                    timezone=row.get("timezone"),
-                    local_code=row.get("local_code"),
-                )
-                canonical_symbol = identity.canonical_symbol
-                normalized_payload = dict(row["normalized_payload"])
-                normalized_payload.update(
-                    {
-                        "symbol": canonical_symbol,
-                        "market": identity.market,
-                        "exchange": identity.exchange,
-                        "currency": identity.currency,
-                        "timezone": identity.timezone,
-                        "local_code": identity.local_code,
-                    }
-                )
-                if canonical_symbol in deduped_rows:
-                    logger.warning(
-                        "Collapsing duplicate snapshot row: raw=%r canonicalized to %s "
-                        "(already seen); keeping last occurrence.",
-                        row.get("symbol"),
-                        canonical_symbol,
-                    )
-                deduped_payloads[canonical_symbol] = normalized_payload
-                deduped_rows[canonical_symbol] = ProviderSnapshotRow(
-                    run_id=run.id,
-                    symbol=canonical_symbol,
-                    exchange=identity.exchange,
-                    row_hash=row["row_hash"],
-                    normalized_payload_json=json.dumps(
-                        normalized_payload, sort_keys=True, default=str
-                    ),
-                    raw_payload_json=None,
-                )
-            imported_payloads.extend(deduped_payloads.values())
-            rows = list(deduped_rows.values())
+            # Build + dedup snapshot rows by canonical symbol (see
+            # _deserialize_snapshot_rows): a bundle's .TWO/.TW phantom pair
+            # re-canonicalizes to one symbol and would otherwise violate
+            # uq_provider_snapshot_row_run_symbol. Row and payload stay in lockstep.
+            deduped = self._deserialize_snapshot_rows(
+                snapshot_rows, run_id=run.id, bundle_market=bundle_market
+            )
+            rows = [snapshot_row for snapshot_row, _ in deduped.values()]
+            imported_payloads.extend(payload for _, payload in deduped.values())
             if rows:
                 db.bulk_save_objects(rows)
             # Dedup may have reduced the snapshot-row count below what the bundle's

--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -437,6 +437,32 @@ class ProviderSnapshotService:
             ).delete(synchronize_session=False)
 
     @staticmethod
+    def _deserialize_universe_rows(rows: Iterable[Dict[str, Any]]) -> list[StockUniverse]:
+        """Deserialize bundle universe rows into StockUniverse objects, collapsing
+        any that canonicalize to the same symbol.
+
+        ``_deserialize_universe_row`` re-canonicalizes each row via the exchange
+        (intentionally — it rewrites bare/board-mismatched symbols). A bundle can
+        therefore contain two rows that resolve to the *same* canonical symbol: e.g.
+        a phantom TW ``.TWO`` copy of a ``.TW`` security whose stored exchange is the
+        TWSE ``XTAI``, which collapses ``.TWO`` -> ``.TW``. Inserting both would hit
+        the ``StockUniverse.symbol`` unique index, so we collapse by canonical symbol
+        (last write wins) and log the collision rather than crash the whole import.
+        """
+        deduped: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            deserialized = ProviderSnapshotService._deserialize_universe_row(row)
+            symbol = deserialized["symbol"]
+            if symbol in deduped:
+                logger.warning(
+                    "Collapsing duplicate universe row for %s on import "
+                    "(canonical symbol collision); keeping last occurrence.",
+                    symbol,
+                )
+            deduped[symbol] = deserialized
+        return [StockUniverse(**row) for row in deduped.values()]
+
+    @staticmethod
     def _replace_market_universe_rows(
         db: Session,
         *,
@@ -446,10 +472,7 @@ class ProviderSnapshotService:
         db.query(StockUniverse).filter(StockUniverse.market == market).delete(
             synchronize_session=False
         )
-        imported_universe = [
-            StockUniverse(**ProviderSnapshotService._deserialize_universe_row(row))
-            for row in rows
-        ]
+        imported_universe = ProviderSnapshotService._deserialize_universe_rows(rows)
         if imported_universe:
             db.bulk_save_objects(imported_universe)
         return len(imported_universe)
@@ -461,10 +484,7 @@ class ProviderSnapshotService:
         rows: Iterable[Dict[str, Any]],
     ) -> int:
         db.query(StockUniverse).delete(synchronize_session=False)
-        imported_universe = [
-            StockUniverse(**ProviderSnapshotService._deserialize_universe_row(row))
-            for row in rows
-        ]
+        imported_universe = ProviderSnapshotService._deserialize_universe_rows(rows)
         if imported_universe:
             db.bulk_save_objects(imported_universe)
         return len(imported_universe)

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -1729,3 +1729,60 @@ def test_replace_market_universe_rows_collapses_phantom_canonical_collisions():
     assert len(persisted) == 1
     assert persisted[0].symbol == "1240.TW"  # both phantoms canonicalize here
     db.close()
+
+
+def test_import_weekly_reference_bundle_collapses_phantom_collisions_end_to_end(tmp_path):
+    # Full import: the phantom .TWO/.TW collapse hits BOTH the universe insert
+    # (ix_stock_universe_symbol) AND the snapshot-row insert
+    # (uq_provider_snapshot_row_run_symbol). Deduping universe rows alone just
+    # moves the crash downstream, so the whole bundle import must survive.
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    service = _make_provider_snapshot_service()
+    snapshot_key = ProviderSnapshotService.snapshot_key_for_market("TW")
+
+    def _uni(symbol):
+        return {
+            "symbol": symbol, "exchange": "XTAI", "market": "TW", "name": "MORNSUN",
+            "currency": "TWD", "timezone": "Asia/Taipei", "local_code": "1240",
+            "is_active": True, "status": UNIVERSE_STATUS_ACTIVE,
+        }
+
+    def _snap(symbol):
+        return {
+            "symbol": symbol, "exchange": "XTAI", "market": "TW",
+            "row_hash": f"hash-{symbol}",
+            "normalized_payload": {"symbol": symbol, "exchange": "XTAI", "market": "TW"},
+        }
+
+    payload = {
+        "schema_version": service.WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION,
+        "market": "TW",
+        "generated_at": "2026-06-03T12:00:00Z",
+        "as_of_date": "2026-06-03",
+        "snapshot": {
+            "snapshot_key": snapshot_key,
+            "run_mode": "publish",
+            "status": "published",
+            "source_revision": f"{snapshot_key}:20260603120000",
+            "created_at": "2026-06-03T12:00:00Z",
+            "published_at": "2026-06-03T12:00:00Z",
+            "rows": [_snap("1240.TW"), _snap("1240.TWO")],
+        },
+        "universe": [_uni("1240.TW"), _uni("1240.TWO")],
+    }
+    bundle_path = tmp_path / "weekly-reference-tw.json.gz"
+    with gzip.open(bundle_path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh, sort_keys=True)
+
+    service.import_weekly_reference_bundle(db, input_path=bundle_path, hydrate_cache=False)
+
+    universe = db.query(StockUniverse).filter(StockUniverse.market == "TW").all()
+    snap_rows = db.query(ProviderSnapshotRow).all()
+    assert [r.symbol for r in universe] == ["1240.TW"]
+    assert [r.symbol for r in snap_rows] == ["1240.TW"]
+    # run metadata clamped to the actual persisted row count, not the pre-dedup 2.
+    run = db.query(ProviderSnapshotRun).filter(ProviderSnapshotRun.snapshot_key == snapshot_key).one()
+    assert run.symbols_total == 1
+    assert run.symbols_published == 1
+    db.close()

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -1786,3 +1786,58 @@ def test_import_weekly_reference_bundle_collapses_phantom_collisions_end_to_end(
     assert run.symbols_total == 1
     assert run.symbols_published == 1
     db.close()
+
+
+def test_import_snapshot_row_preserves_non_default_currency_and_timezone(tmp_path):
+    # A snapshot row carries currency/timezone only inside normalized_payload (the
+    # export format has no top-level keys for them). The import must read them from
+    # there, not hard-overwrite with the market default — otherwise a security that
+    # legitimately trades in a non-default currency gets flattened on re-import.
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    service = _make_provider_snapshot_service()
+    snapshot_key = ProviderSnapshotService.snapshot_key_for_market("TW")
+
+    payload = {
+        "schema_version": service.WEEKLY_REFERENCE_BUNDLE_SCHEMA_VERSION,
+        "market": "TW",
+        "generated_at": "2026-06-03T12:00:00Z",
+        "as_of_date": "2026-06-03",
+        "snapshot": {
+            "snapshot_key": snapshot_key,
+            "run_mode": "publish",
+            "status": "published",
+            "source_revision": f"{snapshot_key}:20260603120000",
+            "created_at": "2026-06-03T12:00:00Z",
+            "published_at": "2026-06-03T12:00:00Z",
+            "rows": [
+                {
+                    "symbol": "9999.TW",
+                    "exchange": "XTAI",
+                    "row_hash": "h",
+                    "normalized_payload": {
+                        "symbol": "9999.TW",
+                        "exchange": "XTAI",
+                        "market": "TW",
+                        "currency": "USD",            # non-default for TW (TWD)
+                        "timezone": "America/New_York",  # non-default for TW
+                    },
+                }
+            ],
+        },
+        "universe": [
+            {"symbol": "9999.TW", "exchange": "XTAI", "market": "TW",
+             "is_active": True, "status": UNIVERSE_STATUS_ACTIVE},
+        ],
+    }
+    bundle_path = tmp_path / "weekly-reference-tw.json.gz"
+    with gzip.open(bundle_path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh, sort_keys=True)
+
+    service.import_weekly_reference_bundle(db, input_path=bundle_path, hydrate_cache=False)
+
+    row = db.query(ProviderSnapshotRow).filter(ProviderSnapshotRow.symbol == "9999.TW").one()
+    stored = json.loads(row.normalized_payload_json)
+    assert stored["currency"] == "USD"               # not flattened to TWD
+    assert stored["timezone"] == "America/New_York"   # not flattened to Asia/Taipei
+    db.close()

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -1700,3 +1700,32 @@ def test_publish_market_snapshot_run_dedups_colliding_canonical_symbols():
     assert run.symbols_total == 1  # clamped to actual persisted rows, not pre-dedup 2
     assert run.symbols_published == 1
     db.close()
+
+
+def test_replace_market_universe_rows_collapses_phantom_canonical_collisions():
+    # Observed in a published TW bundle: phantom .TWO copies of .TW securities,
+    # both carrying the TWSE 'XTAI' exchange (same name/sector as the .TW row).
+    # On import, _deserialize_universe_row re-canonicalizes .TWO + XTAI -> .TW
+    # (exchange wins, by design — see the TPEX test above), colliding with the
+    # genuine .TW row and crashing the import on ix_stock_universe_symbol.
+    # The import must collapse rows that canonicalize to the same symbol.
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+
+    def _row(symbol):
+        return {
+            "symbol": symbol, "exchange": "XTAI", "market": "TW", "name": "MORNSUN",
+            "currency": "TWD", "timezone": "Asia/Taipei", "local_code": "1240",
+            "sector": "Agricultural Technology", "industry": "Agricultural Technology",
+        }
+
+    count = ProviderSnapshotService._replace_market_universe_rows(
+        db, market="TW", rows=[_row("1240.TW"), _row("1240.TWO")]
+    )
+    db.commit()
+
+    persisted = db.query(StockUniverse).filter(StockUniverse.market == "TW").all()
+    assert count == 1
+    assert len(persisted) == 1
+    assert persisted[0].symbol == "1240.TW"  # both phantoms canonicalize here
+    db.close()

--- a/backend/tests/unit/test_prune_phantom_universe_rows_script.py
+++ b/backend/tests/unit/test_prune_phantom_universe_rows_script.py
@@ -1,0 +1,74 @@
+"""Unit tests for the phantom universe-row pruning script core."""
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.stock_universe import StockUniverse, UNIVERSE_STATUS_ACTIVE
+from app.scripts.prune_phantom_universe_rows import prune_phantom_universe_rows
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _add(session, symbol, exchange, market="TW"):
+    session.add(StockUniverse(
+        symbol=symbol, exchange=exchange, market=market,
+        is_active=True, status=UNIVERSE_STATUS_ACTIVE, status_reason="active",
+    ))
+    session.commit()
+
+
+def test_prunes_phantom_two_row_keeping_real_tw():
+    # 1240.TWO + XTAI canonicalizes to 1240.TW (exchange wins), which also exists:
+    # the .TWO row is a phantom and must be deleted, the genuine .TW kept.
+    session = _session()
+    _add(session, "1240.TW", "XTAI")
+    _add(session, "1240.TWO", "XTAI")
+
+    stats = prune_phantom_universe_rows(session)
+
+    symbols = {r.symbol for r in session.query(StockUniverse).all()}
+    assert symbols == {"1240.TW"}
+    assert stats["phantoms"] == 1
+    assert stats["deleted"] == 1
+
+
+def test_keeps_genuine_standalone_two_row():
+    # A real TPEx security (exchange TPEX) canonicalizes to .TWO == its own symbol
+    # and has no .TW sibling: it is NOT a phantom and must be kept.
+    session = _session()
+    _add(session, "6488.TWO", "TPEX")
+
+    stats = prune_phantom_universe_rows(session)
+
+    assert {r.symbol for r in session.query(StockUniverse).all()} == {"6488.TWO"}
+    assert stats["phantoms"] == 0
+
+
+def test_dry_run_reports_without_deleting():
+    session = _session()
+    _add(session, "1240.TW", "XTAI")
+    _add(session, "1240.TWO", "XTAI")
+
+    stats = prune_phantom_universe_rows(session, dry_run=True)
+
+    assert stats["phantoms"] == 1 and stats["deleted"] == 0
+    assert session.query(StockUniverse).count() == 2  # nothing removed
+
+
+def test_market_filter_scopes_the_sweep():
+    session = _session()
+    _add(session, "1240.TW", "XTAI")
+    _add(session, "1240.TWO", "XTAI")
+    _add(session, "0700.HK", "XHKG", market="HK")
+
+    stats = prune_phantom_universe_rows(session, market="hk")
+
+    # HK has no phantom; TW phantom untouched because market-scoped to HK.
+    assert stats["phantoms"] == 0
+    assert session.query(StockUniverse).count() == 3


### PR DESCRIPTION
## Problem

The IBD classification job (a pure *consumer* of the weekly-reference bundle) crashed importing the TW bundle:

```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation)
duplicate key value violates unique constraint "ix_stock_universe_symbol"
```

## Root cause (verified against the published bundle)

The TW bundle's `universe` and `snapshot` lists each carry **888 phantom `.TWO` copies** of real `.TW` securities (identical name/sector), all stamped with the TWSE `XTAI` exchange. On import, `_deserialize_universe_row` re-canonicalizes each row via `resolve_identity` (intentional — it fixes board-mismatched symbols; `test_deserialize_universe_row_normalizes_tpex_symbol_to_two_suffix` relies on it). Because `XTAI` resolves to the `.TW` suffix, every `.TWO` phantom collapses onto its genuine `.TW` sibling → unique-constraint violation that aborts the whole market import.

This is the import-path sibling of the build-path collision fixed in #211 (which only touched `build_market_snapshot_row` / `publish_market_snapshot_run`).

## Fix

1. **`_deserialize_universe_rows`** (new shared helper, used by both `_replace_*` methods) — collapses universe rows that re-canonicalize to the same symbol (last-write-wins, logged). Also removes the duplicated deserialize→`bulk_save_objects` block.
2. **`_deserialize_snapshot_rows`** (sibling helper) — the universe fix alone just moved the crash to the snapshot-row insert (`uq_provider_snapshot_row_run_symbol`); this dedups those too, keeping each `ProviderSnapshotRow` and its hydration payload in lockstep via one symbol-keyed dict. Clamps the imported run's `symbols_total`/`symbols_published` to the actually-persisted count.
3. **Payload fidelity** — snapshot rows carry `currency`/`timezone` only inside `normalized_payload`, so the import now reads them from there instead of flattening a non-default currency/timezone to the market default. (`local_code` is deliberately left to derive from the symbol — it feeds canonicalization.)
4. **`app.scripts.prune_phantom_universe_rows`** — a one-time maintenance script to remove phantom rows from a *persistent* universe DB (local dev / long-running deployment). Published bundles self-heal next weekly cycle via the import dedup, so this is optional/proactive.

## Verified end-to-end against the real published TW bundle

Full `import_weekly_reference_bundle`: 2857 raw rows (1968 `.TW` + 889 `.TWO`) → **universe=1969, snapshot_rows=1969** (888 phantoms collapsed, 1 genuine standalone `.TWO` survives), no IntegrityError.

## Tests (TDD)

- universe dedup, full-import end-to-end (reproduces both the `ix_stock_universe_symbol` and `uq_provider_snapshot_row_run_symbol` crashes), count clamp, payload currency/timezone fidelity, and 4 prune-script cases. Each test was written first and watched fail for the right reason. 72 tests pass across affected modules.

## Note

This fixes the *consumer* side so classification stops crashing; the phantom rows are legacy seeded data (current TW ingest only ever produces `.TWO` with `TPEX`), and the published bundle self-cleans on the next weekly cycle now that the seed step's import path dedups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a data maintenance script to identify and remove duplicate stock universe entries created by symbol canonicalization.

* **Bug Fixes**
  * Improved snapshot and universe data imports to properly deduplicate entries by canonical symbol.
  * Fixed import metadata to accurately reflect persisted row counts.

* **Tests**
  * Added test coverage for phantom row cleanup and deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->