### PR TITLE
feat(groups): Relative Rotation Graph (RRG) for IBD groups & sectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ GATE_4 = \
 GATE_5 = \
   tests/unit/golden/test_golden_detectors.py \
   tests/unit/golden/test_golden_aggregator.py \
-  tests/unit/golden/test_golden_scanner.py
+  tests/unit/golden/test_golden_scanner.py \
+  tests/unit/golden/test_golden_rrg.py
 
 # ── Market-Parity Gate (E6) ─────────────────────────────────────────
 # US parity and non-US correctness for the market-normalization epic.

--- a/backend/app/api/v1/groups.py
+++ b/backend/app/api/v1/groups.py
@@ -19,6 +19,7 @@ from ...schemas.groups import (
     GroupRankingsResponse,
     GroupDetailResponse,
     MoversResponse,
+    RRGResponse,
     CalculationRequest,
     CalculationResponse,
     CalculationStatusResponse,
@@ -29,6 +30,7 @@ from ...schemas.ui_view_snapshot import UISnapshotEnvelope
 from ...domain.analytics.scope import market_scope_tag
 from ...domain.markets.catalog import get_market_catalog
 from ...services.market_group_ranking_service import get_market_group_ranking_service
+from ...services.rrg_service import RRGService
 from ...services.ui_snapshot_service import GroupsBootstrapUnavailableError
 from ...wiring.bootstrap import get_group_rank_service, get_ui_snapshot_service
 
@@ -135,6 +137,49 @@ async def get_current_rankings(
         date=ranking_date,
         total_groups=len(rankings),
         rankings=[GroupRankResponse(**r) for r in rankings],
+        **market_scope_tag(normalized_market),
+    )
+
+
+@router.get("/rrg", response_model=RRGResponse)
+async def get_rrg(
+    tail_weeks: int = Query(8, ge=2, le=20, description="Number of weekly tail points"),
+    scope: str = Query(
+        "groups", pattern="^(groups|sectors)$", description="groups or sectors"
+    ),
+    limit: int = Query(197, ge=1, le=197, description="Top-N series by rank"),
+    market: str = Query("US", description=MARKET_QUERY_DESCRIPTION),
+    db: Session = Depends(get_db),
+):
+    """Relative Rotation Graph coordinates for IBD groups (or GICS-sector roll-ups).
+
+    Each series carries its current (RS-Ratio, RS-Momentum) point plus a weekly
+    tail tracing its path through the Leading/Weakening/Lagging/Improving
+    quadrants. Math is computed server-side (see ``services/rrg_service.py``).
+    """
+    normalized_market = _normalize_market_param(market)
+    service = RRGService(group_rank_service=_get_group_rank_service())
+    payload = service.get_rrg(
+        db, market=normalized_market, scope=scope, tail_weeks=tail_weeks
+    )
+
+    groups = payload["groups"][:limit]
+    if not groups:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "No RRG data available for this market. "
+                "Run a group-ranking backfill first."
+            ),
+        )
+
+    return RRGResponse(
+        date=payload["date"],
+        market=normalized_market,
+        scope=scope,
+        tail_weeks=tail_weeks,
+        total_groups=len(groups),
+        groups=groups,
         **market_scope_tag(normalized_market),
     )
 

--- a/backend/app/schemas/groups.py
+++ b/backend/app/schemas/groups.py
@@ -117,6 +117,45 @@ class MoversResponse(ScopedResponseMixin):
     losers: List[GroupRankResponse] = Field(..., description="Groups with biggest rank declines")
 
 
+class RRGPoint(BaseModel):
+    """A single point on a group's RRG tail."""
+
+    date: str = Field(..., description="Week-start date (YYYY-MM-DD, UTC Sunday origin)")
+    x: float = Field(..., description="RS-Ratio (centered at 100)")
+    y: float = Field(..., description="RS-Momentum (centered at 100)")
+
+
+class RRGGroupResponse(BaseModel):
+    """One group's (or sector's) RRG coordinate plus its recent tail."""
+
+    industry_group: str = Field(..., description="Group or sector name")
+    rank: Optional[int] = Field(None, description="Latest rank (1 = best)")
+    num_stocks: Optional[int] = Field(None, description="Constituent count (dot size)")
+    avg_rs_rating: Optional[float] = Field(None, description="Latest average RS rating")
+    quadrant: str = Field(
+        ..., description="Leading | Weakening | Lagging | Improving"
+    )
+    is_provisional: bool = Field(
+        False, description="True when history was too short for a full-confidence window"
+    )
+    current: RRGPoint = Field(..., description="Most recent point (== tail[-1])")
+    tail: List[RRGPoint] = Field(..., description="Weekly points, oldest -> newest")
+
+
+class RRGResponse(ScopedResponseMixin):
+    """Relative Rotation Graph payload for a market + scope."""
+
+    date: str = Field(..., description="As-of date (latest ranking date)")
+    market: str = Field(..., description="Market code")
+    scope: str = Field(..., description="groups | sectors")
+    normalization: str = Field(
+        "temporal", description="RS-Ratio/Momentum normalization frame"
+    )
+    tail_weeks: int = Field(..., description="Number of weekly tail points requested")
+    total_groups: int = Field(..., description="Number of plotted groups/sectors")
+    groups: List[RRGGroupResponse] = Field(..., description="Plotted series")
+
+
 class CalculationRequest(BaseModel):
     """Request model for manual ranking calculation"""
 

--- a/backend/app/services/rrg_service.py
+++ b/backend/app/services/rrg_service.py
@@ -254,6 +254,7 @@ class RRGService:
             .join(StockUniverse, StockUniverse.symbol == IBDIndustryGroup.symbol)
             .filter(
                 IBDIndustryGroup.market == market,
+                StockUniverse.market == market,
                 StockUniverse.sector.isnot(None),
             )
             .all()

