### PR TITLE
feat(scanner): RS line chart overlay + blue-dot leadership signal

### DIFF
--- a/backend/app/analysis/patterns/models.py
+++ b/backend/app/analysis/patterns/models.py
@@ -649,7 +649,9 @@ SETUP_ENGINE_REQUIRED_KEYS: tuple[str, ...] = (
     "quiet_days_10d",
     "rs",
     "rs_line_new_high",
-    "rs_line_blue_dot",
+    # rs_line_blue_dot is intentionally NOT required: it's a new additive field,
+    # so payloads persisted before it existed (and hand-built test fixtures) must
+    # still validate. Producers emit it; it stays in the TypedDict + field specs.
     "rs_vs_spy_65d",
     "rs_vs_spy_trend_20d",
     "stage",

--- a/backend/app/analysis/patterns/models.py
+++ b/backend/app/analysis/patterns/models.py
@@ -122,6 +122,7 @@ class SetupEnginePayload(TypedDict):
     quiet_days_10d: int | None
     rs: float | None
     rs_line_new_high: bool
+    rs_line_blue_dot: bool
     rs_vs_spy_65d: float | None
     rs_vs_spy_trend_20d: float | None
 
@@ -514,6 +515,14 @@ SETUP_ENGINE_FIELD_SPECS: tuple[SetupEngineFieldSpec, ...] = (
         description="True when RS line has made a new high for timeframe.",
     ),
     SetupEngineFieldSpec(
+        name="rs_line_blue_dot",
+        type_name="bool",
+        nullable=False,
+        unit=None,
+        source_module="backend/app/scanners/setup_engine_scanner.py",
+        description="True when the RS line makes a new high before price (leadership 'blue dot').",
+    ),
+    SetupEngineFieldSpec(
         name="rs_vs_spy_65d",
         type_name="float",
         nullable=True,
@@ -640,6 +649,7 @@ SETUP_ENGINE_REQUIRED_KEYS: tuple[str, ...] = (
     "quiet_days_10d",
     "rs",
     "rs_line_new_high",
+    "rs_line_blue_dot",
     "rs_vs_spy_65d",
     "rs_vs_spy_trend_20d",
     "stage",

--- a/backend/app/analysis/patterns/readiness.py
+++ b/backend/app/analysis/patterns/readiness.py
@@ -32,9 +32,11 @@ class BreakoutReadinessFeatures:
     volume_vs_50d: float | None
     rs: float | None
     rs_line_new_high: bool
-    rs_line_blue_dot: bool
     rs_vs_spy_65d: float | None
     rs_vs_spy_trend_20d: float | None
+    # Defaulted so existing constructors that predate the blue-dot signal still
+    # build (consistent with bb_squeeze below); production sets it by keyword.
+    rs_line_blue_dot: bool = False
     bb_squeeze: bool = False
     quiet_days_10d: int | None = None
     up_down_volume_ratio_10d: float | None = None

--- a/backend/app/analysis/patterns/readiness.py
+++ b/backend/app/analysis/patterns/readiness.py
@@ -225,12 +225,16 @@ def _compute_readiness_core(
             rolling_slope(rs_series, window=trend_lookback)
         )
 
-        rs_tail = rs_series.dropna().tail(rs_lookback)
+        # Evaluate both new-high predicates on one benchmark-aligned frame so RS
+        # and price share the same end date — a trailing-NaN benchmark must not let
+        # the RS window lead the price window and emit a false blue dot.
+        aligned = pd.DataFrame({"rs": rs_series, "price": close}).dropna()
+        rs_tail = aligned["rs"].tail(rs_lookback)
         if not rs_tail.empty:
-            rs_line_new_high = at_new_high(rs_series, window=rs_lookback)
+            rs_line_new_high = at_new_high(aligned["rs"], window=rs_lookback)
             # Blue dot: RS line leads price — RS at a new high while price is not.
             rs_line_blue_dot = bool(
-                rs_line_new_high and not at_new_high(close, window=rs_lookback)
+                rs_line_new_high and not at_new_high(aligned["price"], window=rs_lookback)
             )
             rs_252_max = float(rs_tail.max())
 

--- a/backend/app/analysis/patterns/readiness.py
+++ b/backend/app/analysis/patterns/readiness.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 
 from app.analysis.patterns.technicals import (
+    at_new_high,
     average_true_range,
     bollinger_bands,
     rolling_percentile_rank,
@@ -31,6 +32,7 @@ class BreakoutReadinessFeatures:
     volume_vs_50d: float | None
     rs: float | None
     rs_line_new_high: bool
+    rs_line_blue_dot: bool
     rs_vs_spy_65d: float | None
     rs_vs_spy_trend_20d: float | None
     bb_squeeze: bool = False
@@ -196,6 +198,7 @@ def _compute_readiness_core(
 
     rs: float | None = None
     rs_line_new_high = False
+    rs_line_blue_dot = False
     rs_vs_spy_65d: float | None = None
     rs_vs_spy_trend_20d: float | None = None
 
@@ -222,7 +225,11 @@ def _compute_readiness_core(
 
         rs_tail = rs_series.dropna().tail(rs_lookback)
         if not rs_tail.empty:
-            rs_line_new_high = bool(rs_tail.iloc[-1] >= rs_tail.max() - 1e-12)
+            rs_line_new_high = at_new_high(rs_series, window=rs_lookback)
+            # Blue dot: RS line leads price — RS at a new high while price is not.
+            rs_line_blue_dot = bool(
+                rs_line_new_high and not at_new_high(close, window=rs_lookback)
+            )
             rs_252_max = float(rs_tail.max())
 
         # Capture rs value from 65 days ago for trace.
@@ -239,6 +246,7 @@ def _compute_readiness_core(
         volume_vs_50d=volume_vs_50d,
         rs=rs,
         rs_line_new_high=rs_line_new_high,
+        rs_line_blue_dot=rs_line_blue_dot,
         rs_vs_spy_65d=rs_vs_spy_65d,
         rs_vs_spy_trend_20d=rs_vs_spy_trend_20d,
         bb_squeeze=bb_squeeze,
@@ -369,6 +377,7 @@ def readiness_features_to_payload_fields(
         "volume_vs_50d": features.volume_vs_50d,
         "rs": features.rs,
         "rs_line_new_high": features.rs_line_new_high,
+        "rs_line_blue_dot": features.rs_line_blue_dot,
         "rs_vs_spy_65d": features.rs_vs_spy_65d,
         "rs_vs_spy_trend_20d": features.rs_vs_spy_trend_20d,
         "bb_squeeze": features.bb_squeeze,

--- a/backend/app/analysis/patterns/report.py
+++ b/backend/app/analysis/patterns/report.py
@@ -195,6 +195,7 @@ class SetupEngineReport:
     quiet_days_10d: int | None = None
     rs: float | None = None
     rs_line_new_high: bool = False
+    rs_line_blue_dot: bool = False
     rs_vs_spy_65d: float | None = None
     rs_vs_spy_trend_20d: float | None = None
 
@@ -253,6 +254,7 @@ class SetupEngineReport:
             ),
             "rs": _as_float(self.rs),
             "rs_line_new_high": bool(self.rs_line_new_high),
+            "rs_line_blue_dot": bool(self.rs_line_blue_dot),
             "rs_vs_spy_65d": _as_float(self.rs_vs_spy_65d),
             "rs_vs_spy_trend_20d": _as_float(self.rs_vs_spy_trend_20d),
             "stage": self.stage,

--- a/backend/app/analysis/patterns/rs_line.py
+++ b/backend/app/analysis/patterns/rs_line.py
@@ -1,0 +1,58 @@
+"""RS line (stock / benchmark ratio) and the "blue dot" leadership signal.
+
+The RS line is ``stock_close / benchmark_close``. A "blue dot" (DeepVue/O'Neil
+leadership signal) fires when the RS line makes a new trailing-``lookback`` high
+**before** price does — the RS line is at a new high while price is not.
+
+These helpers produce *series* for chart overlay. The single-point flags used by
+the per-scan Setup Engine field are computed in ``readiness.py`` directly from the
+same ``technicals.at_new_high`` primitive.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from app.analysis.patterns.technicals import rolling_at_new_high
+
+DEFAULT_LOOKBACK = 252
+
+
+def _aligned_ratio(stock_close: pd.Series, benchmark_close: pd.Series) -> pd.Series:
+    stock_close = stock_close.astype(float)
+    aligned_benchmark = benchmark_close.astype(float).reindex(stock_close.index)
+    return stock_close / aligned_benchmark.replace(0.0, np.nan)
+
+
+def compute_rs_line(
+    stock_close: pd.Series,
+    benchmark_close: pd.Series,
+    normalize: bool = True,
+) -> pd.Series:
+    """RS line aligned to the stock's index.
+
+    When ``normalize`` is True the series is scaled to start at 1.0 for display
+    (a positive monotonic transform; it does not affect new-high detection).
+    """
+    rs = _aligned_ratio(stock_close, benchmark_close)
+    if normalize:
+        valid = rs.dropna()
+        if not valid.empty and valid.iloc[0] != 0:
+            rs = rs / valid.iloc[0]
+    return rs
+
+
+def blue_dot_series(
+    stock_close: pd.Series,
+    benchmark_close: pd.Series,
+    lookback: int = DEFAULT_LOOKBACK,
+) -> pd.Series:
+    """Per-date boolean: RS line at a new high while price is not."""
+    rs = _aligned_ratio(stock_close, benchmark_close)
+    frame = pd.DataFrame({"rs": rs, "price": stock_close.astype(float)}).dropna()
+    if frame.empty:
+        return pd.Series([], dtype=bool)
+    rs_new_high = rolling_at_new_high(frame["rs"], window=lookback)
+    price_new_high = rolling_at_new_high(frame["price"], window=lookback)
+    return rs_new_high & (~price_new_high)

--- a/backend/app/analysis/patterns/technicals.py
+++ b/backend/app/analysis/patterns/technicals.py
@@ -324,6 +324,23 @@ def rolling_percentile_rank(series: pd.Series, *, window: int) -> pd.Series:
     return pd.Series(out, index=series.index, name=series.name)
 
 
+_NEW_HIGH_EPS = 1e-12
+
+
+def at_new_high(series: pd.Series, *, window: int) -> bool:
+    """True when the last valid value is at its trailing-``window`` maximum."""
+    tail = series.dropna().tail(window)
+    if tail.empty:
+        return False
+    return bool(tail.iloc[-1] >= tail.max() - _NEW_HIGH_EPS)
+
+
+def rolling_at_new_high(series: pd.Series, *, window: int) -> pd.Series:
+    """Per-element boolean: each value is at its trailing-``window`` running max."""
+    roll_max = series.rolling(window=window, min_periods=1).max()
+    return series >= (roll_max - _NEW_HIGH_EPS)
+
+
 def detect_swings(
     highs: pd.Series,
     lows: pd.Series,

--- a/backend/app/api/v1/_price_history.py
+++ b/backend/app/api/v1/_price_history.py
@@ -9,8 +9,6 @@ symbol→market resolver in the codebase — every call site does its own
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-
 import pandas as pd
 from sqlalchemy.orm import Session
 
@@ -27,11 +25,17 @@ PERIOD_DAYS: dict[str, int] = {
 
 
 def window_cutoff(index: pd.Index, days: int) -> pd.Timestamp:
-    """Return the tz-aware ``now - days`` cutoff aligned to ``index``'s tz."""
-    cutoff = pd.Timestamp(datetime.now() - timedelta(days=days))
-    if getattr(index, "tz", None) is not None:
-        cutoff = cutoff.tz_localize(index.tz)
-    return cutoff
+    """Return the ``now - days`` cutoff, converted to ``index``'s tz.
+
+    Computed in UTC then tz-converted so the boundary is correct regardless of
+    the server's local timezone (a naive local cutoff localized to the index tz
+    would shift the window by the tz offset).
+    """
+    cutoff = pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=days)
+    index_tz = getattr(index, "tz", None)
+    if index_tz is not None:
+        return cutoff.tz_convert(index_tz)
+    return cutoff.tz_localize(None)
 
 
 def resolve_symbol_market(db: Session, symbol: str) -> str | None:

--- a/backend/app/api/v1/_price_history.py
+++ b/backend/app/api/v1/_price_history.py
@@ -1,0 +1,74 @@
+"""Shared helpers for the stock route modules (``stocks`` and ``stocks_rs_line``).
+
+Covers price-history windowing (``PERIOD_DAYS``, ``window_cutoff``,
+``dataframe_to_points``) plus ``resolve_symbol_market``. Kept in one place so
+these don't drift between the two route modules. (There is no canonical public
+symbol→market resolver in the codebase — every call site does its own
+``StockUniverse.market`` lookup — so this is the shared home for the route layer.)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from ...models.stock_universe import StockUniverse
+
+PERIOD_DAYS: dict[str, int] = {
+    "1mo": 30,
+    "3mo": 90,
+    "6mo": 180,
+    "1y": 365,
+    "2y": 730,
+    "5y": 1825,
+}
+
+
+def window_cutoff(index: pd.Index, days: int) -> pd.Timestamp:
+    """Return the tz-aware ``now - days`` cutoff aligned to ``index``'s tz."""
+    cutoff = pd.Timestamp(datetime.now() - timedelta(days=days))
+    if getattr(index, "tz", None) is not None:
+        cutoff = cutoff.tz_localize(index.tz)
+    return cutoff
+
+
+def resolve_symbol_market(db: Session, symbol: str) -> str | None:
+    market = (
+        db.query(StockUniverse.market)
+        .filter(
+            StockUniverse.active_filter(),
+            StockUniverse.symbol == symbol.upper(),
+        )
+        .scalar()
+    )
+    normalized = str(market or "").strip().upper()
+    return normalized or None
+
+
+def dataframe_to_points(data: pd.DataFrame | None, days: int) -> list[dict]:
+    """Filter an OHLCV DataFrame to the last ``days`` and convert to JSON dicts."""
+    if data is None or len(data) == 0:
+        return []
+
+    filtered = data[data.index >= window_cutoff(data.index, days)]
+    if len(filtered) == 0:
+        return []
+
+    df = filtered.reset_index()
+    date_col = df.columns[0]
+    df = df.rename(columns={date_col: "Date"})
+    df["Date"] = pd.to_datetime(df["Date"]).dt.strftime("%Y-%m-%d")
+
+    return [
+        {
+            "date": row["Date"],
+            "open": round(float(row["Open"]), 2),
+            "high": round(float(row["High"]), 2),
+            "low": round(float(row["Low"]), 2),
+            "close": round(float(row["Close"]), 2),
+            "volume": int(row["Volume"]),
+        }
+        for _, row in df.iterrows()
+    ]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -32,6 +32,7 @@ def _include(
 _include("app_runtime", protected=False)
 _include("auth", prefix="/auth", tags=["auth"], protected=False)
 _include("stocks", prefix="/stocks", tags=["stocks"])
+_include("stocks_rs_line", prefix="/stocks", tags=["stocks"])
 _include("technical", prefix="/technical", tags=["technical"])
 _include("scans", prefix="/scans", tags=["scans"])
 _include("universe", prefix="/universe", tags=["universe"])

--- a/backend/app/api/v1/scan_filter_params.py
+++ b/backend/app/api/v1/scan_filter_params.py
@@ -112,6 +112,7 @@ def parse_scan_filters(
     max_se_quiet_days_10d: Optional[float] = Query(None, description="Maximum SE quiet days count (10d)"),
     se_setup_ready: Optional[bool] = Query(None, description="SE setup ready filter"),
     se_rs_line_new_high: Optional[bool] = Query(None, description="SE RS line new high filter"),
+    se_rs_line_blue_dot: Optional[bool] = Query(None, description="SE RS line blue dot filter (RS new high before price)"),
     se_in_early_zone: Optional[bool] = Query(None, description="SE in early zone filter"),
     se_extended_from_pivot: Optional[bool] = Query(None, description="SE extended from pivot filter"),
     se_bb_squeeze: Optional[bool] = Query(None, description="SE BB squeeze filter"),
@@ -307,6 +308,8 @@ def parse_scan_filters(
         f.add_boolean("se_setup_ready", se_setup_ready)
     if se_rs_line_new_high is not None:
         f.add_boolean("se_rs_line_new_high", se_rs_line_new_high)
+    if se_rs_line_blue_dot is not None:
+        f.add_boolean("se_rs_line_blue_dot", se_rs_line_blue_dot)
     if se_in_early_zone is not None:
         f.add_boolean("se_in_early_zone", se_in_early_zone)
     if se_extended_from_pivot is not None:

--- a/backend/app/api/v1/stocks.py
+++ b/backend/app/api/v1/stocks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 """Stock data API endpoints"""
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -37,6 +37,7 @@ from ...wiring.bootstrap import (
     get_uow,
     get_yfinance_service,
 )
+from ._price_history import PERIOD_DAYS, dataframe_to_points, resolve_symbol_market
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -68,21 +69,8 @@ def _build_data_fetcher(db: Session):
     )
 
 
-def _resolve_symbol_market(db: Session, symbol: str) -> str | None:
-    market = (
-        db.query(StockUniverse.market)
-        .filter(
-            StockUniverse.active_filter(),
-            StockUniverse.symbol == symbol.upper(),
-        )
-        .scalar()
-    )
-    normalized = str(market or "").strip().upper()
-    return normalized or None
-
-
 def _get_latest_feature_run_for_symbol(uow, db: Session, symbol: str):
-    market = _resolve_symbol_market(db, symbol)
+    market = resolve_symbol_market(db, symbol)
     if market is not None:
         latest_run = uow.feature_runs.get_latest_published(
             pointer_key=f"latest_published_market:{market}"
@@ -148,54 +136,10 @@ def _get_stock_technicals_payload(
     return fetcher.get_stock_technicals(symbol.upper(), force_refresh=force_refresh)
 
 
-_PERIOD_DAYS = {
-    "1mo": 30,
-    "3mo": 90,
-    "6mo": 180,
-    "1y": 365,
-    "2y": 730,
-    "5y": 1825,
-}
-
-
-def _dataframe_to_points(data, days: int) -> list[dict]:
-    """Filter an OHLCV DataFrame to the last N days and convert to JSON-ready dicts."""
-
-    import pandas as pd
-
-    if data is None or len(data) == 0:
-        return []
-
-    cutoff_date = pd.Timestamp(datetime.now() - timedelta(days=days))
-    if data.index.tz is not None:
-        cutoff_date = cutoff_date.tz_localize(data.index.tz)
-
-    filtered = data[data.index >= cutoff_date]
-    if len(filtered) == 0:
-        return []
-
-    df = filtered.reset_index()
-    date_col = df.columns[0]
-    df = df.rename(columns={date_col: "Date"})
-    df["Date"] = pd.to_datetime(df["Date"]).dt.strftime("%Y-%m-%d")
-
-    return [
-        {
-            "date": row["Date"],
-            "open": round(float(row["Open"]), 2),
-            "high": round(float(row["High"]), 2),
-            "low": round(float(row["Low"]), 2),
-            "close": round(float(row["Close"]), 2),
-            "volume": int(row["Volume"]),
-        }
-        for _, row in df.iterrows()
-    ]
-
-
 def _load_price_history(symbol: str, period: str = "6mo") -> list[dict]:
     """Get historical price data (OHLCV only) from cache."""
 
-    days = _PERIOD_DAYS.get(period)
+    days = PERIOD_DAYS.get(period)
     if days is None:
         raise HTTPException(status_code=422, detail=f"Unsupported period: {period}")
 
@@ -210,7 +154,7 @@ def _load_price_history(symbol: str, period: str = "6mo") -> list[dict]:
             detail=f"Historical data not available for {symbol}. Run a scan to populate cache.",
         )
 
-    result = _dataframe_to_points(data, days)
+    result = dataframe_to_points(data, days)
     if not result:
         raise HTTPException(
             status_code=404,
@@ -901,7 +845,7 @@ async def get_price_history_batch(payload: PriceHistoryBatchRequest):
     whose data is available under the `data` map.
     """
 
-    days = _PERIOD_DAYS.get(payload.period)
+    days = PERIOD_DAYS.get(payload.period)
     if days is None:
         raise HTTPException(
             status_code=422, detail=f"Unsupported period: {payload.period}"
@@ -934,7 +878,7 @@ async def get_price_history_batch(payload: PriceHistoryBatchRequest):
     missing: list[str] = []
     for sym in normalized:
         df = frames.get(sym) if isinstance(frames, dict) else None
-        points = _dataframe_to_points(df, days)
+        points = dataframe_to_points(df, days)
         if points:
             data[sym] = points
         else:

--- a/backend/app/api/v1/stocks_rs_line.py
+++ b/backend/app/api/v1/stocks_rs_line.py
@@ -1,0 +1,73 @@
+"""RS-line chart-overlay endpoint (kept out of the already-large stocks.py)."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ...analysis.patterns.rs_line import blue_dot_series, compute_rs_line
+from ...database import get_db
+from ...schemas.stock import RSLinePoint, RSLineResponse
+from ...services.benchmark_cache_service import BenchmarkCacheService
+from ...services.symbol_format import require_valid_symbol
+from ...wiring.bootstrap import get_price_cache
+from ._price_history import PERIOD_DAYS, resolve_symbol_market, window_cutoff
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+def _load_rs_line(db: Session, symbol: str, period: str) -> RSLineResponse:
+    """Compute the RS line + blue-dot dates for charting.
+
+    New-high detection runs over the full cached window (a 252-day lookback needs
+    more history than the displayed period); the output series is then trimmed to
+    the requested ``period`` so it aligns with the candlestick x-axis.
+    """
+    days = PERIOD_DAYS.get(period)
+    if days is None:
+        raise HTTPException(status_code=422, detail=f"Unsupported period: {period}")
+
+    market = resolve_symbol_market(db, symbol) or "US"
+    cache_period = "5y" if period == "5y" else "2y"
+
+    benchmark_service = BenchmarkCacheService()
+    benchmark_symbol = benchmark_service.get_benchmark_symbol(market)
+
+    stock_df = get_price_cache().get_cached_only(symbol.upper(), period=cache_period)
+    benchmark_df = benchmark_service.get_benchmark_data(market=market, period=cache_period)
+
+    empty = RSLineResponse(symbol=symbol.upper(), benchmark_symbol=benchmark_symbol, rs_line=[], blue_dots=[])
+    if stock_df is None or len(stock_df) == 0 or benchmark_df is None or len(benchmark_df) == 0:
+        logger.warning("RS line unavailable for %s (market=%s): missing cached data", symbol, market)
+        return empty
+
+    rs_line_full = compute_rs_line(stock_df["Close"], benchmark_df["Close"], normalize=True)
+    blue_full = blue_dot_series(stock_df["Close"], benchmark_df["Close"])
+
+    cutoff = window_cutoff(rs_line_full.index, days)
+    rs_window = rs_line_full[rs_line_full.index >= cutoff].dropna()
+    blue_window = blue_full[(blue_full.index >= cutoff) & blue_full]
+
+    return RSLineResponse(
+        symbol=symbol.upper(),
+        benchmark_symbol=benchmark_symbol,
+        rs_line=[RSLinePoint(time=ts.strftime("%Y-%m-%d"), value=round(float(v), 4)) for ts, v in rs_window.items()],
+        blue_dots=[ts.strftime("%Y-%m-%d") for ts in blue_window.index],
+    )
+
+
+@router.get("/{symbol}/rs-line", response_model=RSLineResponse)
+async def get_rs_line(
+    symbol: str = Depends(require_valid_symbol),
+    period: str = "6mo",
+    db: Session = Depends(get_db),
+):
+    """RS line (stock / market benchmark) plus 'blue dot' dates for chart overlay.
+
+    A blue dot marks a date where the RS line made a new 252-day high while price
+    did not — emerging leadership ahead of the breakout.
+    """
+    return _load_rs_line(db, symbol, period)

--- a/backend/app/infra/db/repositories/feature_store_repo.py
+++ b/backend/app/infra/db/repositories/feature_store_repo.py
@@ -828,6 +828,7 @@ def _map_feature_to_scan_result(
     extended["se_up_down_volume_ratio_10d"] = _se.get("up_down_volume_ratio_10d")
     extended["se_quiet_days_10d"] = _se.get("quiet_days_10d")
     extended["se_rs_line_new_high"] = _se.get("rs_line_new_high")
+    extended["se_rs_line_blue_dot"] = _se.get("rs_line_blue_dot")
     extended["se_pivot_price"] = _se.get("pivot_price")
     extended["se_setup_ready"] = _se.get("setup_ready")
     extended["se_quality_score"] = _se.get("quality_score")

--- a/backend/app/infra/db/repositories/scan_result_repo.py
+++ b/backend/app/infra/db/repositories/scan_result_repo.py
@@ -851,6 +851,7 @@ def _map_row_to_domain(
     extended["se_up_down_volume_ratio_10d"] = se_data.get("up_down_volume_ratio_10d")
     extended["se_quiet_days_10d"] = se_data.get("quiet_days_10d")
     extended["se_rs_line_new_high"] = se_data.get("rs_line_new_high")
+    extended["se_rs_line_blue_dot"] = se_data.get("rs_line_blue_dot")
     extended["se_pivot_price"] = se_data.get("pivot_price")
     extended["se_setup_ready"] = se_data.get("setup_ready")
 

--- a/backend/app/infra/query/feature_store_query.py
+++ b/backend/app/infra/query/feature_store_query.py
@@ -140,6 +140,7 @@ _JSON_FIELD_MAP: dict[str, tuple[str, ...]] = {
     # Setup Engine (boolean)
     "se_setup_ready": ("setup_engine", "setup_ready"),
     "se_rs_line_new_high": ("setup_engine", "rs_line_new_high"),
+    "se_rs_line_blue_dot": ("setup_engine", "rs_line_blue_dot"),
     "se_in_early_zone": ("setup_engine", "in_early_zone"),
     "se_extended_from_pivot": ("setup_engine", "extended_from_pivot"),
     "se_bb_squeeze": ("setup_engine", "bb_squeeze"),

--- a/backend/app/infra/query/scan_result_query.py
+++ b/backend/app/infra/query/scan_result_query.py
@@ -123,6 +123,7 @@ _JSON_FIELD_MAP: dict[str, tuple[str, ...]] = {
     # Setup Engine (boolean)
     "se_setup_ready": ("setup_engine", "setup_ready"),
     "se_rs_line_new_high": ("setup_engine", "rs_line_new_high"),
+    "se_rs_line_blue_dot": ("setup_engine", "rs_line_blue_dot"),
     "se_in_early_zone": ("setup_engine", "in_early_zone"),
     "se_extended_from_pivot": ("setup_engine", "extended_from_pivot"),
     "se_bb_squeeze": ("setup_engine", "bb_squeeze"),

--- a/backend/app/scanners/setup_engine_scanner.py
+++ b/backend/app/scanners/setup_engine_scanner.py
@@ -147,6 +147,7 @@ def _coerce_readiness_features(
         volume_vs_50d=_num_or_none("volume_vs_50d"),
         rs=_num_or_none("rs"),
         rs_line_new_high=bool(value.get("rs_line_new_high", False)),
+        rs_line_blue_dot=bool(value.get("rs_line_blue_dot", False)),
         rs_vs_spy_65d=_num_or_none("rs_vs_spy_65d"),
         rs_vs_spy_trend_20d=_num_or_none("rs_vs_spy_trend_20d"),
         bb_squeeze=bool(value.get("bb_squeeze", False)),
@@ -303,6 +304,7 @@ def build_setup_engine_payload(
     quiet_days_10d: int | float | None = None,
     rs: int | float | None = None,
     rs_line_new_high: bool | None = None,
+    rs_line_blue_dot: bool | None = None,
     rs_vs_spy_65d: int | float | None = None,
     rs_vs_spy_trend_20d: int | float | None = None,
     readiness_features: BreakoutReadinessFeatures | Mapping[str, Any] | None = None,
@@ -426,6 +428,11 @@ def build_setup_engine_payload(
             if rs_line_new_high is not None
             else bool(readiness_values["rs_line_new_high"])
         )
+        rs_line_blue_dot = (
+            rs_line_blue_dot
+            if rs_line_blue_dot is not None
+            else bool(readiness_values["rs_line_blue_dot"])
+        )
         rs_vs_spy_65d = (
             rs_vs_spy_65d
             if rs_vs_spy_65d is not None
@@ -468,6 +475,7 @@ def build_setup_engine_payload(
             rs = None
             candidates = []
             rs_line_new_high = False
+            rs_line_blue_dot = False
             rs_vs_spy_65d = None
             rs_vs_spy_trend_20d = None
             stage = None
@@ -585,6 +593,7 @@ def build_setup_engine_payload(
         "quiet_days_10d": norm_quiet_days_10d,
         "rs": _to_float(rs),
         "rs_line_new_high": bool(rs_line_new_high),
+        "rs_line_blue_dot": bool(rs_line_blue_dot),
         "rs_vs_spy_65d": norm_rs_vs_spy,
         "rs_vs_spy_trend_20d": _to_float(rs_vs_spy_trend_20d),
         "stage": stage,

--- a/backend/app/schemas/scanning.py
+++ b/backend/app/schemas/scanning.py
@@ -115,6 +115,7 @@ class ScanResultItem(BaseModel):
     se_up_down_volume_ratio_10d: Optional[float] = None
     se_quiet_days_10d: Optional[float] = None
     se_rs_line_new_high: Optional[bool] = None
+    se_rs_line_blue_dot: Optional[bool] = None
     se_pivot_price: Optional[float] = None
     se_setup_ready: Optional[bool] = None
     se_quality_score: Optional[float] = None
@@ -265,6 +266,7 @@ class ScanResultItem(BaseModel):
             se_up_down_volume_ratio_10d=ef.get("se_up_down_volume_ratio_10d"),
             se_quiet_days_10d=ef.get("se_quiet_days_10d"),
             se_rs_line_new_high=ef.get("se_rs_line_new_high"),
+            se_rs_line_blue_dot=ef.get("se_rs_line_blue_dot"),
             se_pivot_price=ef.get("se_pivot_price"),
             se_setup_ready=ef.get("se_setup_ready"),
             se_quality_score=ef.get("se_quality_score"),

--- a/backend/app/schemas/stock.py
+++ b/backend/app/schemas/stock.py
@@ -103,6 +103,22 @@ class PriceHistoryBatchResponse(BaseModel):
     missing: List[str]
 
 
+class RSLinePoint(BaseModel):
+    """A single point on the RS line (stock / benchmark ratio)."""
+
+    time: str
+    value: float
+
+
+class RSLineResponse(BaseModel):
+    """RS line series + 'blue dot' dates (RS new high before price) for chart overlay."""
+
+    symbol: str
+    benchmark_symbol: str
+    rs_line: List[RSLinePoint]
+    blue_dots: List[str]
+
+
 class StockChartSnapshot(BaseModel):
     """Chart payload for the decision workspace."""
 

--- a/backend/app/services/preset_screens.py
+++ b/backend/app/services/preset_screens.py
@@ -60,6 +60,7 @@ SCALAR_FILTER_TO_FIELD: dict[str, str] = {
 BOOLEAN_FILTER_TO_FIELD: dict[str, str] = {
     "seSetupReady": "se_setup_ready",
     "seRsLineNewHigh": "se_rs_line_new_high",
+    "seRsLineBlueDot": "se_rs_line_blue_dot",
     "vcpDetected": "vcp_detected",
     "vcpReady": "vcp_ready_for_breakout",
     "maAlignment": "ma_alignment",
@@ -119,6 +120,20 @@ PRESET_SCREENS: list[dict] = [
             "minerviniScore": {"min": 50, "max": None},
         },
         "sort_by": "vcp_score",
+        "sort_order": "desc",
+    },
+    {
+        "id": "blue_dot_leaders",
+        "name": "Blue Dot Leaders",
+        "short_name": "Blue Dots",
+        "description": "Stage 2 leaders whose RS line hit a new high before price — emerging leadership ahead of the breakout",
+        "tier": 1,
+        "filters": {
+            "stage": 2,
+            "seRsLineBlueDot": True,
+            "rsRating": {"min": 80, "max": None},
+        },
+        "sort_by": "rs_rating",
         "sort_order": "desc",
     },
     {

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -1957,11 +1957,16 @@ class StaticSiteExportService:
 
     @staticmethod
     def _static_chart_cutoff(index) -> datetime:
-        """The display-window cutoff (``STATIC_CHART_PERIOD_DAYS``) aligned to ``index``'s tz."""
-        cutoff = datetime.utcnow() - timedelta(days=STATIC_CHART_PERIOD_DAYS)
-        if getattr(index, "tz", None) is not None:
-            cutoff = cutoff.replace(tzinfo=index.tz)
-        return cutoff
+        """The display-window cutoff (``STATIC_CHART_PERIOD_DAYS``), converted to ``index``'s tz.
+
+        Computed in UTC and tz-converted (not ``replace(tzinfo=...)``, which would
+        reinterpret the UTC wall time as local and shift the boundary day).
+        """
+        cutoff = pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=STATIC_CHART_PERIOD_DAYS)
+        index_tz = getattr(index, "tz", None)
+        if index_tz is not None:
+            return cutoff.tz_convert(index_tz).to_pydatetime()
+        return cutoff.tz_localize(None).to_pydatetime()
 
     def _serialize_rs_line(
         self, stock_data, benchmark_df

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -17,6 +17,7 @@ from urllib.parse import quote
 import pandas as pd
 from sqlalchemy.orm import Session, sessionmaker
 
+from app.analysis.patterns.rs_line import blue_dot_series, compute_rs_line
 from app.domain.common.query import FilterSpec, SortOrder, SortSpec
 from app.domain.markets.catalog import get_market_catalog
 from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer
@@ -752,10 +753,73 @@ class StaticSiteExportService:
         chart_dir = output_dir / normalized_prefix / "charts"
         chart_dir.mkdir(parents=True, exist_ok=True)
 
+        # Market benchmark (fetched once) drives the per-symbol RS line + blue dots.
+        market = self._run_market(run) or STATIC_DEFAULT_MARKET
+        benchmark_symbol, benchmark_df = self._get_market_benchmark_history(market, period="2y")
+
         entries: list[dict[str, Any]] = []
         skipped_symbols: list[str] = []
         row_by_symbol: dict[str, Any] = {}
         ordered_rows = list(rows)
+
+        def _emit_chart(symbol, *, rank, stock_data, price_df, fundamentals_value) -> None:
+            """Serialize + write one chart payload, recording it in ``entries`` (or skip)."""
+            bars = self._serialize_chart_bars(price_df)
+            if not bars:
+                skipped_symbols.append(symbol)
+                return
+            rs_line, blue_dots = self._serialize_rs_line(price_df, benchmark_df)
+            rel_path = self._chart_payload_path(symbol, path_prefix=normalized_prefix)
+            self._write_json(
+                output_dir / rel_path,
+                {
+                    "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
+                    "generated_at": generated_at,
+                    "as_of_date": run.as_of_date.isoformat(),
+                    "symbol": symbol,
+                    "rank": rank,
+                    "period": STATIC_CHART_PERIOD,
+                    "bars": bars,
+                    "rs_line": rs_line,
+                    "blue_dots": blue_dots,
+                    "benchmark_symbol": benchmark_symbol,
+                    "stock_data": stock_data,
+                    "fundamentals": fundamentals_value,
+                },
+            )
+            entries.append({"symbol": symbol, "rank": rank, "path": rel_path.as_posix()})
+
+        def _expand_extra_charts(candidate_symbols, *, log_label) -> None:
+            """Emit charts for symbols not already exported (preset/group expansion)."""
+            extra = sorted(candidate_symbols - {e["symbol"] for e in entries} - set(skipped_symbols))
+            if not extra:
+                return
+            before = len(entries)
+            ser_by_symbol = {r["symbol"]: r for r in (serialized_rows or []) if r.get("symbol")}
+            for row in ordered_rows:
+                sym = getattr(row, "symbol", None)
+                if sym and sym not in row_by_symbol:
+                    row_by_symbol[sym] = row
+            for offset in range(0, len(extra), STATIC_CHART_LOOKUP_BATCH_SIZE):
+                batch = extra[offset:offset + STATIC_CHART_LOOKUP_BATCH_SIZE]
+                price_data = self._price_cache.get_many_cached_only(batch, period="2y")
+                fundamentals = self._fundamentals_cache.get_many_cached_only(batch)
+                for symbol in batch:
+                    domain_row = row_by_symbol.get(symbol)
+                    stock_data = self._serialize_scan_row(domain_row) if domain_row else ser_by_symbol.get(symbol)
+                    _emit_chart(
+                        symbol,
+                        rank=None,
+                        stock_data=stock_data,
+                        price_df=price_data.get(symbol),
+                        fundamentals_value=fundamentals.get(symbol),
+                    )
+            logger.info(
+                "%s added %d charts (%d extra symbols attempted)",
+                log_label,
+                len(entries) - before,
+                len(extra),
+            )
 
         if serialized_rows is not None:
             raw_rows_by_symbol = {
@@ -795,89 +859,20 @@ class StaticSiteExportService:
                     continue
 
                 row_by_symbol[symbol] = row
-                bars = self._serialize_chart_bars(price_data.get(symbol))
-                if not bars:
-                    skipped_symbols.append(symbol)
-                    continue
-
-                rel_path = self._chart_payload_path(symbol, path_prefix=normalized_prefix)
-                payload = {
-                    "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
-                    "generated_at": generated_at,
-                    "as_of_date": run.as_of_date.isoformat(),
-                    "symbol": symbol,
-                    "rank": rank,
-                    "period": STATIC_CHART_PERIOD,
-                    "bars": bars,
-                    "stock_data": self._serialize_scan_row(row),
-                    "fundamentals": fundamentals.get(symbol),
-                }
-                self._write_json(output_dir / rel_path, payload)
-                entries.append(
-                    {
-                        "symbol": symbol,
-                        "rank": rank,
-                        "path": rel_path.as_posix(),
-                    }
+                _emit_chart(
+                    symbol,
+                    rank=rank,
+                    stock_data=self._serialize_scan_row(row),
+                    price_df=price_data.get(symbol),
+                    fundamentals_value=fundamentals.get(symbol),
                 )
 
         # --- Pass 2: expand preset screen top-N charts ---
         if serialized_rows is not None:
-            preset_symbols = get_preset_chart_symbols(
-                serialized_rows, PRESET_SCREENS, STATIC_CHART_PRESET_TOP_N,
+            _expand_extra_charts(
+                get_preset_chart_symbols(serialized_rows, PRESET_SCREENS, STATIC_CHART_PRESET_TOP_N),
+                log_label="Preset screen expansion",
             )
-            exported_symbols = {e["symbol"] for e in entries}
-            extra_symbols = sorted(preset_symbols - exported_symbols - set(skipped_symbols))
-            entries_before_pass_2 = len(entries)
-
-            if extra_symbols:
-                # Build a lookup from serialized rows for extra symbols
-                ser_by_symbol = {r["symbol"]: r for r in serialized_rows if r.get("symbol")}
-                # Also need domain rows for _serialize_scan_row
-                for row in ordered_rows:
-                    sym = getattr(row, "symbol", None)
-                    if sym and sym not in row_by_symbol:
-                        row_by_symbol[sym] = row
-
-                for batch_start in range(0, len(extra_symbols), STATIC_CHART_LOOKUP_BATCH_SIZE):
-                    batch = extra_symbols[batch_start:batch_start + STATIC_CHART_LOOKUP_BATCH_SIZE]
-                    price_data = self._price_cache.get_many_cached_only(batch, period="2y")
-                    fundamentals = self._fundamentals_cache.get_many_cached_only(batch)
-
-                    for symbol in batch:
-                        bars = self._serialize_chart_bars(price_data.get(symbol))
-                        if not bars:
-                            skipped_symbols.append(symbol)
-                            continue
-
-                        rel_path = self._chart_payload_path(symbol, path_prefix=normalized_prefix)
-                        domain_row = row_by_symbol.get(symbol)
-                        stock_data = self._serialize_scan_row(domain_row) if domain_row else ser_by_symbol.get(symbol)
-                        payload = {
-                            "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
-                            "generated_at": generated_at,
-                            "as_of_date": run.as_of_date.isoformat(),
-                            "symbol": symbol,
-                            "rank": None,
-                            "period": STATIC_CHART_PERIOD,
-                            "bars": bars,
-                            "stock_data": stock_data,
-                            "fundamentals": fundamentals.get(symbol),
-                        }
-                        self._write_json(output_dir / rel_path, payload)
-                        entries.append(
-                            {
-                                "symbol": symbol,
-                                "rank": None,
-                                "path": rel_path.as_posix(),
-                            }
-                        )
-
-                logger.info(
-                    "Preset screen expansion added %d charts (%d extra symbols attempted)",
-                    len(entries) - entries_before_pass_2,
-                    len(extra_symbols),
-                )
 
         # --- Pass 3: expand coverage to all constituents of top-N groups ---
         group_symbols = self._collect_top_group_constituent_symbols(
@@ -885,67 +880,10 @@ class StaticSiteExportService:
             top_n=STATIC_CHART_TOP_N_GROUPS,
         )
         if group_symbols:
-            exported_symbols = {e["symbol"] for e in entries}
-            extra_group_symbols = sorted(
-                group_symbols - exported_symbols - set(skipped_symbols)
+            _expand_extra_charts(
+                group_symbols,
+                log_label=f"Top-{STATIC_CHART_TOP_N_GROUPS} groups expansion",
             )
-            entries_before_pass_3 = len(entries)
-
-            if extra_group_symbols:
-                ser_by_symbol = (
-                    {r["symbol"]: r for r in serialized_rows if r.get("symbol")}
-                    if serialized_rows is not None
-                    else {}
-                )
-                for row in ordered_rows:
-                    sym = getattr(row, "symbol", None)
-                    if sym and sym not in row_by_symbol:
-                        row_by_symbol[sym] = row
-
-                for batch_start in range(0, len(extra_group_symbols), STATIC_CHART_LOOKUP_BATCH_SIZE):
-                    batch = extra_group_symbols[batch_start:batch_start + STATIC_CHART_LOOKUP_BATCH_SIZE]
-                    price_data = self._price_cache.get_many_cached_only(batch, period="2y")
-                    fundamentals = self._fundamentals_cache.get_many_cached_only(batch)
-
-                    for symbol in batch:
-                        bars = self._serialize_chart_bars(price_data.get(symbol))
-                        if not bars:
-                            skipped_symbols.append(symbol)
-                            continue
-
-                        rel_path = self._chart_payload_path(symbol, path_prefix=normalized_prefix)
-                        domain_row = row_by_symbol.get(symbol)
-                        stock_data = (
-                            self._serialize_scan_row(domain_row)
-                            if domain_row
-                            else ser_by_symbol.get(symbol)
-                        )
-                        payload = {
-                            "schema_version": CHART_BUNDLE_SCHEMA_VERSION,
-                            "generated_at": generated_at,
-                            "as_of_date": run.as_of_date.isoformat(),
-                            "symbol": symbol,
-                            "rank": None,
-                            "period": STATIC_CHART_PERIOD,
-                            "bars": bars,
-                            "stock_data": stock_data,
-                            "fundamentals": fundamentals.get(symbol),
-                        }
-                        self._write_json(output_dir / rel_path, payload)
-                        entries.append(
-                            {
-                                "symbol": symbol,
-                                "rank": None,
-                                "path": rel_path.as_posix(),
-                            }
-                        )
-
-                logger.info(
-                    "Top-%d groups expansion added %d charts (%d extra symbols attempted)",
-                    STATIC_CHART_TOP_N_GROUPS,
-                    len(entries) - entries_before_pass_3,
-                    len(extra_group_symbols),
-                )
 
         index_rel_path = normalized_prefix / "charts" / "index.json"
         index_payload = {
@@ -2017,16 +1955,51 @@ class StaticSiteExportService:
             ),
         )
 
+    @staticmethod
+    def _static_chart_cutoff(index) -> datetime:
+        """The display-window cutoff (``STATIC_CHART_PERIOD_DAYS``) aligned to ``index``'s tz."""
+        cutoff = datetime.utcnow() - timedelta(days=STATIC_CHART_PERIOD_DAYS)
+        if getattr(index, "tz", None) is not None:
+            cutoff = cutoff.replace(tzinfo=index.tz)
+        return cutoff
+
+    def _serialize_rs_line(
+        self, stock_data, benchmark_df
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        """RS line series + blue-dot dates for a symbol, trimmed to the bar window.
+
+        New-high detection runs over the full cached history (the 252-day lookback
+        needs more than the displayed window), then output is trimmed to the same
+        ``STATIC_CHART_PERIOD_DAYS`` window as the candles so the overlay aligns.
+        """
+        if (
+            stock_data is None
+            or getattr(stock_data, "empty", True)
+            or benchmark_df is None
+            or benchmark_df.empty
+            or "Close" not in benchmark_df.columns
+        ):
+            return [], []
+
+        rs_line_full = compute_rs_line(stock_data["Close"], benchmark_df["Close"], normalize=True)
+        blue_full = blue_dot_series(stock_data["Close"], benchmark_df["Close"])
+
+        cutoff = self._static_chart_cutoff(rs_line_full.index)
+        rs_window = rs_line_full[rs_line_full.index >= cutoff].dropna()
+        blue_window = blue_full[(blue_full.index >= cutoff) & blue_full]
+
+        rs_line = [
+            {"time": ts.strftime("%Y-%m-%d"), "value": round(float(v), 4)}
+            for ts, v in rs_window.items()
+        ]
+        blue_dots = [ts.strftime("%Y-%m-%d") for ts in blue_window.index]
+        return rs_line, blue_dots
+
     def _serialize_chart_bars(self, data) -> list[dict[str, Any]]:
         if data is None or getattr(data, "empty", True):
             return []
 
-        cutoff_date = datetime.utcnow() - timedelta(days=STATIC_CHART_PERIOD_DAYS)
-        cutoff_ts = cutoff_date
-        if data.index.tz is not None:
-            cutoff_ts = cutoff_date.replace(tzinfo=data.index.tz)
-
-        filtered = data[data.index >= cutoff_ts]
+        filtered = data[data.index >= self._static_chart_cutoff(data.index)]
         if filtered.empty:
             return []
 

--- a/backend/tests/unit/golden/snapshots/scanner_3wt_strict.json
+++ b/backend/tests/unit/golden/snapshots/scanner_3wt_strict.json
@@ -36,6 +36,7 @@
     "up_down_volume_ratio_10d": 0.42857142857142855,
     "quiet_days_10d": 0,
     "rs": 0.18827141790597282,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": false,
     "rs_vs_spy_65d": 2.6772441992311657,
     "rs_vs_spy_trend_20d": -0.00013717277683046307,

--- a/backend/tests/unit/golden/snapshots/scanner_cwh_classic.json
+++ b/backend/tests/unit/golden/snapshots/scanner_cwh_classic.json
@@ -36,6 +36,7 @@
     "up_down_volume_ratio_10d": 4.0,
     "quiet_days_10d": 0,
     "rs": 0.19245283018867926,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": false,
     "rs_vs_spy_65d": -3.197466395177706,
     "rs_vs_spy_trend_20d": -8.53611669833123e-05,

--- a/backend/tests/unit/golden/snapshots/scanner_degraded_no_benchmark.json
+++ b/backend/tests/unit/golden/snapshots/scanner_degraded_no_benchmark.json
@@ -36,6 +36,7 @@
     "up_down_volume_ratio_10d": 0.42857142857142855,
     "quiet_days_10d": 0,
     "rs": null,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": false,
     "rs_vs_spy_65d": null,
     "rs_vs_spy_trend_20d": null,

--- a/backend/tests/unit/golden/snapshots/scanner_first_pullback.json
+++ b/backend/tests/unit/golden/snapshots/scanner_first_pullback.json
@@ -36,6 +36,7 @@
     "up_down_volume_ratio_10d": 1e+16,
     "quiet_days_10d": 0,
     "rs": 0.22641509433962265,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": false,
     "rs_vs_spy_65d": -1.4275185233595833,
     "rs_vs_spy_trend_20d": -4.879131008192197e-05,

--- a/backend/tests/unit/golden/snapshots/scanner_high_score_not_ready.json
+++ b/backend/tests/unit/golden/snapshots/scanner_high_score_not_ready.json
@@ -36,6 +36,7 @@
     "up_down_volume_ratio_10d": 0.6666666666666666,
     "quiet_days_10d": 0,
     "rs": 0.20754716981132076,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": true,
     "rs_vs_spy_65d": 13.189626309709856,
     "rs_vs_spy_trend_20d": 0.00013819510753165041,

--- a/backend/tests/unit/golden/snapshots/scanner_htf_classic.json
+++ b/backend/tests/unit/golden/snapshots/scanner_htf_classic.json
@@ -36,6 +36,7 @@
     "up_down_volume_ratio_10d": 0.0,
     "quiet_days_10d": 0,
     "rs": 0.21132075471698114,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": false,
     "rs_vs_spy_65d": -4.568308374330976,
     "rs_vs_spy_trend_20d": -0.0001505275466967132,

--- a/backend/tests/unit/golden/snapshots/scanner_no_pattern_exponential.json
+++ b/backend/tests/unit/golden/snapshots/scanner_no_pattern_exponential.json
@@ -32,6 +32,7 @@
     "up_down_volume_ratio_10d": 1e+16,
     "quiet_days_10d": 0,
     "rs": 0.7610083219355059,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": true,
     "rs_vs_spy_65d": 40.786615616496036,
     "rs_vs_spy_trend_20d": 0.003818808263349361,

--- a/backend/tests/unit/golden/snapshots/scanner_nr7_inside_day.json
+++ b/backend/tests/unit/golden/snapshots/scanner_nr7_inside_day.json
@@ -36,6 +36,7 @@
     "up_down_volume_ratio_10d": 1e+16,
     "quiet_days_10d": 0,
     "rs": 0.22641509433962265,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": true,
     "rs_vs_spy_65d": 5.2311544308325075,
     "rs_vs_spy_trend_20d": 0.00016748257256090336,

--- a/backend/tests/unit/golden/snapshots/scanner_policy_insufficient.json
+++ b/backend/tests/unit/golden/snapshots/scanner_policy_insufficient.json
@@ -32,6 +32,7 @@
     "up_down_volume_ratio_10d": null,
     "quiet_days_10d": null,
     "rs": null,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": false,
     "rs_vs_spy_65d": null,
     "rs_vs_spy_trend_20d": null,

--- a/backend/tests/unit/golden/snapshots/scanner_vcp_detected.json
+++ b/backend/tests/unit/golden/snapshots/scanner_vcp_detected.json
@@ -36,6 +36,7 @@
     "up_down_volume_ratio_10d": 1e+16,
     "quiet_days_10d": 0,
     "rs": 0.24528301886792453,
+    "rs_line_blue_dot": false,
     "rs_line_new_high": true,
     "rs_vs_spy_65d": 2.795248078266943,
     "rs_vs_spy_trend_20d": 9.924893188794194e-05,

--- a/backend/tests/unit/test_pattern_technical_utils.py
+++ b/backend/tests/unit/test_pattern_technical_utils.py
@@ -5,14 +5,34 @@ import pandas as pd
 import pytest
 
 from app.analysis.patterns.technicals import (
+    at_new_high,
     average_true_range,
     bollinger_band_width_percent,
     detect_swings,
     resample_ohlcv,
+    rolling_at_new_high,
     rolling_linear_regression,
     rolling_percentile_rank,
     true_range_percent,
 )
+
+
+def _new_high_series(values) -> pd.Series:
+    return pd.Series([float(v) for v in values], index=pd.bdate_range("2026-01-05", periods=len(values)))
+
+
+def test_at_new_high_detects_trailing_max_at_last_point():
+    assert at_new_high(_new_high_series([1.0, 2.0, 3.0]), window=252) is True
+    assert at_new_high(_new_high_series([1.0, 3.0, 2.0]), window=252) is False
+
+
+def test_at_new_high_is_false_on_empty_series():
+    assert at_new_high(_new_high_series([]), window=252) is False
+
+
+def test_rolling_at_new_high_flags_each_running_max():
+    result = rolling_at_new_high(_new_high_series([1.0, 2.0, 1.5, 3.0]), window=252)
+    assert result.tolist() == [True, True, False, True]
 
 
 def _sample_ohlcv() -> pd.DataFrame:

--- a/backend/tests/unit/test_rs_line.py
+++ b/backend/tests/unit/test_rs_line.py
@@ -1,0 +1,52 @@
+"""Tests for the RS-line series helpers (chart overlay + blue-dot signal)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.analysis.patterns.rs_line import blue_dot_series, compute_rs_line
+
+
+def _series(values, start="2025-01-02") -> pd.Series:
+    idx = pd.bdate_range(start, periods=len(values))
+    return pd.Series([float(v) for v in values], index=idx)
+
+
+def test_compute_rs_line_returns_normalized_ratio():
+    rs = compute_rs_line(_series([10.0, 20.0, 30.0]), _series([2.0, 4.0, 5.0]), normalize=True)
+
+    # raw ratio = [5.0, 5.0, 6.0]; normalized to start 1.0 = [1.0, 1.0, 1.2]
+    assert rs.tolist() == pytest.approx([1.0, 1.0, 1.2])
+
+
+def test_compute_rs_line_aligns_benchmark_by_index():
+    stock = _series([10.0, 20.0, 30.0])
+    # benchmark carries an extra leading day; reindex must align by date.
+    extra = pd.bdate_range("2025-01-01", periods=4)
+    benchmark = pd.Series([99.0, 10.0, 10.0, 10.0], index=extra)
+
+    rs = compute_rs_line(stock, benchmark, normalize=False)
+
+    assert list(rs.index) == list(stock.index)
+    assert rs.tolist() == pytest.approx([1.0, 2.0, 3.0])
+
+
+def test_blue_dot_series_marks_only_leading_dates():
+    # rs = [1.0, 1.0, 1.1667, 1.1368]; running price high is 110 at idx1.
+    #  idx2: rs new high (1.1667) & price 105 < 110 -> blue dot
+    #  idx3: rs 1.1368 < 1.1667 -> not an rs new high -> no blue dot
+    series = blue_dot_series(_series([100.0, 110.0, 105.0, 108.0]), _series([100.0, 110.0, 90.0, 95.0]))
+
+    assert series.tolist() == [False, False, True, False]
+
+
+def test_blue_dot_series_false_when_price_also_at_new_high():
+    # Both rs and price rise to new highs together -> not a blue dot.
+    series = blue_dot_series(_series([100.0, 105.0, 110.0]), _series([100.0, 100.0, 100.0]))
+
+    assert series.iloc[-1] is False or bool(series.iloc[-1]) is False
+
+
+def test_blue_dot_series_empty_on_insufficient_data():
+    assert blue_dot_series(_series([]), _series([])).empty

--- a/backend/tests/unit/test_setup_engine_persistence.py
+++ b/backend/tests/unit/test_setup_engine_persistence.py
@@ -71,6 +71,7 @@ _SE_PAYLOAD: dict[str, Any] = {
     "quiet_days_10d": 3,
     "rs": 1.12,
     "rs_line_new_high": True,
+    "rs_line_blue_dot": True,
     "rs_vs_spy_65d": 8.5,
     "rs_vs_spy_trend_20d": 0.03,
     "stage": 2,

--- a/backend/tests/unit/test_setup_engine_readiness.py
+++ b/backend/tests/unit/test_setup_engine_readiness.py
@@ -71,6 +71,8 @@ def test_compute_breakout_readiness_features_matches_formula_spec():
     assert computed.volume_vs_50d == pytest.approx(float(volume_vs_50d_series.iloc[-1]))
     assert computed.rs == pytest.approx(float(rs_series.iloc[-1]))
     assert computed.rs_line_new_high is True
+    # Price rises monotonically here, so it is also at a new high -> not a blue dot.
+    assert computed.rs_line_blue_dot is False
     assert computed.rs_vs_spy_65d == pytest.approx(float(rs_vs_spy_65d_series.iloc[-1]))
     assert computed.rs_vs_spy_trend_20d == pytest.approx(
         float(rolling_slope(rs_series, window=20).iloc[-1])
@@ -87,6 +89,39 @@ def test_compute_breakout_readiness_features_matches_formula_spec():
     assert 0 <= computed.quiet_days_10d <= 10
 
 
+def test_compute_breakout_readiness_blue_dot_when_rs_leads_price():
+    periods = 300
+    idx = pd.bdate_range("2025-01-02", periods=periods)
+    # Price climbs, then pulls back over the final 15 bars (no new price high).
+    close = np.concatenate(
+        [np.linspace(100.0, 200.0, periods - 15), np.linspace(200.0, 190.0, 15)]
+    )
+    # Benchmark climbs, then falls harder over the final 15 bars, so the RS line
+    # (close / benchmark) makes a new high at the last bar even though price did not.
+    benchmark = np.concatenate(
+        [np.linspace(50.0, 100.0, periods - 15), np.linspace(100.0, 70.0, 15)]
+    )
+    frame = pd.DataFrame(
+        {
+            "Open": close * 0.995,
+            "High": close * 1.01,
+            "Low": close * 0.99,
+            "Close": close,
+            "Volume": np.linspace(1_000_000.0, 1_500_000.0, periods),
+        },
+        index=idx,
+    )
+
+    computed = compute_breakout_readiness_features(
+        frame,
+        pivot_price=190.0,
+        benchmark_close=pd.Series(benchmark, index=idx),
+    )
+
+    assert computed.rs_line_new_high is True
+    assert computed.rs_line_blue_dot is True
+
+
 def test_compute_breakout_readiness_features_without_benchmark_rs_fields_are_null():
     computed = compute_breakout_readiness_features(
         _price_frame(),
@@ -96,6 +131,7 @@ def test_compute_breakout_readiness_features_without_benchmark_rs_fields_are_nul
 
     assert computed.rs is None
     assert computed.rs_line_new_high is False
+    assert computed.rs_line_blue_dot is False
     assert computed.rs_vs_spy_65d is None
     assert computed.rs_vs_spy_trend_20d is None
 
@@ -135,6 +171,7 @@ def test_readiness_features_to_payload_fields_exports_expected_keys():
         "quiet_days_10d",
         "rs",
         "rs_line_new_high",
+        "rs_line_blue_dot",
         "rs_vs_spy_65d",
         "rs_vs_spy_trend_20d",
     }

--- a/backend/tests/unit/test_stock_workspace_endpoints.py
+++ b/backend/tests/unit/test_stock_workspace_endpoints.py
@@ -733,7 +733,9 @@ def test_resolve_symbol_market_ignores_inactive_universe_rows(session):
     )
     session.commit()
 
-    assert stocks_module._resolve_symbol_market(session, "0700.HK") is None
+    from app.api.v1._price_history import resolve_symbol_market
+
+    assert resolve_symbol_market(session, "0700.HK") is None
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/priceHistory.js
+++ b/frontend/src/api/priceHistory.js
@@ -18,6 +18,19 @@ export const fetchPriceHistory = async (symbol, period = '6mo') => {
 };
 
 /**
+ * Fetch the RS line (stock / market benchmark) and blue-dot dates for a symbol.
+ * @param {string} symbol - Stock symbol
+ * @param {string} period - Time period (default: '6mo')
+ * @returns {Promise<{symbol: string, benchmark_symbol: string, rs_line: Array<{time: string, value: number}>, blue_dots: string[]}>}
+ */
+export const fetchRSLine = async (symbol, period = '6mo') => {
+  const response = await apiClient.get(`/v1/stocks/${symbol}/rs-line`, {
+    params: { period },
+  });
+  return response.data;
+};
+
+/**
  * Fetch OHLCV history for many symbols in a single request.
  * @param {string[]} symbols - Ticker symbols (case-insensitive, deduped server-side)
  * @param {string} period - Time period (default: '6mo')
@@ -35,6 +48,7 @@ export const fetchPriceHistoryBatch = async (symbols, period = '6mo') => {
 export const priceHistoryKeys = {
   all: ['priceHistory'],
   symbol: (symbol, period = '6mo') => ['priceHistory', symbol, period],
+  rsLine: (symbol, period = '6mo') => ['priceHistory', 'rsLine', symbol, period],
   batch: (symbols, period = '6mo') => [
     'priceHistory',
     'batch',

--- a/frontend/src/components/Charts/CandlestickChart.jsx
+++ b/frontend/src/components/Charts/CandlestickChart.jsx
@@ -1,8 +1,8 @@
 import { useRef, useEffect, useLayoutEffect, useState, useMemo } from 'react';
-import { createChart, CrosshairMode, CandlestickSeries, LineSeries, HistogramSeries } from 'lightweight-charts';
+import { createChart, CrosshairMode, CandlestickSeries, LineSeries, HistogramSeries, createSeriesMarkers } from 'lightweight-charts';
 import { Box, CircularProgress, Alert, AlertTitle, Button, ToggleButtonGroup, ToggleButton, useTheme, Skeleton, Typography } from '@mui/material';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { fetchPriceHistory, priceHistoryKeys, PRICE_HISTORY_STALE_TIME } from '../../api/priceHistory';
+import { fetchPriceHistory, fetchRSLine, priceHistoryKeys, PRICE_HISTORY_STALE_TIME } from '../../api/priceHistory';
 
 /**
  * Chart skeleton placeholder that shows chart structure while loading
@@ -305,6 +305,8 @@ function CandlestickChart({
   visibleRange = null,
   onVisibleRangeChange = null,
   priceData = null,
+  rsLineData = null,
+  blueDots = null,
   dataUpdatedAtOverride = null,
   compact = false,
   hideTimeframeToggle = false,
@@ -317,6 +319,8 @@ function CandlestickChart({
   const ema10SeriesRef = useRef(null);
   const ema20SeriesRef = useRef(null);
   const ema50SeriesRef = useRef(null);
+  const rsLineSeriesRef = useRef(null); // RS line (stock / benchmark) overlay
+  const rsMarkersRef = useRef(null); // Blue-dot markers primitive on the RS line
   const prevSymbolRef = useRef(null); // Track previous symbol
   const shouldRestoreRangeRef = useRef(false); // Flag to restore range on next data update
   const isFirstDataLoadRef = useRef(true); // Track first data load
@@ -324,6 +328,7 @@ function CandlestickChart({
   const latestCandleRef = useRef(null); // Store latest candle for default display
 
   const [timeframe, setTimeframe] = useState('daily');
+  const [showRSLine, setShowRSLine] = useState(true); // RS line overlay toggle
   const [legendData, setLegendData] = useState(null); // OHLC legend data on hover
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
@@ -352,6 +357,29 @@ function CandlestickChart({
     // Show stale/cached data immediately while fetching fresh data
     placeholderData: getCachedData,
   });
+
+  // Live RS line + blue-dot dates (interactive surfaces only). Static charts
+  // carry the RS payload in their bundle instead, so the query stays disabled.
+  const { data: fetchedRsData } = useQuery({
+    queryKey: priceHistoryKeys.rsLine(symbol, period),
+    queryFn: () => fetchRSLine(symbol, period),
+    enabled: !!symbol && !priceData && !compact && showRSLine,
+    staleTime: PRICE_HISTORY_STALE_TIME,
+    keepPreviousData: true,
+  });
+
+  // RS data source: bundled payload in static mode, live query otherwise.
+  const rsData = useMemo(() => {
+    if (priceData) {
+      return Array.isArray(rsLineData) && rsLineData.length > 0
+        ? { rs_line: rsLineData, blue_dots: blueDots || [] }
+        : null;
+    }
+    return fetchedRsData;
+  }, [priceData, rsLineData, blueDots, fetchedRsData]);
+
+  // Whether the RS overlay can render at all here (drives the toggle's visibility).
+  const rsAvailable = !priceData || (Array.isArray(rsLineData) && rsLineData.length > 0);
 
   const apiData = priceData ?? fetchedApiData;
   const effectiveDataUpdatedAt = dataUpdatedAtOverride ?? dataUpdatedAt;
@@ -483,6 +511,23 @@ function CandlestickChart({
     });
     ema50SeriesRef.current = ema50Series;
 
+    // Create RS line series on its own overlay price scale so the ratio doesn't
+    // distort the price axis. The scale floats in the upper band and stays
+    // hidden (no axis labels). Blue-dot markers attach to this series.
+    const rsLineSeries = chart.addSeries(LineSeries, {
+      color: '#FFA726', // orange — distinct from the green/cyan EMAs
+      lineWidth: 2,
+      priceScaleId: 'rs',
+      lastValueVisible: false,
+      priceLineVisible: false,
+    });
+    rsLineSeries.priceScale().applyOptions({
+      scaleMargins: { top: 0.05, bottom: 0.55 },
+      visible: false,
+    });
+    rsLineSeriesRef.current = rsLineSeries;
+    rsMarkersRef.current = createSeriesMarkers(rsLineSeries, []);
+
     // Subscribe to crosshair move for OHLC legend (skip in compact mode — legend is hidden)
     if (!compact) chart.subscribeCrosshairMove((param) => {
       if (!param.time || !param.seriesData || !candlestickSeriesRef.current) {
@@ -535,6 +580,8 @@ function CandlestickChart({
       ema10SeriesRef.current = null;
       ema20SeriesRef.current = null;
       ema50SeriesRef.current = null;
+      rsLineSeriesRef.current = null;
+      rsMarkersRef.current = null;
     };
     // `interactive` is intentionally not in the deps: it's only used as the
     // chart's initial handleScroll/handleScale value here, and the dedicated
@@ -665,6 +712,32 @@ function CandlestickChart({
     // Otherwise, don't touch the zoom - let user adjust freely
   }, [chartData, visibleRange]);
 
+  // Update the RS line overlay + blue-dot markers.
+  // Only rendered on the daily timeframe (the RS series is daily); cleared
+  // otherwise so stale points never linger under weekly candles.
+  useEffect(() => {
+    const series = rsLineSeriesRef.current;
+    const markers = rsMarkersRef.current;
+    if (!series || !chartRef.current) return;
+
+    const points = Array.isArray(rsData?.rs_line) ? rsData.rs_line : [];
+    const shouldShow = showRSLine && effectiveTimeframe === 'daily' && points.length > 0;
+
+    if (!shouldShow) {
+      series.setData([]);
+      if (markers) markers.setMarkers([]);
+      return;
+    }
+
+    series.setData(points.map((p) => ({ time: p.time, value: p.value })));
+
+    const timesInSeries = new Set(points.map((p) => p.time));
+    const markerList = (rsData.blue_dots || [])
+      .filter((t) => timesInSeries.has(t))
+      .map((t) => ({ time: t, position: 'inBar', color: '#2196f3', shape: 'circle' }));
+    if (markers) markers.setMarkers(markerList);
+  }, [rsData, showRSLine, effectiveTimeframe]);
+
   // Determine overlay state
   // Only show full loading state if we have no data at all (not even placeholder)
   const hasData = chartData && chartData.candlesticks.length > 0;
@@ -697,19 +770,36 @@ function CandlestickChart({
             boxShadow: 1,
           }}
         >
-          <ToggleButtonGroup
-            value={timeframe}
-            exclusive
-            onChange={(e, newTimeframe) => {
-              if (newTimeframe !== null) {
-                setTimeframe(newTimeframe);
-              }
-            }}
-            size="small"
-          >
-            <ToggleButton value="daily">Daily</ToggleButton>
-            <ToggleButton value="weekly">Weekly</ToggleButton>
-          </ToggleButtonGroup>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            <ToggleButtonGroup
+              value={timeframe}
+              exclusive
+              onChange={(e, newTimeframe) => {
+                if (newTimeframe !== null) {
+                  setTimeframe(newTimeframe);
+                }
+              }}
+              size="small"
+            >
+              <ToggleButton value="daily">Daily</ToggleButton>
+              <ToggleButton value="weekly">Weekly</ToggleButton>
+            </ToggleButtonGroup>
+            {/* RS line overlay toggle — shown only where RS data can load
+                (live charts, or static charts whose bundle carries rs_line). */}
+            {rsAvailable && (
+              <ToggleButtonGroup size="small">
+                <ToggleButton
+                  value="rs"
+                  selected={showRSLine}
+                  disabled={effectiveTimeframe !== 'daily'}
+                  onClick={() => setShowRSLine((prev) => !prev)}
+                  title="RS line (stock vs. benchmark) with blue-dot leadership signals"
+                >
+                  RS
+                </ToggleButton>
+              </ToggleButtonGroup>
+            )}
+          </Box>
         </Box>
       )}
 

--- a/frontend/src/components/Scan/ResultsTable.jsx
+++ b/frontend/src/components/Scan/ResultsTable.jsx
@@ -76,6 +76,7 @@ const columns = [
   { id: 'se_bb_width_pctile_252', label: 'Sqz', sortable: true, width: 45 },
   { id: 'se_volume_vs_50d', label: 'V50', sortable: true, width: 45 },
   { id: 'se_rs_line_new_high', label: 'RSH', sortable: false, width: 35 },
+  { id: 'se_rs_line_blue_dot', label: 'BD', sortable: false, width: 35 },
   { id: 'se_pivot_price', label: 'Pvt$', sortable: true, width: 55 },
   { id: 'rs_rating', label: 'RS', sortable: true, width: 40 },
   { id: 'rs_rating_1m', label: '1M', sortable: true, width: 40 },
@@ -320,6 +321,17 @@ const VirtualTableRow = memo(function VirtualTableRow({
           <CheckIcon sx={{ fontSize: 14, color: 'success.main' }} />
         ) : (
           <CloseIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+        )}
+      </TableCell>
+
+      <TableCell align="center" sx={{ width: 35, minWidth: 35 }}>
+        {row.se_rs_line_blue_dot ? (
+          <Box
+            sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: '#2196f3', display: 'inline-block' }}
+            title="RS line at new high before price (blue dot)"
+          />
+        ) : (
+          <Box component="span" sx={{ color: 'text.disabled' }}>-</Box>
         )}
       </TableCell>
 

--- a/frontend/src/features/scan/components/filterPanel/RatingFiltersSection.jsx
+++ b/frontend/src/features/scan/components/filterPanel/RatingFiltersSection.jsx
@@ -163,6 +163,13 @@ function RatingFiltersSection({
             onChange={(value) => updateFilter('seRsLineNewHigh', value)}
           />
         </Grid>
+        <Grid item xs={6} sm={3} md={1}>
+          <CompactCheckbox
+            label="Blue Dot"
+            value={filters.seRsLineBlueDot}
+            onChange={(value) => updateFilter('seRsLineBlueDot', value)}
+          />
+        </Grid>
         <Grid item xs={12} sm={6} md={2.4}>
           <CompactMultiSelect
             label="SE Pattern"

--- a/frontend/src/features/scan/components/filterPanel/constants.js
+++ b/frontend/src/features/scan/components/filterPanel/constants.js
@@ -64,6 +64,6 @@ export const RATING_KEYS = [
   'compositeScore', 'minerviniScore', 'canslimScore', 'ipoScore',
   'customScore', 'volBreakthroughScore',
   'seSetupScore', 'seDistanceToPivot', 'seBbSqueeze', 'seVolumeVs50d',
-  'seUpDownVolume', 'sePatternPrimary', 'seSetupReady', 'seRsLineNewHigh',
+  'seUpDownVolume', 'sePatternPrimary', 'seSetupReady', 'seRsLineNewHigh', 'seRsLineBlueDot',
   'vcpScore', 'vcpDetected', 'vcpReady', 'passesTemplate',
 ];

--- a/frontend/src/features/scan/components/filterPanel/utils.js
+++ b/frontend/src/features/scan/components/filterPanel/utils.js
@@ -10,6 +10,7 @@ const BOOLEAN_RESET_KEYS = new Set([
   'passesTemplate',
   'seSetupReady',
   'seRsLineNewHigh',
+  'seRsLineBlueDot',
   'pocketPivot',
   'powerTrend',
 ]);
@@ -191,6 +192,9 @@ export function buildActiveFilters(filters) {
   }
   if (filters.seRsLineNewHigh != null) {
     active.push({ key: 'seRsLineNewHigh', label: `RS New Hi: ${filters.seRsLineNewHigh ? 'Yes' : 'No'}` });
+  }
+  if (filters.seRsLineBlueDot != null) {
+    active.push({ key: 'seRsLineBlueDot', label: `Blue Dot: ${filters.seRsLineBlueDot ? 'Yes' : 'No'}` });
   }
   if (filters.pocketPivot != null) {
     active.push({ key: 'pocketPivot', label: `Pocket Pivot: ${filters.pocketPivot ? 'Yes' : 'No'}` });

--- a/frontend/src/features/scan/defaultFilters.js
+++ b/frontend/src/features/scan/defaultFilters.js
@@ -23,6 +23,7 @@ export const buildDefaultScanFilters = () => ({
   sePatternPrimary: [],
   seSetupReady: null,
   seRsLineNewHigh: null,
+  seRsLineBlueDot: null,
   rsRating: { min: null, max: null },
   rs1m: { min: null, max: null },
   rs3m: { min: null, max: null },

--- a/frontend/src/static/StaticChartViewerModal.jsx
+++ b/frontend/src/static/StaticChartViewerModal.jsx
@@ -330,6 +330,8 @@ function StaticChartViewerModal({
                   visibleRange={visibleRange}
                   onVisibleRangeChange={setVisibleRange}
                   priceData={chartPayload?.bars || []}
+                  rsLineData={chartPayload?.rs_line || null}
+                  blueDots={chartPayload?.blue_dots || null}
                   dataUpdatedAtOverride={dataUpdatedAtOverride}
                 />
               ) : (

--- a/frontend/src/utils/filterUtils.js
+++ b/frontend/src/utils/filterUtils.js
@@ -76,6 +76,7 @@ export const buildFilterParams = (filters, options = {}) => {
   }
   if (filters.seSetupReady != null) params.se_setup_ready = filters.seSetupReady;
   if (filters.seRsLineNewHigh != null) params.se_rs_line_new_high = filters.seRsLineNewHigh;
+  if (filters.seRsLineBlueDot != null) params.se_rs_line_blue_dot = filters.seRsLineBlueDot;
 
   // RS ranges
   if (filters.rsRating?.min != null) params.min_rs = filters.rsRating.min;


### PR DESCRIPTION
## What

Adds the relative-strength **RS line** (stock / market-benchmark ratio) to candlestick charts, with **"blue dot"** markers on dates where the RS line makes a new 252-day high **before price does** — the DeepVue/O'Neil signal for emerging leadership ahead of a breakout.

## Changes

**Signal + scan field**
- New `se_rs_line_blue_dot` scan field (`rs_new_high AND NOT price_new_high`), wired through the same chain as the existing `se_rs_line_new_high`: schema → repos/queries → API filter param → results table column ("BD") + Rating-filters checkbox.
- New **"Blue Dot Leaders"** preset screen (Stage 2, RS≥80, blue dot).

**Charts**
- Live: new `GET /v1/stocks/{symbol}/rs-line` endpoint returns the RS-line series + blue-dot dates; `CandlestickChart` overlays the RS line on its own scale with blue-dot markers and an **RS** toggle (daily timeframe).
- Static/daily site: per-symbol chart bundles now embed `rs_line` + `blue_dots`, so the overlay renders on the static site with no live backend. The grid mini-charts intentionally stay RS-free; the RS toggle is hidden wherever RS data can't load.

**Structure (canonical-layer placement)**
- New-high primitives `at_new_high` / `rolling_at_new_high` live in `analysis/patterns/technicals.py` alongside the other rolling helpers.
- RS-line series helpers in `analysis/patterns/rs_line.py`.
- Shared price-history helpers (`PERIOD_DAYS`, `window_cutoff`, `resolve_symbol_market`, `dataframe_to_points`) extracted to `api/v1/_price_history.py`; the RS route lives in `api/v1/stocks_rs_line.py` so `stocks.py` stays under 1k lines.
- `_export_chart_bundle` de-duplicated: one `_emit_chart` + one `_expand_extra_charts` replace three near-identical payload blocks.

## Tests
- `test_rs_line.py` (series + blue-dot logic), new-high primitive cases in `test_pattern_technical_utils.py`, blue-dot assertions in `test_setup_engine_readiness.py`.

## Verification notes
Logic verified standalone (the local env doesn't have the full backend/frontend deps installed); please run `pytest` + `npm run build` in CI. No DB migration required — `se_rs_line_blue_dot` is a computed field carried in existing JSON columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RS line overlay in candlestick charts with blue‑dot markers and a toggle
  * New API endpoint to fetch RS line series and blue‑dot dates

* **Enhancements**
  * "Blue Dot" scan filter, table column indicator, and a "blue_dot_leaders" preset screen
  * RS line overlays included in static chart exports
  * Scan results and Setup Engine payloads now surface the RS blue‑dot readiness flag (optional)

* **Tests**
  * Unit tests added for RS-line computation and new‑high (blue‑dot) detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->