### PR TITLE
feat(frontend): dynamic RS line that floats in the price chart's empty space

### DIFF
--- a/docs/superpowers/plans/2026-06-05-rs-line-dynamic-empty-space.md
+++ b/docs/superpowers/plans/2026-06-05-rs-line-dynamic-empty-space.md
@@ -1,0 +1,585 @@
+# RS Line Dynamic Empty-Space Band — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the RS line dynamic by floating it in the price chart's empty space — its band grows to use available room and shrinks to a safe floor strip on divergence — without ever overlapping the candles.
+
+**Architecture:** A pure, unit-tested helper (`rsBand.js`) computes the tallest overlap-free RS scale margin for the visible window (log price scale, linear RS scale), clamped to a 12%–38% band. `CandlestickChart.jsx` applies it to the `rs` overlay scale and recomputes on data change and on pan/zoom (debounced).
+
+**Tech Stack:** React, lightweight-charts v5 (overlay price scales + `scaleMargins`), Vitest. Node 22 via nvm.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-rs-line-dynamic-empty-space-design.md`
+
+**Environment note:** All frontend commands need Node 22:
+```bash
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use 22
+```
+Run from `frontend/`. If `node_modules` is missing, run `npm install` first.
+
+---
+
+## File Structure
+
+- **Create** `frontend/src/components/Charts/rsBand.js` — pure helpers: `priceLowFraction`, `rsFraction`, `computeRsBand`, `rsBandForRange`. No React/chart imports.
+- **Create** `frontend/src/components/Charts/rsBand.test.js` — Vitest unit tests for the helpers.
+- **Modify** `frontend/src/components/Charts/CandlestickChart.jsx` — apply the computed band to the `rs` scale; recompute on data + visible-range change; track the band top for the "RS" label.
+
+---
+
+## Task 1: Pure band-math helpers (`computeRsBand`)
+
+**Files:**
+- Create: `frontend/src/components/Charts/rsBand.js`
+- Test: `frontend/src/components/Charts/rsBand.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/components/Charts/rsBand.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest';
+import {
+  priceLowFraction,
+  rsFraction,
+  computeRsBand,
+} from './rsBand';
+
+// Layout constants mirrored from rsBand.js defaults, for assertion math.
+const TOP = 0.05;
+const FLOOR = 0.66;
+const RS_BOTTOM = 0.78;
+const MIN_BAND = 0.12;
+const MAX_BAND = 0.38;
+const FLOOR_TOP = RS_BOTTOM - MIN_BAND; // 0.66
+const CAP_TOP = RS_BOTTOM - MAX_BAND; // 0.40
+
+// Assert the RS line never sits above any candle low (no overlap), using the
+// same screen-mapping the production code uses.
+function assertNoOverlap({ lows, highs, rsValues }, rTop) {
+  const priceMin = Math.min(...lows);
+  const priceMax = Math.max(...highs);
+  const rsMin = Math.min(...rsValues);
+  const rsMax = Math.max(...rsValues);
+  for (let i = 0; i < lows.length; i++) {
+    const plf = priceLowFraction(lows[i], priceMin, priceMax, TOP, FLOOR);
+    const rsf = rsFraction(rsValues[i], rsMin, rsMax, rTop, RS_BOTTOM);
+    // rsf must be at or below the candle low (larger fraction = lower on screen).
+    expect(rsf).toBeGreaterThanOrEqual(plf - 1e-9);
+  }
+}
+
+describe('computeRsBand', () => {
+  it('returns the floor strip for fewer than 2 bars', () => {
+    expect(computeRsBand({ lows: [10], highs: [11], rsValues: [1] })).toBeCloseTo(FLOOR_TOP, 6);
+    expect(computeRsBand({ lows: [], highs: [], rsValues: [] })).toBeCloseTo(FLOOR_TOP, 6);
+  });
+
+  it('returns the floor strip when RS is flat', () => {
+    const data = { lows: [10, 20, 30], highs: [11, 21, 31], rsValues: [2, 2, 2] };
+    expect(computeRsBand(data)).toBeCloseTo(FLOOR_TOP, 6);
+  });
+
+  it('returns the floor strip when a price is non-positive (log undefined)', () => {
+    const data = { lows: [0, 20, 30], highs: [11, 21, 31], rsValues: [1, 2, 3] };
+    expect(computeRsBand(data)).toBeCloseTo(FLOOR_TOP, 6);
+  });
+
+  it('expands to a taller band on a correlated uptrend, with no overlap', () => {
+    const data = {
+      lows: [100, 110, 120, 130, 140, 150],
+      highs: [102, 112, 122, 132, 142, 153],
+      rsValues: [1, 2, 3, 4, 5, 6],
+    };
+    const rTop = computeRsBand(data);
+    expect(rTop).toBeLessThan(FLOOR_TOP); // taller than the floor strip
+    expect(rTop).toBeGreaterThanOrEqual(CAP_TOP); // never past the cap
+    assertNoOverlap(data, rTop);
+  });
+
+  it('caps the band height at maxBand on a steep correlated uptrend', () => {
+    const data = {
+      lows: [10, 20, 40, 80, 160, 320],
+      highs: [11, 21, 42, 84, 168, 336],
+      rsValues: [1, 2, 3, 4, 5, 6],
+    };
+    const rTop = computeRsBand(data);
+    expect(rTop).toBeCloseTo(CAP_TOP, 6); // pinned to the 38% cap
+    assertNoOverlap(data, rTop);
+  });
+
+  it('collapses to the floor strip on divergence (price up, RS down)', () => {
+    const data = {
+      lows: [100, 110, 120, 130, 140, 150],
+      highs: [102, 112, 122, 132, 142, 153],
+      rsValues: [6, 5, 4, 3, 2, 1],
+    };
+    const rTop = computeRsBand(data);
+    expect(rTop).toBeCloseTo(FLOOR_TOP, 6);
+    assertNoOverlap(data, rTop);
+  });
+
+  it('lands at an intermediate height on partial divergence, no overlap', () => {
+    const data = {
+      lows: [100, 110, 120, 130, 140, 150],
+      highs: [102, 112, 122, 132, 142, 153],
+      rsValues: [3, 1, 2, 4, 5, 6], // lowest-price bar has a mid RS value
+    };
+    const rTop = computeRsBand(data);
+    expect(rTop).toBeGreaterThan(CAP_TOP);
+    expect(rTop).toBeLessThan(FLOOR_TOP);
+    assertNoOverlap(data, rTop);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd frontend
+export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use 22
+npm run test:run -- src/components/Charts/rsBand.test.js
+```
+Expected: FAIL — `Failed to resolve import "./rsBand"` (module does not exist yet).
+
+- [ ] **Step 3: Implement `rsBand.js`**
+
+Create `frontend/src/components/Charts/rsBand.js`:
+
+```js
+// Pure geometry helpers for placing the RS overlay line in the price chart's
+// empty space without overlapping the candles. All Y values are fractions of
+// the chart pane (0 = top, 1 = bottom). The price ("right") scale is
+// logarithmic; the RS scale is linear. No React or chart imports — unit-tested
+// in isolation (see rsBand.test.js) and consumed by CandlestickChart.jsx.
+
+const DEFAULTS = {
+  priceBandTop: 0.05, // top margin of the price band
+  priceFloor: 0.66, // bottom of the price band when RS is shown
+  rsBottom: 0.78, // bottom of the RS band (above the volume band at 0.80)
+  gap: 0.012, // min screen gutter between the RS line and the nearest candle
+  minBand: 0.12, // thinnest RS band (the always-empty floor strip)
+  maxBand: 0.38, // tallest RS band (cap, so RS never dominates the chart)
+};
+
+// Screen fraction of a price low on the logarithmic price scale.
+export function priceLowFraction(low, priceMin, priceMax, top, floor) {
+  const lnMax = Math.log(priceMax);
+  return top + ((lnMax - Math.log(low)) / (lnMax - Math.log(priceMin))) * (floor - top);
+}
+
+// Screen fraction of an RS value on the linear RS scale spanning [rTop, rsBottom].
+export function rsFraction(rs, rsMin, rsMax, rTop, rsBottom) {
+  const a = (rsMax - rs) / (rsMax - rsMin);
+  return rTop + a * (rsBottom - rTop);
+}
+
+// Compute the RS scale's top margin (rTop) so the RS line uses as much empty
+// space below the candles as possible while staying at or below every candle
+// low. Returns a value in [rsBottom - maxBand, rsBottom - minBand].
+export function computeRsBand(input) {
+  const {
+    lows, highs, rsValues,
+    priceBandTop, priceFloor, rsBottom, gap, minBand, maxBand,
+  } = { ...DEFAULTS, ...input };
+
+  const floorTop = rsBottom - minBand; // thinnest band (degraded / safe floor)
+  const capTop = rsBottom - maxBand; // tallest band (capped)
+
+  const n = Math.min(lows?.length || 0, highs?.length || 0, rsValues?.length || 0);
+  if (n < 2) return floorTop;
+
+  const priceMin = Math.min(...lows.slice(0, n));
+  const priceMax = Math.max(...highs.slice(0, n));
+  const rsMin = Math.min(...rsValues.slice(0, n));
+  const rsMax = Math.max(...rsValues.slice(0, n));
+
+  // Degenerate cases fall back to the always-empty floor strip.
+  if (rsMax === rsMin) return floorTop;
+  if (priceMin <= 0 || priceMax <= 0 || priceMax === priceMin) return floorTop;
+
+  // Start at the tallest allowed band; raise rTop as bars constrain it.
+  let computedRTop = capTop;
+  for (let i = 0; i < n; i++) {
+    const a = (rsMax - rsValues[i]) / (rsMax - rsMin); // 0 at RS max, 1 at RS min
+    if (a >= 1) continue; // RS-min bar: unconstrained from above
+    const plf = priceLowFraction(lows[i], priceMin, priceMax, priceBandTop, priceFloor);
+    // Smallest rTop keeping rsf_i >= plf_i + gap:
+    const rTopI = (plf + gap - a * rsBottom) / (1 - a);
+    if (rTopI > computedRTop) computedRTop = rTopI;
+  }
+
+  // Clamp into [capTop, floorTop]. The floor strip is empty by construction, so
+  // pinning to floorTop is always overlap-free even if the gap can't be met.
+  return Math.min(Math.max(computedRTop, capTop), floorTop);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+npm run test:run -- src/components/Charts/rsBand.test.js
+```
+Expected: PASS — all 7 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/admin/Documents/Work/stock-screener/.claude/worktrees/fix+rs-line-below-price
+git add frontend/src/components/Charts/rsBand.js frontend/src/components/Charts/rsBand.test.js
+git commit -m "feat(frontend): add pure computeRsBand helper for dynamic RS band"
+```
+
+---
+
+## Task 2: Visible-range alignment helper (`rsBandForRange`)
+
+**Files:**
+- Modify: `frontend/src/components/Charts/rsBand.js`
+- Test: `frontend/src/components/Charts/rsBand.test.js`
+
+This aligns RS values to candles by time, filters to the visible range, and calls `computeRsBand`. Pure, so unit-tested.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `frontend/src/components/Charts/rsBand.test.js`:
+
+```js
+import { rsBandForRange } from './rsBand';
+
+describe('rsBandForRange', () => {
+  const candles = [
+    { time: '2025-01-01', high: 102, low: 100 },
+    { time: '2025-01-02', high: 112, low: 110 },
+    { time: '2025-01-03', high: 122, low: 120 },
+    { time: '2025-01-04', high: 132, low: 130 },
+  ];
+  const rsLine = [
+    { time: '2025-01-01', value: 1 },
+    { time: '2025-01-02', value: 2 },
+    { time: '2025-01-03', value: 3 },
+    { time: '2025-01-04', value: 4 },
+  ];
+
+  it('returns the floor strip when fewer than 2 bars are in range', () => {
+    const r = rsBandForRange(candles, rsLine, { from: '2025-01-01', to: '2025-01-01' });
+    expect(r).toBeCloseTo(0.66, 6); // rsBottom - minBand
+  });
+
+  it('uses all bars when range is null', () => {
+    const full = rsBandForRange(candles, rsLine, null);
+    expect(full).toBeLessThanOrEqual(0.66);
+  });
+
+  it('only includes bars present in BOTH candles and rs line, within range', () => {
+    const partialRs = rsLine.slice(0, 2); // only first two have RS values
+    const r = rsBandForRange(candles, partialRs, null);
+    // 2 aligned bars -> still computes (>= cap, <= floor)
+    expect(r).toBeGreaterThanOrEqual(0.4);
+    expect(r).toBeLessThanOrEqual(0.66);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+npm run test:run -- src/components/Charts/rsBand.test.js
+```
+Expected: FAIL — `rsBandForRange is not a function` / import unresolved.
+
+- [ ] **Step 3: Implement `rsBandForRange`**
+
+Append to `frontend/src/components/Charts/rsBand.js`:
+
+```js
+// Align RS values to candles by time, filter to the visible range, and compute
+// the RS band top. `range` is lightweight-charts' getVisibleRange() result
+// ({ from, to }) or null. Times are the same type as the series data
+// (ISO 'YYYY-MM-DD' strings here), so direct comparison is chronological.
+export function rsBandForRange(candles, rsLine, range) {
+  const rsByTime = new Map((rsLine || []).map((p) => [p.time, p.value]));
+  const lows = [];
+  const highs = [];
+  const rsValues = [];
+  for (const c of candles || []) {
+    if (range && (c.time < range.from || c.time > range.to)) continue;
+    const v = rsByTime.get(c.time);
+    if (v === undefined) continue;
+    lows.push(c.low);
+    highs.push(c.high);
+    rsValues.push(v);
+  }
+  return computeRsBand({ lows, highs, rsValues });
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+npm run test:run -- src/components/Charts/rsBand.test.js
+```
+Expected: PASS — all `computeRsBand` and `rsBandForRange` tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/admin/Documents/Work/stock-screener/.claude/worktrees/fix+rs-line-below-price
+git add frontend/src/components/Charts/rsBand.js frontend/src/components/Charts/rsBand.test.js
+git commit -m "feat(frontend): add rsBandForRange to align RS to visible candles"
+```
+
+---
+
+## Task 3: Wire the dynamic band into `CandlestickChart.jsx`
+
+**Files:**
+- Modify: `frontend/src/components/Charts/CandlestickChart.jsx`
+
+No unit test (canvas chart wiring); verified by the existing test suite (no regressions) plus visual verification in a browser.
+
+- [ ] **Step 1: Import the helper and add band-top state**
+
+At the top of the file, add the import after the existing `priceHistory` import:
+
+```js
+import { rsBandForRange } from './rsBand';
+```
+
+Find the `useState` for `timeframe` (near the top of the component body) and add, right after the `legendData` state:
+
+```js
+const [rsBandTop, setRsBandTop] = useState(0.66); // top margin of the live RS band
+```
+
+- [ ] **Step 2: Set the RS scale's initial margin to the floor strip**
+
+In the init `useLayoutEffect`, find:
+
+```js
+    rsLineSeries.priceScale().applyOptions({
+      scaleMargins: { top: 0.64, bottom: 0.24 },
+      visible: false,
+    });
+```
+
+Replace the `scaleMargins` line so the RS scale starts at the floor strip (the dynamic effect overrides it once data is present):
+
+```js
+    rsLineSeries.priceScale().applyOptions({
+      scaleMargins: { top: 0.66, bottom: 0.22 },
+      visible: false,
+    });
+```
+
+- [ ] **Step 3: Update the price/volume reclaim numbers**
+
+Find the "RS strip layout" `useLayoutEffect` (it applies `scaleMargins` to the candlestick and volume scales based on `rsStripShown`). Replace its body's `if/else` with the new floor (0.66) / full (0.78) numbers:
+
+```js
+    if (rsStripShown) {
+      candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.34 } });
+      volume.priceScale().applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
+    } else {
+      candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.22 } });
+      volume.priceScale().applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
+    }
+```
+
+(Price floor `0.66` = bottom margin `0.34` when RS shown; full `0.78` = `0.22` when hidden. Volume fixed at `[0.80, 1.00]`.)
+
+- [ ] **Step 4: Add the dynamic RS-band effect**
+
+Immediately AFTER the existing "RS strip layout" `useLayoutEffect` (the one edited in Step 3), add this new effect:
+
+```js
+  // Dynamic RS band: size the RS overlay scale so the line fills the empty space
+  // below the candles without overlapping them. Recomputes on data change and on
+  // pan/zoom (price re-auto-scales to the visible window, so the safe band moves).
+  // Debounced; the 12%-38% clamp lives in computeRsBand. Skipped when RS is hidden.
+  useEffect(() => {
+    const chart = chartRef.current;
+    const rsSeries = rsLineSeriesRef.current;
+    if (!chart || !rsSeries || !rsStripShown) return;
+
+    const candles = chartData?.candlesticks || [];
+    const rsLine = rsData?.rs_line || [];
+
+    const apply = () => {
+      const rTop = rsBandForRange(candles, rsLine, chart.timeScale().getVisibleRange());
+      rsSeries.priceScale().applyOptions({ scaleMargins: { top: rTop, bottom: 0.22 } });
+      setRsBandTop(rTop);
+    };
+
+    apply();
+    const debouncedApply = debounce(apply, 80);
+    const timeScale = chart.timeScale();
+    timeScale.subscribeVisibleTimeRangeChange(debouncedApply);
+    return () => {
+      debouncedApply.cancel();
+      timeScale.unsubscribeVisibleTimeRangeChange(debouncedApply);
+    };
+  }, [chartData, rsData, rsStripShown]);
+```
+
+- [ ] **Step 5: Make the "RS" label track the live band top**
+
+Find the RS label JSX (the `<Typography>` with `top: '64%'` and the text `RS`). Replace its `top` value so it follows the band:
+
+```jsx
+            top: `${(rsBandTop * 100).toFixed(1)}%`,
+```
+
+- [ ] **Step 6: Lint and build to verify no errors**
+
+```bash
+cd frontend
+export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use 22
+npm run lint
+npm run build
+```
+Expected: lint passes (no new errors in `CandlestickChart.jsx` / `rsBand.js`); build succeeds.
+
+- [ ] **Step 7: Run the full frontend test suite (no regressions)**
+
+```bash
+npm run test:run
+```
+Expected: PASS — existing tests still green, plus the new `rsBand` tests.
+
+- [ ] **Step 8: Visual verification (offline static-mode harness)**
+
+Create a throwaway harness to render the chart with static props (no backend), then drive it with Playwright. Create `frontend/rs-verify.html`:
+
+```html
+<!DOCTYPE html>
+<html><head><meta charset="utf-8" /><title>RS dynamic band</title></head>
+<body style="margin:0;background:#121212"><div id="root"></div>
+<script type="module" src="/src/rsVerify.jsx"></script></body></html>
+```
+
+Create `frontend/src/rsVerify.jsx`:
+
+```jsx
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import CandlestickChart from './components/Charts/CandlestickChart';
+
+function build(diverge) {
+  const priceData = [];
+  const start = new Date('2025-01-01');
+  for (let i = 0; i < 180; i++) {
+    const d = new Date(start); d.setDate(start.getDate() + i);
+    const base = 100 + Math.sin(i / 15) * 6 + i * 0.5; // clear uptrend
+    const open = base + Math.sin(i) * 1.4;
+    const close = base + Math.cos(i * 0.7) * 1.4;
+    const high = Math.max(open, close) + 1.3;
+    const low = Math.min(open, close) - 1.3;
+    const volume = 1_000_000 + Math.round(Math.abs(Math.sin(i * 0.3)) * 600_000);
+    priceData.push({ date: d.toISOString().slice(0, 10), open, high, low, close, volume });
+  }
+  // correlated: RS rises with price; diverge: RS falls while price rises.
+  const rsLineData = priceData.map((p, i) => ({
+    time: p.date,
+    value: diverge ? (2 - i * 0.006) : (1 + i * 0.01),
+  }));
+  const blueDots = [priceData[60].date, priceData[150].date];
+  return { priceData, rsLineData, blueDots };
+}
+
+const theme = createTheme({ palette: { mode: 'dark' } });
+const qc = new QueryClient();
+function Chart({ diverge, label }) {
+  const { priceData, rsLineData, blueDots } = build(diverge);
+  return (
+    <div style={{ margin: '12px 24px' }}>
+      <div style={{ color: '#bbb', font: '12px monospace', marginBottom: 4 }}>{label}</div>
+      <div style={{ width: 960, height: 560 }}>
+        <CandlestickChart symbol="TEST" priceData={priceData} rsLineData={rsLineData} blueDots={blueDots} height={560} />
+      </div>
+    </div>
+  );
+}
+createRoot(document.getElementById('root')).render(
+  <ThemeProvider theme={theme}><CssBaseline /><QueryClientProvider client={qc}>
+    <Chart diverge={false} label="Correlated — RS should rise into the empty space (tall band)" />
+    <Chart diverge={true} label="Divergence — RS should degrade to the floor strip (thin band)" />
+  </QueryClientProvider></ThemeProvider>
+);
+```
+
+Start the dev server (binary directly to avoid the npx→npm rewrite):
+
+```bash
+cd frontend
+export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use 22
+node node_modules/vite/bin/vite.js --port 5199 --strictPort
+```
+
+Open `http://localhost:5199/rs-verify.html` in a browser (or Playwright). **Verify:**
+1. Correlated chart: the orange RS line uses a tall band and rises noticeably (its peak above the lowest price bar), with **no candle contact**.
+2. Divergence chart: the RS line sits in a thin floor strip near the bottom, **no overlap**.
+3. The "RS" label sits at the top of the RS band in both.
+
+- [ ] **Step 9: Remove the harness and verify a clean tree**
+
+```bash
+cd /Users/admin/Documents/Work/stock-screener/.claude/worktrees/fix+rs-line-below-price
+rm -f frontend/rs-verify.html frontend/src/rsVerify.jsx
+git status --short
+```
+Expected: only `frontend/src/components/Charts/CandlestickChart.jsx` modified (the helper + tests were committed in Tasks 1-2).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/components/Charts/CandlestickChart.jsx
+git commit -m "feat(frontend): float RS line in the price chart's empty space"
+```
+
+---
+
+## Final: update the PR
+
+- [ ] **Step 1: Push and confirm the PR reflects the new approach**
+
+```bash
+cd /Users/admin/Documents/Work/stock-screener/.claude/worktrees/fix+rs-line-below-price
+git push
+```
+
+- [ ] **Step 2: Update PR #215 description** so it reflects the dynamic band (superseding the fixed strip):
+
+```bash
+gh pr edit 215 --body "$(cat <<'EOF'
+## Summary
+
+Reworks the RS (relative-strength) line so it is **dynamic and readable** instead
+of flattened into a thin reserved strip. The line now floats in the price chart's
+**empty space**: its band grows to use available room (peak may rise above the
+lowest price bar) and shrinks to a safe floor strip on divergence — **never
+overlapping the candles**. Still one chart, one time axis.
+
+## How it works
+
+- New pure helper `frontend/src/components/Charts/rsBand.js` (`computeRsBand`,
+  `rsBandForRange`) computes the tallest overlap-free RS scale margin for the
+  visible window — log price scale, linear RS scale — clamped to a **12%–38%**
+  band. Fully unit-tested (`rsBand.test.js`).
+- `CandlestickChart.jsx` applies it to the `rs` overlay scale and **recomputes on
+  data change and on pan/zoom** (debounced 80ms), because price re-auto-scales to
+  the visible window. The "RS" label tracks the live band top.
+- Price reclaims full height when the RS line is hidden (toggle off / weekly).
+
+## Verification
+
+- Unit tests: correlated uptrend → tall band, no overlap; divergence → floor
+  strip; flat / <2 bars / non-positive price → floor strip; cap + min respected.
+- Visual (Playwright, static-mode harness): correlated rises into the empty space;
+  divergence degrades to the floor strip; separation stress test holds.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-06-05-rs-line-dynamic-empty-space.md
+++ b/docs/superpowers/plans/2026-06-05-rs-line-dynamic-empty-space.md
@@ -549,10 +549,10 @@ cd /Users/admin/Documents/Work/stock-screener/.claude/worktrees/fix+rs-line-belo
 git push
 ```
 
-- [ ] **Step 2: Update PR #215 description** so it reflects the dynamic band (superseding the fixed strip):
+- [ ] **Step 2: Update PR #216 description** so it reflects the dynamic band (superseding the fixed strip):
 
 ```bash