--- a/backend/app/services/rrg_service.py
+++ b/backend/app/services/rrg_service.py
@@ -1,0 +1,454 @@
+"""Relative Rotation Graph (RRG) service.
+
+Turns the stored daily ``ibd_group_ranks.avg_rs_rating`` time series into the
+RS-Ratio (x) / RS-Momentum (y) coordinate pair plus a weekly "tail" that traces
+each group's (or sector's) path through the four RRG quadrants:
+
+    Leading (x>=100, y>=100)   — strong and getting stronger
+    Weakening (x>=100, y<100)  — strong but momentum rolling over
+    Lagging (x<100, y<100)     — weak and getting weaker
+    Improving (x<100, y>=100)  — weak but momentum turning up
+
+Design notes
+------------
+* ``avg_rs_rating`` is already a 0-100 *cross-sectional* percentile (RS vs the
+  benchmark universe). We therefore normalize **temporally** — z-scoring each
+  group against its *own* trailing history — rather than cross-sectionally again,
+  which would double-normalize and largely re-encode the existing rank column.
+  A ``frame`` hook is left for a future cross-sectional A/B without an API break.
+* All the heavy lifting here is **pure** float math (no DB, no pandas, no RNG),
+  so it is golden-snapshot testable under ``make gate-5``. The DB-aware
+  orchestrator (``RRGService``) imports sqlalchemy/models lazily inside its
+  methods so this module stays importable without the full app bootstrap.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Tunable constants (module-level so they can be adjusted without touching the
+# call sites and so tests can reference them by name).
+# ---------------------------------------------------------------------------
+
+SMOOTH_RATIO_SPAN = 5       # EMA span (weekly points) applied to the raw RS series
+Z_WINDOW = 26               # trailing window (weeks) for the RS-Ratio z-score
+RATIO_SCALE = 5.0           # ±2σ -> roughly 90..110 (conventional RRG band)
+MOM_WINDOW = 4              # lookback (weeks) for the RS-Ratio rate-of-change
+SMOOTH_MOM_SPAN = 3         # EMA span (weekly points) applied to the momentum ROC
+MOM_Z_WINDOW = 13           # trailing window (weeks) for the RS-Momentum z-score
+MOM_SCALE = 5.0             # momentum display scale (matches ratio for a square plot)
+DISPLAY_CLAMP: Tuple[float, float] = (80.0, 120.0)  # guardrail against outliers
+
+MIN_TAIL_WEEKS = 12         # below this, a group is omitted entirely
+MIN_WEEKS = Z_WINDOW + MOM_WINDOW   # full-confidence threshold (~30 weeks)
+MAX_FILL_WEEKS = 2          # carry-forward at most this many empty weeks
+
+EPS = 1e-6
+
+DEFAULT_TAIL_WEEKS = 8
+DEFAULT_LOOKBACK_DAYS = 400  # enough daily rows to build Z_WINDOW + tail weeks
+
+
+@dataclass(frozen=True)
+class RRGParams:
+    """Parameters controlling the RRG transform."""
+
+    tail_weeks: int = DEFAULT_TAIL_WEEKS
+    smooth_ratio_span: int = SMOOTH_RATIO_SPAN
+    z_window: int = Z_WINDOW
+    mom_window: int = MOM_WINDOW
+
+
+def _week_start(d: date) -> date:
+    """UTC Sunday-origin start of the ISO-ish week containing ``d``.
+
+    Matches the frontend ``aggregateToWeekly`` rule (JS ``getUTCDay()`` where
+    Sunday==0): ``dow = (weekday()+1) % 7`` maps Mon..Sun -> 1..0, so we step
+    back to the preceding Sunday.
+    """
+    dow = (d.weekday() + 1) % 7
+    return d - timedelta(days=dow)
+
+
+def _bucket_weekly(
+    daily: Sequence[Tuple[date, float]],
+) -> List[Tuple[date, float]]:
+    """Collapse a daily ``(date, value)`` series to one close-of-week point.
+
+    Each week is keyed by its UTC Sunday start; the value kept is the latest
+    trading day's value within that week. Output is ascending by week start.
+    Tolerant of unsorted input.
+    """
+    latest: dict[date, Tuple[date, float]] = {}
+    for d, value in daily:
+        wk = _week_start(d)
+        prev = latest.get(wk)
+        if prev is None or d >= prev[0]:
+            latest[wk] = (d, value)
+    return [(wk, latest[wk][1]) for wk in sorted(latest)]
+
+
+def _ema(values: Sequence[float], span: int) -> List[float]:
+    """Exponential moving average, ``adjust=False`` (seed = first value).
+
+    Equivalent to ``pandas.Series(values).ewm(span=span, adjust=False).mean()``
+    but dependency-free and deterministic.
+    """
+    if not values:
+        return []
+    alpha = 2.0 / (span + 1.0)
+    out = [float(values[0])]
+    for v in values[1:]:
+        out.append(alpha * float(v) + (1.0 - alpha) * out[-1])
+    return out
+
+
+def classify_quadrant(x: float, y: float) -> str:
+    """Map an (RS-Ratio, RS-Momentum) point to its RRG quadrant.
+
+    The 100/100 cross is the origin; boundary values (exactly 100) belong to the
+    strong/rising side so a brand-new "at-typical" series reads as Leading.
+    """
+    strong = x >= 100.0
+    rising = y >= 100.0
+    if strong and rising:
+        return "Leading"
+    if strong and not rising:
+        return "Weakening"
+    if not strong and not rising:
+        return "Lagging"
+    return "Improving"  # weak but rising
+
+
+def _clamp(v: float) -> float:
+    lo, hi = DISPLAY_CLAMP
+    return max(lo, min(hi, v))
+
+
+def _centered_zscore_series(
+    values: Sequence[float], window: int, scale: float
+) -> List[float]:
+    """Per-point trailing temporal z-score, re-centered at 100 and clamped.
+
+    For each index ``i`` the z-score uses the trailing ``window`` values ending
+    at ``i`` (population std). A flat/zero-variance window yields z=0 -> 100 (EPS
+    guard). This is the shared normalization behind both RRG axes — z-scoring
+    each axis against its *own* recent history is what makes points orbit the
+    100/100 center rather than saturate."""
+    out: List[float] = []
+    for i in range(len(values)):
+        start = max(0, i - window + 1)
+        w = values[start : i + 1]
+        n = len(w)
+        mu = sum(w) / n
+        sd = math.sqrt(sum((v - mu) ** 2 for v in w) / n)
+        z = 0.0 if sd < EPS else (values[i] - mu) / sd
+        out.append(_clamp(100.0 + scale * z))
+    return out
+
+
+def _rs_ratio_series(weekly_vals: Sequence[float], params: RRGParams) -> List[float]:
+    """RS-Ratio (x): EMA-smooth the raw RS series, then a trailing temporal
+    z-score centered at 100 over up to ``z_window`` weeks."""
+    smooth = _ema(weekly_vals, params.smooth_ratio_span)
+    return _centered_zscore_series(smooth, params.z_window, RATIO_SCALE)
+
+
+def _rs_momentum_series(rs_ratio: Sequence[float], params: RRGParams) -> List[float]:
+    """RS-Momentum (y): EMA-smoothed rate-of-change of the RS-Ratio, then its
+    OWN trailing temporal z-score centered at 100.
+
+    Returns a list aligned to absolute indices ``[mom_window, len)`` — the j-th
+    entry corresponds to weekly index ``mom_window + j``. Already centered at 100
+    (the caller plots it directly)."""
+    mw = params.mom_window
+    roc = [rs_ratio[i] - rs_ratio[i - mw] for i in range(mw, len(rs_ratio))]
+    roc_smooth = _ema(roc, SMOOTH_MOM_SPAN)
+    return _centered_zscore_series(roc_smooth, MOM_Z_WINDOW, MOM_SCALE)
+
+
+def compute_group_rrg(
+    daily_series: Sequence[Tuple[date, float]],
+    params: Optional[RRGParams] = None,
+) -> Optional[Dict[str, Any]]:
+    """Full RRG pipeline for ONE series (a group or a sector).
+
+    Pure: no DB, no RNG. This is the golden-snapshot surface. Returns a dict
+    ``{current, tail, is_provisional}`` or ``None`` when there is not enough
+    history (< ``MIN_TAIL_WEEKS`` weekly points) to plot a meaningful tail.
+
+    * ``current`` / ``tail`` points are ``{"date", "x", "y"}`` (x=RS-Ratio,
+      y=RS-Momentum, both centered at 100), ascending oldest->newest.
+    * ``is_provisional`` is True when the series is shorter than ``MIN_WEEKS``,
+      so the most recent point used a shortened (sub-``z_window``) window.
+    """
+    params = params or RRGParams()
+    weekly = _bucket_weekly(daily_series)
+    if len(weekly) < MIN_TAIL_WEEKS:
+        return None
+
+    weeks = [w for w, _ in weekly]
+    vals = [v for _, v in weekly]
+
+    rs_ratio = _rs_ratio_series(vals, params)
+    roc_smooth = _rs_momentum_series(rs_ratio, params)
+
+    mw = params.mom_window
+    points: List[Dict[str, Any]] = []
+    for j, y in enumerate(roc_smooth):
+        i = mw + j
+        points.append(
+            {
+                "date": weeks[i].isoformat(),
+                "x": round(rs_ratio[i], 4),
+                "y": round(y, 4),
+            }
+        )
+
+    if not points:
+        return None
+
+    tail = points[-params.tail_weeks :]
+    return {
+        "current": tail[-1],
+        "tail": tail,
+        "is_provisional": len(weekly) < MIN_WEEKS,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DB-aware orchestrator. All sqlalchemy/model imports are LAZY (inside methods)
+# so the pure-math surface above stays importable without the app bootstrap.
+# ---------------------------------------------------------------------------
+
+
+class RRGService:
+    """Builds RRG payloads from the stored daily group-rank history.
+
+    The math lives in the pure functions above; this class only sources the
+    ``avg_rs_rating`` series (one batched query) and decorates each result with
+    rank/num_stocks/quadrant metadata. Sector scope rolls groups up to their
+    dominant GICS sector and aggregates the same series.
+    """
+
+    def __init__(self, *, group_rank_service: Any) -> None:
+        self._group_rank_service = group_rank_service
+
+    def get_group_sector_map(self, db: Any, market: str = "US") -> Dict[str, str]:
+        """Map each IBD industry group -> its constituents' dominant GICS sector.
+
+        Derived from ``StockUniverse.sector`` (fully populated) via a majority
+        vote, since the codebase has no IBD-native sector taxonomy.
+        """
+        from collections import Counter, defaultdict
+
+        from ..models.industry import IBDIndustryGroup
+        from ..models.stock_universe import StockUniverse
+
+        rows = (
+            db.query(IBDIndustryGroup.industry_group, StockUniverse.sector)
+            .join(StockUniverse, StockUniverse.symbol == IBDIndustryGroup.symbol)
+            .filter(
+                IBDIndustryGroup.market == market,
+                StockUniverse.sector.isnot(None),
+            )
+            .all()
+        )
+        votes: dict[str, Counter] = defaultdict(Counter)
+        for group, sector in rows:
+            if sector:
+                votes[group][sector] += 1
+        return {group: ctr.most_common(1)[0][0] for group, ctr in votes.items()}
+
+    def get_rrg(
+        self,
+        db: Any,
+        *,
+        market: str = "US",
+        scope: str = "groups",
+        tail_weeks: int = DEFAULT_TAIL_WEEKS,
+        lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    ) -> Dict[str, Any]:
+        """Assemble the RRG payload for one market + scope (``groups``/``sectors``)."""
+        return self.get_rrg_scopes(
+            db,
+            market=market,
+            scopes=(scope,),
+            tail_weeks=tail_weeks,
+            lookback_days=lookback_days,
+        )[scope]
+
+    def get_rrg_scopes(
+        self,
+        db: Any,
+        *,
+        market: str = "US",
+        scopes: Sequence[str] = ("groups",),
+        tail_weeks: int = DEFAULT_TAIL_WEEKS,
+        lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    ) -> Dict[str, Dict[str, Any]]:
+        """Compute several scopes from a SINGLE input fetch.
+
+        The current rankings + batched history are read once and every requested
+        scope is derived from them, so the static exporter can emit groups and
+        sectors without re-querying. ``get_rrg`` is the single-scope shorthand.
+        """
+        market = (market or "US").upper()
+        params = RRGParams(tail_weeks=tail_weeks)
+        latest_date, meta, group_series = self._fetch_inputs(db, market, lookback_days)
+        if latest_date is None:
+            return {
+                scope: {"date": None, "market": market, "scope": scope, "groups": []}
+                for scope in scopes
+            }
+        return {
+            scope: self._build_scope_payload(
+                db, market, scope, latest_date, meta, group_series, params
+            )
+            for scope in scopes
+        }
+
+    def _fetch_inputs(
+        self, db: Any, market: str, lookback_days: int
+    ) -> Tuple[
+        Optional[str],
+        Dict[str, Dict[str, Any]],
+        Dict[str, List[Tuple[date, float, int]]],
+    ]:
+        """Read the current rankings (metadata) + batched group history (one query)."""
+        from datetime import date as _date
+
+        from ..models.industry import IBDGroupRank
+
+        current = self._group_rank_service.get_current_rankings(
+            db, limit=197, market=market
+        )
+        if not current:
+            return None, {}, {}
+
+        latest_date = current[0]["date"]  # ISO string
+        meta = {row["industry_group"]: row for row in current}
+
+        cutoff = _date.fromisoformat(latest_date) - timedelta(days=lookback_days)
+        rows = (
+            db.query(
+                IBDGroupRank.industry_group,
+                IBDGroupRank.date,
+                IBDGroupRank.avg_rs_rating,
+                IBDGroupRank.num_stocks,
+            )
+            .filter(IBDGroupRank.market == market, IBDGroupRank.date >= cutoff)
+            .order_by(IBDGroupRank.industry_group, IBDGroupRank.date)
+            .all()
+        )
+        return latest_date, meta, self._collect_group_series(rows)
+
+    def _build_scope_payload(
+        self,
+        db: Any,
+        market: str,
+        scope: str,
+        latest_date: str,
+        meta: Dict[str, Dict[str, Any]],
+        group_series: Dict[str, List[Tuple[date, float, int]]],
+        params: RRGParams,
+    ) -> Dict[str, Any]:
+        if scope == "sectors":
+            series, scope_meta = self._aggregate_sectors(db, market, group_series)
+        else:
+            series = {
+                g: [(d, rs) for (d, rs, _ns) in pts]
+                for g, pts in group_series.items()
+            }
+            scope_meta = meta
+
+        groups_out: List[Dict[str, Any]] = []
+        for name, daily in series.items():
+            rrg = compute_group_rrg(daily, params)
+            if rrg is None:
+                continue
+            info = scope_meta.get(name, {})
+            cur = rrg["current"]
+            groups_out.append(
+                {
+                    "industry_group": name,
+                    "rank": info.get("rank"),
+                    "num_stocks": info.get("num_stocks"),
+                    "avg_rs_rating": info.get("avg_rs_rating"),
+                    "quadrant": classify_quadrant(cur["x"], cur["y"]),
+                    "is_provisional": rrg["is_provisional"],
+                    "current": cur,
+                    "tail": rrg["tail"],
+                }
+            )
+
+        groups_out.sort(key=lambda g: (g["rank"] is None, g["rank"] or 0))
+        return {
+            "date": latest_date,
+            "market": market,
+            "scope": scope,
+            "groups": groups_out,
+        }
+
+    @staticmethod
+    def _collect_group_series(
+        rows: Sequence[Tuple[str, date, float, Optional[int]]],
+    ) -> Dict[str, List[Tuple[date, float, int]]]:
+        from collections import defaultdict
+
+        series: dict[str, List[Tuple[date, float, int]]] = defaultdict(list)
+        for group, d, rs, ns in rows:
+            series[group].append((d, float(rs), int(ns or 0)))
+        return series
+
+    def _aggregate_sectors(
+        self,
+        db: Any,
+        market: str,
+        group_series: Dict[str, List[Tuple[date, float, int]]],
+    ) -> Tuple[Dict[str, List[Tuple[date, float]]], Dict[str, Dict[str, Any]]]:
+        """Roll group series up to num_stocks-weighted sector series + sector meta."""
+        from collections import defaultdict
+
+        sector_of = self.get_group_sector_map(db, market)
+        # sector -> date -> [weighted_sum, weight_sum]
+        agg: dict[str, dict[date, List[float]]] = defaultdict(
+            lambda: defaultdict(lambda: [0.0, 0.0])
+        )
+        for group, points in group_series.items():
+            sector = sector_of.get(group)
+            if not sector:
+                continue
+            for d, rs, ns in points:
+                cell = agg[sector][d]
+                cell[0] += rs * ns
+                cell[1] += ns
+
+        series: Dict[str, List[Tuple[date, float]]] = {}
+        meta: Dict[str, Dict[str, Any]] = {}
+        ranked: List[Tuple[str, float]] = []
+        for sector, by_date in agg.items():
+            pts: List[Tuple[date, float]] = []
+            last_weight = 0.0
+            for d in sorted(by_date):
+                wsum, nsum = by_date[d]
+                if nsum > 0:
+                    pts.append((d, wsum / nsum))
+                    last_weight = nsum
+            if not pts:
+                continue
+            series[sector] = pts
+            meta[sector] = {
+                "avg_rs_rating": round(pts[-1][1], 4),
+                "num_stocks": int(last_weight),
+            }
+            ranked.append((sector, pts[-1][1]))
+
+        ranked.sort(key=lambda t: t[1], reverse=True)
+        for rank, (sector, _rs) in enumerate(ranked, start=1):
+            meta[sector]["rank"] = rank
+        return series, meta

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -38,6 +38,7 @@ from app.services.preset_screens import (
     get_preset_chart_symbols,
     resolve_preset_screens_for_defaults,
 )
+from app.services.rrg_service import RRGService
 from app.services.ui_snapshot_service import UISnapshotService
 from app.wiring.bootstrap import (
     get_benchmark_cache,
@@ -387,6 +388,18 @@ class StaticSiteExportService:
                 serialized_rows=serialized_rows,
             ),
         )
+        rrg_payload = self._build_optional_section_payload(
+            section=f"{market} rrg",
+            warnings=warnings,
+            generated_at=generated_at,
+            expected_as_of_date=latest_run.as_of_date,
+            build=lambda: self._build_groups_rrg_payload(
+                db=db,
+                generated_at=generated_at,
+                expected_as_of_date=latest_run.as_of_date,
+                market=market,
+            ),
+        )
         chart_manifest = self._export_chart_bundle(
             output_dir=output_dir,
             generated_at=generated_at,
@@ -436,9 +449,11 @@ class StaticSiteExportService:
 
         breadth_path = path_prefix / "breadth.json"
         groups_path = path_prefix / "groups.json"
+        groups_rrg_path = path_prefix / "groups_rrg.json"
         home_path = path_prefix / "home.json"
         self._write_json(output_dir / breadth_path, breadth_payload)
         self._write_json(output_dir / groups_path, groups_payload)
+        self._write_json(output_dir / groups_rrg_path, rrg_payload)
         self._write_json(output_dir / home_path, home_payload)
 
         return {
@@ -449,6 +464,7 @@ class StaticSiteExportService:
                 "scan": True,
                 "breadth": bool(breadth_payload.get("available", True)),
                 "groups": bool(groups_payload.get("available", False)),
+                "rrg": bool(rrg_payload.get("available", False)),
                 "charts": bool(chart_manifest.get("available", False)),
             },
             "pages": {
@@ -463,6 +479,7 @@ class StaticSiteExportService:
                     "limit": chart_manifest["limit"],
                     "symbols_total": chart_manifest["symbols_total"],
                 },
+                "groups_rrg": {"path": groups_rrg_path.as_posix()},
             },
             "freshness": home_payload.get("freshness", {}),
         }
@@ -570,6 +587,54 @@ class StaticSiteExportService:
         if not market_entries and not allow_empty:
             raise RuntimeError("No market artifacts are available to combine into a static-site bundle")
         return market_entries, warnings
+
+    def _build_groups_rrg_payload(
+        self,
+        *,
+        db: Session,
+        generated_at: str,
+        expected_as_of_date: date,
+        market: str,
+    ) -> dict[str, Any]:
+        """Pre-compute the Relative Rotation Graph payload for the static bundle.
+
+        There is no live API in static mode, so RRG coordinates are baked here
+        using the SAME pure math as the live endpoint (``RRGService`` ->
+        ``compute_group_rrg``), emitting the same ``{date, market, scope,
+        groups[]}`` shape the shared ``RRGChart`` consumes. Both scopes
+        (groups + sectors) are stored so the static page's toggle works offline.
+
+        US reads ``ibd_group_ranks`` directly; non-US markets have no such
+        history yet, so the section is reported unavailable (handled gracefully
+        by the caller). RRG tails want ~30 weekly points (~7 months) of
+        ``avg_rs_rating`` history — when the exported DB is shallower, the math
+        flags ``is_provisional`` / omits thin groups rather than fabricating.
+        """
+        service = RRGService(group_rank_service=get_group_rank_service())
+        scopes = service.get_rrg_scopes(db, market=market, scopes=("groups", "sectors"))
+        groups_rrg = scopes["groups"]
+        sectors_rrg = scopes["sectors"]
+
+        if not groups_rrg.get("groups"):
+            raise StaticSiteSectionUnavailableError(
+                section=f"{market} rrg",
+                reason=(
+                    "No RRG data could be computed (group-rank history is too "
+                    "short or absent for this market)."
+                ),
+            )
+
+        return {
+            "schema_version": STATIC_SITE_SCHEMA_VERSION,
+            "generated_at": generated_at,
+            "available": True,
+            "market": market,
+            "as_of_date": groups_rrg.get("date") or expected_as_of_date.isoformat(),
+            "payload": {
+                "groups": groups_rrg,
+                "sectors": sectors_rrg,
+            },
+        }
 
     def _build_optional_section_payload(
         self,

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -451,10 +451,24 @@ class StaticSiteExportService:
         groups_path = path_prefix / "groups.json"
         groups_rrg_path = path_prefix / "groups_rrg.json"
         home_path = path_prefix / "home.json"
+        rrg_available = bool(rrg_payload.get("available", False))
         self._write_json(output_dir / breadth_path, breadth_payload)
         self._write_json(output_dir / groups_path, groups_payload)
-        self._write_json(output_dir / groups_rrg_path, rrg_payload)
         self._write_json(output_dir / home_path, home_payload)
+
+        assets: dict[str, Any] = {
+            "charts": {
+                "path": chart_manifest["path"],
+                "limit": chart_manifest["limit"],
+                "symbols_total": chart_manifest["symbols_total"],
+            },
+        }
+        # Only publish the RRG asset/file for markets that actually have it, so
+        # the static page hides the RRG toggle (gated on assets.groups_rrg.path)
+        # instead of offering an empty view that triggers a wasted fetch.
+        if rrg_available:
+            self._write_json(output_dir / groups_rrg_path, rrg_payload)
+            assets["groups_rrg"] = {"path": groups_rrg_path.as_posix()}
 
         return {
             "market": market,
@@ -464,7 +478,7 @@ class StaticSiteExportService:
                 "scan": True,
                 "breadth": bool(breadth_payload.get("available", True)),
                 "groups": bool(groups_payload.get("available", False)),
-                "rrg": bool(rrg_payload.get("available", False)),
+                "rrg": rrg_available,
                 "charts": bool(chart_manifest.get("available", False)),
             },
             "pages": {
@@ -473,14 +487,7 @@ class StaticSiteExportService:
                 "breadth": {"path": breadth_path.as_posix()},
                 "groups": {"path": groups_path.as_posix()},
             },
-            "assets": {
-                "charts": {
-                    "path": chart_manifest["path"],
-                    "limit": chart_manifest["limit"],
-                    "symbols_total": chart_manifest["symbols_total"],
-                },
-                "groups_rrg": {"path": groups_rrg_path.as_posix()},
-            },
+            "assets": assets,
             "freshness": home_payload.get("freshness", {}),
         }
 

--- a/backend/tests/unit/golden/test_golden_rrg.py
+++ b/backend/tests/unit/golden/test_golden_rrg.py
@@ -1,0 +1,211 @@
+"""Golden regression tests for the RRG (Relative Rotation Graph) math.
+
+These exercise the pure functions in ``app.services.rrg_service`` that turn a
+daily ``avg_rs_rating`` series into RS-Ratio (x) / RS-Momentum (y) coordinates
+plus a weekly tail. The math is deterministic float arithmetic with no DB and no
+RNG, so the snapshots below are stable.
+
+The module is intentionally free of heavy (sqlalchemy/DB) imports at module top,
+so this file imports only the pure surface and runs without the app bootstrap.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from app.services.rrg_service import (
+    MIN_TAIL_WEEKS,
+    RRGParams,
+    _bucket_weekly,
+    _ema,
+    classify_quadrant,
+    compute_group_rrg,
+)
+
+
+def _daily(n_days: int, value_fn, start: date = date(2024, 1, 1)):
+    """Build a deterministic daily (date, value) series over ``n_days`` business
+    days, value = ``value_fn(business_day_index)``."""
+    out = []
+    d = start
+    i = 0
+    while len(out) < n_days:
+        if d.weekday() < 5:  # Mon..Fri
+            out.append((d, float(value_fn(i))))
+            i += 1
+        d += timedelta(days=1)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Quadrant classification — the four RRG quadrants split at the 100/100 cross
+# ---------------------------------------------------------------------------
+
+
+def test_classify_quadrant_maps_each_corner():
+    # x = RS-Ratio, y = RS-Momentum; boundary value 100 belongs to the
+    # strong/rising side (>=).
+    assert classify_quadrant(105.0, 103.0) == "Leading"     # strong + rising
+    assert classify_quadrant(105.0, 97.0) == "Weakening"    # strong + falling
+    assert classify_quadrant(95.0, 97.0) == "Lagging"       # weak + falling
+    assert classify_quadrant(95.0, 103.0) == "Improving"    # weak + rising
+
+
+def test_classify_quadrant_boundaries_are_inclusive_on_strong_side():
+    # Exactly on the cross counts as Leading (>=100 on both axes).
+    assert classify_quadrant(100.0, 100.0) == "Leading"
+    assert classify_quadrant(100.0, 99.9) == "Weakening"
+    assert classify_quadrant(99.9, 100.0) == "Improving"
+
+
+# ---------------------------------------------------------------------------
+# Weekly bucketing — UTC Sunday-origin week start, close-of-week value
+# (mirrors the frontend aggregateToWeekly rule fixed in commit e4406584).
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_weekly_uses_utc_sunday_start_and_close_of_week():
+    # Mon 2024-01-01 .. Fri 2024-01-05 all fall in the week starting Sun 2023-12-31.
+    days = [
+        (date(2024, 1, 1), 10.0),
+        (date(2024, 1, 2), 11.0),
+        (date(2024, 1, 3), 12.0),
+        (date(2024, 1, 4), 13.0),
+        (date(2024, 1, 5), 14.0),
+    ]
+    assert _bucket_weekly(days) == [(date(2023, 12, 31), 14.0)]
+
+
+def test_bucket_weekly_one_point_per_week_ascending():
+    # Unsorted input spanning two weeks -> one close-of-week point per week,
+    # ascending by week start.
+    days = [
+        (date(2024, 1, 12), 22.0),  # Fri, week of 2024-01-07
+        (date(2024, 1, 5), 14.0),   # Fri, week of 2023-12-31
+        (date(2024, 1, 8), 20.0),   # Mon, week of 2024-01-07
+    ]
+    assert _bucket_weekly(days) == [
+        (date(2023, 12, 31), 14.0),
+        (date(2024, 1, 7), 22.0),
+    ]
+
+
+def test_bucket_weekly_sunday_maps_to_itself():
+    # A Sunday is its own week start (getUTCDay() == 0).
+    assert _bucket_weekly([(date(2024, 1, 7), 5.0)]) == [(date(2024, 1, 7), 5.0)]
+
+
+# ---------------------------------------------------------------------------
+# EMA — adjust=False recursion (seed = first value), matches pandas ewm.
+# ---------------------------------------------------------------------------
+
+
+def test_ema_seeds_on_first_value_and_recurses():
+    # span=2 -> alpha = 2/3. Hand-computed:
+    #   e0 = 1
+    #   e1 = 2/3*2 + 1/3*1 = 5/3
+    #   e2 = 2/3*3 + 1/3*5/3 = 23/9
+    out = _ema([1.0, 2.0, 3.0], span=2)
+    assert len(out) == 3
+    assert abs(out[0] - 1.0) < 1e-12
+    assert abs(out[1] - 5.0 / 3.0) < 1e-12
+    assert abs(out[2] - 23.0 / 9.0) < 1e-12
+
+
+def test_ema_constant_series_is_flat():
+    assert _ema([7.0, 7.0, 7.0, 7.0], span=5) == [7.0, 7.0, 7.0, 7.0]
+
+
+def test_ema_empty_returns_empty():
+    assert _ema([], span=3) == []
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline behavior — compute_group_rrg
+# ---------------------------------------------------------------------------
+
+
+def test_compute_group_rrg_flat_series_centers_at_100():
+    # A perfectly flat RS series sits dead-center: x == y == 100 (EPS guard on
+    # the zero-variance window) -> Leading by the inclusive boundary rule.
+    series = _daily(200, lambda i: 50.0)  # ~40 weeks
+    result = compute_group_rrg(series, RRGParams())
+    assert result is not None
+    cur = result["current"]
+    assert cur["x"] == 100.0
+    assert cur["y"] == 100.0
+    assert result["is_provisional"] is False  # ~40 weeks >= MIN_WEEKS
+    assert classify_quadrant(cur["x"], cur["y"]) == "Leading"
+
+
+def test_compute_group_rrg_returns_none_for_short_history():
+    # Fewer than MIN_TAIL_WEEKS weekly points -> not enough to plot.
+    series = _daily(5 * (MIN_TAIL_WEEKS - 2), lambda i: 50.0)  # ~10 weeks
+    assert compute_group_rrg(series, RRGParams()) is None
+
+
+def test_compute_group_rrg_default_tail_length():
+    series = _daily(200, lambda i: 50.0)
+    result = compute_group_rrg(series, RRGParams())
+    assert len(result["tail"]) == RRGParams().tail_weeks  # default 8
+
+
+def test_compute_group_rrg_rising_series_is_leading():
+    # Steadily rising RS -> recent value above its own trailing mean (x>100) and
+    # still climbing (y>100) -> Leading.
+    series = _daily(200, lambda i: 40.0 + 0.1 * i)
+    result = compute_group_rrg(series, RRGParams())
+    cur = result["current"]
+    assert cur["x"] > 100.0
+    assert cur["y"] > 100.0
+    assert classify_quadrant(cur["x"], cur["y"]) == "Leading"
+
+
+def test_compute_group_rrg_falling_series_is_lagging():
+    # Steadily falling RS -> below own trailing mean (x<100) and still dropping
+    # (y<100) -> Lagging.
+    series = _daily(200, lambda i: 60.0 - 0.1 * i)
+    result = compute_group_rrg(series, RRGParams())
+    cur = result["current"]
+    assert cur["x"] < 100.0
+    assert cur["y"] < 100.0
+    assert classify_quadrant(cur["x"], cur["y"]) == "Lagging"
+
+
+def test_compute_group_rrg_tail_points_are_chronological():
+    series = _daily(200, lambda i: 40.0 + 0.1 * i)
+    tail = compute_group_rrg(series, RRGParams())["tail"]
+    dates = [p["date"] for p in tail]
+    assert dates == sorted(dates)
+    assert tail[-1] == compute_group_rrg(series, RRGParams())["current"]
+
+
+# ---------------------------------------------------------------------------
+# Golden numeric pins — lock the exact transform output so a future refactor
+# can't silently shift the math. Captured from the reference implementation;
+# regenerate intentionally if the methodology changes.
+# ---------------------------------------------------------------------------
+
+
+def test_golden_leading_archetype_pinned():
+    # Steady linear RS rise from 40 -> ~60 over ~40 weeks.
+    series = _daily(200, lambda i: 40.0 + 0.1 * i)
+    result = compute_group_rrg(series, RRGParams())
+    assert result["current"] == {"date": "2024-09-29", "x": 108.334, "y": 106.0963}
+    assert result["tail"][0] == {"date": "2024-08-11", "x": 108.3453, "y": 97.7609}
+    assert result["is_provisional"] is False
+
+
+def test_golden_lagging_archetype_pinned():
+    series = _daily(200, lambda i: 60.0 - 0.1 * i)
+    result = compute_group_rrg(series, RRGParams())
+    assert result["current"] == {"date": "2024-09-29", "x": 91.666, "y": 93.9037}
+
+
+def test_golden_provisional_short_history_flagged():
+    # ~20 weeks: enough to plot (>= MIN_TAIL_WEEKS) but below MIN_WEEKS, so the
+    # most-recent point used a shortened window -> provisional.
+    series = _daily(100, lambda i: 40.0 + 0.1 * i)
+    result = compute_group_rrg(series, RRGParams())
+    assert result["is_provisional"] is True
+    assert result["current"] == {"date": "2024-05-12", "x": 108.5403, "y": 96.4545}

