### PR TITLE
Resolve static preset filters at export for Leaders in Leading Groups

### DIFF
--- a/backend/app/services/preset_screens.py
+++ b/backend/app/services/preset_screens.py
@@ -1,13 +1,14 @@
 """Preset stock screen definitions for the static site.
 
 Each preset is a named filter configuration using the frontend's camelCase
-filter key names (matching scanClient.js and defaultFilters.js). Presets are
-embedded in the scan manifest and consumed client-side — no backend scanner
-logic is involved at runtime.
+filter key names (matching scanClient.js and defaultFilters.js). Static export
+materializes market defaults into these definitions before embedding them in
+the scan manifest, so static-site consumers can use screen["filters"] directly.
 """
 
 from __future__ import annotations
 
+import copy
 import heapq
 
 RANGE_FILTER_TO_FIELD: dict[str, str] = {
@@ -215,7 +216,6 @@ PRESET_SCREENS: list[dict] = [
         "short_name": "Leaders",
         "description": "Strong report-card stocks in top 40 IBD industry groups",
         "tier": 2,
-        "apply_default_filters": True,
         "filters": {
             "ibdGroupRank": {"min": None, "max": 40},
             "rsRating": {"min": 80, "max": None},
@@ -453,21 +453,40 @@ PRESET_SCREENS: list[dict] = [
 ]
 
 
+STATIC_PRESET_DEFAULT_FILTER_KEYS: dict[str, tuple[str, ...]] = {
+    "leaders_in_leading_groups": ("minVolume",),
+}
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _effective_preset_filters(
-    preset: dict,
+def resolve_preset_screens_for_defaults(
+    presets: list[dict],
     default_filters: dict | None = None,
-) -> dict:
-    """Return preset filters after optional inherited manifest defaults."""
+) -> list[dict]:
+    """Return static preset screens with market defaults materialized.
 
-    filters: dict = {}
-    if preset.get("apply_default_filters"):
-        filters.update(default_filters or {})
-    filters.update(preset.get("filters") or {})
-    return filters
+    Static manifests should be self-contained: consumers should be able to use
+    screen["filters"] directly without knowing which defaults the market uses.
+    """
+
+    defaults = default_filters or {}
+    resolved: list[dict] = []
+    for preset in presets:
+        screen = copy.deepcopy(preset)
+        inherited = {
+            key: defaults[key]
+            for key in STATIC_PRESET_DEFAULT_FILTER_KEYS.get(preset.get("id"), ())
+            if key in defaults
+        }
+        screen["filters"] = {
+            **inherited,
+            **(screen.get("filters") or {}),
+        }
+        resolved.append(screen)
+    return resolved
 
 
 def _matches_preset_filters(row: dict, filters: dict) -> bool:
@@ -527,7 +546,6 @@ def get_preset_chart_symbols(
     serialized_rows: list[dict],
     presets: list[dict] | None = None,
     top_n: int = 200,
-    default_filters: dict | None = None,
 ) -> set[str]:
     """Return the union of top-N symbols per preset screen, used to expand
     static-site chart coverage beyond the composite-score ranking.
@@ -537,7 +555,7 @@ def get_preset_chart_symbols(
 
     symbols: set[str] = set()
     for preset in presets:
-        filters = _effective_preset_filters(preset, default_filters)
+        filters = preset.get("filters") or {}
         matching = [
             row for row in serialized_rows
             if _matches_preset_filters(row, filters)

--- a/backend/app/services/preset_screens.py
+++ b/backend/app/services/preset_screens.py
@@ -215,11 +215,10 @@ PRESET_SCREENS: list[dict] = [
         "short_name": "Leaders",
         "description": "Strong report-card stocks in top 40 IBD industry groups",
         "tier": 2,
+        "apply_default_filters": True,
         "filters": {
             "ibdGroupRank": {"min": None, "max": 40},
             "rsRating": {"min": 80, "max": None},
-            "compositeScore": {"min": 70, "max": None},
-            "minVolume": 100_000_000,
         },
         "sort_by": "composite_score",
         "sort_order": "desc",
@@ -458,6 +457,19 @@ PRESET_SCREENS: list[dict] = [
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _effective_preset_filters(
+    preset: dict,
+    default_filters: dict | None = None,
+) -> dict:
+    """Return preset filters after optional inherited manifest defaults."""
+
+    filters: dict = {}
+    if preset.get("apply_default_filters"):
+        filters.update(default_filters or {})
+    filters.update(preset.get("filters") or {})
+    return filters
+
+
 def _matches_preset_filters(row: dict, filters: dict) -> bool:
     """Check if a serialized scan row matches a preset's filter criteria.
 
@@ -471,6 +483,8 @@ def _matches_preset_filters(row: dict, filters: dict) -> bool:
             continue
 
         if key in SCALAR_FILTER_TO_FIELD:
+            if value is None:
+                continue
             field = SCALAR_FILTER_TO_FIELD[key]
             row_val = row.get(field)
             if row_val is None or row_val < value:
@@ -496,6 +510,8 @@ def _matches_preset_filters(row: dict, filters: dict) -> bool:
             field = RANGE_FILTER_TO_FIELD[key]
             row_val = row.get(field)
             if isinstance(value, dict):
+                if value.get("min") is None and value.get("max") is None:
+                    continue
                 if row_val is None:
                     return False
                 if value.get("min") is not None and row_val < value["min"]:
@@ -511,6 +527,7 @@ def get_preset_chart_symbols(
     serialized_rows: list[dict],
     presets: list[dict] | None = None,
     top_n: int = 200,
+    default_filters: dict | None = None,
 ) -> set[str]:
     """Return the union of top-N symbols per preset screen, used to expand
     static-site chart coverage beyond the composite-score ranking.
@@ -520,9 +537,10 @@ def get_preset_chart_symbols(
 
     symbols: set[str] = set()
     for preset in presets:
+        filters = _effective_preset_filters(preset, default_filters)
         matching = [
             row for row in serialized_rows
-            if _matches_preset_filters(row, preset["filters"])
+            if _matches_preset_filters(row, filters)
         ]
         sort_field = preset.get("sort_by", "composite_score")
         descending = preset.get("sort_order", "desc") == "desc"

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -33,7 +33,11 @@ from app.schemas.groups import (
 )
 from app.schemas.scanning import FilterOptionsResponse, ScanResultItem
 from app.services.breadth_attribution_service import BreadthAttributionService
-from app.services.preset_screens import PRESET_SCREENS, get_preset_chart_symbols
+from app.services.preset_screens import (
+    PRESET_SCREENS,
+    get_preset_chart_symbols,
+    resolve_preset_screens_for_defaults,
+)
 from app.services.ui_snapshot_service import UISnapshotService
 from app.wiring.bootstrap import (
     get_benchmark_cache,
@@ -391,6 +395,7 @@ class StaticSiteExportService:
             serialized_rows=serialized_rows,
             path_prefix=path_prefix,
             groups_payload=groups_payload,
+            preset_screens=scan_manifest.get("preset_screens"),
         )
         breadth_payload = self._build_optional_section_payload(
             section=f"{market} breadth",
@@ -690,6 +695,10 @@ class StaticSiteExportService:
         self._annotate_percentile_ranks(serialized_rows)
         serialized_rows = self._sort_static_scan_rows(serialized_rows)
         resolved_default_filters = self.resolve_static_default_filters(market)
+        resolved_preset_screens = resolve_preset_screens_for_defaults(
+            PRESET_SCREENS,
+            resolved_default_filters,
+        )
         default_filtered_rows = self._apply_static_default_filters(
             serialized_rows, default_filters=resolved_default_filters
         )
@@ -730,7 +739,7 @@ class StaticSiteExportService:
                 gics_sectors=list(filter_options.gics_sectors),
                 ratings=list(filter_options.ratings),
             ).model_dump(mode="json"),
-            "preset_screens": PRESET_SCREENS,
+            "preset_screens": resolved_preset_screens,
             "chunks": chunk_refs,
             "initial_rows": default_filtered_rows[:50],
             "preview_rows": default_filtered_rows[:10],
@@ -748,6 +757,7 @@ class StaticSiteExportService:
         serialized_rows: list[dict[str, Any]] | None = None,
         path_prefix: Path | None = None,
         groups_payload: dict[str, Any] | None = None,
+        preset_screens: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         normalized_prefix = Path() if path_prefix is None else Path(path_prefix)
         chart_dir = output_dir / normalized_prefix / "charts"
@@ -869,13 +879,11 @@ class StaticSiteExportService:
 
         # --- Pass 2: expand preset screen top-N charts ---
         if serialized_rows is not None:
-            preset_default_filters = self.resolve_static_default_filters(market)
             _expand_extra_charts(
                 get_preset_chart_symbols(
                     serialized_rows,
-                    PRESET_SCREENS,
+                    PRESET_SCREENS if preset_screens is None else preset_screens,
                     STATIC_CHART_PRESET_TOP_N,
-                    default_filters=preset_default_filters,
                 ),
                 log_label="Preset screen expansion",
             )

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -869,8 +869,14 @@ class StaticSiteExportService:
 
         # --- Pass 2: expand preset screen top-N charts ---
         if serialized_rows is not None:
+            preset_default_filters = self.resolve_static_default_filters(market)
             _expand_extra_charts(
-                get_preset_chart_symbols(serialized_rows, PRESET_SCREENS, STATIC_CHART_PRESET_TOP_N),
+                get_preset_chart_symbols(
+                    serialized_rows,
+                    PRESET_SCREENS,
+                    STATIC_CHART_PRESET_TOP_N,
+                    default_filters=preset_default_filters,
+                ),
                 log_label="Preset screen expansion",
             )
 

--- a/backend/tests/unit/test_preset_screens.py
+++ b/backend/tests/unit/test_preset_screens.py
@@ -1,8 +1,8 @@
 from app.services.preset_screens import (
     PRESET_SCREENS,
-    _effective_preset_filters,
     _matches_preset_filters,
     get_preset_chart_symbols,
+    resolve_preset_screens_for_defaults,
 )
 
 
@@ -28,7 +28,7 @@ def test_leaders_in_leading_groups_preset_filters_for_v1_contract():
     assert screen["name"] == "Leaders in Leading Groups"
     assert screen["sort_by"] == "composite_score"
     assert screen["sort_order"] == "desc"
-    assert screen["apply_default_filters"] is True
+    assert "apply_default_filters" not in screen
     assert "compositeScore" not in screen["filters"]
     assert "minVolume" not in screen["filters"]
     assert _matches_preset_filters(matching, screen["filters"]) is True
@@ -42,20 +42,28 @@ def test_leaders_in_leading_groups_preset_filters_for_v1_contract():
     ) is False
 
 
-def test_leaders_effective_filters_inherit_market_defaults():
+def test_resolved_leaders_filters_materialize_market_defaults():
     screen = _leaders_screen()
 
-    filters = _effective_preset_filters(screen, {"minVolume": 1_300_000})
+    [resolved_screen] = resolve_preset_screens_for_defaults(
+        [screen],
+        {"minVolume": 1_300_000},
+    )
 
-    assert filters == {
+    assert resolved_screen["filters"] == {
         "minVolume": 1_300_000,
         "ibdGroupRank": {"min": None, "max": 40},
         "rsRating": {"min": 80, "max": None},
     }
+    assert "minVolume" not in screen["filters"]
 
 
-def test_preset_chart_symbols_apply_inherited_market_defaults():
+def test_preset_chart_symbols_use_resolved_market_defaults():
     screen = _leaders_screen()
+    [resolved_screen] = resolve_preset_screens_for_defaults(
+        [screen],
+        {"minVolume": 1_300_000},
+    )
     rows = [
         {
             "symbol": "LIQUID",
@@ -75,9 +83,8 @@ def test_preset_chart_symbols_apply_inherited_market_defaults():
 
     assert get_preset_chart_symbols(
         rows,
-        presets=[screen],
+        presets=[resolved_screen],
         top_n=5,
-        default_filters={"minVolume": 1_300_000},
     ) == {"LIQUID"}
 
 

--- a/backend/tests/unit/test_preset_screens.py
+++ b/backend/tests/unit/test_preset_screens.py
@@ -1,4 +1,9 @@
-from app.services.preset_screens import PRESET_SCREENS, _matches_preset_filters
+from app.services.preset_screens import (
+    PRESET_SCREENS,
+    _effective_preset_filters,
+    _matches_preset_filters,
+    get_preset_chart_symbols,
+)
 
 
 def _leaders_screen():
@@ -16,13 +21,16 @@ def test_leaders_in_leading_groups_preset_filters_for_v1_contract():
         "symbol": "LEAD",
         "ibd_group_rank": 40,
         "rs_rating": 80,
-        "composite_score": 70,
-        "volume": 100_000_000,
+        "composite_score": 64.23,
+        "volume": 1_500_000,
     }
 
     assert screen["name"] == "Leaders in Leading Groups"
     assert screen["sort_by"] == "composite_score"
     assert screen["sort_order"] == "desc"
+    assert screen["apply_default_filters"] is True
+    assert "compositeScore" not in screen["filters"]
+    assert "minVolume" not in screen["filters"]
     assert _matches_preset_filters(matching, screen["filters"]) is True
     assert _matches_preset_filters(
         {**matching, "ibd_group_rank": 41},
@@ -32,11 +40,52 @@ def test_leaders_in_leading_groups_preset_filters_for_v1_contract():
         {**matching, "rs_rating": 79},
         screen["filters"],
     ) is False
+
+
+def test_leaders_effective_filters_inherit_market_defaults():
+    screen = _leaders_screen()
+
+    filters = _effective_preset_filters(screen, {"minVolume": 1_300_000})
+
+    assert filters == {
+        "minVolume": 1_300_000,
+        "ibdGroupRank": {"min": None, "max": 40},
+        "rsRating": {"min": 80, "max": None},
+    }
+
+
+def test_preset_chart_symbols_apply_inherited_market_defaults():
+    screen = _leaders_screen()
+    rows = [
+        {
+            "symbol": "LIQUID",
+            "ibd_group_rank": 10,
+            "rs_rating": 90,
+            "volume": 2_000_000,
+            "composite_score": 64.0,
+        },
+        {
+            "symbol": "THIN",
+            "ibd_group_rank": 5,
+            "rs_rating": 99,
+            "volume": 900_000,
+            "composite_score": 99.0,
+        },
+    ]
+
+    assert get_preset_chart_symbols(
+        rows,
+        presets=[screen],
+        top_n=5,
+        default_filters={"minVolume": 1_300_000},
+    ) == {"LIQUID"}
+
+
+def test_noop_scalar_and_range_filters_match_like_frontend():
+    row = {"symbol": "ROW", "volume": None, "composite_score": None}
+
+    assert _matches_preset_filters(row, {"minVolume": None}) is True
     assert _matches_preset_filters(
-        {**matching, "composite_score": 69},
-        screen["filters"],
-    ) is False
-    assert _matches_preset_filters(
-        {**matching, "volume": 99_999_999},
-        screen["filters"],
-    ) is False
+        row,
+        {"compositeScore": {"min": None, "max": None}},
+    ) is True

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -508,6 +508,12 @@ def test_export_scan_bundle_chunks_large_result_sets(service_and_session_factory
     assert manifest["chunk_size"] == 3
     assert manifest["rows_total"] == 5
     assert manifest["default_filters"] == {"minVolume": 100_000_000}
+    leaders_screen = next(
+        screen for screen in manifest["preset_screens"]
+        if screen["id"] == "leaders_in_leading_groups"
+    )
+    assert "apply_default_filters" not in leaders_screen
+    assert leaders_screen["filters"]["minVolume"] == 100_000_000
     assert manifest["default_filtered_rows_total"] == 3
     assert [row["symbol"] for row in manifest["initial_rows"]] == ["SYM0", "SYM2", "SYM4"]
     assert [row["symbol"] for row in manifest["preview_rows"]] == ["SYM0", "SYM2", "SYM4"]
@@ -639,6 +645,11 @@ def test_export_scan_bundle_uses_sg_threshold_for_sg_market(
         )
 
     assert manifest["default_filters"] == {"minVolume": 1_300_000}
+    leaders_screen = next(
+        screen for screen in manifest["preset_screens"]
+        if screen["id"] == "leaders_in_leading_groups"
+    )
+    assert leaders_screen["filters"]["minVolume"] == 1_300_000
     assert manifest["default_filtered_rows_total"] == 3
     assert [row["symbol"] for row in manifest["initial_rows"]] == ["SG0", "SG1", "SG2"]
 
@@ -700,6 +711,11 @@ def test_export_scan_bundle_unknown_market_disables_volume_filter(
         )
 
     assert manifest["default_filters"] == {"minVolume": None}
+    leaders_screen = next(
+        screen for screen in manifest["preset_screens"]
+        if screen["id"] == "leaders_in_leading_groups"
+    )
+    assert leaders_screen["filters"]["minVolume"] is None
     assert manifest["default_filtered_rows_total"] == manifest["rows_total"] == 2
 
 

--- a/frontend/src/static/hooks/usePresetScreens.js
+++ b/frontend/src/static/hooks/usePresetScreens.js
@@ -2,18 +2,14 @@ import { useMemo, useState } from 'react';
 import { applyScanFilterDefaults } from '../../features/scan/defaultFilters';
 import { filterStaticScanRows } from '../scanClient';
 
-export function buildFiltersFromPreset(screen, defaultFilters = {}) {
-  return applyScanFilterDefaults({
-    ...(screen.apply_default_filters ? defaultFilters : {}),
-    ...screen.filters,
-  });
+export function buildFiltersFromPreset(screen) {
+  return applyScanFilterDefaults(screen?.filters ?? {});
 }
 
 export function usePresetScreens({
   screens,
   allRows,
   hydrationComplete,
-  defaultFilters = {},
 }) {
   const [activeScreenId, setActiveScreenId] = useState(null);
 
@@ -22,10 +18,10 @@ export function usePresetScreens({
     return Object.fromEntries(
       screens.map((s) => [
         s.id,
-        filterStaticScanRows(allRows, buildFiltersFromPreset(s, defaultFilters)).length,
+        filterStaticScanRows(allRows, buildFiltersFromPreset(s)).length,
       ]),
     );
-  }, [allRows, defaultFilters, hydrationComplete, screens]);
+  }, [allRows, hydrationComplete, screens]);
 
   return { activeScreenId, setActiveScreenId, matchCounts };
 }

--- a/frontend/src/static/hooks/usePresetScreens.js
+++ b/frontend/src/static/hooks/usePresetScreens.js
@@ -2,11 +2,19 @@ import { useMemo, useState } from 'react';
 import { applyScanFilterDefaults } from '../../features/scan/defaultFilters';
 import { filterStaticScanRows } from '../scanClient';
 
-export function buildFiltersFromPreset(screen) {
-  return applyScanFilterDefaults(screen.filters);
+export function buildFiltersFromPreset(screen, defaultFilters = {}) {
+  return applyScanFilterDefaults({
+    ...(screen.apply_default_filters ? defaultFilters : {}),
+    ...screen.filters,
+  });
 }
 
-export function usePresetScreens({ screens, allRows, hydrationComplete }) {
+export function usePresetScreens({
+  screens,
+  allRows,
+  hydrationComplete,
+  defaultFilters = {},
+}) {
   const [activeScreenId, setActiveScreenId] = useState(null);
 
   const matchCounts = useMemo(() => {
@@ -14,10 +22,10 @@ export function usePresetScreens({ screens, allRows, hydrationComplete }) {
     return Object.fromEntries(
       screens.map((s) => [
         s.id,
-        filterStaticScanRows(allRows, buildFiltersFromPreset(s)).length,
+        filterStaticScanRows(allRows, buildFiltersFromPreset(s, defaultFilters)).length,
       ]),
     );
-  }, [allRows, hydrationComplete, screens]);
+  }, [allRows, defaultFilters, hydrationComplete, screens]);
 
   return { activeScreenId, setActiveScreenId, matchCounts };
 }

--- a/frontend/src/static/pages/StaticHomePage.jsx
+++ b/frontend/src/static/pages/StaticHomePage.jsx
@@ -118,12 +118,12 @@ function StaticHomePage() {
       return EMPTY_RESULTS;
     }
     return sortStaticScanRows(
-      filterStaticScanRows(scanRows, buildFiltersFromPreset(leadingGroupScreen, scanDefaultFilters)),
+      filterStaticScanRows(scanRows, buildFiltersFromPreset(leadingGroupScreen)),
       leadingGroupScreen.sort_by,
       leadingGroupScreen.sort_order,
       { prioritizeCompositeScanMode: false }
     ).slice(0, DEFAULT_TOP_RESULTS);
-  }, [leadingGroupScreen, scanDefaultFilters, scanRows]);
+  }, [leadingGroupScreen, scanRows]);
 
   const chartEntries = useMemo(() => chartIndexQuery.data?.symbols || [], [chartIndexQuery.data]);
   const chartEnabledSymbols = useMemo(() => new Set(chartEntries.map((e) => e.symbol)), [chartEntries]);

--- a/frontend/src/static/pages/StaticHomePage.jsx
+++ b/frontend/src/static/pages/StaticHomePage.jsx
@@ -34,7 +34,6 @@ import DailyScanRowsTable from '../components/DailyScanRowsTable';
 import { buildFiltersFromPreset } from '../hooks/usePresetScreens';
 
 const EMPTY_RESULTS = [];
-const DEFAULT_MIN_VOLUME = 100_000_000;
 const DEFAULT_TOP_RESULTS = 20;
 const LEADERS_SCREEN_ID = 'leaders_in_leading_groups';
 
@@ -76,6 +75,7 @@ function StaticHomePage() {
       });
       return {
         rows: Array.from(rowsBySymbol.values()),
+        defaultFilters: scanManifest.default_filters || {},
         presetScreens: scanManifest.preset_screens || [],
       };
     },
@@ -90,12 +90,16 @@ function StaticHomePage() {
   const [modalNavigationSymbols, setModalNavigationSymbols] = useState([]);
   const [marketCapMin, setMarketCapMin] = useState('');
   const topGroups = homeQuery.data?.top_groups ?? EMPTY_RESULTS;
+  const scanDefaultFilters = useMemo(
+    () => scanBundleQuery.data?.defaultFilters ?? {},
+    [scanBundleQuery.data?.defaultFilters]
+  );
   const topCandidateFilters = useMemo(
     () => applyScanFilterDefaults({
-      minVolume: DEFAULT_MIN_VOLUME,
+      ...scanDefaultFilters,
       ...(marketCapMin !== '' ? { marketCapUsd: { min: Number(marketCapMin), max: null } } : {}),
     }),
-    [marketCapMin]
+    [marketCapMin, scanDefaultFilters]
   );
   const scanRows = scanBundleQuery.data?.rows ?? EMPTY_RESULTS;
   const topResults = useMemo(() => {
@@ -114,12 +118,12 @@ function StaticHomePage() {
       return EMPTY_RESULTS;
     }
     return sortStaticScanRows(
-      filterStaticScanRows(scanRows, buildFiltersFromPreset(leadingGroupScreen)),
+      filterStaticScanRows(scanRows, buildFiltersFromPreset(leadingGroupScreen, scanDefaultFilters)),
       leadingGroupScreen.sort_by,
       leadingGroupScreen.sort_order,
       { prioritizeCompositeScanMode: false }
     ).slice(0, DEFAULT_TOP_RESULTS);
-  }, [leadingGroupScreen, scanRows]);
+  }, [leadingGroupScreen, scanDefaultFilters, scanRows]);
 
   const chartEntries = useMemo(() => chartIndexQuery.data?.symbols || [], [chartIndexQuery.data]);
   const chartEnabledSymbols = useMemo(() => new Set(chartEntries.map((e) => e.symbol)), [chartEntries]);
@@ -261,7 +265,11 @@ function StaticHomePage() {
       <DailyScanRowsTable
         testId="top-scan-candidates-section"
         title="Top Scan Candidates"
-        subtitle="Dollar volume > $100M. Click a row for chart details."
+        subtitle={
+          topCandidateFilters.minVolume == null
+            ? 'No default liquidity floor. Click a row for chart details.'
+            : `Dollar volume >= ${formatNumber(topCandidateFilters.minVolume)}. Click a row for chart details.`
+        }
         rows={topResults}
         chartEnabledSymbols={chartEnabledSymbols}
         navigationSymbols={topNavigationSymbols}
@@ -293,7 +301,7 @@ function StaticHomePage() {
       <DailyScanRowsTable
         testId="leaders-in-leading-groups-section"
         title="Leaders in Leading Groups"
-        subtitle="Top 20 by report card: group rank <=40, RS >=80, score >=70, dollar volume >= $100M."
+        subtitle="Top 20 by report card: group rank <=40, RS >=80, using this market's default liquidity floor."
         rows={leadingGroupRows}
         chartEnabledSymbols={chartEnabledSymbols}
         navigationSymbols={leadingGroupNavigationSymbols}

--- a/frontend/src/static/pages/StaticHomePage.jsx
+++ b/frontend/src/static/pages/StaticHomePage.jsx
@@ -135,6 +135,10 @@ function StaticHomePage() {
     () => leadingGroupRows.map((r) => r.symbol).filter((s) => chartEnabledSymbols.has(s)),
     [leadingGroupRows, chartEnabledSymbols],
   );
+  const leadingGroupMinVolume = leadingGroupScreen?.filters?.minVolume;
+  const leadingGroupSubtitle = leadingGroupMinVolume == null
+    ? 'Top 20 by report card: group rank <=40, RS >=80.'
+    : `Top 20 by report card: group rank <=40, RS >=80, dollar volume >= ${formatNumber(leadingGroupMinVolume)}.`;
 
   if (manifestQuery.isLoading || homeQuery.isLoading || scanBundleQuery.isLoading) {
     return (
@@ -301,7 +305,7 @@ function StaticHomePage() {
       <DailyScanRowsTable
         testId="leaders-in-leading-groups-section"
         title="Leaders in Leading Groups"
-        subtitle="Top 20 by report card: group rank <=40, RS >=80, using this market's default liquidity floor."
+        subtitle={leadingGroupSubtitle}
         rows={leadingGroupRows}
         chartEnabledSymbols={chartEnabledSymbols}
         navigationSymbols={leadingGroupNavigationSymbols}

--- a/frontend/src/static/pages/StaticHomePage.test.jsx
+++ b/frontend/src/static/pages/StaticHomePage.test.jsx
@@ -64,20 +64,20 @@ const manifest = {
   },
 };
 
-const leadersPresetScreen = {
+const makeLeadersPresetScreen = (minVolume = 100_000_000) => ({
   id: 'leaders_in_leading_groups',
   name: 'Leaders in Leading Groups',
   short_name: 'Leaders',
   description: 'Strong report-card stocks in top 40 IBD groups',
   tier: 2,
-  apply_default_filters: true,
   filters: {
+    minVolume,
     ibdGroupRank: { min: null, max: 40 },
     rsRating: { min: 80, max: null },
   },
   sort_by: 'composite_score',
   sort_order: 'desc',
-};
+});
 
 const makeLeaderRow = (index, overrides = {}) => ({
   symbol: `LEAD${String(index).padStart(2, '0')}`,
@@ -154,7 +154,7 @@ describe('StaticHomePage', () => {
       chunks: [
         { path: 'markets/us/scan/chunks/chunk-0001.json' },
       ],
-      preset_screens: [leadersPresetScreen],
+      preset_screens: [makeLeadersPresetScreen()],
     };
     scanChunkPayload = {
       rows: [
@@ -302,6 +302,7 @@ describe('StaticHomePage', () => {
 
   it('uses the static scan manifest default volume for Daily top candidates', async () => {
     scanManifestPayload.default_filters = { minVolume: 1_300_000 };
+    scanManifestPayload.preset_screens = [makeLeadersPresetScreen(1_300_000)];
     scanManifestPayload.initial_rows = [
       {
         symbol: 'LOCALPASS',
@@ -338,6 +339,7 @@ describe('StaticHomePage', () => {
 
   it('uses market liquidity defaults and composite ranking for leaders in leading groups', async () => {
     scanManifestPayload.default_filters = { minVolume: 1_300_000 };
+    scanManifestPayload.preset_screens = [makeLeadersPresetScreen(1_300_000)];
     scanManifestPayload.initial_rows = [
       makeLeaderRow(1, {
         symbol: 'LOCALLEAD',
@@ -402,7 +404,7 @@ describe('StaticHomePage', () => {
           chunks: [
             { path: 'markets/us/scan/chunks/chunk-0001.json' },
           ],
-          preset_screens: [leadersPresetScreen],
+          preset_screens: [makeLeadersPresetScreen()],
         };
       }
 

--- a/frontend/src/static/pages/StaticHomePage.test.jsx
+++ b/frontend/src/static/pages/StaticHomePage.test.jsx
@@ -70,11 +70,10 @@ const leadersPresetScreen = {
   short_name: 'Leaders',
   description: 'Strong report-card stocks in top 40 IBD groups',
   tier: 2,
+  apply_default_filters: true,
   filters: {
     ibdGroupRank: { min: null, max: 40 },
     rsRating: { min: 80, max: null },
-    compositeScore: { min: 70, max: null },
-    minVolume: 100_000_000,
   },
   sort_by: 'composite_score',
   sort_order: 'desc',
@@ -137,6 +136,7 @@ describe('StaticHomePage', () => {
       top_groups: [],
     };
     scanManifestPayload = {
+      default_filters: { minVolume: 100_000_000 },
       initial_rows: [
         {
           symbol: 'NVDA',
@@ -298,6 +298,69 @@ describe('StaticHomePage', () => {
         navigationSymbols: ['NVDA', 'AAPL'],
       });
     });
+  });
+
+  it('uses the static scan manifest default volume for Daily top candidates', async () => {
+    scanManifestPayload.default_filters = { minVolume: 1_300_000 };
+    scanManifestPayload.initial_rows = [
+      {
+        symbol: 'LOCALPASS',
+        company_name: 'Local Liquid',
+        composite_score: 88.0,
+        current_price: 12,
+        rating: 'Buy',
+        volume: 5_000_000,
+        market_cap: 2_000_000_000,
+        currency: 'SGD',
+        price_sparkline_data: null,
+        rs_sparkline_data: null,
+      },
+      {
+        symbol: 'TOOTHIN',
+        company_name: 'Too Thin',
+        composite_score: 99.0,
+        current_price: 8,
+        rating: 'Buy',
+        volume: 900_000,
+        market_cap: 2_000_000_000,
+        currency: 'SGD',
+        price_sparkline_data: null,
+        rs_sparkline_data: null,
+      },
+    ];
+    scanManifestPayload.chunks = [];
+
+    renderWithProviders(<StaticHomePage />);
+
+    expect(await screen.findByText('LOCALPASS')).toBeInTheDocument();
+    expect(screen.queryByText('TOOTHIN')).not.toBeInTheDocument();
+  });
+
+  it('uses market liquidity defaults and composite ranking for leaders in leading groups', async () => {
+    scanManifestPayload.default_filters = { minVolume: 1_300_000 };
+    scanManifestPayload.initial_rows = [
+      makeLeaderRow(1, {
+        symbol: 'LOCALLEAD',
+        composite_score: 64.23,
+        rs_rating: 94.94,
+        volume: 2_000_000,
+        ibd_group_rank: 26,
+      }),
+      makeLeaderRow(2, {
+        symbol: 'THINLEAD',
+        composite_score: 65.0,
+        rs_rating: 99,
+        volume: 900_000,
+        ibd_group_rank: 10,
+      }),
+    ];
+    scanManifestPayload.chunks = [];
+
+    renderWithProviders(<StaticHomePage />);
+
+    const leadersSection = await screen.findByTestId('leaders-in-leading-groups-section');
+    expect(within(leadersSection).getByText('LOCALLEAD')).toBeInTheDocument();
+    expect(within(leadersSection).queryByText('THINLEAD')).not.toBeInTheDocument();
   });
 
   it('shows top 20 leaders in leading groups after top scan candidates with leader-scoped chart navigation', async () => {

--- a/frontend/src/static/pages/StaticHomePage.test.jsx
+++ b/frontend/src/static/pages/StaticHomePage.test.jsx
@@ -361,8 +361,34 @@ describe('StaticHomePage', () => {
     renderWithProviders(<StaticHomePage />);
 
     const leadersSection = await screen.findByTestId('leaders-in-leading-groups-section');
+    expect(
+      within(leadersSection).getByText('Top 20 by report card: group rank <=40, RS >=80, dollar volume >= 1,300,000.')
+    ).toBeInTheDocument();
     expect(within(leadersSection).getByText('LOCALLEAD')).toBeInTheDocument();
     expect(within(leadersSection).queryByText('THINLEAD')).not.toBeInTheDocument();
+  });
+
+  it('omits the leaders liquidity subtitle when the resolved preset has no volume floor', async () => {
+    scanManifestPayload.default_filters = { minVolume: null };
+    scanManifestPayload.preset_screens = [makeLeadersPresetScreen(null)];
+    scanManifestPayload.initial_rows = [
+      makeLeaderRow(1, {
+        symbol: 'NOFLOOR',
+        volume: 1,
+        ibd_group_rank: 10,
+        rs_rating: 90,
+      }),
+    ];
+    scanManifestPayload.chunks = [];
+
+    renderWithProviders(<StaticHomePage />);
+
+    const leadersSection = await screen.findByTestId('leaders-in-leading-groups-section');
+    expect(
+      within(leadersSection).getByText('Top 20 by report card: group rank <=40, RS >=80.')
+    ).toBeInTheDocument();
+    expect(within(leadersSection).queryByText(/dollar volume >=/i)).not.toBeInTheDocument();
+    expect(within(leadersSection).getByText('NOFLOOR')).toBeInTheDocument();
   });
 
   it('shows top 20 leaders in leading groups after top scan candidates with leader-scoped chart navigation', async () => {

--- a/frontend/src/static/pages/StaticScanPage.jsx
+++ b/frontend/src/static/pages/StaticScanPage.jsx
@@ -182,7 +182,6 @@ function StaticScanPage() {
     screens: presetScreens,
     allRows: hydratedRows,
     hydrationComplete,
-    defaultFilters: manifestDefaultFilterValues,
   });
 
   const handleSelectScreen = useCallback((screenId) => {
@@ -194,14 +193,13 @@ function StaticScanPage() {
     } else {
       const screen = presetScreens?.find((s) => s.id === screenId);
       if (screen) {
-        setFilters(buildFiltersFromPreset(screen, manifestDefaultFilterValues));
+        setFilters(buildFiltersFromPreset(screen));
         setSortBy(screen.sort_by);
         setSortOrder(screen.sort_order);
       }
     }
   }, [
     presetScreens,
-    manifestDefaultFilterValues,
     manifestDefaultFilters,
     manifestDefaultSortBy,
     manifestDefaultSortOrder,

--- a/frontend/src/static/pages/StaticScanPage.jsx
+++ b/frontend/src/static/pages/StaticScanPage.jsx
@@ -66,9 +66,13 @@ function StaticScanPage() {
     }),
     []
   );
-  const manifestDefaultFilters = useMemo(
-    () => applyScanFilterDefaults(scanManifestQuery.data?.default_filters),
+  const manifestDefaultFilterValues = useMemo(
+    () => scanManifestQuery.data?.default_filters ?? {},
     [scanManifestQuery.data?.default_filters]
+  );
+  const manifestDefaultFilters = useMemo(
+    () => applyScanFilterDefaults(manifestDefaultFilterValues),
+    [manifestDefaultFilterValues]
   );
   const manifestDefaultSortBy = scanManifestQuery.data?.sort?.field ?? 'composite_score';
   const manifestDefaultSortOrder = scanManifestQuery.data?.sort?.order ?? 'desc';
@@ -178,6 +182,7 @@ function StaticScanPage() {
     screens: presetScreens,
     allRows: hydratedRows,
     hydrationComplete,
+    defaultFilters: manifestDefaultFilterValues,
   });
 
   const handleSelectScreen = useCallback((screenId) => {
@@ -189,12 +194,19 @@ function StaticScanPage() {
     } else {
       const screen = presetScreens?.find((s) => s.id === screenId);
       if (screen) {
-        setFilters(buildFiltersFromPreset(screen));
+        setFilters(buildFiltersFromPreset(screen, manifestDefaultFilterValues));
         setSortBy(screen.sort_by);
         setSortOrder(screen.sort_order);
       }
     }
-  }, [presetScreens, manifestDefaultFilters, manifestDefaultSortBy, manifestDefaultSortOrder, setActiveScreenId]);
+  }, [
+    presetScreens,
+    manifestDefaultFilterValues,
+    manifestDefaultFilters,
+    manifestDefaultSortBy,
+    manifestDefaultSortOrder,
+    setActiveScreenId,
+  ]);
 
   const filterKey = useMemo(() => getStableFilterKey(filters), [filters]);
   useEffect(() => {

--- a/frontend/src/static/pages/StaticScanPage.test.jsx
+++ b/frontend/src/static/pages/StaticScanPage.test.jsx
@@ -371,8 +371,8 @@ describe('StaticScanPage', () => {
                 short_name: 'Leaders',
                 description: 'Strong report-card stocks in top 40 IBD groups',
                 tier: 2,
-                apply_default_filters: true,
                 filters: {
+                  minVolume: 100000000,
                   ibdGroupRank: { min: null, max: 40 },
                   rsRating: { min: 80, max: null },
                 },

--- a/frontend/src/static/pages/StaticScanPage.test.jsx
+++ b/frontend/src/static/pages/StaticScanPage.test.jsx
@@ -320,7 +320,7 @@ describe('StaticScanPage', () => {
             run_id: 9,
             sort: { field: 'composite_score', order: 'desc' },
             default_page_size: 50,
-            rows_total: 3,
+            rows_total: 4,
             default_filters: { minVolume: 100000000 },
             default_filtered_rows_total: 3,
             filter_options: {
@@ -355,6 +355,14 @@ describe('StaticScanPage', () => {
                 volume: 150000000,
                 ibd_group_rank: 41,
               },
+              {
+                symbol: 'THINLEAD',
+                company_name: 'Thin Leader Inc',
+                composite_score: 99,
+                rs_rating: 99,
+                volume: 500000,
+                ibd_group_rank: 5,
+              },
             ],
             preset_screens: [
               {
@@ -363,11 +371,10 @@ describe('StaticScanPage', () => {
                 short_name: 'Leaders',
                 description: 'Strong report-card stocks in top 40 IBD groups',
                 tier: 2,
+                apply_default_filters: true,
                 filters: {
                   ibdGroupRank: { min: null, max: 40 },
                   rsRating: { min: 80, max: null },
-                  compositeScore: { min: 70, max: null },
-                  minVolume: 100000000,
                 },
                 sort_by: 'composite_score',
                 sort_order: 'desc',
@@ -410,6 +417,7 @@ describe('StaticScanPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('results-table-rows')).toHaveTextContent('IPOLEAD,LEAD');
       expect(screen.getByTestId('results-table-rows')).not.toHaveTextContent('LATE');
+      expect(screen.getByTestId('results-table-rows')).not.toHaveTextContent('THINLEAD');
     });
   });
 


### PR DESCRIPTION
## Summary
- Materialized market-specific default filters into static preset screens during export so the scan manifest is self-contained.
- Simplified the static Daily and Scan pages to consume `preset_screens[*].filters` directly instead of threading inherited defaults through the UI.
- Kept `Leaders in Leading Groups` opinionated but market-aware: top group rank + RS criteria, with liquidity resolved per market.
- Updated chart expansion to use the resolved preset list and covered the new contract with backend and frontend tests.

## Testing
- Backend unit tests for preset resolution, scan filter parsing, and static export passed.
- Frontend Vitest coverage for `StaticHomePage`, `StaticScanPage`, and `scanClient` passed.
- Full frontend test suite passed, and lint/whitespace checks were clean aside from two pre-existing warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Preset screens now apply market-specific default filters instead of hardcoded values
  * Updated "Leaders in Leading Groups" to use ranking and rating metrics for filtering
  * Improved preset descriptions to accurately reflect market-specific liquidity thresholds

* **Bug Fixes**
  * Enhanced filter logic to handle missing or undefined filter values gracefully

<!-- end of auto-generated comment: release notes by coderabbit.ai -->