-gh pr edit 215 --body "$(cat <<'EOF'
+gh pr edit 216 --body "$(cat <<'EOF'
 ## Summary
 
 Reworks the RS (relative-strength) line so it is **dynamic and readable** instead

--- a/docs/superpowers/specs/2026-06-05-rs-line-dynamic-empty-space-design.md
+++ b/docs/superpowers/specs/2026-06-05-rs-line-dynamic-empty-space-design.md
@@ -1,0 +1,147 @@
+# RS line: dynamic band in the price area's empty space
+
+**Date:** 2026-06-05
+**Status:** Approved design — ready for implementation plan
+**Component:** `frontend/src/components/Charts/CandlestickChart.jsx`
+**Builds on:** PR #215 (moved the RS line into a fixed strip below the price)
+
+## Problem
+
+PR #215 placed the relative-strength (RS) line in a reserved strip below the
+candles (`rs` overlay scale at `scaleMargins {top: 0.64, bottom: 0.24}`). The
+strip is ~12% of the pane, so the RS line is auto-scaled into a thin band and
+looks **flat** — its movement is too small to read. Its peak always sits below
+the lowest price bar, which guarantees no overlap but wastes the large empty
+area inside the price chart (e.g. the lower-right region during an uptrend).
+
+## Goal
+
+Let the RS line use the **empty space inside the price area** so it becomes
+dynamic and readable — its peak may rise *above* the lowest price bar — while
+**never overlapping the candles**. When there isn't enough safe space
+(price/RS divergence, choppy or zoomed-in windows), it degrades gracefully
+toward a thin floor strip rather than overlapping.
+
+This is "Option B" from brainstorming, with **capped-dynamic** behavior.
+
+## Layout model
+
+Three regions in a single chart pane (fractions of pane height, 0 = top):
+
+| Region | RS shown | RS hidden |
+| --- | --- | --- |
+| Price + EMAs (`right` scale) | `[0.05, 0.66]` | `[0.05, 0.78]` |
+| RS line (`rs` scale) | `[rTop, 0.78]` (dynamic) | not drawn |
+| Volume (`volume` scale) | `[0.80, 1.00]` | `[0.80, 1.00]` |
+
+Compressing the price band to a `0.66` floor (when RS is shown) guarantees
+`[0.66, 0.78]` is **always empty** — no candle is ever below the price floor.
+That empty band is the RS line's **floor strip** and its enforced minimum
+(~12%, matching today's look). Above `0.66`, candles exist but with empty
+pockets; the RS line expands up into those pockets when it is safe to do so.
+
+The existing RS toggle and `rsStripShown` flag are retained. When RS is hidden
+(toggled off or weekly timeframe), price expands to `[0.05, 0.78]` (the
+reclaim behavior from PR #215 is kept, with updated numbers).
+
+## Core algorithm: `computeRsBand()`
+
+A **pure, testable** function (no chart dependency) that returns the RS scale's
+top margin `rTop` for the current visible window.
+
+Inputs (for the visible bars only):
+- `lows[]` — price low per bar (used for the per-bar non-overlap constraint)
+- `highs[]` — price high per bar (used only for `priceMax`, the scale's top)
+- `rsValues[]` — RS value per bar (aligned to the same bars)
+- Constants: `priceBandTop = 0.05`, `priceFloor = 0.66`, `rsBottom = 0.78`,
+  `gap = 0.012`, `minBand = 0.12`, `maxBand = 0.38`
+
+Steps:
+1. `priceMin = min(lows)`, `priceMax = max(highs)` over the visible window —
+   the same range lightweight-charts auto-scales to. (Use highs for the max to
+   match the candlestick scale, which spans lows..highs.)
+2. **Price screen position is logarithmic** — the `right` price scale is created
+   with `mode: 1` (log). For each visible bar:
+   `plf_i = priceBandTop + (ln(priceMax) - ln(low_i)) / (ln(priceMax) - ln(priceMin)) * (priceFloor - priceBandTop)`
+3. The RS scale is **linear**. With band `[rTop, rsBottom]`:
+   `rsf_i = rTop + a_i * (rsBottom - rTop)`, where
+   `a_i = (rsMax - rs_i) / (rsMax - rsMin)` in `[0, 1]`
+   (0 when `rs_i` is the max, 1 when it is the min).
+4. Non-overlap constraint: `rsf_i >= plf_i + gap` for every visible bar.
+   Solve each for the minimum `rTop` (taller band = smaller `rTop`):
+   `rTop_i = (plf_i + gap - a_i * rsBottom) / (1 - a_i)` for `a_i < 1`
+   (skip `a_i == 1`, the RS-min bar, which is unconstrained from above).
+   `computedRTop = max_i(rTop_i)`.
+5. **Clamp:** `rTop = clamp(computedRTop, rsBottom - maxBand, rsBottom - minBand)`
+   → `rTop ∈ [0.40, 0.66]`, band height ∈ `[0.12, 0.38]`.
+   If `computedRTop > rsBottom - minBand` (even the min strip would overlap),
+   `rTop` pins to `rsBottom - minBand = 0.66` — the floor strip, which is empty
+   by construction, so still no overlap.
+
+Degenerate inputs return the floor strip (`rTop = 0.66`):
+- `rsMax == rsMin` (flat RS) — `a_i` undefined.
+- fewer than 2 visible bars.
+- any non-positive price (log undefined) in the window — guard and fall back.
+
+## Wiring in `CandlestickChart.jsx`
+
+- **Remove** the fixed `rs` scaleMargins (`{top: 0.64, bottom: 0.24}`) and the
+  PR #215 reclaim `useLayoutEffect` in its current form.
+- **Price/volume margins** continue to be driven by `rsStripShown`:
+  - price: `rsStripShown ? {top: 0.05, bottom: 0.34} : {top: 0.05, bottom: 0.22}`
+    (price floor `0.66` vs `0.78`)
+  - volume: `{top: 0.80, bottom: 0}` (fixed)
+- **New effect** computes and applies the RS band:
+  - reads the visible logical range from the chart's time scale, slices the
+    `lows`/`rsValues` arrays to it, calls `computeRsBand()`, and applies
+    `rsScale.applyOptions({ scaleMargins: { top: rTop, bottom: 0.22 } })`.
+  - **Recompute triggers:** RS data / chart data change, and
+    `subscribeVisibleTimeRangeChange` (debounced ~80ms — price re-auto-scales
+    on pan/zoom, so the safe band changes). Static charts compute once on load.
+  - Skipped when `rsStripShown` is false.
+- The RS line series data and blue-dot markers are unchanged; only the `rs`
+  scale's margins move.
+
+## "RS" label
+
+The label from PR #215 is pinned at a fixed `top: '64%'`. Since the RS band now
+moves, the label should track `rTop` (e.g. `top: \`${rTop * 100}%\``) so it stays
+at the top of the live RS band. Keep it gated on `!compact`.
+
+## Edge cases
+
+- Flat RS / <2 bars / non-positive price → floor strip (no overlap, ~12%).
+- RS hidden or weekly timeframe → effect skipped, price uses full `[0.05, 0.78]`.
+- `interactive = false` (static charts) → no pan/zoom; computes once from the
+  initial visible range.
+- Rapid pan/zoom → debounced recompute; band "breathes" (expected, bounded by
+  the 12%–38% clamp).
+
+## Testing
+
+**Unit tests for `computeRsBand()`** (pure function, primary coverage):
+- Correlated uptrend → tall band near the cap; assert `rsf_i >= plf_i` for all i
+  (no overlap) using the same screen-mapping math.
+- Divergence (price up, RS down) → clamps to `minBand`.
+- Flat RS / single bar / non-positive price → floor strip.
+- Max cap respected (band height never exceeds `maxBand`).
+- Min height respected (band height never below `minBand`).
+
+**Visual verification (Playwright, offline static-mode harness):**
+- Correlated case: RS rises into the empty lower-right, no candle contact.
+- Divergence case: RS degrades to the floor strip, no overlap.
+- Separation stress test (extreme candles, RS at band edges, volume spike) at
+  full and small heights.
+- RS toggle off → price reclaims to full height; label disappears.
+
+## Out of scope
+
+- Changing what the RS line plots (still the raw stock/benchmark ratio).
+- Volume layout changes beyond its fixed `[0.80, 1.00]` band.
+- A separate pane (Option A) — explicitly not chosen.
+
+## Tunable constants (defaults)
+
+`priceFloor = 0.66`, `rsBottom = 0.78`, `volumeTop = 0.80`, `gap = 0.012`,
+`minBand = 0.12`, `maxBand = 0.38`, `debounceMs = 80`. These are expected to be
+adjusted during visual verification.

--- a/frontend/src/components/Charts/CandlestickChart.jsx
+++ b/frontend/src/components/Charts/CandlestickChart.jsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useLayoutEffect, useState, useMemo } from 'react';
-import { createChart, CrosshairMode, CandlestickSeries, LineSeries, HistogramSeries, createSeriesMarkers } from 'lightweight-charts';
 import { Box, CircularProgress, Alert, AlertTitle, Button, ToggleButtonGroup, ToggleButton, useTheme, Typography } from '@mui/material';
+import { createPriceChartSeries } from './createPriceChartSeries';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchPriceHistory, fetchRSLine, priceHistoryKeys, PRICE_HISTORY_STALE_TIME } from '../../api/priceHistory';
 import { rsBandForRange } from './rsBand';
@@ -174,109 +174,29 @@ function CandlestickChart({
     const chartWidth = containerWidth > 0 ? containerWidth : 800;
     const chartHeight = containerHeight > 0 ? containerHeight : height;
 
-    const chart = createChart(chartContainerRef.current, {
+    const {
+      chart,
+      volumeSeries,
+      candlestickSeries,
+      ema10Series,
+      ema20Series,
+      ema50Series,
+      rsLineSeries,
+      rsMarkers,
+    } = createPriceChartSeries(chartContainerRef.current, {
       width: chartWidth,
       height: chartHeight,
-      layout: {
-        background: { type: 'solid', color: isDarkMode ? '#1e1e1e' : '#ffffff' },
-        textColor: isDarkMode ? '#d1d4dc' : '#333333',
-      },
-      grid: {
-        vertLines: { color: isDarkMode ? '#363a45' : '#e0e0e0' },
-        horzLines: { color: isDarkMode ? '#363a45' : '#e0e0e0' },
-      },
-      crosshair: {
-        mode: CrosshairMode.Normal,
-      },
-      rightPriceScale: {
-        borderColor: isDarkMode ? '#485263' : '#cccccc',
-        mode: 1, // Logarithmic scale
-      },
-      timeScale: {
-        borderColor: isDarkMode ? '#485263' : '#cccccc',
-        timeVisible: true,
-        secondsVisible: false,
-      },
-      handleScroll: interactive,
-      handleScale: interactive,
+      isDarkMode,
+      interactive,
     });
-
     chartRef.current = chart;
-
-    // Create volume series (at bottom)
-    const volumeSeries = chart.addSeries(HistogramSeries, {
-      priceFormat: {
-        type: 'volume',
-      },
-      priceScaleId: 'volume',
-    });
-    volumeSeries.priceScale().applyOptions({
-      scaleMargins: {
-        top: 0.7, // Neutral default; reapplied by the RS strip layout effect.
-        bottom: 0,
-      },
-    });
     volumeSeriesRef.current = volumeSeries;
-
-    // Create candlestick series
-    const candlestickSeries = chart.addSeries(CandlestickSeries, {
-      upColor: '#2196f3',
-      downColor: '#E619CD',
-      borderVisible: false,
-      wickUpColor: '#2196f3',
-      wickDownColor: '#E619CD',
-      priceScaleId: 'right',
-    });
-    // Price/volume vertical bands are applied reactively below (see the
-    // "RS strip layout" effect) so they can reclaim the RS strip's space when
-    // the RS line is hidden. A neutral default avoids a flash before it runs.
-    candlestickSeries.priceScale().applyOptions({
-      scaleMargins: { top: 0.05, bottom: 0.3 },
-    });
     candlestickSeriesRef.current = candlestickSeries;
-
-    // Create EMA 10 line series (Bright Green)
-    const ema10Series = chart.addSeries(LineSeries, {
-      color: '#4CF64D',
-      lineWidth: 2,
-      priceScaleId: 'right',
-    });
     ema10SeriesRef.current = ema10Series;
-
-    // Create EMA 20 line series (Cyan)
-    const ema20Series = chart.addSeries(LineSeries, {
-      color: '#87FBFB',
-      lineWidth: 2,
-      priceScaleId: 'right',
-    });
     ema20SeriesRef.current = ema20Series;
-
-    // Create EMA 50 line series (Green)
-    const ema50Series = chart.addSeries(LineSeries, {
-      color: '#38CD07',
-      lineWidth: 2,
-      priceScaleId: 'right',
-    });
     ema50SeriesRef.current = ema50Series;
-
-    // Create RS line series on its own overlay price scale so the ratio doesn't
-    // distort the price axis. The scale occupies a dedicated band *below* the
-    // candlesticks (between price and volume), so it reads as a separate strip
-    // rather than another moving average; it stays hidden (no axis labels).
-    // Blue-dot markers attach to this series.
-    const rsLineSeries = chart.addSeries(LineSeries, {
-      color: '#FFA726', // orange — distinct from the green/cyan EMAs
-      lineWidth: 2,
-      priceScaleId: 'rs',
-      lastValueVisible: false,
-      priceLineVisible: false,
-    });
-    rsLineSeries.priceScale().applyOptions({
-      scaleMargins: { top: 0.66, bottom: 0.22 },
-      visible: false,
-    });
     rsLineSeriesRef.current = rsLineSeries;
-    rsMarkersRef.current = createSeriesMarkers(rsLineSeries, []);
+    rsMarkersRef.current = rsMarkers;
 
     // Subscribe to crosshair move for OHLC legend (skip in compact mode — legend is hidden)
     if (!compact) chart.subscribeCrosshairMove((param) => {

--- a/frontend/src/components/Charts/CandlestickChart.jsx
+++ b/frontend/src/components/Charts/CandlestickChart.jsx
@@ -3,6 +3,7 @@ import { createChart, CrosshairMode, CandlestickSeries, LineSeries, HistogramSer
 import { Box, CircularProgress, Alert, AlertTitle, Button, ToggleButtonGroup, ToggleButton, useTheme, Skeleton, Typography } from '@mui/material';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchPriceHistory, fetchRSLine, priceHistoryKeys, PRICE_HISTORY_STALE_TIME } from '../../api/priceHistory';
+import { rsBandForRange } from './rsBand';
 
 /**
  * Chart skeleton placeholder that shows chart structure while loading
@@ -330,6 +331,7 @@ function CandlestickChart({
   const [timeframe, setTimeframe] = useState('daily');
   const [showRSLine, setShowRSLine] = useState(true); // RS line overlay toggle
   const [legendData, setLegendData] = useState(null); // OHLC legend data on hover
+  const [rsBandTop, setRsBandTop] = useState(0.66); // top margin of the live RS band
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
 
@@ -534,7 +536,7 @@ function CandlestickChart({
       priceLineVisible: false,
     });
     rsLineSeries.priceScale().applyOptions({
-      scaleMargins: { top: 0.64, bottom: 0.24 },
+      scaleMargins: { top: 0.66, bottom: 0.22 },
       visible: false,
     });
     rsLineSeriesRef.current = rsLineSeries;
@@ -748,25 +750,64 @@ function CandlestickChart({
     if (markers) markers.setMarkers(markerList);
   }, [rsData, rsStripShown]);
 
-  // RS strip layout: when the RS line is shown, compress price + volume to
-  // leave a dedicated strip between them (the 'rs' scale lives at [0.64, 0.76]);
-  // when it's hidden, expand price + volume to reclaim that space so the chart
-  // doesn't carry an empty band. Runs after the init layout effect (same commit,
-  // ordered after) and re-runs on chart re-creation so fresh series get the
-  // right bands. useLayoutEffect keeps the resize off-screen (no flash).
+  // RS strip layout: when the RS line is shown, compress price to a 0.66 floor
+  // so the [0.66, 0.78] band below it is always empty (the RS scale floats in
+  // [rTop, 0.78], sized dynamically by the effect below); when hidden, expand
+  // price to 0.78 to reclaim that space so the chart doesn't carry an empty
+  // band. Runs after the init layout effect (same commit, ordered after) and
+  // re-runs on chart re-creation so fresh series get the right bands.
+  // useLayoutEffect keeps the resize off-screen (no flash).
   useLayoutEffect(() => {
     const candle = candlestickSeriesRef.current;
     const volume = volumeSeriesRef.current;
     if (!candle || !volume || !chartRef.current) return;
 
     if (rsStripShown) {
-      candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.4 } });
+      candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.34 } });
       volume.priceScale().applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
     } else {
-      candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.3 } });
-      volume.priceScale().applyOptions({ scaleMargins: { top: 0.7, bottom: 0 } });
+      candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.22 } });
+      volume.priceScale().applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
     }
   }, [rsStripShown, symbol, height, isDarkMode, compact]);
+
+  // Dynamic RS band: size the RS overlay scale so the line fills the empty space
+  // below the candles without overlapping them. Recomputes on data change and on
+  // pan/zoom (price re-auto-scales to the visible window, so the safe band moves).
+  // Debounced; the 12%-38% clamp lives in computeRsBand. Skipped when RS is hidden.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart || !rsLineSeriesRef.current || !rsStripShown) return;
+
+    // candles/rsLine are captured per effect run. They stay fresh because the
+    // effect re-subscribes (and the cleanup cancels the pending debounce) whenever
+    // chartData/rsData change, so a stale debounced callback can never fire.
+    const candles = chartData?.candlesticks || [];
+    const rsLine = rsData?.rs_line || [];
+
+    const apply = () => {
+      const liveChart = chartRef.current;
+      const rsSeries = rsLineSeriesRef.current;
+      if (!liveChart || !rsSeries) return; // guard against teardown mid-debounce
+      const rTop = rsBandForRange(candles, rsLine, liveChart.timeScale().getVisibleRange());
+      rsSeries.priceScale().applyOptions({ scaleMargins: { top: rTop, bottom: 0.22 } });
+      setRsBandTop(rTop);
+    };
+
+    apply();
+    const debouncedApply = debounce(apply, 80);
+    const timeScale = chart.timeScale();
+    timeScale.subscribeVisibleTimeRangeChange(debouncedApply);
+    return () => {
+      debouncedApply.cancel();
+      // Only unsubscribe if this exact chart is still mounted. On unmount or a
+      // symbol-change recreate, the old chart (and its time scale) is already
+      // disposed, and calling unsubscribe on it would throw.
+      if (chartRef.current === chart) {
+        timeScale.unsubscribeVisibleTimeRangeChange(debouncedApply);
+      }
+    };
+  }, [chartData, rsData, rsStripShown]);
 
   // Determine overlay state
   // Only show full loading state if we have no data at all (not even placeholder)
@@ -898,7 +939,7 @@ function CandlestickChart({
           variant="caption"
           sx={{
             position: 'absolute',
-            top: '64%',
+            top: `${(rsBandTop * 100).toFixed(1)}%`,
             left: 8,
             zIndex: 10,
             color: '#FFA726',

--- a/frontend/src/components/Charts/CandlestickChart.jsx
+++ b/frontend/src/components/Charts/CandlestickChart.jsx
@@ -1,163 +1,11 @@
 import { useRef, useEffect, useLayoutEffect, useState, useMemo } from 'react';
 import { createChart, CrosshairMode, CandlestickSeries, LineSeries, HistogramSeries, createSeriesMarkers } from 'lightweight-charts';
-import { Box, CircularProgress, Alert, AlertTitle, Button, ToggleButtonGroup, ToggleButton, useTheme, Skeleton, Typography } from '@mui/material';
+import { Box, CircularProgress, Alert, AlertTitle, Button, ToggleButtonGroup, ToggleButton, useTheme, Typography } from '@mui/material';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchPriceHistory, fetchRSLine, priceHistoryKeys, PRICE_HISTORY_STALE_TIME } from '../../api/priceHistory';
 import { rsBandForRange } from './rsBand';
-
-/**
- * Chart skeleton placeholder that shows chart structure while loading
- */
-const ChartSkeleton = ({ height, isDarkMode }) => {
-  const bgColor = isDarkMode ? '#1e1e1e' : '#ffffff';
-  const lineColor = isDarkMode ? '#363a45' : '#e0e0e0';
-  const skeletonColor = isDarkMode ? '#2a2a2a' : '#f0f0f0';
-
-  return (
-    <Box
-      sx={{
-        width: '100%',
-        height: height,
-        bgcolor: bgColor,
-        position: 'relative',
-        display: 'flex',
-        flexDirection: 'column',
-        p: 2,
-      }}
-    >
-      {/* Y-axis area */}
-      <Box sx={{ display: 'flex', flex: 1 }}>
-        {/* Price axis labels (left side simulation) */}
-        <Box sx={{ width: 60, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', pr: 1 }}>
-          {[...Array(6)].map((_, i) => (
-            <Skeleton
-              key={i}
-              variant="text"
-              width={40}
-              height={16}
-              sx={{ bgcolor: skeletonColor }}
-            />
-          ))}
-        </Box>
-
-        {/* Chart area */}
-        <Box sx={{ flex: 1, position: 'relative', borderLeft: `1px solid ${lineColor}`, borderBottom: `1px solid ${lineColor}` }}>
-          {/* Horizontal grid lines */}
-          {[...Array(5)].map((_, i) => (
-            <Box
-              key={i}
-              sx={{
-                position: 'absolute',
-                left: 0,
-                right: 0,
-                top: `${(i + 1) * 16.67}%`,
-                borderTop: `1px dashed ${lineColor}`,
-                opacity: 0.5,
-              }}
-            />
-          ))}
-
-          {/* Candlestick skeleton bars */}
-          <Box sx={{
-            display: 'flex',
-            alignItems: 'flex-end',
-            height: '70%',
-            gap: '2px',
-            px: 1,
-            pt: 2,
-          }}>
-            {[...Array(40)].map((_, i) => {
-              // Create varied heights for realistic look
-              const minHeight = 20;
-              const height = minHeight + Math.sin(i * 0.3) * 30 + Math.random() * 20;
-
-              return (
-                <Box
-                  key={i}
-                  sx={{
-                    flex: 1,
-                    maxWidth: 12,
-                    height: `${height}%`,
-                    bgcolor: skeletonColor,
-                    borderRadius: 0.5,
-                    animation: 'pulse 1.5s ease-in-out infinite',
-                    animationDelay: `${i * 0.02}s`,
-                    '@keyframes pulse': {
-                      '0%, 100%': { opacity: 0.4 },
-                      '50%': { opacity: 0.7 },
-                    },
-                  }}
-                />
-              );
-            })}
-          </Box>
-
-          {/* Volume skeleton bars at bottom */}
-          <Box sx={{
-            display: 'flex',
-            alignItems: 'flex-end',
-            height: '25%',
-            gap: '2px',
-            px: 1,
-            borderTop: `1px solid ${lineColor}`,
-            pt: 0.5,
-          }}>
-            {[...Array(40)].map((_, i) => {
-              const height = 20 + Math.random() * 60;
-              return (
-                <Box
-                  key={i}
-                  sx={{
-                    flex: 1,
-                    maxWidth: 12,
-                    height: `${height}%`,
-                    bgcolor: skeletonColor,
-                    borderRadius: 0.5,
-                    opacity: 0.5,
-                    animation: 'pulse 1.5s ease-in-out infinite',
-                    animationDelay: `${i * 0.02}s`,
-                  }}
-                />
-              );
-            })}
-          </Box>
-        </Box>
-      </Box>
-
-      {/* X-axis area (time labels) */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-around', pt: 1, pl: 8 }}>
-        {[...Array(6)].map((_, i) => (
-          <Skeleton
-            key={i}
-            variant="text"
-            width={50}
-            height={16}
-            sx={{ bgcolor: skeletonColor }}
-          />
-        ))}
-      </Box>
-
-      {/* Loading indicator */}
-      <Box
-        sx={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 1,
-        }}
-      >
-        <CircularProgress size={32} sx={{ color: isDarkMode ? '#666' : '#bbb' }} />
-        <Typography variant="caption" color="text.secondary">
-          Loading chart...
-        </Typography>
-      </Box>
-    </Box>
-  );
-};
+import ChartSkeleton from './ChartSkeleton';
+import { transformToCandlestickData } from './candlestickData';
 
 // Debounce utility
 const debounce = (fn, ms) => {
@@ -170,118 +18,6 @@ const debounce = (fn, ms) => {
     clearTimeout(timer);
   };
   return debounced;
-};
-
-/**
- * Calculate EMA (Exponential Moving Average)
- */
-const calculateEMA = (data, period) => {
-  if (!data || data.length < period) return [];
-
-  const k = 2 / (period + 1);
-  const emaData = [];
-
-  // Calculate initial SMA as first EMA value
-  let ema = 0;
-  for (let i = 0; i < period; i++) {
-    ema += data[i].close;
-  }
-  ema = ema / period;
-  emaData.push({ time: data[period - 1].date, value: ema });
-
-  // Calculate EMA for remaining data
-  for (let i = period; i < data.length; i++) {
-    ema = data[i].close * k + ema * (1 - k);
-    emaData.push({ time: data[i].date, value: ema });
-  }
-
-  return emaData;
-};
-
-/**
- * Aggregate daily data to weekly
- */
-const aggregateToWeekly = (dailyData) => {
-  if (!dailyData || dailyData.length === 0) return [];
-
-  const weeklyData = [];
-  let currentWeek = null;
-
-  dailyData.forEach((day) => {
-    const date = new Date(day.date);
-    const weekStart = new Date(date);
-    weekStart.setDate(date.getDate() - date.getDay()); // Start of week (Sunday)
-    const weekKey = weekStart.toISOString().split('T')[0];
-
-    if (!currentWeek || currentWeek.weekKey !== weekKey) {
-      if (currentWeek) {
-        weeklyData.push(currentWeek.data);
-      }
-      currentWeek = {
-        weekKey,
-        data: {
-          date: day.date,
-          open: day.open,
-          high: day.high,
-          low: day.low,
-          close: day.close,
-          volume: day.volume,
-        }
-      };
-    } else {
-      currentWeek.data.high = Math.max(currentWeek.data.high, day.high);
-      currentWeek.data.low = Math.min(currentWeek.data.low, day.low);
-      currentWeek.data.close = day.close;
-      currentWeek.data.volume += day.volume;
-      currentWeek.data.date = day.date; // Use latest date for the week
-    }
-  });
-
-  if (currentWeek) {
-    weeklyData.push(currentWeek.data);
-  }
-
-  return weeklyData;
-};
-
-/**
- * Transform API data to TradingView Lightweight Charts format
- */
-const transformToCandlestickData = (apiData, timeframe = 'daily') => {
-  if (!apiData || apiData.length === 0) {
-    return { candlesticks: [], volume: [], ema10: [], ema20: [], ema50: [] };
-  }
-
-  // Aggregate to weekly if needed
-  const processedData = timeframe === 'weekly' ? aggregateToWeekly(apiData) : apiData;
-
-  const candlesticks = [];
-  const volume = [];
-
-  processedData.forEach((d) => {
-    // Candlestick data
-    candlesticks.push({
-      time: d.date,
-      open: d.open,
-      high: d.high,
-      low: d.low,
-      close: d.close,
-    });
-
-    // Volume data
-    volume.push({
-      time: d.date,
-      value: d.volume,
-      color: d.close >= d.open ? 'rgba(33, 150, 243, 0.5)' : 'rgba(230, 25, 205, 0.5)',
-    });
-  });
-
-  // Calculate EMAs
-  const ema10 = calculateEMA(processedData, 10);
-  const ema20 = calculateEMA(processedData, 20);
-  const ema50 = calculateEMA(processedData, 50);
-
-  return { candlesticks, volume, ema10, ema20, ema50 };
 };
 
 /**
@@ -762,13 +498,11 @@ function CandlestickChart({
     const volume = volumeSeriesRef.current;
     if (!candle || !volume || !chartRef.current) return;
 
-    if (rsStripShown) {
-      candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.34 } });
-      volume.priceScale().applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
-    } else {
-      candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.22 } });
-      volume.priceScale().applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
-    }
+    // RS shown -> compress price to a 0.66 floor (bottom 0.34) so [0.66, 0.78] is
+    // an always-empty strip the RS band lives in; hidden -> full height (0.78).
+    const candleBottom = rsStripShown ? 0.34 : 0.22;
+    candle.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: candleBottom } });
+    volume.priceScale().applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
   }, [rsStripShown, symbol, height, isDarkMode, compact]);
 
   // Dynamic RS band: size the RS overlay scale so the line fills the empty space

--- a/frontend/src/components/Charts/ChartSkeleton.jsx
+++ b/frontend/src/components/Charts/ChartSkeleton.jsx
@@ -1,0 +1,157 @@
+import { Box, Skeleton, CircularProgress, Typography } from '@mui/material';
+
+/**
+ * Chart skeleton placeholder that shows chart structure while loading
+ */
+const ChartSkeleton = ({ height, isDarkMode }) => {
+  const bgColor = isDarkMode ? '#1e1e1e' : '#ffffff';
+  const lineColor = isDarkMode ? '#363a45' : '#e0e0e0';
+  const skeletonColor = isDarkMode ? '#2a2a2a' : '#f0f0f0';
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: height,
+        bgcolor: bgColor,
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        p: 2,
+      }}
+    >
+      {/* Y-axis area */}
+      <Box sx={{ display: 'flex', flex: 1 }}>
+        {/* Price axis labels (left side simulation) */}
+        <Box sx={{ width: 60, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', pr: 1 }}>
+          {[...Array(6)].map((_, i) => (
+            <Skeleton
+              key={i}
+              variant="text"
+              width={40}
+              height={16}
+              sx={{ bgcolor: skeletonColor }}
+            />
+          ))}
+        </Box>
+
+        {/* Chart area */}
+        <Box sx={{ flex: 1, position: 'relative', borderLeft: `1px solid ${lineColor}`, borderBottom: `1px solid ${lineColor}` }}>
+          {/* Horizontal grid lines */}
+          {[...Array(5)].map((_, i) => (
+            <Box
+              key={i}
+              sx={{
+                position: 'absolute',
+                left: 0,
+                right: 0,
+                top: `${(i + 1) * 16.67}%`,
+                borderTop: `1px dashed ${lineColor}`,
+                opacity: 0.5,
+              }}
+            />
+          ))}
+
+          {/* Candlestick skeleton bars */}
+          <Box sx={{
+            display: 'flex',
+            alignItems: 'flex-end',
+            height: '70%',
+            gap: '2px',
+            px: 1,
+            pt: 2,
+          }}>
+            {[...Array(40)].map((_, i) => {
+              // Create varied heights for realistic look
+              const minHeight = 20;
+              const height = minHeight + Math.sin(i * 0.3) * 30 + Math.random() * 20;
+
+              return (
+                <Box
+                  key={i}
+                  sx={{
+                    flex: 1,
+                    maxWidth: 12,
+                    height: `${height}%`,
+                    bgcolor: skeletonColor,
+                    borderRadius: 0.5,
+                    animation: 'pulse 1.5s ease-in-out infinite',
+                    animationDelay: `${i * 0.02}s`,
+                    '@keyframes pulse': {
+                      '0%, 100%': { opacity: 0.4 },
+                      '50%': { opacity: 0.7 },
+                    },
+                  }}
+                />
+              );
+            })}
+          </Box>
+
+          {/* Volume skeleton bars at bottom */}
+          <Box sx={{
+            display: 'flex',
+            alignItems: 'flex-end',
+            height: '25%',
+            gap: '2px',
+            px: 1,
+            borderTop: `1px solid ${lineColor}`,
+            pt: 0.5,
+          }}>
+            {[...Array(40)].map((_, i) => {
+              const height = 20 + Math.random() * 60;
+              return (
+                <Box
+                  key={i}
+                  sx={{
+                    flex: 1,
+                    maxWidth: 12,
+                    height: `${height}%`,
+                    bgcolor: skeletonColor,
+                    borderRadius: 0.5,
+                    opacity: 0.5,
+                    animation: 'pulse 1.5s ease-in-out infinite',
+                    animationDelay: `${i * 0.02}s`,
+                  }}
+                />
+              );
+            })}
+          </Box>
+        </Box>
+      </Box>
+
+      {/* X-axis area (time labels) */}
+      <Box sx={{ display: 'flex', justifyContent: 'space-around', pt: 1, pl: 8 }}>
+        {[...Array(6)].map((_, i) => (
+          <Skeleton
+            key={i}
+            variant="text"
+            width={50}
+            height={16}
+            sx={{ bgcolor: skeletonColor }}
+          />
+        ))}
+      </Box>
+
+      {/* Loading indicator */}
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        <CircularProgress size={32} sx={{ color: isDarkMode ? '#666' : '#bbb' }} />
+        <Typography variant="caption" color="text.secondary">
+          Loading chart...
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default ChartSkeleton;

--- a/frontend/src/components/Charts/candlestickData.js
+++ b/frontend/src/components/Charts/candlestickData.js
@@ -34,9 +34,12 @@ export const aggregateToWeekly = (dailyData) => {
   let currentWeek = null;
 
   dailyData.forEach((day) => {
-    const date = new Date(day.date);
+    // Bucket weeks in UTC. `day.date` is a date-only string (UTC midnight); using
+    // local getDay/setDate before a UTC toISOString() would shift week boundaries
+    // by the viewer's timezone, so use the UTC getters/setters throughout.
+    const date = new Date(`${day.date}T00:00:00Z`);
     const weekStart = new Date(date);
-    weekStart.setDate(date.getDate() - date.getDay()); // Start of week (Sunday)
+    weekStart.setUTCDate(date.getUTCDate() - date.getUTCDay()); // Start of week (Sunday, UTC)
     const weekKey = weekStart.toISOString().split('T')[0];
 
     if (!currentWeek || currentWeek.weekKey !== weekKey) {

--- a/frontend/src/components/Charts/candlestickData.js
+++ b/frontend/src/components/Charts/candlestickData.js
@@ -1,0 +1,111 @@
+/**
+ * Calculate EMA (Exponential Moving Average)
+ */
+export const calculateEMA = (data, period) => {
+  if (!data || data.length < period) return [];
+
+  const k = 2 / (period + 1);
+  const emaData = [];
+
+  // Calculate initial SMA as first EMA value
+  let ema = 0;
+  for (let i = 0; i < period; i++) {
+    ema += data[i].close;
+  }
+  ema = ema / period;
+  emaData.push({ time: data[period - 1].date, value: ema });
+
+  // Calculate EMA for remaining data
+  for (let i = period; i < data.length; i++) {
+    ema = data[i].close * k + ema * (1 - k);
+    emaData.push({ time: data[i].date, value: ema });
+  }
+
+  return emaData;
+};
+
+/**
+ * Aggregate daily data to weekly
+ */
+export const aggregateToWeekly = (dailyData) => {
+  if (!dailyData || dailyData.length === 0) return [];
+
+  const weeklyData = [];
+  let currentWeek = null;
+
+  dailyData.forEach((day) => {
+    const date = new Date(day.date);
+    const weekStart = new Date(date);
+    weekStart.setDate(date.getDate() - date.getDay()); // Start of week (Sunday)
+    const weekKey = weekStart.toISOString().split('T')[0];
+
+    if (!currentWeek || currentWeek.weekKey !== weekKey) {
+      if (currentWeek) {
+        weeklyData.push(currentWeek.data);
+      }
+      currentWeek = {
+        weekKey,
+        data: {
+          date: day.date,
+          open: day.open,
+          high: day.high,
+          low: day.low,
+          close: day.close,
+          volume: day.volume,
+        }
+      };
+    } else {
+      currentWeek.data.high = Math.max(currentWeek.data.high, day.high);
+      currentWeek.data.low = Math.min(currentWeek.data.low, day.low);
+      currentWeek.data.close = day.close;
+      currentWeek.data.volume += day.volume;
+      currentWeek.data.date = day.date; // Use latest date for the week
+    }
+  });
+
+  if (currentWeek) {
+    weeklyData.push(currentWeek.data);
+  }
+
+  return weeklyData;
+};
+
+/**
+ * Transform API data to TradingView Lightweight Charts format
+ */
+export const transformToCandlestickData = (apiData, timeframe = 'daily') => {
+  if (!apiData || apiData.length === 0) {
+    return { candlesticks: [], volume: [], ema10: [], ema20: [], ema50: [] };
+  }
+
+  // Aggregate to weekly if needed
+  const processedData = timeframe === 'weekly' ? aggregateToWeekly(apiData) : apiData;
+
+  const candlesticks = [];
+  const volume = [];
+
+  processedData.forEach((d) => {
+    // Candlestick data
+    candlesticks.push({
+      time: d.date,
+      open: d.open,
+      high: d.high,
+      low: d.low,
+      close: d.close,
+    });
+
+    // Volume data
+    volume.push({
+      time: d.date,
+      value: d.volume,
+      color: d.close >= d.open ? 'rgba(33, 150, 243, 0.5)' : 'rgba(230, 25, 205, 0.5)',
+    });
+  });
+
+  // Calculate EMAs
+  const ema10 = calculateEMA(processedData, 10);
+  const ema20 = calculateEMA(processedData, 20);
+  const ema50 = calculateEMA(processedData, 50);
+
+  return { candlesticks, volume, ema10, ema20, ema50 };
+};

--- a/frontend/src/components/Charts/createPriceChartSeries.js
+++ b/frontend/src/components/Charts/createPriceChartSeries.js
@@ -1,0 +1,86 @@
+import {
+  createChart,
+  CrosshairMode,
+  CandlestickSeries,
+  LineSeries,
+  HistogramSeries,
+  createSeriesMarkers,
+} from 'lightweight-charts';
+
+// Create the price chart and all of its series in one place, returning every
+// handle the component needs to drive. Vertical bands (scaleMargins) are neutral
+// defaults here; the component's "RS strip layout" and "dynamic RS band" effects
+// reapply them reactively based on whether the RS line is shown.
+export function createPriceChartSeries(container, { width, height, isDarkMode, interactive }) {
+  const chart = createChart(container, {
+    width,
+    height,
+    layout: {
+      background: { type: 'solid', color: isDarkMode ? '#1e1e1e' : '#ffffff' },
+      textColor: isDarkMode ? '#d1d4dc' : '#333333',
+    },
+    grid: {
+      vertLines: { color: isDarkMode ? '#363a45' : '#e0e0e0' },
+      horzLines: { color: isDarkMode ? '#363a45' : '#e0e0e0' },
+    },
+    crosshair: { mode: CrosshairMode.Normal },
+    rightPriceScale: {
+      borderColor: isDarkMode ? '#485263' : '#cccccc',
+      mode: 1, // Logarithmic scale
+    },
+    timeScale: {
+      borderColor: isDarkMode ? '#485263' : '#cccccc',
+      timeVisible: true,
+      secondsVisible: false,
+    },
+    handleScroll: interactive,
+    handleScale: interactive,
+  });
+
+  // Volume (bottom). Neutral scaleMargins; reapplied by the RS strip layout effect.
+  const volumeSeries = chart.addSeries(HistogramSeries, {
+    priceFormat: { type: 'volume' },
+    priceScaleId: 'volume',
+  });
+  volumeSeries.priceScale().applyOptions({ scaleMargins: { top: 0.7, bottom: 0 } });
+
+  // Candlesticks. Neutral scaleMargins; reapplied by the RS strip layout effect.
+  const candlestickSeries = chart.addSeries(CandlestickSeries, {
+    upColor: '#2196f3',
+    downColor: '#E619CD',
+    borderVisible: false,
+    wickUpColor: '#2196f3',
+    wickDownColor: '#E619CD',
+    priceScaleId: 'right',
+  });
+  candlestickSeries.priceScale().applyOptions({ scaleMargins: { top: 0.05, bottom: 0.3 } });
+
+  // EMA 10 / 20 / 50 — share the price ('right') scale.
+  const ema10Series = chart.addSeries(LineSeries, { color: '#4CF64D', lineWidth: 2, priceScaleId: 'right' });
+  const ema20Series = chart.addSeries(LineSeries, { color: '#87FBFB', lineWidth: 2, priceScaleId: 'right' });
+  const ema50Series = chart.addSeries(LineSeries, { color: '#38CD07', lineWidth: 2, priceScaleId: 'right' });
+
+  // RS line on its own hidden overlay scale (orange — distinct from the EMAs). It
+  // sits in a band below the candles; blue-dot markers attach to it. The band is
+  // sized dynamically by the "dynamic RS band" effect.
+  const rsLineSeries = chart.addSeries(LineSeries, {
+    color: '#FFA726',
+    lineWidth: 2,
+    priceScaleId: 'rs',
+    lastValueVisible: false,
+    priceLineVisible: false,
+  });
+  rsLineSeries.priceScale().applyOptions({ scaleMargins: { top: 0.66, bottom: 0.22 }, visible: false });
+  const rsMarkers = createSeriesMarkers(rsLineSeries, []);
+
+  return {
+    chart,
+    volumeSeries,
+    candlestickSeries,
+    ema10Series,
+    ema20Series,
+    ema50Series,
+    rsLineSeries,
+    rsMarkers,
+  };
+}

--- a/frontend/src/components/Charts/rsBand.js
+++ b/frontend/src/components/Charts/rsBand.js
@@ -1,0 +1,72 @@
+// Pure geometry helpers for placing the RS overlay line in the price chart's
+// empty space without overlapping the candles. All Y values are fractions of
+// the chart pane (0 = top, 1 = bottom). The price ("right") scale is
+// logarithmic; the RS scale is linear. No React or chart imports — unit-tested
+// in isolation (see rsBand.test.js) and consumed by CandlestickChart.jsx.
+
+const DEFAULTS = {
+  priceBandTop: 0.05, // top margin of the price band
+  priceFloor: 0.66, // bottom of the price band when RS is shown
+  rsBottom: 0.78, // bottom of the RS band (above the volume band at 0.80)
+  gap: 0.012, // min screen gutter between the RS line and the nearest candle
+  minBand: 0.12, // thinnest RS band (the always-empty floor strip)
+  maxBand: 0.38, // tallest RS band (cap, so RS never dominates the chart)
+};
+
+// Screen fraction of a price low on the logarithmic price scale.
+// Precondition: priceMin > 0 and priceMax > priceMin (callers validate this;
+// computeRsBand guards before calling).
+export function priceLowFraction(low, priceMin, priceMax, top, floor) {
+  const lnMax = Math.log(priceMax);
+  return top + ((lnMax - Math.log(low)) / (lnMax - Math.log(priceMin))) * (floor - top);
+}
+
+// Screen fraction of an RS value on the linear RS scale spanning [rTop, rsBottom].
+export function rsFraction(rs, rsMin, rsMax, rTop, rsBottom) {
+  const a = (rsMax - rs) / (rsMax - rsMin);
+  return rTop + a * (rsBottom - rTop);
+}
+
+// Compute the RS scale's top margin (rTop) so the RS line uses as much empty
+// space below the candles as possible while staying at or below every candle
+// low. Returns a value in [rsBottom - maxBand, rsBottom - minBand].
+export function computeRsBand(input) {
+  const {
+    lows, highs, rsValues,
+    priceBandTop, priceFloor, rsBottom, gap, minBand, maxBand,
+  } = { ...DEFAULTS, ...input };
+
+  const floorTop = rsBottom - minBand; // thinnest band (degraded / safe floor)
+  const capTop = rsBottom - maxBand; // tallest band (capped)
+
+  const n = Math.min(lows?.length || 0, highs?.length || 0, rsValues?.length || 0);
+  if (n < 2) return floorTop;
+
+  const priceMin = Math.min(...lows.slice(0, n));
+  const priceMax = Math.max(...highs.slice(0, n));
+  const rsMin = Math.min(...rsValues.slice(0, n));
+  const rsMax = Math.max(...rsValues.slice(0, n));
+
+  // Degenerate cases fall back to the always-empty floor strip.
+  if (rsMax === rsMin) return floorTop;
+  if (priceMin <= 0 || priceMax <= 0 || priceMax === priceMin) return floorTop;
+
+  // Start at the tallest allowed band; raise rTop as bars constrain it.
+  let computedRTop = capTop;
+  for (let i = 0; i < n; i++) {
+    const a = (rsMax - rsValues[i]) / (rsMax - rsMin); // 0 at RS max, 1 at RS min
+    // RS-min bar (a === 1): division by (1 - a) is undefined, so skip it. This
+    // is safe because that bar maps to rsBottom (0.78), which is always below
+    // priceFloor (0.66) by far more than `gap` — so the no-overlap + gap
+    // constraint holds for it by construction.
+    if (a >= 1) continue;
+    const plf = priceLowFraction(lows[i], priceMin, priceMax, priceBandTop, priceFloor);
+    // Smallest rTop keeping rsf_i >= plf_i + gap:
+    const rTopI = (plf + gap - a * rsBottom) / (1 - a);
+    if (rTopI > computedRTop) computedRTop = rTopI;
+  }
+
+  // Clamp into [capTop, floorTop]. The floor strip is empty by construction, so
+  // pinning to floorTop is always overlap-free even if the gap can't be met.
+  return Math.min(Math.max(computedRTop, capTop), floorTop);
+}

--- a/frontend/src/components/Charts/rsBand.js
+++ b/frontend/src/components/Charts/rsBand.js
@@ -70,3 +70,23 @@ export function computeRsBand(input) {
   // pinning to floorTop is always overlap-free even if the gap can't be met.
   return Math.min(Math.max(computedRTop, capTop), floorTop);
 }
+
+// Align RS values to candles by time, filter to the visible range, and compute
+// the RS band top. `range` is lightweight-charts' getVisibleRange() result
+// ({ from, to }) or null. Times are the same type as the series data
+// (ISO 'YYYY-MM-DD' strings here), so direct comparison is chronological.
+export function rsBandForRange(candles, rsLine, range) {
+  const rsByTime = new Map((rsLine || []).map((p) => [p.time, p.value]));
+  const lows = [];
+  const highs = [];
+  const rsValues = [];
+  for (const c of candles || []) {
+    if (range && (c.time < range.from || c.time > range.to)) continue;
+    const v = rsByTime.get(c.time);
+    if (v === undefined) continue;
+    lows.push(c.low);
+    highs.push(c.high);
+    rsValues.push(v);
+  }
+  return computeRsBand({ lows, highs, rsValues });
+}

--- a/frontend/src/components/Charts/rsBand.test.js
+++ b/frontend/src/components/Charts/rsBand.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  priceLowFraction,
+  rsFraction,
+  computeRsBand,
+} from './rsBand';
+
+// Layout constants mirrored from rsBand.js defaults, for assertion math.
+const TOP = 0.05;
+const FLOOR = 0.66;
+const RS_BOTTOM = 0.78;
+const MIN_BAND = 0.12;
+const MAX_BAND = 0.38;
+const FLOOR_TOP = RS_BOTTOM - MIN_BAND; // 0.66 — top of the RS floor strip (numerically equals FLOOR, but a different concept)
+const CAP_TOP = RS_BOTTOM - MAX_BAND; // 0.40
+
+const GAP = 0.012; // mirrors DEFAULTS.gap in rsBand.js
+
+// Assert the RS line never sits above any candle low (no overlap), using the
+// same screen-mapping the production code uses.
+function assertNoOverlap({ lows, highs, rsValues }, rTop) {
+  const priceMin = Math.min(...lows);
+  const priceMax = Math.max(...highs);
+  const rsMin = Math.min(...rsValues);
+  const rsMax = Math.max(...rsValues);
+  for (let i = 0; i < lows.length; i++) {
+    const plf = priceLowFraction(lows[i], priceMin, priceMax, TOP, FLOOR);
+    const rsf = rsFraction(rsValues[i], rsMin, rsMax, rTop, RS_BOTTOM);
+    // rsf must be at or below the candle low (larger fraction = lower on screen).
+    expect(rsf).toBeGreaterThanOrEqual(plf - 1e-9);
+  }
+}
+
+// In the non-degraded cases (band not pinned to the floor) the RS line keeps a
+// full `gap` gutter below every candle low. Asserts that stronger property.
+function assertGapMet({ lows, highs, rsValues }, rTop) {
+  const priceMin = Math.min(...lows);
+  const priceMax = Math.max(...highs);
+  const rsMin = Math.min(...rsValues);
+  const rsMax = Math.max(...rsValues);
+  for (let i = 0; i < lows.length; i++) {
+    const plf = priceLowFraction(lows[i], priceMin, priceMax, TOP, FLOOR);
+    const rsf = rsFraction(rsValues[i], rsMin, rsMax, rTop, RS_BOTTOM);
+    expect(rsf).toBeGreaterThanOrEqual(plf + GAP - 1e-9);
+  }
+}
+
+describe('computeRsBand', () => {
+  it('returns the floor strip for fewer than 2 bars', () => {
+    expect(computeRsBand({ lows: [10], highs: [11], rsValues: [1] })).toBeCloseTo(FLOOR_TOP, 6);
+    expect(computeRsBand({ lows: [], highs: [], rsValues: [] })).toBeCloseTo(FLOOR_TOP, 6);
+  });
+
+  it('returns the floor strip when RS is flat', () => {
+    const data = { lows: [10, 20, 30], highs: [11, 21, 31], rsValues: [2, 2, 2] };
+    expect(computeRsBand(data)).toBeCloseTo(FLOOR_TOP, 6);
+  });
+
+  it('returns the floor strip when a price is non-positive (log undefined)', () => {
+    const data = { lows: [0, 20, 30], highs: [11, 21, 31], rsValues: [1, 2, 3] };
+    expect(computeRsBand(data)).toBeCloseTo(FLOOR_TOP, 6);
+  });
+
+  it('expands to a taller band on a correlated uptrend, with no overlap', () => {
+    const data = {
+      lows: [100, 110, 120, 130, 140, 150],
+      highs: [102, 112, 122, 132, 142, 153],
+      rsValues: [1, 2, 3, 4, 5, 6],
+    };
+    const rTop = computeRsBand(data);
+    expect(rTop).toBeLessThan(FLOOR_TOP); // taller than the floor strip
+    expect(rTop).toBeGreaterThanOrEqual(CAP_TOP); // never past the cap
+    assertNoOverlap(data, rTop);
+    assertGapMet(data, rTop);
+  });
+
+  it('caps the band height at maxBand on a steep correlated uptrend', () => {
+    const data = {
+      lows: [10, 20, 40, 80, 160, 320],
+      highs: [11, 21, 42, 84, 168, 336],
+      rsValues: [1, 2, 3, 4, 5, 6],
+    };
+    const rTop = computeRsBand(data);
+    expect(rTop).toBeCloseTo(CAP_TOP, 6); // pinned to the 38% cap
+    assertNoOverlap(data, rTop);
+    assertGapMet(data, rTop);
+  });
+
+  it('collapses to the floor strip on divergence (price up, RS down)', () => {
+    const data = {
+      lows: [100, 110, 120, 130, 140, 150],
+      highs: [102, 112, 122, 132, 142, 153],
+      rsValues: [6, 5, 4, 3, 2, 1],
+    };
+    const rTop = computeRsBand(data);
+    expect(rTop).toBeCloseTo(FLOOR_TOP, 6);
+    assertNoOverlap(data, rTop);
+  });
+
+  it('lands at an intermediate height on partial divergence, no overlap', () => {
+    const data = {
+      lows: [100, 110, 120, 130, 140, 150],
+      highs: [102, 112, 122, 132, 142, 153],
+      rsValues: [3, 1, 2, 4, 5, 6], // lowest-price bar has a mid RS value
+    };
+    const rTop = computeRsBand(data);
+    expect(rTop).toBeGreaterThan(CAP_TOP);
+    expect(rTop).toBeLessThan(FLOOR_TOP);
+    assertNoOverlap(data, rTop);
+    assertGapMet(data, rTop);
+  });
+});

--- a/frontend/src/components/Charts/rsBand.test.js
+++ b/frontend/src/components/Charts/rsBand.test.js
@@ -3,6 +3,7 @@ import {
   priceLowFraction,
   rsFraction,
   computeRsBand,
+  rsBandForRange,
 } from './rsBand';
 
 // Layout constants mirrored from rsBand.js defaults, for assertion math.
@@ -108,5 +109,44 @@ describe('computeRsBand', () => {
     expect(rTop).toBeLessThan(FLOOR_TOP);
     assertNoOverlap(data, rTop);
     assertGapMet(data, rTop);
+  });
+});
+
+describe('rsBandForRange', () => {
+  const candles = [
+    { time: '2025-01-01', high: 102, low: 100 },
+    { time: '2025-01-02', high: 112, low: 110 },
+    { time: '2025-01-03', high: 122, low: 120 },
+    { time: '2025-01-04', high: 132, low: 130 },
+  ];
+  const rsLine = [
+    { time: '2025-01-01', value: 1 },
+    { time: '2025-01-02', value: 2 },
+    { time: '2025-01-03', value: 3 },
+    { time: '2025-01-04', value: 4 },
+  ];
+
+  it('returns the floor strip when fewer than 2 bars are in range', () => {
+    const r = rsBandForRange(candles, rsLine, { from: '2025-01-01', to: '2025-01-01' });
+    expect(r).toBeCloseTo(FLOOR_TOP, 6); // rsBottom - minBand
+  });
+
+  it('uses all bars when range is null', () => {
+    const full = rsBandForRange(candles, rsLine, null);
+    expect(full).toBeLessThanOrEqual(FLOOR_TOP);
+  });
+
+  it('only includes bars present in BOTH candles and rs line, within range', () => {
+    const partialRs = rsLine.slice(0, 2); // only first two have RS values
+    const r = rsBandForRange(candles, partialRs, null);
+    // 2 aligned bars -> still computes (>= cap, <= floor)
+    expect(r).toBeGreaterThanOrEqual(CAP_TOP);
+    expect(r).toBeLessThanOrEqual(FLOOR_TOP);
+  });
+
+  it('returns the floor strip when the range excludes all bars', () => {
+    // Range is entirely after the data, so every candle is filtered out.
+    const r = rsBandForRange(candles, rsLine, { from: '2025-02-01', to: '2025-02-28' });
+    expect(r).toBeCloseTo(FLOOR_TOP, 6);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #215 (which moved the RS line into a fixed strip below the price). That strip auto-scaled the RS line into ~12% of height, so it looked **flat and unreadable**. This makes the RS line **dynamic**: it floats in the price chart's empty space, growing to use available room and shrinking to a safe floor strip on price/RS divergence — and **never overlaps the candles**. Its peak can now rise above the lowest price bar (the original goal). Still one chart, one time axis.

## How it works

- **`rsBand.js`** (new, pure, unit-tested) — `computeRsBand()` finds the tallest overlap-free RS scale margin for the visible window (logarithmic price scale, linear RS scale), clamped to a **12%–38%** band; `rsBandForRange()` aligns RS values to candles by time and filters to the visible range.
- **`CandlestickChart.jsx`** — applies the computed margin to the `rs` overlay scale and **recomputes on data change + pan/zoom** (debounced 80ms, since price re-auto-scales to the visible window). The "RS" label tracks the live band top. Price reclaims full height when the RS line is hidden (toggle off / weekly).

## Maintainability (decomposition)

This work would have pushed `CandlestickChart.jsx` over 1000 lines, so the file was decomposed along the way (all behavior-preserving):
- `ChartSkeleton.jsx` — loading skeleton extracted
- `candlestickData.js` — pure OHLCV→series transforms + EMA extracted
- `createPriceChartSeries.js` — chart + 6-series construction factory extracted
- RS strip-layout branches deduped

Net: `CandlestickChart.jsx` **965 → 719 lines**; the init effect **177 → ~90 lines**.

## Verification

- **Unit tests** (`rsBand.test.js`, 11): correlated uptrend → tall band + no-overlap property; divergence → floor strip; flat / <2 bars / non-positive price → floor; cap + min respected; gap-margin met in non-degraded cases; time-range filtering.
- **Visual (Playwright, static-mode harness)**: correlated → RS rises into the empty space (peak above the lowest bar), divergence → degrades to the floor strip, separation stress test (extreme candles, RS at band edges, volume spike) holds at full and small heights, and the chart renders identically after each decomposition.

## Test Plan
- [ ] `cd frontend && npm run test:run` — rsBand suite green
- [ ] Open a stock chart, confirm the orange RS line is dynamic below the candles and never overlaps them; toggle RS off → price reclaims the space; switch to weekly → RS hides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RS line now dynamically repositions within the chart’s empty space to avoid overlapping candlesticks; RS label tracks the live band top.
  * Added an animated chart loading skeleton for a nicer initial load experience.
  * Improved chart rendering with consolidated price/volume/indicator series for smoother updates.

* **Tests**
  * Added comprehensive unit tests validating RS band positioning across edge cases.

* **Documentation**
  * Added implementation plan and design spec for dynamic RS band behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->