--- a/backend/tests/unit/test_rrg_service.py
+++ b/backend/tests/unit/test_rrg_service.py
@@ -1,0 +1,165 @@
+"""Unit tests for the RRG DB orchestrator (``RRGService``).
+
+Uses an in-memory SQLite database seeded with ``IBDGroupRank`` history and a
+minimal stub for the current-rankings lookup, so it exercises the single
+batched query, group omission, and the sector roll-up without the full app.
+
+(The pure RRG math is covered separately by
+``tests/unit/golden/test_golden_rrg.py``.)
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.industry import IBDGroupRank, IBDIndustryGroup
+from app.models.stock_universe import StockUniverse
+from app.services.rrg_service import RRGService
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _weekly_fridays(n_weeks: int, start: date = date(2024, 1, 5)):
+    """n_weeks consecutive Fridays, ascending."""
+    return [start + timedelta(weeks=k) for k in range(n_weeks)]
+
+
+def _seed_group(session, *, market, group, dates, rs_fn, num_stocks=10, rank=1):
+    for i, d in enumerate(dates):
+        session.add(
+            IBDGroupRank(
+                market=market,
+                industry_group=group,
+                date=d,
+                rank=rank,
+                avg_rs_rating=float(rs_fn(i)),
+                num_stocks=num_stocks,
+                num_stocks_rs_above_80=0,
+            )
+        )
+    session.commit()
+
+
+class _StubRankService:
+    """Minimal stand-in for IBDGroupRankService.get_current_rankings."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_current_rankings(self, db, limit=197, market="US"):
+        return [r for r in self._rows if r["market"] == market][:limit]
+
+
+def test_get_rrg_groups_scope_returns_quadrants_and_tails():
+    session = _session()
+    dates = _weekly_fridays(40)
+    _seed_group(session, market="US", group="AlphaTech", dates=dates,
+                rs_fn=lambda i: 40 + 0.6 * i, num_stocks=12, rank=1)
+    _seed_group(session, market="US", group="BetaMetals", dates=dates,
+                rs_fn=lambda i: 60 - 0.6 * i, num_stocks=8, rank=2)
+
+    latest = dates[-1].isoformat()
+    stub = _StubRankService([
+        {"market": "US", "industry_group": "AlphaTech", "date": latest,
+         "rank": 1, "num_stocks": 12, "avg_rs_rating": 64.0},
+        {"market": "US", "industry_group": "BetaMetals", "date": latest,
+         "rank": 2, "num_stocks": 8, "avg_rs_rating": 36.0},
+    ])
+    payload = RRGService(group_rank_service=stub).get_rrg(session, market="US")
+
+    assert payload["date"] == latest
+    assert payload["scope"] == "groups"
+    by_name = {g["industry_group"]: g for g in payload["groups"]}
+    assert set(by_name) == {"AlphaTech", "BetaMetals"}
+
+    alpha = by_name["AlphaTech"]
+    assert alpha["quadrant"] == "Leading"      # rising RS
+    assert alpha["current"]["x"] > 100 and alpha["current"]["y"] > 100
+    assert alpha["current"] == alpha["tail"][-1]
+    assert by_name["BetaMetals"]["quadrant"] == "Lagging"  # falling RS
+
+    # Sorted by rank ascending.
+    assert [g["industry_group"] for g in payload["groups"]] == ["AlphaTech", "BetaMetals"]
+
+
+def test_get_rrg_omits_groups_with_too_little_history():
+    session = _session()
+    dates = _weekly_fridays(40)
+    _seed_group(session, market="US", group="AlphaTech", dates=dates,
+                rs_fn=lambda i: 40 + 0.6 * i)
+    # Only 5 weekly points -> below MIN_TAIL_WEEKS -> omitted.
+    _seed_group(session, market="US", group="TinyNew", dates=_weekly_fridays(5),
+                rs_fn=lambda i: 50.0)
+
+    latest = dates[-1].isoformat()
+    stub = _StubRankService([
+        {"market": "US", "industry_group": "AlphaTech", "date": latest,
+         "rank": 1, "num_stocks": 10, "avg_rs_rating": 64.0},
+        {"market": "US", "industry_group": "TinyNew", "date": latest,
+         "rank": 2, "num_stocks": 3, "avg_rs_rating": 50.0},
+    ])
+    payload = RRGService(group_rank_service=stub).get_rrg(session, market="US")
+    assert [g["industry_group"] for g in payload["groups"]] == ["AlphaTech"]
+
+
+def test_get_rrg_sectors_scope_rolls_groups_into_gics_sectors():
+    session = _session()
+    dates = _weekly_fridays(40)
+    _seed_group(session, market="US", group="AlphaTech", dates=dates,
+                rs_fn=lambda i: 40 + 0.6 * i, num_stocks=12)
+    _seed_group(session, market="US", group="GammaChips", dates=dates,
+                rs_fn=lambda i: 42 + 0.5 * i, num_stocks=8)
+    _seed_group(session, market="US", group="BetaMetals", dates=dates,
+                rs_fn=lambda i: 60 - 0.6 * i, num_stocks=10)
+
+    # Group -> dominant GICS sector via constituents.
+    for sym, grp, sector in [
+        ("AAA", "AlphaTech", "Technology"),
+        ("CCC", "GammaChips", "Technology"),
+        ("MMM", "BetaMetals", "Basic Materials"),
+    ]:
+        session.add(IBDIndustryGroup(symbol=sym, industry_group=grp, market="US"))
+        session.add(StockUniverse(symbol=sym, market="US", sector=sector))
+    session.commit()
+
+    latest = dates[-1].isoformat()
+    stub = _StubRankService([
+        {"market": "US", "industry_group": "AlphaTech", "date": latest,
+         "rank": 1, "num_stocks": 12, "avg_rs_rating": 64.0},
+        {"market": "US", "industry_group": "GammaChips", "date": latest,
+         "rank": 2, "num_stocks": 8, "avg_rs_rating": 62.0},
+        {"market": "US", "industry_group": "BetaMetals", "date": latest,
+         "rank": 3, "num_stocks": 10, "avg_rs_rating": 36.0},
+    ])
+    payload = RRGService(group_rank_service=stub).get_rrg(
+        session, market="US", scope="sectors"
+    )
+
+    assert payload["scope"] == "sectors"
+    sectors = {g["industry_group"]: g for g in payload["groups"]}
+    assert set(sectors) == {"Technology", "Basic Materials"}
+    # Technology aggregates two rising groups -> Leading; num_stocks summed.
+    assert sectors["Technology"]["quadrant"] == "Leading"
+    assert sectors["Technology"]["num_stocks"] == 20
+    assert sectors["Basic Materials"]["quadrant"] == "Lagging"
+
+
+def test_get_group_sector_map_majority_vote():
+    session = _session()
+    for sym, sector in [("A1", "Technology"), ("A2", "Technology"), ("A3", "Healthcare")]:
+        session.add(IBDIndustryGroup(symbol=sym, industry_group="AlphaTech", market="US"))
+        session.add(StockUniverse(symbol=sym, market="US", sector=sector))
+    session.commit()
+
+    mapping = RRGService(group_rank_service=_StubRankService([])).get_group_sector_map(
+        session, market="US"
+    )
+    assert mapping["AlphaTech"] == "Technology"  # 2 vs 1

--- a/frontend/src/api/groups.js
+++ b/frontend/src/api/groups.js
@@ -55,6 +55,22 @@ export const getGroupDetail = async (industryGroup, days = 180, market = 'US') =
 };
 
 /**
+ * Get Relative Rotation Graph (RRG) coordinates for groups or sector roll-ups.
+ *
+ * @param {string} scope - 'groups' or 'sectors'
+ * @param {number} tailWeeks - Number of weekly tail points (default: 8)
+ * @param {number} limit - Top-N series by rank (default: 197)
+ * @param {string} market - Market code (default: 'US')
+ * @returns {Promise<Object>} RRG response: { date, market, scope, groups: [...] }
+ */
+export const getRRG = async (scope = 'groups', tailWeeks = 8, limit = 197, market = 'US') => {
+  const response = await apiClient.get('/v1/groups/rrg', {
+    params: { scope, tail_weeks: tailWeeks, limit, market }
+  });
+  return response.data;
+};
+
+/**
  * Get summary statistics for ranking data.
  *
  * @returns {Promise<Object>} Summary with total_records, date range, etc.

--- a/frontend/src/components/Charts/RRGChart.jsx
+++ b/frontend/src/components/Charts/RRGChart.jsx
@@ -1,0 +1,212 @@
+/**
+ * Relative Rotation Graph (RRG)
+ *
+ * Plots each IBD group (or sector roll-up) by RS-Ratio (x) vs RS-Momentum (y),
+ * with a weekly "tail" tracing its path through the four quadrants:
+ *
+ *     Leading   (x>=100, y>=100)  green
+ *     Weakening (x>=100, y<100)   orange
+ *     Lagging   (x<100,  y<100)   red
+ *     Improving (x<100,  y>=100)  blue
+ *
+ * Coordinates are pre-computed server-side (see backend rrg_service.py), so this
+ * component is purely presentational. It is shared by the live Group Rankings
+ * page and the static-site Groups page — both pass the same `{ groups: [...] }`.
+ */
+import { useMemo } from 'react';
+import {
+  ScatterChart,
+  Scatter,
+  Cell,
+  XAxis,
+  YAxis,
+  ZAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ReferenceArea,
+  ResponsiveContainer,
+} from 'recharts';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  CircularProgress,
+  Alert,
+} from '@mui/material';
+import { QUADRANT_COLORS, QUADRANT_FILLS, quadrantColor } from './rrgColors';
+
+/** Symmetric axis bounds around the 100/100 cross, padded to the data extent. */
+const computeBound = (groups) => {
+  let maxAbs = 8;
+  for (const g of groups) {
+    const pts = [g.current, ...(g.tail || [])];
+    for (const p of pts) {
+      maxAbs = Math.max(maxAbs, Math.abs(p.x - 100), Math.abs(p.y - 100));
+    }
+  }
+  return Math.min(20, Math.ceil(maxAbs) + 1);
+};
+
+const RRGTooltip = ({ active, payload }) => {
+  if (!active || !payload || !payload.length) return null;
+  const g = payload[0]?.payload;
+  if (!g) return null;
+  return (
+    <Box
+      sx={{
+        backgroundColor: 'background.paper',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        p: 1.5,
+        boxShadow: 2,
+        minWidth: 180,
+      }}
+    >
+      <Typography variant="body2" sx={{ fontWeight: 700, mb: 0.5 }}>
+        {g.industry_group}
+      </Typography>
+      <Typography variant="caption" sx={{ color: quadrantColor(g.quadrant), fontWeight: 600 }}>
+        {g.quadrant}
+        {g.is_provisional ? ' · provisional' : ''}
+      </Typography>
+      <Typography variant="body2" sx={{ mt: 0.5 }}>
+        Rank: {g.rank ?? '—'} · RS: {g.avg_rs_rating != null ? g.avg_rs_rating.toFixed(1) : '—'}
+      </Typography>
+      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+        Ratio {g.x?.toFixed(1)} · Momentum {g.y?.toFixed(1)}
+      </Typography>
+    </Box>
+  );
+};
+
+/**
+ * @param {Object[]} props.data.groups - RRGGroupResponse[] from the API
+ */
+export default function RRGChart({ data, isLoading, error, onSelectGroup, height = 560 }) {
+  const groups = useMemo(() => (data?.groups ?? []), [data]);
+
+  const bound = useMemo(() => computeBound(groups), [groups]);
+  const lo = 100 - bound;
+  const hi = 100 + bound;
+
+  // Flatten current points (each carries the full group for tooltip/click).
+  const currentPoints = useMemo(
+    () => groups.map((g) => ({ ...g, ...g.current })),
+    [groups],
+  );
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height }}>
+          <CircularProgress />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent>
+          <Alert severity="error">
+            Failed to load RRG data{error?.message ? `: ${error.message}` : '.'}
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!groups.length) {
+    return (
+      <Card>
+        <CardContent>
+          <Alert severity="info">
+            No RRG data available yet. Group-ranking history is required to plot rotation.
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Relative Rotation Graph — {data?.scope === 'sectors' ? 'Sectors' : 'Groups'}
+          {data?.date ? ` · ${data.date}` : ''}
+        </Typography>
+        <ResponsiveContainer width="100%" height={height}>
+          <ScatterChart margin={{ top: 20, right: 30, bottom: 20, left: 10 }}>
+            <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+
+            {/* Quadrant backdrops */}
+            <ReferenceArea x1={100} x2={hi} y1={100} y2={hi} fill={QUADRANT_FILLS.Leading} fillOpacity={1}
+              label={{ value: 'Leading', position: 'insideTopRight', fill: QUADRANT_COLORS.Leading, fontSize: 12 }} />
+            <ReferenceArea x1={100} x2={hi} y1={lo} y2={100} fill={QUADRANT_FILLS.Weakening} fillOpacity={1}
+              label={{ value: 'Weakening', position: 'insideBottomRight', fill: QUADRANT_COLORS.Weakening, fontSize: 12 }} />
+            <ReferenceArea x1={lo} x2={100} y1={lo} y2={100} fill={QUADRANT_FILLS.Lagging} fillOpacity={1}
+              label={{ value: 'Lagging', position: 'insideBottomLeft', fill: QUADRANT_COLORS.Lagging, fontSize: 12 }} />
+            <ReferenceArea x1={lo} x2={100} y1={100} y2={hi} fill={QUADRANT_FILLS.Improving} fillOpacity={1}
+              label={{ value: 'Improving', position: 'insideTopLeft', fill: QUADRANT_COLORS.Improving, fontSize: 12 }} />
+
+            <ReferenceLine x={100} stroke="#9e9e9e" strokeDasharray="4 4" />
+            <ReferenceLine y={100} stroke="#9e9e9e" strokeDasharray="4 4" />
+
+            <XAxis
+              type="number"
+              dataKey="x"
+              name="RS-Ratio"
+              domain={[lo, hi]}
+              tickCount={5}
+              label={{ value: 'RS-Ratio', position: 'insideBottom', offset: -10, fontSize: 12 }}
+            />
+            <YAxis
+              type="number"
+              dataKey="y"
+              name="RS-Momentum"
+              domain={[lo, hi]}
+              tickCount={5}
+              label={{ value: 'RS-Momentum', angle: -90, position: 'insideLeft', fontSize: 12 }}
+            />
+            <ZAxis type="number" dataKey="num_stocks" range={[60, 500]} name="Constituents" />
+            <Tooltip content={<RRGTooltip />} cursor={{ strokeDasharray: '3 3' }} />
+
+            {/* Tails: one connected polyline per group, dots hidden. */}
+            {groups.map((g) => (
+              <Scatter
+                key={`tail-${g.industry_group}`}
+                data={g.tail}
+                line={{ stroke: quadrantColor(g.quadrant), strokeWidth: 1.25, strokeOpacity: 0.5 }}
+                lineType="joint"
+                shape={() => null}
+                isAnimationActive={false}
+                legendType="none"
+              />
+            ))}
+
+            {/* Current dots — colored by quadrant, clickable. */}
+            <Scatter
+              data={currentPoints}
+              isAnimationActive={false}
+              onClick={(pt) => onSelectGroup?.(pt?.industry_group)}
+              cursor="pointer"
+            >
+              {currentPoints.map((p) => (
+                <Cell
+                  key={`dot-${p.industry_group}`}
+                  fill={quadrantColor(p.quadrant)}
+                  fillOpacity={p.is_provisional ? 0.35 : 0.9}
+                  stroke={quadrantColor(p.quadrant)}
+                />
+              ))}
+            </Scatter>
+          </ScatterChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/Charts/RRGChart.test.jsx
+++ b/frontend/src/components/Charts/RRGChart.test.jsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import RRGChart from './RRGChart';
+import { QUADRANT_COLORS } from './rrgColors';
+
+const sampleData = {
+  date: '2024-09-29',
+  market: 'US',
+  scope: 'groups',
+  groups: [
+    {
+      industry_group: 'AlphaTech',
+      rank: 1,
+      num_stocks: 12,
+      avg_rs_rating: 64.0,
+      quadrant: 'Leading',
+      is_provisional: false,
+      current: { date: '2024-09-29', x: 108.3, y: 106.1 },
+      tail: [
+        { date: '2024-08-11', x: 104.0, y: 98.0 },
+        { date: '2024-09-29', x: 108.3, y: 106.1 },
+      ],
+    },
+    {
+      industry_group: 'BetaMetals',
+      rank: 2,
+      num_stocks: 8,
+      avg_rs_rating: 36.0,
+      quadrant: 'Lagging',
+      is_provisional: false,
+      current: { date: '2024-09-29', x: 91.7, y: 93.9 },
+      tail: [
+        { date: '2024-08-11', x: 95.0, y: 99.0 },
+        { date: '2024-09-29', x: 91.7, y: 93.9 },
+      ],
+    },
+  ],
+};
+
+describe('RRGChart', () => {
+  it('renders the header with scope and as-of date', () => {
+    renderWithProviders(<RRGChart data={sampleData} />);
+    expect(screen.getByText(/Relative Rotation Graph/)).toBeInTheDocument();
+    expect(screen.getByText(/Groups/)).toBeInTheDocument();
+    expect(screen.getByText(/2024-09-29/)).toBeInTheDocument();
+  });
+
+  it('labels the sectors scope when provided', () => {
+    renderWithProviders(<RRGChart data={{ ...sampleData, scope: 'sectors' }} />);
+    expect(screen.getByText(/Sectors/)).toBeInTheDocument();
+  });
+
+  it('shows a spinner while loading', () => {
+    renderWithProviders(<RRGChart data={null} isLoading />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('shows an error alert on failure', () => {
+    renderWithProviders(<RRGChart data={null} error={{ message: 'boom' }} />);
+    expect(screen.getByText(/Failed to load RRG data/)).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+
+  it('shows an empty-state message when there are no groups', () => {
+    renderWithProviders(<RRGChart data={{ groups: [] }} />);
+    expect(screen.getByText(/No RRG data available/)).toBeInTheDocument();
+  });
+
+  it('exposes stable quadrant colors', () => {
+    // Guards the live + static charts against color drift.
+    expect(QUADRANT_COLORS).toMatchObject({
+      Leading: '#4caf50',
+      Weakening: '#ff9800',
+      Lagging: '#f44336',
+      Improving: '#2196f3',
+    });
+  });
+});

--- a/frontend/src/components/Charts/RRGViewToggle.jsx
+++ b/frontend/src/components/Charts/RRGViewToggle.jsx
@@ -1,0 +1,22 @@
+/**
+ * Shared Table/RRG + Groups/Sectors toggle used by both the live and static
+ * Group Rankings pages, so the control can't drift between the two trees.
+ */
+import { Box, ToggleButton, ToggleButtonGroup } from '@mui/material';
+
+export default function RRGViewToggle({ view, onView, scope, onScope, sx }) {
+  return (
+    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center', ...sx }}>
+      <ToggleButtonGroup size="small" exclusive value={view} onChange={(e, v) => v && onView(v)}>
+        <ToggleButton value="table">Table</ToggleButton>
+        <ToggleButton value="rrg">RRG</ToggleButton>
+      </ToggleButtonGroup>
+      {view === 'rrg' && (
+        <ToggleButtonGroup size="small" exclusive value={scope} onChange={(e, v) => v && onScope(v)}>
+          <ToggleButton value="groups">Groups</ToggleButton>
+          <ToggleButton value="sectors">Sectors</ToggleButton>
+        </ToggleButtonGroup>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/components/Charts/rrgColors.js
+++ b/frontend/src/components/Charts/rrgColors.js
@@ -1,0 +1,19 @@
+/**
+ * Shared RRG quadrant colors — single source of truth for the live and static
+ * charts (and any consumer that colors by quadrant, e.g. a detail modal).
+ */
+export const QUADRANT_COLORS = {
+  Leading: '#4caf50',
+  Weakening: '#ff9800',
+  Lagging: '#f44336',
+  Improving: '#2196f3',
+};
+
+export const QUADRANT_FILLS = {
+  Leading: 'rgba(76, 175, 80, 0.08)',
+  Weakening: 'rgba(255, 152, 0, 0.08)',
+  Lagging: 'rgba(244, 67, 54, 0.08)',
+  Improving: 'rgba(33, 150, 243, 0.08)',
+};
+
+export const quadrantColor = (q) => QUADRANT_COLORS[q] || '#9e9e9e';

--- a/frontend/src/pages/GroupRankingsPage.jsx
+++ b/frontend/src/pages/GroupRankingsPage.jsx
@@ -594,6 +594,11 @@ function GroupRankingsPage() {
     snapshotEnabled,
   ]);
 
+  // The RRG view has its own query (and the static-friendly RRGChart); the
+  // table-only rankings/movers fetches are skipped while it's active so a
+  // rankings-endpoint failure can't block a healthy RRG view.
+  const isRrgView = view === 'rrg';
+
   // Fetch current rankings
   const {
     data: rankings,
@@ -603,7 +608,7 @@ function GroupRankingsPage() {
   } = useQuery({
     queryKey: ['groupRankings', selectedMarket],
     queryFn: () => getCurrentRankings(197, selectedMarket),
-    enabled: liveQueriesEnabled,
+    enabled: liveQueriesEnabled && !isRrgView,
     refetchInterval: 60000,
     staleTime: 60_000,
   });
@@ -615,7 +620,7 @@ function GroupRankingsPage() {
   } = useQuery({
     queryKey: ['groupMovers', selectedPeriod, selectedMarket],
     queryFn: () => getRankMovers(selectedPeriod, 10, selectedMarket),
-    enabled: liveQueriesEnabled,
+    enabled: liveQueriesEnabled && !isRrgView,
     staleTime: 60_000,
   });
 
@@ -760,7 +765,7 @@ function GroupRankingsPage() {
     ) : null
   );
 
-  if (errorRankings) {
+  if (errorRankings && !isRrgView) {
     return (
       <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
         <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>

--- a/frontend/src/pages/GroupRankingsPage.jsx
+++ b/frontend/src/pages/GroupRankingsPage.jsx
@@ -38,9 +38,12 @@ import {
   getCurrentRankings,
   getRankMovers,
   getGroupDetail,
+  getRRG,
   triggerCalculation,
   getCalculationStatus,
 } from '../api/groups';
+import RRGChart from '../components/Charts/RRGChart';
+import RRGViewToggle from '../components/Charts/RRGViewToggle';
 import {
   LineChart,
   Line,
@@ -525,6 +528,8 @@ function GroupRankingsPage() {
       : (availableMarkets[0] || 'US');
   });
   const [selectedGroup, setSelectedGroup] = useState(null);
+  const [view, setView] = useState('table'); // 'table' | 'rrg'
+  const [rrgScope, setRrgScope] = useState('groups'); // 'groups' | 'sectors'
   const [orderBy, setOrderBy] = useState('rank');
   const [order, setOrder] = useState('asc');
   const [isCalculating, setIsCalculating] = useState(false);
@@ -611,6 +616,18 @@ function GroupRankingsPage() {
     queryKey: ['groupMovers', selectedPeriod, selectedMarket],
     queryFn: () => getRankMovers(selectedPeriod, 10, selectedMarket),
     enabled: liveQueriesEnabled,
+    staleTime: 60_000,
+  });
+
+  // Fetch RRG coordinates (only when the RRG view is active)
+  const {
+    data: rrgData,
+    isLoading: isLoadingRRG,
+    error: errorRRG,
+  } = useQuery({
+    queryKey: ['groupRRG', selectedMarket, rrgScope],
+    queryFn: () => getRRG(rrgScope, 8, 197, selectedMarket),
+    enabled: liveQueriesEnabled && view === 'rrg',
     staleTime: 60_000,
   });
 
@@ -789,7 +806,23 @@ function GroupRankingsPage() {
 
       {renderCalculationErrorAlert({ mb: 1.5 })}
 
-      {isLoadingRankings ? (
+      {/* View toggle: ranked table vs Relative Rotation Graph */}
+      <RRGViewToggle
+        view={view}
+        onView={setView}
+        scope={rrgScope}
+        onScope={setRrgScope}
+        sx={{ mb: 1.5 }}
+      />
+
+      {view === 'rrg' ? (
+        <RRGChart
+          data={rrgData}
+          isLoading={isLoadingRRG}
+          error={errorRRG}
+          onSelectGroup={(name) => rrgScope === 'groups' && setSelectedGroup(name)}
+        />
+      ) : isLoadingRankings ? (
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />
         </Box>

--- a/frontend/src/static/dataClient.js
+++ b/frontend/src/static/dataClient.js
@@ -23,6 +23,17 @@ export const useStaticManifest = () => useQuery({
   gcTime: Infinity,
 });
 
+export const useStaticGroupsRRG = (marketEntry) => {
+  const path = marketEntry?.assets?.groups_rrg?.path;
+  return useQuery({
+    queryKey: ['staticGroupsRRG', path],
+    queryFn: () => fetchStaticJson(path),
+    enabled: Boolean(path),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+};
+
 export const getStaticSupportedMarkets = (manifest) => {
   if (Array.isArray(manifest?.supported_markets) && manifest.supported_markets.length > 0) {
     return manifest.supported_markets;

--- a/frontend/src/static/pages/StaticGroupsPage.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Alert,
@@ -146,6 +146,14 @@ function StaticGroupsPage() {
   const [selectedGroup, setSelectedGroup] = useState(null);
   const [view, setView] = useState('table'); // 'table' | 'rrg'
   const [rrgScope, setRrgScope] = useState('groups'); // 'groups' | 'sectors'
+
+  // Markets without an RRG bundle hide the toggle, so never strand the page in
+  // the RRG branch with no way back to the table.
+  useEffect(() => {
+    if (!rrgAvailable && view !== 'table') {
+      setView('table');
+    }
+  }, [rrgAvailable, view]);
 
   if (manifestQuery.isLoading || groupsQuery.isLoading) {
     return (

--- a/frontend/src/static/pages/StaticGroupsPage.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.jsx
@@ -14,9 +14,16 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import { useStaticManifest, fetchStaticJson, resolveStaticMarketEntry } from '../dataClient';
+import {
+  useStaticManifest,
+  fetchStaticJson,
+  resolveStaticMarketEntry,
+  useStaticGroupsRRG,
+} from '../dataClient';
 import { useStaticChartIndex } from '../chartClient';
 import StaticGroupDetailModal from '../StaticGroupDetailModal';
+import RRGChart from '../../components/Charts/RRGChart';
+import RRGViewToggle from '../../components/Charts/RRGViewToggle';
 import RankChangeCell from '../../components/shared/RankChangeCell';
 import TickerCell from '../../components/common/TickerCell';
 import { useStaticMarket } from '../StaticMarketContext';
@@ -53,53 +60,9 @@ function MoversCard({ title, rows }) {
   );
 }
 
-function StaticGroupsPage() {
-  const manifestQuery = useStaticManifest();
-  const { selectedMarket } = useStaticMarket();
-  const marketEntry = useMemo(
-    () => resolveStaticMarketEntry(manifestQuery.data, selectedMarket),
-    [manifestQuery.data, selectedMarket],
-  );
-  const groupsQuery = useQuery({
-    queryKey: ['staticGroups', marketEntry.pages?.groups?.path],
-    queryFn: () => fetchStaticJson(marketEntry.pages.groups.path),
-    enabled: Boolean(marketEntry.pages?.groups?.path),
-    staleTime: Infinity,
-  });
-  const chartIndexQuery = useStaticChartIndex(marketEntry.assets?.charts?.path);
-  const [selectedGroup, setSelectedGroup] = useState(null);
-
-  if (manifestQuery.isLoading || groupsQuery.isLoading) {
-    return (
-      <Box display="flex" justifyContent="center" py={8}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (manifestQuery.isError || groupsQuery.isError) {
-    return <Alert severity="error">Failed to load group rankings.</Alert>;
-  }
-
-  if (!groupsQuery.data?.available) {
-    return <Alert severity="info">{groupsQuery.data?.message || 'No group rankings are available.'}</Alert>;
-  }
-
-  const payload = groupsQuery.data.payload || {};
-  const rankings = payload.rankings?.rankings || [];
-  const movers = payload.movers || {};
-  const moversPeriod = payload.movers_period || movers.period || '1w';
-  const groupDetails = payload.group_details || {};
-
+function GroupsTableView({ movers, moversPeriod, rankings, onSelectGroup }) {
   return (
-    <Box>
-      <Typography variant="h5" sx={{ fontWeight: 700, letterSpacing: '-0.5px', mb: 0.5 }}>
-        {marketEntry.display_name} Group Rankings
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 2, fontSize: '12px' }}>
-        Latest ranking date: {payload.rankings?.date || '-'}.
-      </Typography>
-
+    <>
       <Grid container spacing={1.5} sx={{ mb: 2 }}>
         <Grid item xs={12} md={6}>
           <MoversCard title={`Top Gainers (${moversPeriod.toUpperCase()})`} rows={movers.gainers} />
@@ -133,12 +96,12 @@ function StaticGroupsPage() {
                 <TableRow
                   key={row.industry_group}
                   hover
-                  onClick={() => setSelectedGroup(row.industry_group)}
+                  onClick={() => onSelectGroup(row.industry_group)}
                   tabIndex={0}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter' || event.key === ' ') {
                       event.preventDefault();
-                      setSelectedGroup(row.industry_group);
+                      onSelectGroup(row.industry_group);
                     }
                   }}
                   sx={{ cursor: 'pointer' }}
@@ -160,6 +123,86 @@ function StaticGroupsPage() {
           </Table>
         </TableContainer>
       </Paper>
+    </>
+  );
+}
+
+function StaticGroupsPage() {
+  const manifestQuery = useStaticManifest();
+  const { selectedMarket } = useStaticMarket();
+  const marketEntry = useMemo(
+    () => resolveStaticMarketEntry(manifestQuery.data, selectedMarket),
+    [manifestQuery.data, selectedMarket],
+  );
+  const groupsQuery = useQuery({
+    queryKey: ['staticGroups', marketEntry.pages?.groups?.path],
+    queryFn: () => fetchStaticJson(marketEntry.pages.groups.path),
+    enabled: Boolean(marketEntry.pages?.groups?.path),
+    staleTime: Infinity,
+  });
+  const chartIndexQuery = useStaticChartIndex(marketEntry.assets?.charts?.path);
+  const rrgQuery = useStaticGroupsRRG(marketEntry);
+  const rrgAvailable = Boolean(marketEntry.assets?.groups_rrg?.path);
+  const [selectedGroup, setSelectedGroup] = useState(null);
+  const [view, setView] = useState('table'); // 'table' | 'rrg'
+  const [rrgScope, setRrgScope] = useState('groups'); // 'groups' | 'sectors'
+
+  if (manifestQuery.isLoading || groupsQuery.isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" py={8}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (manifestQuery.isError || groupsQuery.isError) {
+    return <Alert severity="error">Failed to load group rankings.</Alert>;
+  }
+
+  if (!groupsQuery.data?.available) {
+    return <Alert severity="info">{groupsQuery.data?.message || 'No group rankings are available.'}</Alert>;
+  }
+
+  const payload = groupsQuery.data.payload || {};
+  const rankings = payload.rankings?.rankings || [];
+  const movers = payload.movers || {};
+  const moversPeriod = payload.movers_period || movers.period || '1w';
+  const groupDetails = payload.group_details || {};
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ fontWeight: 700, letterSpacing: '-0.5px', mb: 0.5 }}>
+        {marketEntry.display_name} Group Rankings
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2, fontSize: '12px' }}>
+        Latest ranking date: {payload.rankings?.date || '-'}.
+      </Typography>
+
+      {rrgAvailable && (
+        <RRGViewToggle
+          view={view}
+          onView={setView}
+          scope={rrgScope}
+          onScope={setRrgScope}
+          sx={{ mb: 2 }}
+        />
+      )}
+
+      {view === 'rrg' ? (
+        <RRGChart
+          data={rrgQuery.data?.payload?.[rrgScope]}
+          isLoading={rrgQuery.isLoading}
+          error={rrgQuery.isError ? rrgQuery.error : null}
+          onSelectGroup={(name) => rrgScope === 'groups' && setSelectedGroup(name)}
+        />
+      ) : (
+        <GroupsTableView
+          movers={movers}
+          moversPeriod={moversPeriod}
+          rankings={rankings}
+          onSelectGroup={setSelectedGroup}
+        />
+      )}
 
       <StaticGroupDetailModal
         group={selectedGroup}

--- a/frontend/src/static/pages/StaticGroupsPage.test.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.test.jsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
@@ -96,5 +96,74 @@ describe('StaticGroupsPage', () => {
     expect(screen.getByRole('columnheader', { name: '1W' })).toBeInTheDocument();
     expect(screen.getAllByText('Semiconductors').length).toBeGreaterThan(0);
     expect(screen.getByText('+3')).toBeInTheDocument();
+  });
+
+  it('renders the RRG chart from the baked bundle when the toggle is selected', async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      const path = String(url).split('/static-data/')[1];
+      if (path === 'manifest.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            pages: { groups: { path: 'groups.json' } },
+            assets: { groups_rrg: { path: 'groups_rrg.json' } },
+          }),
+        };
+      }
+      if (path === 'groups.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            available: true,
+            payload: {
+              movers_period: '1w',
+              rankings: { date: '2026-03-31', rankings: [] },
+              movers: { gainers: [], losers: [] },
+            },
+          }),
+        };
+      }
+      if (path === 'groups_rrg.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            available: true,
+            payload: {
+              groups: {
+                date: '2026-03-31',
+                scope: 'groups',
+                groups: [
+                  {
+                    industry_group: 'Semiconductors',
+                    rank: 1,
+                    num_stocks: 14,
+                    avg_rs_rating: 92.5,
+                    quadrant: 'Leading',
+                    is_provisional: false,
+                    current: { date: '2026-03-31', x: 108.3, y: 106.1 },
+                    tail: [
+                      { date: '2026-02-01', x: 104.0, y: 98.0 },
+                      { date: '2026-03-31', x: 108.3, y: 106.1 },
+                    ],
+                  },
+                ],
+              },
+              sectors: { date: '2026-03-31', scope: 'sectors', groups: [] },
+            },
+          }),
+        };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'US Group Rankings' })).toBeInTheDocument();
+    // Switch from the table view to the Relative Rotation Graph.
+    fireEvent.click(screen.getByRole('button', { name: 'RRG' }));
+    expect(await screen.findByText(/Relative Rotation Graph/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

Adds a **Relative Rotation Graph** to the Groups tab: each IBD industry group (or GICS-sector roll-up) plotted by **RS-Ratio (x)** vs **RS-Momentum (y)** with a weekly **tail** tracing its path through the **Leading → Weakening → Lagging → Improving** quadrants. Clicking a dot reuses the existing group-detail modal.

Ships on **both** delivery paths under the same "Groups" tab:
- **Live app** → `GET /v1/groups/rrg`
- **Static site** → pre-baked `groups_rrg.json` (no live API in static mode)

## How it's structured

One pure math module, two producers, one shared chart:

- **Math (`rrg_service.py`, pure + golden-tested):** `compute_group_rrg()` derives RS-Ratio/Momentum from the stored daily `ibd_group_ranks.avg_rs_rating` series. **Temporal normalization** — each axis is z-scored against its *own* trailing history (centered at 100), avoiding double-normalizing the already-cross-sectional RS Rating. Weekly bucketing uses the UTC Sunday-origin rule shared with the frontend chart aggregator. Short history degrades gracefully (`is_provisional` / omit), never fabricates.
- **Live producer:** `RRGService` — single batched query + GICS-sector roll-up. `get_rrg_scopes()` reads inputs **once** and derives every scope, so the static export stays atomic.
- **Static producer:** `static_site_export_service` bakes `groups_rrg.json` + a manifest asset, reusing the same math.
- **Frontend:** shared `RRGChart` (Recharts ScatterChart: quadrant backdrop, tails, clickable dots), `RRGViewToggle`, and `rrgColors` as a single source of truth — wired into both `GroupRankingsPage` (live) and `StaticGroupsPage` (static) with Table/RRG + Groups/Sectors toggles.

## Tests

- Golden RRG math (added to `make gate-5`), SQLite orchestrator test, component + static-page tests.
- Verified locally: 17/17 golden math, 42/42 static suite, 6/6 chart, lint 0/0. `make gate-5` + the SQLite/static-export checks run in CI (need the full backend env).

## Scope / notes

- **US-first**; non-US markets report unavailable gracefully (Phase 6 follow-up).
- **Operational watch-item:** the static export computes RRG from `ibd_group_ranks`; tails want ~7 months of history. If the CI-seeded DB is shallow, the math flags `is_provisional`/omits thin groups — worth eyeballing the first exported `groups_rrg.json` for real multi-month tails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Relative Rotation Graph (RRG) visualization for groups and sectors, selectable scope, and interactive chart with quadrant, current point, and historical tail.
  * New RRG view toggle to switch between table and chart; static site export now includes per-market RRG payloads.
* **Tests**
  * Added unit and golden snapshot tests covering RRG math, bucketing, quadrants, and service behavior.
* **Chores**
  * Expanded CI quality gate to include the RRG golden test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->