### PR TITLE
Harden IN static site daily run robustness

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -244,10 +244,23 @@ jobs:
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          if [ "$status" -eq 79 ]; then
+            echo "Market ${{ matrix.market }} produced diagnostics but no current market artifact will be uploaded; combine will use fallback artifacts if available."
+            echo "has_artifact=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$status" -ne 0 ]; then
             exit "$status"
           fi
           echo "has_artifact=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload market diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-market-diagnostics-${{ matrix.market }}
+          path: /tmp/static-data/diagnostics/${{ env.MARKET_LOWER }}
+          if-no-files-found: ignore
 
       - name: Build daily price bundle
         if: ${{ steps.export-market.outputs.has_artifact == 'true' }}

--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -1051,6 +1051,14 @@ def build_daily_snapshot(
         result.failed_symbols, result.skipped_symbols, result.row_count,
         result.duration_seconds, result.dq_passed,
     )
+    failure_diagnostics = dict(result.failure_diagnostics or {})
+    diagnostic_counts = failure_diagnostics.get("reason_counts", {})
+    if diagnostic_counts:
+        logger.warning(
+            "build_daily_snapshot failure diagnostics for %s: %s",
+            effective_market,
+            diagnostic_counts,
+        )
 
     if result.status == "published":
         metadata_refresh_stats = _enrich_feature_run_with_ibd_metadata(
@@ -1103,4 +1111,5 @@ def build_daily_snapshot(
         "metadata_refresh": metadata_refresh_stats if result.status == "published" else None,
         "cleaned_stale_runs": cleaned_stale_runs,
         "warnings": list(result.warnings),
+        "failure_diagnostics": failure_diagnostics,
     }

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -4,29 +4,30 @@ from __future__ import annotations
 
 import argparse
 import json
-import time
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Any, Literal
-
-from sqlalchemy import func
 
 from app.config import settings
 from app.database import SessionLocal
 from app.infra.db.models.feature_store import FeatureRunPointer
 from app.models.industry import IBDGroupRank
 from app.models.market_breadth import MarketBreadth
-from app.models.stock import StockPrice
-from app.models.stock_universe import StockUniverse
 from app.domain.markets import market_registry
 from app.scripts._runtime import prepare_runtime, repo_root
 from app.services.breadth_calculator_service import BreadthCalculatorService
 from app.services.bulk_data_fetcher import BulkDataFetcher
 from app.services.ibd_industry_service import IBDIndustryService
-from app.services.static_site_export_service import StaticSiteExportService
+from app.services.static_daily_price_refresh_service import (
+    StaticDailyPriceRefreshService,
+    static_daily_price_refresh_batch_size as _static_daily_price_refresh_batch_size,
+)
+from app.services.static_site_export_service import (
+    NoPublishedStaticMarketArtifact,
+    StaticSiteExportService,
+)
 from app.tasks.data_fetch_lock import disable_serialized_data_fetch_lock
 from app.tasks.workload_coordination import disable_serialized_market_workload
-from app.utils.symbol_support import split_supported_price_symbols
 from app.wiring.bootstrap import (
     get_group_rank_service,
     get_market_calendar_service,
@@ -35,9 +36,6 @@ from app.wiring.bootstrap import (
 )
 
 
-STATIC_DAILY_PRICE_REFRESH_PERIOD = "7d"
-STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD = "2y"
-STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE = 250
 STATIC_GROUP_HISTORY_LOOKBACK_DAYS = 100
 STATIC_BREADTH_HISTORY_MIN_TRADING_DAYS = 20
 STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
@@ -47,17 +45,6 @@ STATIC_EXPORT_MARKETS = market_registry.supported_market_codes()
 STATIC_DEFAULT_MARKET = "US"
 STATIC_EXPORT_SKIPPED_EXIT_CODE = 78
 STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE = 79
-
-# Markets where Yahoo's 429 backoff windows are long enough that a single
-# refresh pass routinely leaves a tail of rate-limited symbols. For these
-# markets we wait ``STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS`` after the main
-# loop and replay only the symbols whose failure looks transient, in a
-# smaller batch (``STATIC_RATE_LIMITED_RETRY_BATCH_SIZE``). The Yahoo 429
-# window typically clears in 2-5 minutes; 300s is a safe single retry that
-# doesn't double the IN job runtime.
-STATIC_RATE_LIMITED_RETRY_MARKETS = frozenset({"IN"})
-STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS = 300
-STATIC_RATE_LIMITED_RETRY_BATCH_SIZE = 25
 
 
 def _default_output_dir() -> Path:
@@ -77,18 +64,6 @@ def _resolve_latest_completed_trading_date(market: str) -> date:
     stale date when NYSE traded but the target exchange did not.
     """
     return get_market_calendar_service().last_completed_trading_day(market)
-
-
-def _iter_chunks(items: list[str], chunk_size: int) -> list[list[str]]:
-    return [items[index:index + chunk_size] for index in range(0, len(items), chunk_size)]
-
-
-def _static_daily_price_refresh_batch_size(market: str | None) -> int:
-    if market:
-        from app.services.rate_budget_policy import get_rate_budget_policy
-
-        return get_rate_budget_policy().get_batch_size("yfinance", market)
-    return STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE
 
 
 def _market_pointer_key(market: str) -> str:
@@ -140,6 +115,12 @@ def _selected_market_non_publishable_snapshot(
     return None if _snapshot_publishable(snapshot) else snapshot
 
 
+def _snapshot_skipped_not_trading_day(snapshot: dict[str, Any] | None) -> bool:
+    if snapshot is None:
+        return False
+    return snapshot.get("status") == "skipped" and snapshot.get("reason") == "not_trading_day"
+
+
 def _write_market_diagnostics(output_dir: Path, market: str, snapshot: dict[str, Any]) -> Path:
     diagnostics_dir = output_dir / "diagnostics" / market.lower()
     diagnostics_dir.mkdir(parents=True, exist_ok=True)
@@ -163,258 +144,13 @@ def _write_market_diagnostics(output_dir: Path, market: str, snapshot: dict[str,
 
 
 def _refresh_static_daily_prices(*, as_of_date: date, market: str | None = None) -> dict[str, Any]:
-    """Refresh recent price bars in batches without Redis or warmup metadata."""
-    price_cache = get_price_cache()
-    fetcher = BulkDataFetcher()
-
-    with SessionLocal() as db:
-        query = (
-            db.query(StockUniverse.symbol)
-            .filter(StockUniverse.is_active.is_(True))
-            .order_by(StockUniverse.market_cap.desc().nullslast(), StockUniverse.symbol.asc())
-        )
-        if market is not None:
-            query = query.filter(StockUniverse.market == market)
-        active_symbols = [symbol for symbol, in query.all()]
-        supported_symbols, skipped_symbols = split_supported_price_symbols(active_symbols)
-        latest_rows = (
-            db.query(StockPrice.symbol, func.max(StockPrice.date))
-            .filter(StockPrice.symbol.in_(supported_symbols))
-            .group_by(StockPrice.symbol)
-            .all()
-        )
-
-    latest_by_symbol = {symbol: latest_date for symbol, latest_date in latest_rows}
-    db_fresh_symbols = [
-        symbol for symbol in supported_symbols if latest_by_symbol.get(symbol) is not None and latest_by_symbol[symbol] >= as_of_date
-    ]
-    stale_symbols = [
-        symbol for symbol in supported_symbols if latest_by_symbol.get(symbol) is not None and latest_by_symbol[symbol] < as_of_date
-    ]
-    no_history_symbols = [
-        symbol for symbol in supported_symbols if symbol not in latest_by_symbol
-    ]
-
-    if not stale_symbols and not no_history_symbols:
-        print(
-            f"[static-daily prices] Database already has fresh price rows for "
-            f"{len(db_fresh_symbols):,} supported symbols as of {as_of_date}.",
-            flush=True,
-        )
-        return {
-            "status": "skipped",
-            "market": market,
-            "as_of_date": as_of_date.isoformat(),
-            "total_active_symbols": len(active_symbols),
-            "supported_symbols": len(supported_symbols),
-            "db_fresh_symbols": len(db_fresh_symbols),
-            "stale_symbols": len(stale_symbols),
-            "no_history_symbols": len(no_history_symbols),
-            "skipped_unsupported_symbols": len(skipped_symbols),
-            "yahoo_fetched_symbols": 0,
-            "yahoo_failed_symbols": 0,
-        }
-
-    batch_size = _static_daily_price_refresh_batch_size(market)
-    total_batches = (
-        (len(stale_symbols) + batch_size - 1) // batch_size
-        + (len(no_history_symbols) + batch_size - 1) // batch_size
+    service = StaticDailyPriceRefreshService(
+        session_factory=SessionLocal,
+        price_cache=get_price_cache(),
+        fetcher=BulkDataFetcher(),
+        batch_size_for_market=_static_daily_price_refresh_batch_size,
     )
-
-    print(
-        f"[static-daily prices] Refreshing {len(stale_symbols):,} stale and "
-        f"{len(no_history_symbols):,} no-history symbols in {total_batches} batches for {as_of_date} "
-        f"(DB fresh: {len(db_fresh_symbols):,}, unsupported skipped: {len(skipped_symbols):,}).",
-        flush=True,
-    )
-
-    def _fetch_and_store(symbols: list[str], *, period: str) -> tuple[int, int, list[str]]:
-        refreshed_count = 0
-        failed_count = 0
-        rate_limited: list[str] = []
-        total_symbols = len(symbols)
-        if not symbols:
-            return 0, 0, []
-        total_group_batches = (total_symbols + batch_size - 1) // batch_size
-        for batch_index, batch_symbols in enumerate(
-            _iter_chunks(symbols, batch_size),
-            start=1,
-        ):
-            processed_before = refreshed_count + failed_count
-            print(
-                f"[static-daily prices] Batch {batch_index}/{total_group_batches}: "
-                f"{processed_before:,}/{total_symbols:,} processed, fetching "
-                f"{len(batch_symbols):,} symbols from Yahoo ({period}).",
-                flush=True,
-            )
-            batch_results = fetcher.fetch_prices_in_batches(
-                batch_symbols,
-                period=period,
-                start_batch_size=batch_size,
-                market=market,
-            )
-            batch_to_store: dict[str, Any] = {}
-            for symbol, payload in batch_results.items():
-                price_data = payload.get("price_data")
-                if not payload.get("has_error") and price_data is not None and not price_data.empty:
-                    batch_to_store[symbol] = price_data
-                    refreshed_count += 1
-                else:
-                    failed_count += 1
-                    if _is_rate_limit_failure(payload):
-                        rate_limited.append(symbol)
-            if batch_to_store:
-                price_cache.store_batch_in_cache(
-                    batch_to_store,
-                    also_store_db=True,
-                    market=market,
-                )
-            print(
-                f"[static-daily prices] Batch {batch_index}/{total_group_batches} complete: "
-                f"{refreshed_count + failed_count:,}/{total_symbols:,} processed, "
-                f"{refreshed_count:,} refreshed, {failed_count:,} failed.",
-                flush=True,
-            )
-        return refreshed_count, failed_count, rate_limited
-
-    stale_refreshed, stale_failed, stale_rate_limited = _fetch_and_store(
-        stale_symbols,
-        period=STATIC_DAILY_PRICE_REFRESH_PERIOD,
-    )
-    bootstrap_refreshed, bootstrap_failed, bootstrap_rate_limited = _fetch_and_store(
-        no_history_symbols,
-        period=STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
-    )
-    refreshed = stale_refreshed + bootstrap_refreshed
-    failed = stale_failed + bootstrap_failed
-    rate_limited_symbols_by_period = {
-        STATIC_DAILY_PRICE_REFRESH_PERIOD: stale_rate_limited,
-        STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD: bootstrap_rate_limited,
-    }
-
-    retry_stats = _retry_rate_limited_failures(
-        market=market,
-        rate_limited_symbols_by_period=rate_limited_symbols_by_period,
-        fetcher=fetcher,
-        price_cache=price_cache,
-    )
-    refreshed += retry_stats["recovered"]
-    failed -= retry_stats["recovered"]
-
-    return {
-        "status": "completed",
-        "market": market,
-        "as_of_date": as_of_date.isoformat(),
-        "total_active_symbols": len(active_symbols),
-        "supported_symbols": len(supported_symbols),
-        "db_fresh_symbols": len(db_fresh_symbols),
-        "stale_symbols": len(stale_symbols),
-        "no_history_symbols": len(no_history_symbols),
-        "skipped_unsupported_symbols": len(skipped_symbols),
-        "yahoo_fetched_symbols": refreshed,
-        "yahoo_failed_symbols": failed,
-        "rate_limited_retry": retry_stats,
-    }
-
-
-def _is_rate_limit_failure(payload: dict[str, Any]) -> bool:
-    """Return True when ``payload`` describes a transient 429/rate-limit miss.
-
-    Symbol-level Yahoo errors include "Too Many Requests" / "rate" / "429" /
-    "throttl" in the error string. Permanent failures (delisted ticker,
-    unknown symbol, empty data after retries) don't match — those must be
-    excluded so we don't waste another 5-min wait retrying tickers that will
-    never come back.
-    """
-    if not payload.get("has_error"):
-        return False
-    error = str(payload.get("error") or "").lower()
-    if not error:
-        return False
-    indicators = ("rate", "429", "too many", "limit", "throttl")
-    return any(token in error for token in indicators)
-
-
-def _retry_rate_limited_failures(
-    *,
-    market: str | None,
-    rate_limited_symbols_by_period: dict[str, list[str]],
-    fetcher: BulkDataFetcher,
-    price_cache: Any,
-) -> dict[str, Any]:
-    """One-shot retry of rate-limited symbols after a fixed cool-down.
-
-    Gated on ``market in STATIC_RATE_LIMITED_RETRY_MARKETS`` because only
-    IN currently sees Yahoo 429 windows long enough to leave a recoverable
-    tail after the first pass. Permanent-looking failures from the main
-    loop (delisted, no data) are excluded by ``_is_rate_limit_failure``,
-    so this retry replays only the slice that's plausibly recoverable.
-    """
-    skipped_payload: dict[str, Any] = {
-        "attempted": 0,
-        "recovered": 0,
-        "still_failed": 0,
-        "wait_seconds": 0,
-        "batch_size": STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
-    }
-    retry_groups = [
-        (period, sorted(set(symbols)))
-        for period, symbols in rate_limited_symbols_by_period.items()
-        if symbols
-    ]
-    attempted = sum(len(symbols) for _period, symbols in retry_groups)
-    if not attempted:
-        return skipped_payload
-    normalized = (market or "").upper()
-    if normalized not in STATIC_RATE_LIMITED_RETRY_MARKETS:
-        print(
-            f"[static-daily prices] Skipping rate-limited retry for market={normalized or 'shared'}: "
-            f"{attempted} symbols looked throttled but market is outside the retry allowlist.",
-            flush=True,
-        )
-        return skipped_payload
-
-    print(
-        f"[static-daily prices:{normalized}] Yahoo flagged {attempted} symbols as rate-limited; "
-        f"waiting {STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS}s then retrying with batch size "
-        f"{STATIC_RATE_LIMITED_RETRY_BATCH_SIZE}.",
-        flush=True,
-    )
-    time.sleep(STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS)
-
-    recovered = 0
-    for period, unique_symbols in retry_groups:
-        retry_results = fetcher.fetch_prices_in_batches(
-            unique_symbols,
-            period=period,
-            start_batch_size=STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
-            market=market,
-        )
-        recovered_payload: dict[str, Any] = {}
-        for symbol, payload in retry_results.items():
-            price_data = payload.get("price_data")
-            if not payload.get("has_error") and price_data is not None and not price_data.empty:
-                recovered_payload[symbol] = price_data
-                recovered += 1
-        if recovered_payload:
-            price_cache.store_batch_in_cache(
-                recovered_payload,
-                also_store_db=True,
-                market=market,
-            )
-    still_failed = attempted - recovered
-    print(
-        f"[static-daily prices:{normalized}] Rate-limited retry complete: "
-        f"{recovered}/{attempted} recovered, {still_failed} still failed.",
-        flush=True,
-    )
-    return {
-        "attempted": attempted,
-        "recovered": recovered,
-        "still_failed": still_failed,
-        "wait_seconds": STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS,
-        "batch_size": STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
-    }
+    return service.refresh(as_of_date=as_of_date, market=market)
 
 
 def _generate_trading_dates(
@@ -779,27 +515,6 @@ def _run_daily_refresh(
     return results, warnings
 
 
-def _market_refresh_skipped_not_trading_day(refresh_results: dict[str, Any], market: str | None) -> bool:
-    if market is None:
-        return False
-    feature_snapshots = refresh_results.get("feature_snapshots", {})
-    if not isinstance(feature_snapshots, dict):
-        return False
-    snapshot = feature_snapshots.get(market.upper())
-    if not isinstance(snapshot, dict):
-        return False
-    return snapshot.get("status") == "skipped" and snapshot.get("reason") == "not_trading_day"
-
-
-def _is_no_current_artifact_error(exc: RuntimeError) -> bool:
-    message = str(exc)
-    return (
-        "No published feature run is available for static-site export" in message
-        or "No market-scoped published feature runs are available for static-site export"
-        in message
-    )
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -862,7 +577,6 @@ def main() -> int:
 
     refresh_warnings: list[str] = []
     selected_market_non_publishable_snapshot: dict[str, Any] | None = None
-    selected_market_diagnostics_path: Path | None = None
     if args.combine_artifacts_dir:
         result = StaticSiteExportService.combine_market_artifacts(
             Path(args.combine_artifacts_dir),
@@ -895,18 +609,7 @@ def main() -> int:
                 refresh_results,
                 args.market,
             )
-            if selected_market_non_publishable_snapshot is not None and args.market is not None:
-                selected_market_diagnostics_path = _write_market_diagnostics(
-                    Path(args.output_dir),
-                    args.market,
-                    selected_market_non_publishable_snapshot,
-                )
-                print(
-                    f"Static site export diagnostics written for market {args.market}: "
-                    f"{selected_market_diagnostics_path}"
-                )
-
-            if _market_refresh_skipped_not_trading_day(refresh_results, args.market):
+            if _snapshot_skipped_not_trading_day(selected_market_non_publishable_snapshot):
                 print(
                     f"Static site export skipped for market {args.market} because it is not a trading day."
                 )
@@ -920,14 +623,13 @@ def main() -> int:
                 markets=((args.market,) if args.market else None),
                 write_manifest=args.market is None,
             )
-        except RuntimeError as exc:
+        except NoPublishedStaticMarketArtifact:
             if (
                 args.market is not None
                 and args.refresh_daily
                 and selected_market_non_publishable_snapshot is not None
-                and _is_no_current_artifact_error(exc)
             ):
-                selected_market_diagnostics_path = _write_market_diagnostics(
+                _write_market_diagnostics(
                     Path(args.output_dir),
                     args.market,
                     selected_market_non_publishable_snapshot,

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import time
 from datetime import date, timedelta
 from pathlib import Path
@@ -45,6 +46,7 @@ STATIC_BUILD_MODE_FULL = "full"
 STATIC_EXPORT_MARKETS = market_registry.supported_market_codes()
 STATIC_DEFAULT_MARKET = "US"
 STATIC_EXPORT_SKIPPED_EXIT_CODE = 78
+STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE = 79
 
 # Markets where Yahoo's 429 backoff windows are long enough that a single
 # refresh pass routinely leaves a tail of rate-limited symbols. For these
@@ -107,6 +109,57 @@ def _upsert_feature_run_pointer(*, pointer_key: str, run_id: int) -> None:
         else:
             pointer.run_id = run_id
         db.commit()
+
+
+def _snapshot_publishable(snapshot: dict[str, Any]) -> bool:
+    status = snapshot.get("status")
+    if status == "published":
+        return True
+    if status == "skipped" and snapshot.get("reason") == "already_published":
+        return True
+    if status is None and (
+        snapshot.get("run_id") is not None
+        or snapshot.get("existing_run_id") is not None
+    ):
+        return True
+    return False
+
+
+def _selected_market_non_publishable_snapshot(
+    refresh_results: dict[str, Any],
+    market: str | None,
+) -> dict[str, Any] | None:
+    if market is None:
+        return None
+    feature_snapshots = refresh_results.get("feature_snapshots", {})
+    if not isinstance(feature_snapshots, dict):
+        return None
+    snapshot = feature_snapshots.get(market.upper())
+    if not isinstance(snapshot, dict):
+        return None
+    return None if _snapshot_publishable(snapshot) else snapshot
+
+
+def _write_market_diagnostics(output_dir: Path, market: str, snapshot: dict[str, Any]) -> Path:
+    diagnostics_dir = output_dir / "diagnostics" / market.lower()
+    diagnostics_dir.mkdir(parents=True, exist_ok=True)
+    diagnostics_path = diagnostics_dir / "snapshot-failure.json"
+    payload: dict[str, Any] = {
+        "market": market.upper(),
+        "status": snapshot.get("status"),
+        "failed_symbols": snapshot.get("failed_symbols", []),
+        "row_count": snapshot.get("row_count"),
+        "warnings": snapshot.get("warnings", []),
+        "failure_diagnostics": snapshot.get("failure_diagnostics", {}),
+    }
+    for key in ("reason", "run_id", "existing_run_id"):
+        if key in snapshot:
+            payload[key] = snapshot[key]
+    diagnostics_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return diagnostics_path
 
 
 def _refresh_static_daily_prices(*, as_of_date: date, market: str | None = None) -> dict[str, Any]:
@@ -556,16 +609,6 @@ def _run_daily_refresh(
 
     warnings: list[str] = []
 
-    def _snapshot_ready(snapshot: dict[str, Any]) -> bool:
-        status = snapshot.get("status")
-        if status == "published":
-            return True
-        if status == "skipped" and snapshot.get("reason") == "already_published":
-            return True
-        if status is None and (snapshot.get("run_id") is not None or snapshot.get("existing_run_id") is not None):
-            return True
-        return False
-
     selected_markets = (market,) if market is not None else STATIC_EXPORT_MARKETS
     as_of_by_market: dict[str, date] = {
         selected_market: _resolve_latest_completed_trading_date(selected_market)
@@ -629,7 +672,7 @@ def _run_daily_refresh(
         group_rank_history: dict[str, Any] = {}
         for selected_market in selected_markets:
             snapshot = feature_snapshots.get(selected_market, {})
-            if not _snapshot_ready(snapshot):
+            if not _snapshot_publishable(snapshot):
                 group_rank_history[selected_market] = {
                     "status": "skipped",
                     "market": selected_market,
@@ -659,7 +702,7 @@ def _run_daily_refresh(
         ibd_metadata_refresh: dict[str, Any] = {}
         for selected_market in selected_markets:
             snapshot = feature_snapshots.get(selected_market, {})
-            if not _snapshot_ready(snapshot):
+            if not _snapshot_publishable(snapshot):
                 ibd_metadata_refresh[selected_market] = {
                     "status": "skipped",
                     "market": selected_market,
@@ -693,7 +736,7 @@ def _run_daily_refresh(
         for snapshot_market, snapshot in feature_snapshots.items():
             if snapshot_market == STATIC_DEFAULT_MARKET:
                 continue
-            if _snapshot_ready(snapshot):
+            if _snapshot_publishable(snapshot):
                 continue
             status = snapshot.get("status")
             reason = snapshot.get("reason")
@@ -707,7 +750,7 @@ def _run_daily_refresh(
         if STATIC_DEFAULT_MARKET in feature_snapshots:
             default_snapshot = feature_snapshots.get(STATIC_DEFAULT_MARKET, {})
             default_snapshot_status = default_snapshot.get("status")
-            default_snapshot_ready = _snapshot_ready(default_snapshot)
+            default_snapshot_ready = _snapshot_publishable(default_snapshot)
             default_run_id = (
                 default_snapshot.get("run_id")
                 or default_snapshot.get("existing_run_id")
@@ -746,6 +789,10 @@ def _market_refresh_skipped_not_trading_day(refresh_results: dict[str, Any], mar
     if not isinstance(snapshot, dict):
         return False
     return snapshot.get("status") == "skipped" and snapshot.get("reason") == "not_trading_day"
+
+
+def _is_no_current_artifact_error(exc: RuntimeError) -> bool:
+    return "No published feature run is available for static-site export" in str(exc)
 
 
 def main() -> int:
@@ -809,6 +856,8 @@ def main() -> int:
         raise SystemExit("--fallback-artifacts-dir requires --combine-artifacts-dir")
 
     refresh_warnings: list[str] = []
+    selected_market_non_publishable_snapshot: dict[str, Any] | None = None
+    selected_market_diagnostics_path: Path | None = None
     if args.combine_artifacts_dir:
         result = StaticSiteExportService.combine_market_artifacts(
             Path(args.combine_artifacts_dir),
@@ -837,6 +886,21 @@ def main() -> int:
             for warning in refresh_warnings:
                 print(f"  - warning: {warning}")
 
+            selected_market_non_publishable_snapshot = _selected_market_non_publishable_snapshot(
+                refresh_results,
+                args.market,
+            )
+            if selected_market_non_publishable_snapshot is not None and args.market is not None:
+                selected_market_diagnostics_path = _write_market_diagnostics(
+                    Path(args.output_dir),
+                    args.market,
+                    selected_market_non_publishable_snapshot,
+                )
+                print(
+                    f"Static site export diagnostics written for market {args.market}: "
+                    f"{selected_market_diagnostics_path}"
+                )
+
             if _market_refresh_skipped_not_trading_day(refresh_results, args.market):
                 print(
                     f"Static site export skipped for market {args.market} because it is not a trading day."
@@ -844,12 +908,29 @@ def main() -> int:
                 return STATIC_EXPORT_SKIPPED_EXIT_CODE
 
         service = StaticSiteExportService(SessionLocal)
-        result = service.export(
-            Path(args.output_dir),
-            clean=not args.no_clean,
-            markets=((args.market,) if args.market else None),
-            write_manifest=args.market is None,
-        )
+        try:
+            result = service.export(
+                Path(args.output_dir),
+                clean=not args.no_clean,
+                markets=((args.market,) if args.market else None),
+                write_manifest=args.market is None,
+            )
+        except RuntimeError as exc:
+            if (
+                args.market is not None
+                and args.refresh_daily
+                and selected_market_non_publishable_snapshot is not None
+                and selected_market_diagnostics_path is not None
+                and selected_market_diagnostics_path.exists()
+                and _is_no_current_artifact_error(exc)
+            ):
+                print(
+                    f"Static site export skipped for market {args.market}; "
+                    "no current artifact was produced, diagnostics were uploaded, "
+                    "and the combine job can use fallback artifacts."
+                )
+                return STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+            raise
 
     print("Static site export complete:")
     print(f"  - output_dir: {result.output_dir}")

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -792,7 +792,12 @@ def _market_refresh_skipped_not_trading_day(refresh_results: dict[str, Any], mar
 
 
 def _is_no_current_artifact_error(exc: RuntimeError) -> bool:
-    return "No published feature run is available for static-site export" in str(exc)
+    message = str(exc)
+    return (
+        "No published feature run is available for static-site export" in message
+        or "No market-scoped published feature runs are available for static-site export"
+        in message
+    )
 
 
 def main() -> int:
@@ -920,10 +925,13 @@ def main() -> int:
                 args.market is not None
                 and args.refresh_daily
                 and selected_market_non_publishable_snapshot is not None
-                and selected_market_diagnostics_path is not None
-                and selected_market_diagnostics_path.exists()
                 and _is_no_current_artifact_error(exc)
             ):
+                selected_market_diagnostics_path = _write_market_diagnostics(
+                    Path(args.output_dir),
+                    args.market,
+                    selected_market_non_publishable_snapshot,
+                )
                 print(
                     f"Static site export skipped for market {args.market}; "
                     "no current artifact was produced, diagnostics were uploaded, "

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -234,11 +234,14 @@ def _refresh_static_daily_prices(*, as_of_date: date, market: str | None = None)
     )
     refreshed = stale_refreshed + bootstrap_refreshed
     failed = stale_failed + bootstrap_failed
-    rate_limited_symbols = stale_rate_limited + bootstrap_rate_limited
+    rate_limited_symbols_by_period = {
+        STATIC_DAILY_PRICE_REFRESH_PERIOD: stale_rate_limited,
+        STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD: bootstrap_rate_limited,
+    }
 
     retry_stats = _retry_rate_limited_failures(
         market=market,
-        rate_limited_symbols=rate_limited_symbols,
+        rate_limited_symbols_by_period=rate_limited_symbols_by_period,
         fetcher=fetcher,
         price_cache=price_cache,
     )
@@ -282,7 +285,7 @@ def _is_rate_limit_failure(payload: dict[str, Any]) -> bool:
 def _retry_rate_limited_failures(
     *,
     market: str | None,
-    rate_limited_symbols: list[str],
+    rate_limited_symbols_by_period: dict[str, list[str]],
     fetcher: BulkDataFetcher,
     price_cache: Any,
 ) -> dict[str, Any]:
@@ -301,54 +304,59 @@ def _retry_rate_limited_failures(
         "wait_seconds": 0,
         "batch_size": STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
     }
-    if not rate_limited_symbols:
+    retry_groups = [
+        (period, sorted(set(symbols)))
+        for period, symbols in rate_limited_symbols_by_period.items()
+        if symbols
+    ]
+    attempted = sum(len(symbols) for _period, symbols in retry_groups)
+    if not attempted:
         return skipped_payload
     normalized = (market or "").upper()
     if normalized not in STATIC_RATE_LIMITED_RETRY_MARKETS:
-        if rate_limited_symbols:
-            print(
-                f"[static-daily prices] Skipping rate-limited retry for market={normalized or 'shared'}: "
-                f"{len(rate_limited_symbols)} symbols looked throttled but market is outside the retry allowlist.",
-                flush=True,
-            )
+        print(
+            f"[static-daily prices] Skipping rate-limited retry for market={normalized or 'shared'}: "
+            f"{attempted} symbols looked throttled but market is outside the retry allowlist.",
+            flush=True,
+        )
         return skipped_payload
 
-    unique_symbols = sorted(set(rate_limited_symbols))
     print(
-        f"[static-daily prices:{normalized}] Yahoo flagged {len(unique_symbols)} symbols as rate-limited; "
+        f"[static-daily prices:{normalized}] Yahoo flagged {attempted} symbols as rate-limited; "
         f"waiting {STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS}s then retrying with batch size "
         f"{STATIC_RATE_LIMITED_RETRY_BATCH_SIZE}.",
         flush=True,
     )
     time.sleep(STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS)
 
-    retry_results = fetcher.fetch_prices_in_batches(
-        unique_symbols,
-        period=STATIC_DAILY_PRICE_REFRESH_PERIOD,
-        start_batch_size=STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
-        market=market,
-    )
-    recovered_payload: dict[str, Any] = {}
     recovered = 0
-    for symbol, payload in retry_results.items():
-        price_data = payload.get("price_data")
-        if not payload.get("has_error") and price_data is not None and not price_data.empty:
-            recovered_payload[symbol] = price_data
-            recovered += 1
-    if recovered_payload:
-        price_cache.store_batch_in_cache(
-            recovered_payload,
-            also_store_db=True,
+    for period, unique_symbols in retry_groups:
+        retry_results = fetcher.fetch_prices_in_batches(
+            unique_symbols,
+            period=period,
+            start_batch_size=STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
             market=market,
         )
-    still_failed = len(unique_symbols) - recovered
+        recovered_payload: dict[str, Any] = {}
+        for symbol, payload in retry_results.items():
+            price_data = payload.get("price_data")
+            if not payload.get("has_error") and price_data is not None and not price_data.empty:
+                recovered_payload[symbol] = price_data
+                recovered += 1
+        if recovered_payload:
+            price_cache.store_batch_in_cache(
+                recovered_payload,
+                also_store_db=True,
+                market=market,
+            )
+    still_failed = attempted - recovered
     print(
         f"[static-daily prices:{normalized}] Rate-limited retry complete: "
-        f"{recovered}/{len(unique_symbols)} recovered, {still_failed} still failed.",
+        f"{recovered}/{attempted} recovered, {still_failed} still failed.",
         flush=True,
     )
     return {
-        "attempted": len(unique_symbols),
+        "attempted": attempted,
         "recovered": recovered,
         "still_failed": still_failed,
         "wait_seconds": STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS,

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -35,6 +35,7 @@ from app.wiring.bootstrap import (
 
 
 STATIC_DAILY_PRICE_REFRESH_PERIOD = "7d"
+STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD = "2y"
 STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE = 250
 STATIC_GROUP_HISTORY_LOOKBACK_DAYS = 100
 STATIC_BREADTH_HISTORY_MIN_TRADING_DAYS = 20
@@ -78,6 +79,14 @@ def _resolve_latest_completed_trading_date(market: str) -> date:
 
 def _iter_chunks(items: list[str], chunk_size: int) -> list[list[str]]:
     return [items[index:index + chunk_size] for index in range(0, len(items), chunk_size)]
+
+
+def _static_daily_price_refresh_batch_size(market: str | None) -> int:
+    if market:
+        from app.services.rate_budget_policy import get_rate_budget_policy
+
+        return get_rate_budget_policy().get_batch_size("yfinance", market)
+    return STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE
 
 
 def _market_pointer_key(market: str) -> str:
@@ -133,19 +142,12 @@ def _refresh_static_daily_prices(*, as_of_date: date, market: str | None = None)
         symbol for symbol in supported_symbols if symbol not in latest_by_symbol
     ]
 
-    if not stale_symbols:
-        if no_history_symbols:
-            print(
-                "[static-daily prices] No reusable cached price history found; "
-                "relying on the batch-only feature snapshot path for full history fetch.",
-                flush=True,
-            )
-        else:
-            print(
-                f"[static-daily prices] Database already has fresh price rows for "
-                f"{len(db_fresh_symbols):,} supported symbols as of {as_of_date}.",
-                flush=True,
-            )
+    if not stale_symbols and not no_history_symbols:
+        print(
+            f"[static-daily prices] Database already has fresh price rows for "
+            f"{len(db_fresh_symbols):,} supported symbols as of {as_of_date}.",
+            flush=True,
+        )
         return {
             "status": "skipped",
             "market": market,
@@ -160,50 +162,79 @@ def _refresh_static_daily_prices(*, as_of_date: date, market: str | None = None)
             "yahoo_failed_symbols": 0,
         }
 
-    refreshed = 0
-    failed = 0
-    rate_limited_symbols: list[str] = []
-    total = len(stale_symbols)
-    total_batches = (total + STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE - 1) // STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE
+    batch_size = _static_daily_price_refresh_batch_size(market)
+    total_batches = (
+        (len(stale_symbols) + batch_size - 1) // batch_size
+        + (len(no_history_symbols) + batch_size - 1) // batch_size
+    )
 
     print(
-        f"[static-daily prices] Refreshing {total:,} stale symbols in {total_batches} batches "
-        f"for {as_of_date} (DB fresh: {len(db_fresh_symbols):,}, unsupported skipped: {len(skipped_symbols):,}).",
+        f"[static-daily prices] Refreshing {len(stale_symbols):,} stale and "
+        f"{len(no_history_symbols):,} no-history symbols in {total_batches} batches for {as_of_date} "
+        f"(DB fresh: {len(db_fresh_symbols):,}, unsupported skipped: {len(skipped_symbols):,}).",
         flush=True,
     )
 
-    for batch_index, batch_symbols in enumerate(
-        _iter_chunks(stale_symbols, STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE),
-        start=1,
-    ):
-        processed_before = refreshed + failed
-        print(
-            f"[static-daily prices] Batch {batch_index}/{total_batches}: "
-            f"{processed_before:,}/{total:,} processed, fetching {len(batch_symbols):,} symbols from Yahoo.",
-            flush=True,
-        )
-        batch_results = fetcher.fetch_prices_in_batches(
-            batch_symbols,
-            period=STATIC_DAILY_PRICE_REFRESH_PERIOD,
-            market=market,
-        )
-        batch_to_store: dict[str, Any] = {}
-        for symbol, payload in batch_results.items():
-            price_data = payload.get("price_data")
-            if not payload.get("has_error") and price_data is not None and not price_data.empty:
-                batch_to_store[symbol] = price_data
-                refreshed += 1
-            else:
-                failed += 1
-                if _is_rate_limit_failure(payload):
-                    rate_limited_symbols.append(symbol)
-        if batch_to_store:
-            price_cache.store_batch_in_cache(batch_to_store, also_store_db=True)
-        print(
-            f"[static-daily prices] Batch {batch_index}/{total_batches} complete: "
-            f"{refreshed + failed:,}/{total:,} processed, {refreshed:,} refreshed, {failed:,} failed.",
-            flush=True,
-        )
+    def _fetch_and_store(symbols: list[str], *, period: str) -> tuple[int, int, list[str]]:
+        refreshed_count = 0
+        failed_count = 0
+        rate_limited: list[str] = []
+        total_symbols = len(symbols)
+        if not symbols:
+            return 0, 0, []
+        total_group_batches = (total_symbols + batch_size - 1) // batch_size
+        for batch_index, batch_symbols in enumerate(
+            _iter_chunks(symbols, batch_size),
+            start=1,
+        ):
+            processed_before = refreshed_count + failed_count
+            print(
+                f"[static-daily prices] Batch {batch_index}/{total_group_batches}: "
+                f"{processed_before:,}/{total_symbols:,} processed, fetching "
+                f"{len(batch_symbols):,} symbols from Yahoo ({period}).",
+                flush=True,
+            )
+            batch_results = fetcher.fetch_prices_in_batches(
+                batch_symbols,
+                period=period,
+                start_batch_size=batch_size,
+                market=market,
+            )
+            batch_to_store: dict[str, Any] = {}
+            for symbol, payload in batch_results.items():
+                price_data = payload.get("price_data")
+                if not payload.get("has_error") and price_data is not None and not price_data.empty:
+                    batch_to_store[symbol] = price_data
+                    refreshed_count += 1
+                else:
+                    failed_count += 1
+                    if _is_rate_limit_failure(payload):
+                        rate_limited.append(symbol)
+            if batch_to_store:
+                price_cache.store_batch_in_cache(
+                    batch_to_store,
+                    also_store_db=True,
+                    market=market,
+                )
+            print(
+                f"[static-daily prices] Batch {batch_index}/{total_group_batches} complete: "
+                f"{refreshed_count + failed_count:,}/{total_symbols:,} processed, "
+                f"{refreshed_count:,} refreshed, {failed_count:,} failed.",
+                flush=True,
+            )
+        return refreshed_count, failed_count, rate_limited
+
+    stale_refreshed, stale_failed, stale_rate_limited = _fetch_and_store(
+        stale_symbols,
+        period=STATIC_DAILY_PRICE_REFRESH_PERIOD,
+    )
+    bootstrap_refreshed, bootstrap_failed, bootstrap_rate_limited = _fetch_and_store(
+        no_history_symbols,
+        period=STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+    )
+    refreshed = stale_refreshed + bootstrap_refreshed
+    failed = stale_failed + bootstrap_failed
+    rate_limited_symbols = stale_rate_limited + bootstrap_rate_limited
 
     retry_stats = _retry_rate_limited_failures(
         market=market,
@@ -305,7 +336,11 @@ def _retry_rate_limited_failures(
             recovered_payload[symbol] = price_data
             recovered += 1
     if recovered_payload:
-        price_cache.store_batch_in_cache(recovered_payload, also_store_db=True)
+        price_cache.store_batch_in_cache(
+            recovered_payload,
+            also_store_db=True,
+            market=market,
+        )
     still_failed = len(unique_symbols) - recovered
     print(
         f"[static-daily prices:{normalized}] Rate-limited retry complete: "

--- a/backend/app/services/static_daily_price_refresh_service.py
+++ b/backend/app/services/static_daily_price_refresh_service.py
@@ -1,0 +1,307 @@
+"""Static-site daily price refresh orchestration."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Callable
+
+from sqlalchemy import func
+
+from app.models.stock import StockPrice
+from app.models.stock_universe import StockUniverse
+from app.services.bulk_data_fetcher import BulkDataFetcher
+from app.utils.symbol_support import split_supported_price_symbols
+
+
+STATIC_DAILY_PRICE_REFRESH_PERIOD = "7d"
+STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD = "2y"
+STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE = 250
+
+# Markets where Yahoo's 429 backoff windows are long enough that a single
+# refresh pass routinely leaves a tail of rate-limited symbols. For these
+# markets we wait ``STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS`` after the main
+# loop and replay only the symbols whose failure looks transient, in a
+# smaller batch (``STATIC_RATE_LIMITED_RETRY_BATCH_SIZE``).
+STATIC_RATE_LIMITED_RETRY_MARKETS = frozenset({"IN"})
+STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS = 300
+STATIC_RATE_LIMITED_RETRY_BATCH_SIZE = 25
+
+
+def static_daily_price_refresh_batch_size(market: str | None) -> int:
+    if market:
+        from app.services.rate_budget_policy import get_rate_budget_policy
+
+        return get_rate_budget_policy().get_batch_size("yfinance", market)
+    return STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE
+
+
+def _iter_chunks(items: list[str], chunk_size: int) -> list[list[str]]:
+    return [items[index:index + chunk_size] for index in range(0, len(items), chunk_size)]
+
+
+def _is_rate_limit_failure(payload: dict[str, Any]) -> bool:
+    if not payload.get("has_error"):
+        return False
+    error = str(payload.get("error") or "").lower()
+    if not error:
+        return False
+    indicators = ("rate", "429", "too many", "limit", "throttl")
+    return any(token in error for token in indicators)
+
+
+class StaticDailyPriceRefreshService:
+    """Refresh price rows needed by the static-site snapshot build."""
+
+    def __init__(
+        self,
+        *,
+        session_factory,
+        price_cache,
+        fetcher: BulkDataFetcher,
+        batch_size_for_market: Callable[[str | None], int] = static_daily_price_refresh_batch_size,
+        sleep: Callable[[float], None] | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._price_cache = price_cache
+        self._fetcher = fetcher
+        self._batch_size_for_market = batch_size_for_market
+        if sleep is None:
+            import time
+
+            sleep = time.sleep
+        self._sleep = sleep
+
+    def refresh(self, *, as_of_date: date, market: str | None = None) -> dict[str, Any]:
+        with self._session_factory() as db:
+            query = (
+                db.query(StockUniverse.symbol)
+                .filter(StockUniverse.is_active.is_(True))
+                .order_by(StockUniverse.market_cap.desc().nullslast(), StockUniverse.symbol.asc())
+            )
+            if market is not None:
+                query = query.filter(StockUniverse.market == market)
+            active_symbols = [symbol for symbol, in query.all()]
+            supported_symbols, skipped_symbols = split_supported_price_symbols(active_symbols)
+            latest_rows = (
+                db.query(StockPrice.symbol, func.max(StockPrice.date))
+                .filter(StockPrice.symbol.in_(supported_symbols))
+                .group_by(StockPrice.symbol)
+                .all()
+            )
+
+        latest_by_symbol = {symbol: latest_date for symbol, latest_date in latest_rows}
+        db_fresh_symbols = [
+            symbol
+            for symbol in supported_symbols
+            if latest_by_symbol.get(symbol) is not None
+            and latest_by_symbol[symbol] >= as_of_date
+        ]
+        stale_symbols = [
+            symbol
+            for symbol in supported_symbols
+            if latest_by_symbol.get(symbol) is not None
+            and latest_by_symbol[symbol] < as_of_date
+        ]
+        no_history_symbols = [
+            symbol for symbol in supported_symbols if symbol not in latest_by_symbol
+        ]
+
+        if not stale_symbols and not no_history_symbols:
+            print(
+                f"[static-daily prices] Database already has fresh price rows for "
+                f"{len(db_fresh_symbols):,} supported symbols as of {as_of_date}.",
+                flush=True,
+            )
+            return {
+                "status": "skipped",
+                "market": market,
+                "as_of_date": as_of_date.isoformat(),
+                "total_active_symbols": len(active_symbols),
+                "supported_symbols": len(supported_symbols),
+                "db_fresh_symbols": len(db_fresh_symbols),
+                "stale_symbols": len(stale_symbols),
+                "no_history_symbols": len(no_history_symbols),
+                "skipped_unsupported_symbols": len(skipped_symbols),
+                "yahoo_fetched_symbols": 0,
+                "yahoo_failed_symbols": 0,
+            }
+
+        batch_size = self._batch_size_for_market(market)
+        total_batches = (
+            (len(stale_symbols) + batch_size - 1) // batch_size
+            + (len(no_history_symbols) + batch_size - 1) // batch_size
+        )
+
+        print(
+            f"[static-daily prices] Refreshing {len(stale_symbols):,} stale and "
+            f"{len(no_history_symbols):,} no-history symbols in {total_batches} batches for {as_of_date} "
+            f"(DB fresh: {len(db_fresh_symbols):,}, unsupported skipped: {len(skipped_symbols):,}).",
+            flush=True,
+        )
+
+        stale_refreshed, stale_failed, stale_rate_limited = self._fetch_and_store(
+            stale_symbols,
+            period=STATIC_DAILY_PRICE_REFRESH_PERIOD,
+            batch_size=batch_size,
+            market=market,
+        )
+        bootstrap_refreshed, bootstrap_failed, bootstrap_rate_limited = self._fetch_and_store(
+            no_history_symbols,
+            period=STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+            batch_size=batch_size,
+            market=market,
+        )
+        refreshed = stale_refreshed + bootstrap_refreshed
+        failed = stale_failed + bootstrap_failed
+        retry_stats = self._retry_rate_limited_failures(
+            market=market,
+            rate_limited_symbols_by_period={
+                STATIC_DAILY_PRICE_REFRESH_PERIOD: stale_rate_limited,
+                STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD: bootstrap_rate_limited,
+            },
+        )
+        refreshed += retry_stats["recovered"]
+        failed -= retry_stats["recovered"]
+
+        return {
+            "status": "completed",
+            "market": market,
+            "as_of_date": as_of_date.isoformat(),
+            "total_active_symbols": len(active_symbols),
+            "supported_symbols": len(supported_symbols),
+            "db_fresh_symbols": len(db_fresh_symbols),
+            "stale_symbols": len(stale_symbols),
+            "no_history_symbols": len(no_history_symbols),
+            "skipped_unsupported_symbols": len(skipped_symbols),
+            "yahoo_fetched_symbols": refreshed,
+            "yahoo_failed_symbols": failed,
+            "rate_limited_retry": retry_stats,
+        }
+
+    def _fetch_and_store(
+        self,
+        symbols: list[str],
+        *,
+        period: str,
+        batch_size: int,
+        market: str | None,
+    ) -> tuple[int, int, list[str]]:
+        refreshed_count = 0
+        failed_count = 0
+        rate_limited: list[str] = []
+        total_symbols = len(symbols)
+        if not symbols:
+            return 0, 0, []
+        total_group_batches = (total_symbols + batch_size - 1) // batch_size
+        for batch_index, batch_symbols in enumerate(
+            _iter_chunks(symbols, batch_size),
+            start=1,
+        ):
+            processed_before = refreshed_count + failed_count
+            print(
+                f"[static-daily prices] Batch {batch_index}/{total_group_batches}: "
+                f"{processed_before:,}/{total_symbols:,} processed, fetching "
+                f"{len(batch_symbols):,} symbols from Yahoo ({period}).",
+                flush=True,
+            )
+            batch_results = self._fetcher.fetch_prices_in_batches(
+                batch_symbols,
+                period=period,
+                start_batch_size=batch_size,
+                market=market,
+            )
+            batch_to_store: dict[str, Any] = {}
+            for symbol, payload in batch_results.items():
+                price_data = payload.get("price_data")
+                if not payload.get("has_error") and price_data is not None and not price_data.empty:
+                    batch_to_store[symbol] = price_data
+                    refreshed_count += 1
+                else:
+                    failed_count += 1
+                    if _is_rate_limit_failure(payload):
+                        rate_limited.append(symbol)
+            if batch_to_store:
+                self._price_cache.store_batch_in_cache(
+                    batch_to_store,
+                    also_store_db=True,
+                    market=market,
+                )
+            print(
+                f"[static-daily prices] Batch {batch_index}/{total_group_batches} complete: "
+                f"{refreshed_count + failed_count:,}/{total_symbols:,} processed, "
+                f"{refreshed_count:,} refreshed, {failed_count:,} failed.",
+                flush=True,
+            )
+        return refreshed_count, failed_count, rate_limited
+
+    def _retry_rate_limited_failures(
+        self,
+        *,
+        market: str | None,
+        rate_limited_symbols_by_period: dict[str, list[str]],
+    ) -> dict[str, Any]:
+        skipped_payload: dict[str, Any] = {
+            "attempted": 0,
+            "recovered": 0,
+            "still_failed": 0,
+            "wait_seconds": 0,
+            "batch_size": STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
+        }
+        retry_groups = [
+            (period, sorted(set(symbols)))
+            for period, symbols in rate_limited_symbols_by_period.items()
+            if symbols
+        ]
+        attempted = sum(len(symbols) for _period, symbols in retry_groups)
+        if not attempted:
+            return skipped_payload
+        normalized = (market or "").upper()
+        if normalized not in STATIC_RATE_LIMITED_RETRY_MARKETS:
+            print(
+                f"[static-daily prices] Skipping rate-limited retry for market={normalized or 'shared'}: "
+                f"{attempted} symbols looked throttled but market is outside the retry allowlist.",
+                flush=True,
+            )
+            return skipped_payload
+
+        print(
+            f"[static-daily prices:{normalized}] Yahoo flagged {attempted} symbols as rate-limited; "
+            f"waiting {STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS}s then retrying with batch size "
+            f"{STATIC_RATE_LIMITED_RETRY_BATCH_SIZE}.",
+            flush=True,
+        )
+        self._sleep(STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS)
+
+        recovered = 0
+        for period, unique_symbols in retry_groups:
+            retry_results = self._fetcher.fetch_prices_in_batches(
+                unique_symbols,
+                period=period,
+                start_batch_size=STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
+                market=market,
+            )
+            recovered_payload: dict[str, Any] = {}
+            for symbol, payload in retry_results.items():
+                price_data = payload.get("price_data")
+                if not payload.get("has_error") and price_data is not None and not price_data.empty:
+                    recovered_payload[symbol] = price_data
+                    recovered += 1
+            if recovered_payload:
+                self._price_cache.store_batch_in_cache(
+                    recovered_payload,
+                    also_store_db=True,
+                    market=market,
+                )
+        still_failed = attempted - recovered
+        print(
+            f"[static-daily prices:{normalized}] Rate-limited retry complete: "
+            f"{recovered}/{attempted} recovered, {still_failed} still failed.",
+            flush=True,
+        )
+        return {
+            "attempted": attempted,
+            "recovered": recovered,
+            "still_failed": still_failed,
+            "wait_seconds": STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS,
+            "batch_size": STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
+        }

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -202,6 +202,14 @@ class StaticSiteExportResult:
     manifest: dict[str, Any]
 
 
+class NoPublishedStaticMarketArtifact(RuntimeError):
+    """Raised when static export cannot find a published market artifact source."""
+
+    def __init__(self, message: str, *, markets: tuple[str, ...] = ()) -> None:
+        self.markets = tuple(markets)
+        super().__init__(message)
+
+
 class StaticSiteSectionUnavailableError(RuntimeError):
     """Raised when an optional static-site section cannot be exported for the target date."""
 
@@ -248,9 +256,13 @@ class StaticSiteExportService:
             if not available_markets:
                 latest_run = self._get_latest_published_run(db)
                 if latest_run is None:
-                    raise RuntimeError("No published feature run is available for static-site export")
-                raise RuntimeError(
-                    "No market-scoped published feature runs are available for static-site export"
+                    raise NoPublishedStaticMarketArtifact(
+                        "No published feature run is available for static-site export",
+                        markets=selected_markets,
+                    )
+                raise NoPublishedStaticMarketArtifact(
+                    "No market-scoped published feature runs are available for static-site export",
+                    markets=selected_markets,
                 )
 
             for market in available_markets:
@@ -354,7 +366,10 @@ class StaticSiteExportService:
     ) -> dict[str, Any]:
         latest_run = self._get_latest_published_run(db, market=market)
         if latest_run is None:
-            raise RuntimeError(f"No published feature run is available for static-site export market {market}")
+            raise NoPublishedStaticMarketArtifact(
+                f"No published feature run is available for static-site export market {market}",
+                markets=(market,),
+            )
 
         path_prefix = Path("markets") / market.lower()
         scan_rows, filter_options = self._load_scan_export_source(db, latest_run)

--- a/backend/app/use_cases/feature_store/build_daily_snapshot.py
+++ b/backend/app/use_cases/feature_store/build_daily_snapshot.py
@@ -254,7 +254,7 @@ class FailureDiagnosticsCollector:
         *,
         symbol: str,
         reason: str,
-        error: object | None = None,
+        error: str | None = None,
         data_errors: dict[str, str] | None = None,
     ) -> None:
         self.reason_counts[reason] += 1
@@ -705,6 +705,9 @@ class BuildDailyFeatureSnapshotUseCase:
                             sym, cmd.as_of_date, result
                         )
                         return sym, row, bool(result.get("passes_template")), None
+                    error = None
+                    if isinstance(result, dict) and result.get("error") is not None:
+                        error = str(result.get("error"))
                     return (
                         sym,
                         None,
@@ -712,11 +715,7 @@ class BuildDailyFeatureSnapshotUseCase:
                         {
                             "symbol": sym,
                             "reason": "scanner_error_result",
-                            "error": (
-                                result.get("error")
-                                if isinstance(result, dict)
-                                else None
-                            ),
+                            "error": error,
                             "data_errors": _extract_data_errors(result),
                         },
                     )

--- a/backend/app/use_cases/feature_store/build_daily_snapshot.py
+++ b/backend/app/use_cases/feature_store/build_daily_snapshot.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, replace
 from datetime import date
@@ -65,6 +66,8 @@ logger = logging.getLogger(__name__)
 
 # Singleton calendar instance (thread-safe, immutable schedule data).
 _nyse_calendar = mcal.get_calendar("NYSE")
+
+MAX_FAILURE_DIAGNOSTIC_SAMPLES = 50
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +134,27 @@ def _resolve_result_status(result_dict: object) -> str:
         return "insufficient_history"
 
     return "ok"
+
+
+def _extract_data_errors(result: object) -> dict[str, str]:
+    """Extract scanner data errors from a result payload."""
+    if not isinstance(result, dict):
+        return {}
+
+    details = result.get("details")
+    if not isinstance(details, dict):
+        return {}
+
+    data_errors = details.get("data_errors")
+    if not isinstance(data_errors, dict):
+        return {}
+
+    return {str(key): str(value) for key, value in data_errors.items()}
+
+
+def _format_exception(exc: Exception) -> str:
+    """Format an exception for bounded per-symbol diagnostics."""
+    return f"{exc.__class__.__name__}: {exc}"
 
 
 def _serialize_universe_definition(universe_def: object) -> dict[str, object]:
@@ -214,6 +238,43 @@ class BuildDailySnapshotResult:
     warnings: tuple[str, ...]
     row_count: int
     duration_seconds: float
+    failure_diagnostics: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class FailureDiagnosticsCollector:
+    """Bounded collection of per-symbol scan failure diagnostics."""
+
+    reason_counts: Counter[str] = field(default_factory=Counter)
+    samples: list[dict[str, object]] = field(default_factory=list)
+    sample_limit: int = MAX_FAILURE_DIAGNOSTIC_SAMPLES
+
+    def record(
+        self,
+        *,
+        symbol: str,
+        reason: str,
+        error: object | None = None,
+        data_errors: dict[str, str] | None = None,
+    ) -> None:
+        self.reason_counts[reason] += 1
+        if len(self.samples) >= self.sample_limit:
+            return
+        self.samples.append(
+            {
+                "symbol": symbol,
+                "reason": reason,
+                "error": error,
+                "data_errors": data_errors or {},
+            }
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "reason_counts": dict(self.reason_counts),
+            "samples": list(self.samples),
+            "sample_limit": self.sample_limit,
+        }
 
 
 class BootstrapCacheCoverageInsufficient(RuntimeError):
@@ -478,6 +539,7 @@ class BuildDailyFeatureSnapshotUseCase:
         progress_state: _SnapshotRunProgress,
     ) -> BuildDailySnapshotResult:
         start_time = time.monotonic()
+        failure_diagnostics = FailureDiagnosticsCollector()
         effective_chunk_size = (
             cmd.static_chunk_size
             if cmd.require_bulk_prefetch and cmd.static_chunk_size is not None
@@ -568,6 +630,7 @@ class BuildDailyFeatureSnapshotUseCase:
                     warnings=(*run_warnings, "Cancelled by user"),
                     row_count=uow.feature_store.count_by_run_id(run_id),
                     duration_seconds=round(duration, 2),
+                    failure_diagnostics=failure_diagnostics.to_dict(),
                 )
 
             # 3b — Scan each symbol in the chunk
@@ -601,11 +664,29 @@ class BuildDailyFeatureSnapshotUseCase:
                     pre_fetched_data = {}
 
             chunk_rows: list[FeatureRowWrite] = []
-            def _scan_symbol(symbol: str) -> tuple[str, FeatureRowWrite | None, bool]:
+
+            def _scan_symbol(
+                symbol: str,
+            ) -> tuple[
+                str,
+                FeatureRowWrite | None,
+                bool,
+                dict[str, object] | None,
+            ]:
                 sym = symbol.upper()
                 try:
                     if cache_only_symbol_data and sym not in pre_fetched_data:
-                        return sym, None, False
+                        return (
+                            sym,
+                            None,
+                            False,
+                            {
+                                "symbol": sym,
+                                "reason": "bulk_prefetch_missing",
+                                "error": None,
+                                "data_errors": {},
+                            },
+                        )
                     scan_kwargs: dict[str, object] = {}
                     if merged_requirements is not None:
                         scan_kwargs["pre_merged_requirements"] = merged_requirements
@@ -619,22 +700,49 @@ class BuildDailyFeatureSnapshotUseCase:
                         **scan_kwargs,
                     )
                     result_status = _resolve_result_status(result)
-                    if result and result_status != "error":
+                    if isinstance(result, dict) and result and result_status != "error":
                         row = _map_orchestrator_to_feature_row(
                             sym, cmd.as_of_date, result
                         )
-                        return sym, row, bool(result.get("passes_template"))
-                    return sym, None, False
-                except Exception:
+                        return sym, row, bool(result.get("passes_template")), None
+                    return (
+                        sym,
+                        None,
+                        False,
+                        {
+                            "symbol": sym,
+                            "reason": "scanner_error_result",
+                            "error": (
+                                result.get("error")
+                                if isinstance(result, dict)
+                                else None
+                            ),
+                            "data_errors": _extract_data_errors(result),
+                        },
+                    )
+                except Exception as exc:
                     logger.debug(
                         "Error scanning %s in run %d",
                         sym,
                         run_id,
                         exc_info=True,
                     )
-                    return sym, None, False
+                    return (
+                        sym,
+                        None,
+                        False,
+                        {
+                            "symbol": sym,
+                            "reason": "scan_exception",
+                            "error": _format_exception(exc),
+                            "data_errors": {},
+                        },
+                    )
 
-            outcomes_by_symbol: dict[str, tuple[FeatureRowWrite | None, bool]] = {}
+            outcomes_by_symbol: dict[
+                str,
+                tuple[FeatureRowWrite | None, bool, dict[str, object] | None],
+            ] = {}
             if (
                 cmd.require_bulk_prefetch
                 and cmd.static_parallel_workers > 1
@@ -646,20 +754,25 @@ class BuildDailyFeatureSnapshotUseCase:
                         executor.submit(_scan_symbol, symbol): symbol for symbol in chunk
                     }
                     for future in as_completed(futures):
-                        sym, row, passed = future.result()
-                        outcomes_by_symbol[sym] = (row, passed)
+                        sym, row, passed, diagnostic = future.result()
+                        outcomes_by_symbol[sym] = (row, passed, diagnostic)
             else:
                 for symbol in chunk:
-                    sym, row, passed = _scan_symbol(symbol)
-                    outcomes_by_symbol[sym] = (row, passed)
+                    sym, row, passed, diagnostic = _scan_symbol(symbol)
+                    outcomes_by_symbol[sym] = (row, passed, diagnostic)
 
             for symbol in chunk:
-                row, passed = outcomes_by_symbol.get(symbol.upper(), (None, False))
+                row, passed, diagnostic = outcomes_by_symbol.get(
+                    symbol.upper(),
+                    (None, False, None),
+                )
                 if row is not None:
                     chunk_rows.append(row)
                     if passed:
                         progress_state.passed_symbols += 1
                 else:
+                    if diagnostic is not None:
+                        failure_diagnostics.record(**diagnostic)
                     progress_state.failed_symbols += 1
                 progress_state.attempted_symbols += 1
 
@@ -762,6 +875,7 @@ class BuildDailyFeatureSnapshotUseCase:
             warnings=(*run_warnings, *pub_result.warnings),
             row_count=actual_count,
             duration_seconds=round(duration, 2),
+            failure_diagnostics=failure_diagnostics.to_dict(),
         )
 
 

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import date
+import json
 from pathlib import Path
 from types import SimpleNamespace
 import sys
@@ -1298,6 +1299,150 @@ def test_main_returns_skip_code_for_market_not_trading_day(monkeypatch, tmp_path
     captured = capsys.readouterr()
     assert "Static site export skipped for market TW because it is not a trading day." in captured.out
     assert export_calls == []
+
+
+def test_write_market_diagnostics_records_quarantined_snapshot(tmp_path):
+    path = export_script._write_market_diagnostics(  # noqa: SLF001 - intentional unit test coverage
+        tmp_path / "out",
+        "in",
+        {
+            "status": "quarantined",
+            "reason": "data_quality_gate",
+            "run_id": 91,
+            "existing_run_id": 77,
+            "failed_symbols": ["RELIANCE.NS", "TCS.NS"],
+            "row_count": 4312,
+            "warnings": ["price rows missing"],
+            "failure_diagnostics": {"failed_symbol_count": 2},
+            "ignored": "not exported",
+        },
+    )
+
+    assert path == tmp_path / "out" / "diagnostics" / "in" / "snapshot-failure.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload == {
+        "market": "IN",
+        "status": "quarantined",
+        "reason": "data_quality_gate",
+        "run_id": 91,
+        "existing_run_id": 77,
+        "failed_symbols": ["RELIANCE.NS", "TCS.NS"],
+        "row_count": 4312,
+        "warnings": ["price rows missing"],
+        "failure_diagnostics": {"failed_symbol_count": 2},
+    }
+
+
+def test_main_returns_no_current_artifact_code_for_quarantined_selected_market(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    output_dir = tmp_path / "out"
+
+    monkeypatch.setattr(export_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(
+        export_script,
+        "_run_daily_refresh",
+        lambda **_kwargs: (
+            {
+                "feature_snapshots": {
+                    "IN": {
+                        "status": "quarantined",
+                        "reason": "data_quality_gate",
+                        "market": "IN",
+                        "run_id": 91,
+                        "failed_symbols": ["TCS.NS"],
+                        "row_count": 4312,
+                        "failure_diagnostics": {"failed_symbol_count": 1},
+                    }
+                }
+            },
+            [],
+        ),
+    )
+
+    class ExportRaisesNoCurrentArtifact:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def export(self, *_args, **_kwargs):
+            raise RuntimeError(
+                "No published feature run is available for static-site export market IN"
+            )
+
+    monkeypatch.setattr(export_script, "StaticSiteExportService", ExportRaisesNoCurrentArtifact)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_static_site.py",
+            "--output-dir",
+            str(output_dir),
+            "--refresh-daily",
+            "--market",
+            "IN",
+        ],
+    )
+
+    assert export_script.main() == 79
+
+    diagnostics_path = output_dir / "diagnostics" / "in" / "snapshot-failure.json"
+    assert diagnostics_path.exists()
+    payload = json.loads(diagnostics_path.read_text(encoding="utf-8"))
+    assert payload["market"] == "IN"
+    assert payload["status"] == "quarantined"
+    assert payload["failure_diagnostics"] == {"failed_symbol_count": 1}
+    captured = capsys.readouterr()
+    assert "fallback" in captured.out
+    assert "skipped" in captured.out
+
+
+def test_main_reraises_unrelated_runtime_errors_for_non_ready_selected_market(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(export_script, "prepare_runtime", lambda: None)
+    monkeypatch.setattr(
+        export_script,
+        "_run_daily_refresh",
+        lambda **_kwargs: (
+            {
+                "feature_snapshots": {
+                    "IN": {
+                        "status": "quarantined",
+                        "market": "IN",
+                        "failure_diagnostics": {"failed_symbol_count": 1},
+                    }
+                }
+            },
+            [],
+        ),
+    )
+
+    class ExportRaisesUnrelatedRuntimeError:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def export(self, *_args, **_kwargs):
+            raise RuntimeError("database connection dropped")
+
+    monkeypatch.setattr(export_script, "StaticSiteExportService", ExportRaisesUnrelatedRuntimeError)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_static_site.py",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--refresh-daily",
+            "--market",
+            "IN",
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="database connection dropped"):
+        export_script.main()
 
 
 def _seed_in_universe(session_factory):

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -12,17 +12,12 @@ import sys
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
 import app.scripts.export_static_site as export_script
 import app.tasks.fundamentals_tasks as fundamentals_tasks
 import app.tasks.universe_tasks as universe_tasks
-from app.database import Base
 from app.domain.markets import market_registry
 from app.interfaces.tasks import feature_store_tasks
-from app.models.stock import StockPrice
-from app.models.stock_universe import StockUniverse
 
 
 def test_static_export_markets_match_market_registry():
@@ -670,216 +665,6 @@ def test_run_daily_refresh_uses_static_daily_mode_and_group_rank_bypass(monkeypa
     }
 
 
-def test_refresh_static_daily_prices_filters_to_selected_market(monkeypatch):
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
-    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
-
-    with session_factory() as db:
-        db.add_all(
-            [
-                StockUniverse(symbol="0700.HK", market="HK", is_active=True, market_cap=100.0),
-                StockUniverse(symbol="9988.HK", market="HK", is_active=True, market_cap=90.0),
-                StockUniverse(symbol="AAPL", market="US", is_active=True, market_cap=120.0),
-                StockUniverse(symbol="BAD-W", market="HK", is_active=True, market_cap=80.0),
-            ]
-        )
-        db.add(
-            StockPrice(
-                symbol="0700.HK",
-                date=date(2026, 4, 1),
-                open=1.0,
-                high=1.0,
-                low=1.0,
-                close=1.0,
-                volume=1000,
-            )
-        )
-        db.add(
-            StockPrice(
-                symbol="AAPL",
-                date=date(2026, 4, 1),
-                open=1.0,
-                high=1.0,
-                low=1.0,
-                close=1.0,
-                volume=1000,
-            )
-        )
-        db.commit()
-
-    fetch_calls: list[dict] = []
-    stored_batches: list[dict] = []
-
-    class _FakeFetcher:
-        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
-            fetch_calls.append(
-                {
-                    "symbols": list(symbols),
-                    "period": period,
-                    "market": market,
-                    "start_batch_size": start_batch_size,
-                }
-            )
-            return {
-                symbol: {"price_data": SimpleNamespace(empty=False), "has_error": False}
-                for symbol in symbols
-            }
-
-    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
-    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
-    monkeypatch.setattr(export_script, "_static_daily_price_refresh_batch_size", lambda market: 25)
-    monkeypatch.setattr(
-        export_script,
-        "get_price_cache",
-        lambda: SimpleNamespace(
-            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
-                {
-                    "symbols": sorted(payload.keys()),
-                    "also_store_db": also_store_db,
-                    "market": market,
-                }
-            )
-        ),
-    )
-
-    result = export_script._refresh_static_daily_prices(  # noqa: SLF001 - intentional unit test coverage
-        as_of_date=date(2026, 4, 2),
-        market="HK",
-    )
-
-    assert result["market"] == "HK"
-    assert result["total_active_symbols"] == 3
-    assert result["supported_symbols"] == 2
-    assert result["skipped_unsupported_symbols"] == 1
-    assert fetch_calls == [
-        {
-            "symbols": ["0700.HK"],
-            "period": "7d",
-            "market": "HK",
-            "start_batch_size": 25,
-        },
-        {
-            "symbols": ["9988.HK"],
-            "period": "2y",
-            "market": "HK",
-            "start_batch_size": 25,
-        },
-    ]
-    assert stored_batches == [
-        {"symbols": ["0700.HK"], "also_store_db": True, "market": "HK"},
-        {"symbols": ["9988.HK"], "also_store_db": True, "market": "HK"},
-    ]
-
-
-def test_refresh_static_daily_prices_fetches_no_history_symbols_with_full_period(monkeypatch):
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
-    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
-
-    with session_factory() as db:
-        db.add_all(
-            [
-                StockUniverse(symbol="OLD.NS", market="IN", is_active=True, market_cap=100.0),
-                StockUniverse(symbol="NEW.NS", market="IN", is_active=True, market_cap=90.0),
-            ]
-        )
-        db.add(
-            StockPrice(
-                symbol="OLD.NS",
-                date=date(2026, 6, 3),
-                open=1.0,
-                high=1.0,
-                low=1.0,
-                close=1.0,
-                volume=1000,
-            )
-        )
-        db.commit()
-
-    fetch_calls = []
-    stored_batches = []
-
-    class _FakeFetcher:
-        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
-            fetch_calls.append(
-                {
-                    "symbols": list(symbols),
-                    "period": period,
-                    "market": market,
-                    "start_batch_size": start_batch_size,
-                }
-            )
-            return {
-                symbol: {"price_data": SimpleNamespace(empty=False), "has_error": False}
-                for symbol in symbols
-            }
-
-    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
-    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
-    monkeypatch.setattr(export_script, "_static_daily_price_refresh_batch_size", lambda market: 25)
-    monkeypatch.setattr(
-        export_script,
-        "get_price_cache",
-        lambda: SimpleNamespace(
-            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
-                {
-                    "symbols": sorted(payload.keys()),
-                    "also_store_db": also_store_db,
-                    "market": market,
-                }
-            )
-        ),
-    )
-
-    result = export_script._refresh_static_daily_prices(  # noqa: SLF001 - intentional unit test coverage
-        as_of_date=date(2026, 6, 4),
-        market="IN",
-    )
-
-    assert fetch_calls == [
-        {
-            "symbols": ["OLD.NS"],
-            "period": "7d",
-            "market": "IN",
-            "start_batch_size": 25,
-        },
-        {
-            "symbols": ["NEW.NS"],
-            "period": "2y",
-            "market": "IN",
-            "start_batch_size": 25,
-        },
-    ]
-    assert stored_batches == [
-        {"symbols": ["OLD.NS"], "also_store_db": True, "market": "IN"},
-        {"symbols": ["NEW.NS"], "also_store_db": True, "market": "IN"},
-    ]
-    assert result["stale_symbols"] == 1
-    assert result["no_history_symbols"] == 1
-    assert result["yahoo_fetched_symbols"] == 2
-
-
-def test_static_daily_price_refresh_batch_size_uses_market_policy(monkeypatch):
-    import app.services.rate_budget_policy as rate_budget_policy
-
-    calls = []
-
-    class _FakePolicy:
-        def get_batch_size(self, provider, market):
-            calls.append((provider, market))
-            return 31
-
-    monkeypatch.setattr(rate_budget_policy, "get_rate_budget_policy", lambda: _FakePolicy())
-
-    assert export_script._static_daily_price_refresh_batch_size("IN") == 31  # noqa: SLF001
-    assert calls == [("yfinance", "IN")]
-    assert (
-        export_script._static_daily_price_refresh_batch_size(None)  # noqa: SLF001
-        == export_script.STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE
-    )
-
-
 def test_run_daily_refresh_reenriches_ibd_metadata_after_group_rank_backfill(monkeypatch):
     """Group ranks for ``as_of_date`` are backfilled by ``_ensure_group_rank_history``
     only after ``build_daily_snapshot`` has already run its inner enrichment.
@@ -1254,6 +1039,7 @@ def test_main_passes_fallback_artifacts_dir_to_combine(monkeypatch, tmp_path):
 
 def test_main_returns_skip_code_for_market_not_trading_day(monkeypatch, tmp_path, capsys):
     export_calls: list[object] = []
+    output_dir = tmp_path / "out"
 
     monkeypatch.setattr(export_script, "prepare_runtime", lambda: None)
     monkeypatch.setattr(
@@ -1288,7 +1074,7 @@ def test_main_returns_skip_code_for_market_not_trading_day(monkeypatch, tmp_path
         [
             "export_static_site.py",
             "--output-dir",
-            str(tmp_path / "out"),
+            str(output_dir),
             "--refresh-daily",
             "--market",
             "TW",
@@ -1300,6 +1086,7 @@ def test_main_returns_skip_code_for_market_not_trading_day(monkeypatch, tmp_path
     captured = capsys.readouterr()
     assert "Static site export skipped for market TW because it is not a trading day." in captured.out
     assert export_calls == []
+    assert not (output_dir / "diagnostics" / "tw" / "snapshot-failure.json").exists()
 
 
 def test_write_market_diagnostics_records_quarantined_snapshot(tmp_path):
@@ -1334,18 +1121,10 @@ def test_write_market_diagnostics_records_quarantined_snapshot(tmp_path):
     }
 
 
-@pytest.mark.parametrize(
-    "error_message",
-    [
-        "No published feature run is available for static-site export market IN",
-        "No market-scoped published feature runs are available for static-site export",
-    ],
-)
 def test_main_returns_no_current_artifact_code_for_quarantined_selected_market(
     monkeypatch,
     tmp_path,
     capsys,
-    error_message,
 ):
     output_dir = tmp_path / "out"
 
@@ -1377,7 +1156,10 @@ def test_main_returns_no_current_artifact_code_for_quarantined_selected_market(
 
         def export(self, output_dir_arg, *_args, **_kwargs):
             shutil.rmtree(output_dir_arg, ignore_errors=True)
-            raise RuntimeError(error_message)
+            raise export_script.NoPublishedStaticMarketArtifact(
+                "No current IN artifact",
+                markets=("IN",),
+            )
 
     monkeypatch.setattr(export_script, "StaticSiteExportService", ExportRaisesNoCurrentArtifact)
     monkeypatch.setattr(
@@ -1451,320 +1233,3 @@ def test_main_reraises_unrelated_runtime_errors_for_non_ready_selected_market(
 
     with pytest.raises(RuntimeError, match="database connection dropped"):
         export_script.main()
-
-
-def _seed_in_universe(session_factory):
-    """Insert three IN tickers — two with stale prices, one fresh — into a
-    sqlite session so ``_refresh_static_daily_prices`` has work to do."""
-    with session_factory() as db:
-        db.add_all(
-            [
-                StockUniverse(symbol="RELIANCE.NS", market="IN", is_active=True, market_cap=300.0),
-                StockUniverse(symbol="TCS.NS", market="IN", is_active=True, market_cap=200.0),
-                StockUniverse(symbol="INFY.NS", market="IN", is_active=True, market_cap=100.0),
-            ]
-        )
-        # All three rows have stale prices so the refresh loop will try Yahoo
-        # for all of them — that gives us deterministic batching.
-        for symbol in ("RELIANCE.NS", "TCS.NS", "INFY.NS"):
-            db.add(
-                StockPrice(
-                    symbol=symbol,
-                    date=date(2026, 4, 1),
-                    open=1.0,
-                    high=1.0,
-                    low=1.0,
-                    close=1.0,
-                    volume=1000,
-                )
-            )
-        db.commit()
-
-
-def test_refresh_static_daily_prices_retries_in_rate_limited_failures(monkeypatch):
-    """When the first IN pass leaves rate-limited failures behind, the script
-    waits ``STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS`` and retries only the
-    throttled symbols with ``STATIC_RATE_LIMITED_RETRY_BATCH_SIZE``. The
-    refreshed count must include the recovered symbols, and permanent
-    failures must NOT be retried."""
-
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
-    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
-    _seed_in_universe(session_factory)
-
-    fetch_calls: list[dict] = []
-    stored_batches: list[dict] = []
-    sleeps: list[float] = []
-
-    class _FakeFetcher:
-        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
-            fetch_calls.append(
-                {
-                    "symbols": list(symbols),
-                    "period": period,
-                    "start_batch_size": start_batch_size,
-                    "market": market,
-                }
-            )
-            if len(fetch_calls) == 1:
-                return {
-                    "RELIANCE.NS": {
-                        "price_data": SimpleNamespace(empty=False),
-                        "has_error": False,
-                    },
-                    "TCS.NS": {
-                        "price_data": None,
-                        "has_error": True,
-                        "error": "Too Many Requests (429)",
-                    },
-                    "INFY.NS": {
-                        "price_data": None,
-                        "has_error": True,
-                        "error": "delisted: no price data",
-                    },
-                }
-            # Retry pass recovers TCS.
-            return {
-                "TCS.NS": {
-                    "price_data": SimpleNamespace(empty=False),
-                    "has_error": False,
-                },
-            }
-
-    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
-    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
-    monkeypatch.setattr(
-        export_script,
-        "get_price_cache",
-        lambda: SimpleNamespace(
-            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
-                {
-                    "symbols": sorted(payload.keys()),
-                    "also_store_db": also_store_db,
-                    "market": market,
-                }
-            )
-        ),
-    )
-    monkeypatch.setattr(export_script.time, "sleep", lambda seconds: sleeps.append(seconds))
-
-    result = export_script._refresh_static_daily_prices(  # noqa: SLF001
-        as_of_date=date(2026, 4, 2),
-        market="IN",
-    )
-
-    assert sleeps == [export_script.STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS]
-    assert len(fetch_calls) == 2, "Expected one initial pass + one retry pass"
-    # Retry must only include the rate-limited symbol; the delisted INFY symbol
-    # is filtered out by ``_is_rate_limit_failure``.
-    assert fetch_calls[1]["symbols"] == ["TCS.NS"]
-    assert fetch_calls[1]["start_batch_size"] == export_script.STATIC_RATE_LIMITED_RETRY_BATCH_SIZE
-    assert fetch_calls[1]["market"] == "IN"
-    # Both the initial successful symbol and the recovered retry symbol are
-    # stored. INFY is never persisted.
-    stored_symbols = {symbol for batch in stored_batches for symbol in batch["symbols"]}
-    assert stored_symbols == {"RELIANCE.NS", "TCS.NS"}
-    assert result["rate_limited_retry"] == {
-        "attempted": 1,
-        "recovered": 1,
-        "still_failed": 0,
-        "wait_seconds": export_script.STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS,
-        "batch_size": export_script.STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
-    }
-    assert result["yahoo_fetched_symbols"] == 2  # 1 initial + 1 recovered
-    assert result["yahoo_failed_symbols"] == 1  # INFY remains permanent failure
-
-
-def test_refresh_static_daily_prices_retries_no_history_rate_limits_with_bootstrap_period(monkeypatch):
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
-    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
-
-    with session_factory() as db:
-        db.add(StockUniverse(symbol="NEW.NS", market="IN", is_active=True, market_cap=100.0))
-        db.commit()
-
-    fetch_calls: list[dict] = []
-    stored_batches: list[dict] = []
-    sleeps: list[float] = []
-
-    class _FakeFetcher:
-        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
-            fetch_calls.append(
-                {
-                    "symbols": list(symbols),
-                    "period": period,
-                    "start_batch_size": start_batch_size,
-                    "market": market,
-                }
-            )
-            if len(fetch_calls) == 1:
-                return {
-                    "NEW.NS": {
-                        "price_data": None,
-                        "has_error": True,
-                        "error": "Too Many Requests (429)",
-                    },
-                }
-            return {
-                "NEW.NS": {
-                    "price_data": SimpleNamespace(empty=False),
-                    "has_error": False,
-                },
-            }
-
-    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
-    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
-    monkeypatch.setattr(export_script, "_static_daily_price_refresh_batch_size", lambda market: 25)
-    monkeypatch.setattr(
-        export_script,
-        "get_price_cache",
-        lambda: SimpleNamespace(
-            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
-                {
-                    "symbols": sorted(payload.keys()),
-                    "also_store_db": also_store_db,
-                    "market": market,
-                }
-            )
-        ),
-    )
-    monkeypatch.setattr(export_script.time, "sleep", lambda seconds: sleeps.append(seconds))
-
-    result = export_script._refresh_static_daily_prices(  # noqa: SLF001
-        as_of_date=date(2026, 6, 4),
-        market="IN",
-    )
-
-    assert sleeps == [export_script.STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS]
-    assert fetch_calls == [
-        {
-            "symbols": ["NEW.NS"],
-            "period": "2y",
-            "start_batch_size": 25,
-            "market": "IN",
-        },
-        {
-            "symbols": ["NEW.NS"],
-            "period": "2y",
-            "start_batch_size": export_script.STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
-            "market": "IN",
-        },
-    ]
-    assert stored_batches == [
-        {"symbols": ["NEW.NS"], "also_store_db": True, "market": "IN"},
-    ]
-    assert result["rate_limited_retry"]["recovered"] == 1
-    assert result["yahoo_fetched_symbols"] == 1
-    assert result["yahoo_failed_symbols"] == 0
-
-
-def test_refresh_static_daily_prices_skips_retry_for_non_in_markets(monkeypatch):
-    """The retry path is gated to markets in
-    ``STATIC_RATE_LIMITED_RETRY_MARKETS`` so it does not change behavior for
-    US/HK/JP/etc. Rate-limited failures from those markets fall through to
-    the existing DQ gate."""
-
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
-    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
-
-    with session_factory() as db:
-        db.add(StockUniverse(symbol="0700.HK", market="HK", is_active=True, market_cap=100.0))
-        db.add(
-            StockPrice(
-                symbol="0700.HK",
-                date=date(2026, 4, 1),
-                open=1.0,
-                high=1.0,
-                low=1.0,
-                close=1.0,
-                volume=1000,
-            )
-        )
-        db.commit()
-
-    fetch_calls: list[dict] = []
-    sleeps: list[float] = []
-
-    class _FakeFetcher:
-        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
-            fetch_calls.append({"symbols": list(symbols), "market": market})
-            return {
-                symbol: {
-                    "price_data": None,
-                    "has_error": True,
-                    "error": "429 rate limited",
-                }
-                for symbol in symbols
-            }
-
-    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
-    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
-    monkeypatch.setattr(
-        export_script,
-        "get_price_cache",
-        lambda: SimpleNamespace(store_batch_in_cache=lambda *_args, **_kwargs: None),
-    )
-    monkeypatch.setattr(export_script.time, "sleep", lambda seconds: sleeps.append(seconds))
-
-    result = export_script._refresh_static_daily_prices(  # noqa: SLF001
-        as_of_date=date(2026, 4, 2),
-        market="HK",
-    )
-
-    assert len(fetch_calls) == 1, "HK must not trigger the rate-limited retry"
-    assert sleeps == [], "HK must not wait for a retry"
-    assert result["rate_limited_retry"] == {
-        "attempted": 0,
-        "recovered": 0,
-        "still_failed": 0,
-        "wait_seconds": 0,
-        "batch_size": export_script.STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
-    }
-
-
-def test_refresh_static_daily_prices_skips_retry_when_no_rate_limited_failures(monkeypatch):
-    """If the first IN pass succeeds (or all failures are permanent), the
-    retry path is a no-op — no sleep, no extra Yahoo call."""
-
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
-    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
-    _seed_in_universe(session_factory)
-
-    fetch_calls: list[dict] = []
-    sleeps: list[float] = []
-
-    class _FakeFetcher:
-        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
-            fetch_calls.append({"symbols": list(symbols)})
-            # All permanent failures: delisted/unknown symbol.
-            return {
-                symbol: {
-                    "price_data": None,
-                    "has_error": True,
-                    "error": "delisted: no price data",
-                }
-                for symbol in symbols
-            }
-
-    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
-    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
-    monkeypatch.setattr(
-        export_script,
-        "get_price_cache",
-        lambda: SimpleNamespace(store_batch_in_cache=lambda *_args, **_kwargs: None),
-    )
-    monkeypatch.setattr(export_script.time, "sleep", lambda seconds: sleeps.append(seconds))
-
-    result = export_script._refresh_static_daily_prices(  # noqa: SLF001
-        as_of_date=date(2026, 4, 2),
-        market="IN",
-    )
-
-    assert len(fetch_calls) == 1, "Permanent failures must not trigger a retry"
-    assert sleeps == []
-    assert result["rate_limited_retry"]["attempted"] == 0
-    assert result["yahoo_failed_symbols"] == 3

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -1423,6 +1423,90 @@ def test_refresh_static_daily_prices_retries_in_rate_limited_failures(monkeypatc
     assert result["yahoo_failed_symbols"] == 1  # INFY remains permanent failure
 
 
+def test_refresh_static_daily_prices_retries_no_history_rate_limits_with_bootstrap_period(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
+    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
+
+    with session_factory() as db:
+        db.add(StockUniverse(symbol="NEW.NS", market="IN", is_active=True, market_cap=100.0))
+        db.commit()
+
+    fetch_calls: list[dict] = []
+    stored_batches: list[dict] = []
+    sleeps: list[float] = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append(
+                {
+                    "symbols": list(symbols),
+                    "period": period,
+                    "start_batch_size": start_batch_size,
+                    "market": market,
+                }
+            )
+            if len(fetch_calls) == 1:
+                return {
+                    "NEW.NS": {
+                        "price_data": None,
+                        "has_error": True,
+                        "error": "Too Many Requests (429)",
+                    },
+                }
+            return {
+                "NEW.NS": {
+                    "price_data": SimpleNamespace(empty=False),
+                    "has_error": False,
+                },
+            }
+
+    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
+    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
+    monkeypatch.setattr(export_script, "_static_daily_price_refresh_batch_size", lambda market: 25)
+    monkeypatch.setattr(
+        export_script,
+        "get_price_cache",
+        lambda: SimpleNamespace(
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(export_script.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    result = export_script._refresh_static_daily_prices(  # noqa: SLF001
+        as_of_date=date(2026, 6, 4),
+        market="IN",
+    )
+
+    assert sleeps == [export_script.STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS]
+    assert fetch_calls == [
+        {
+            "symbols": ["NEW.NS"],
+            "period": "2y",
+            "start_batch_size": 25,
+            "market": "IN",
+        },
+        {
+            "symbols": ["NEW.NS"],
+            "period": "2y",
+            "start_batch_size": export_script.STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
+            "market": "IN",
+        },
+    ]
+    assert stored_batches == [
+        {"symbols": ["NEW.NS"], "also_store_db": True, "market": "IN"},
+    ]
+    assert result["rate_limited_retry"]["recovered"] == 1
+    assert result["yahoo_fetched_symbols"] == 1
+    assert result["yahoo_failed_symbols"] == 0
+
+
 def test_refresh_static_daily_prices_skips_retry_for_non_in_markets(monkeypatch):
     """The retry path is gated to markets in
     ``STATIC_RATE_LIMITED_RETRY_MARKETS`` so it does not change behavior for

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from datetime import date
 import json
 from pathlib import Path
+import shutil
 from types import SimpleNamespace
 import sys
 from unittest.mock import MagicMock
@@ -1333,10 +1334,18 @@ def test_write_market_diagnostics_records_quarantined_snapshot(tmp_path):
     }
 
 
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "No published feature run is available for static-site export market IN",
+        "No market-scoped published feature runs are available for static-site export",
+    ],
+)
 def test_main_returns_no_current_artifact_code_for_quarantined_selected_market(
     monkeypatch,
     tmp_path,
     capsys,
+    error_message,
 ):
     output_dir = tmp_path / "out"
 
@@ -1366,10 +1375,9 @@ def test_main_returns_no_current_artifact_code_for_quarantined_selected_market(
         def __init__(self, *_args, **_kwargs):
             pass
 
-        def export(self, *_args, **_kwargs):
-            raise RuntimeError(
-                "No published feature run is available for static-site export market IN"
-            )
+        def export(self, output_dir_arg, *_args, **_kwargs):
+            shutil.rmtree(output_dir_arg, ignore_errors=True)
+            raise RuntimeError(error_message)
 
     monkeypatch.setattr(export_script, "StaticSiteExportService", ExportRaisesNoCurrentArtifact)
     monkeypatch.setattr(

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -716,6 +716,7 @@ def test_refresh_static_daily_prices_filters_to_selected_market(monkeypatch):
                     "symbols": list(symbols),
                     "period": period,
                     "market": market,
+                    "start_batch_size": start_batch_size,
                 }
             )
             return {
@@ -725,12 +726,17 @@ def test_refresh_static_daily_prices_filters_to_selected_market(monkeypatch):
 
     monkeypatch.setattr(export_script, "SessionLocal", session_factory)
     monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
+    monkeypatch.setattr(export_script, "_static_daily_price_refresh_batch_size", lambda market: 25)
     monkeypatch.setattr(
         export_script,
         "get_price_cache",
         lambda: SimpleNamespace(
-            store_batch_in_cache=lambda payload, also_store_db=True: stored_batches.append(
-                {"symbols": sorted(payload.keys()), "also_store_db": also_store_db}
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
             )
         ),
     )
@@ -744,8 +750,132 @@ def test_refresh_static_daily_prices_filters_to_selected_market(monkeypatch):
     assert result["total_active_symbols"] == 3
     assert result["supported_symbols"] == 2
     assert result["skipped_unsupported_symbols"] == 1
-    assert fetch_calls == [{"symbols": ["0700.HK"], "period": "7d", "market": "HK"}]
-    assert stored_batches == [{"symbols": ["0700.HK"], "also_store_db": True}]
+    assert fetch_calls == [
+        {
+            "symbols": ["0700.HK"],
+            "period": "7d",
+            "market": "HK",
+            "start_batch_size": 25,
+        },
+        {
+            "symbols": ["9988.HK"],
+            "period": "2y",
+            "market": "HK",
+            "start_batch_size": 25,
+        },
+    ]
+    assert stored_batches == [
+        {"symbols": ["0700.HK"], "also_store_db": True, "market": "HK"},
+        {"symbols": ["9988.HK"], "also_store_db": True, "market": "HK"},
+    ]
+
+
+def test_refresh_static_daily_prices_fetches_no_history_symbols_with_full_period(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
+    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
+
+    with session_factory() as db:
+        db.add_all(
+            [
+                StockUniverse(symbol="OLD.NS", market="IN", is_active=True, market_cap=100.0),
+                StockUniverse(symbol="NEW.NS", market="IN", is_active=True, market_cap=90.0),
+            ]
+        )
+        db.add(
+            StockPrice(
+                symbol="OLD.NS",
+                date=date(2026, 6, 3),
+                open=1.0,
+                high=1.0,
+                low=1.0,
+                close=1.0,
+                volume=1000,
+            )
+        )
+        db.commit()
+
+    fetch_calls = []
+    stored_batches = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append(
+                {
+                    "symbols": list(symbols),
+                    "period": period,
+                    "market": market,
+                    "start_batch_size": start_batch_size,
+                }
+            )
+            return {
+                symbol: {"price_data": SimpleNamespace(empty=False), "has_error": False}
+                for symbol in symbols
+            }
+
+    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
+    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
+    monkeypatch.setattr(export_script, "_static_daily_price_refresh_batch_size", lambda market: 25)
+    monkeypatch.setattr(
+        export_script,
+        "get_price_cache",
+        lambda: SimpleNamespace(
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
+            )
+        ),
+    )
+
+    result = export_script._refresh_static_daily_prices(  # noqa: SLF001 - intentional unit test coverage
+        as_of_date=date(2026, 6, 4),
+        market="IN",
+    )
+
+    assert fetch_calls == [
+        {
+            "symbols": ["OLD.NS"],
+            "period": "7d",
+            "market": "IN",
+            "start_batch_size": 25,
+        },
+        {
+            "symbols": ["NEW.NS"],
+            "period": "2y",
+            "market": "IN",
+            "start_batch_size": 25,
+        },
+    ]
+    assert stored_batches == [
+        {"symbols": ["OLD.NS"], "also_store_db": True, "market": "IN"},
+        {"symbols": ["NEW.NS"], "also_store_db": True, "market": "IN"},
+    ]
+    assert result["stale_symbols"] == 1
+    assert result["no_history_symbols"] == 1
+    assert result["yahoo_fetched_symbols"] == 2
+
+
+def test_static_daily_price_refresh_batch_size_uses_market_policy(monkeypatch):
+    import app.services.rate_budget_policy as rate_budget_policy
+
+    calls = []
+
+    class _FakePolicy:
+        def get_batch_size(self, provider, market):
+            calls.append((provider, market))
+            return 31
+
+    monkeypatch.setattr(rate_budget_policy, "get_rate_budget_policy", lambda: _FakePolicy())
+
+    assert export_script._static_daily_price_refresh_batch_size("IN") == 31  # noqa: SLF001
+    assert calls == [("yfinance", "IN")]
+    assert (
+        export_script._static_daily_price_refresh_batch_size(None)  # noqa: SLF001
+        == export_script.STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE
+    )
 
 
 def test_run_daily_refresh_reenriches_ibd_metadata_after_group_rank_backfill(monkeypatch):
@@ -1255,8 +1385,12 @@ def test_refresh_static_daily_prices_retries_in_rate_limited_failures(monkeypatc
         export_script,
         "get_price_cache",
         lambda: SimpleNamespace(
-            store_batch_in_cache=lambda payload, also_store_db=True: stored_batches.append(
-                {"symbols": sorted(payload.keys()), "also_store_db": also_store_db}
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
             )
         ),
     )

--- a/backend/tests/unit/test_feature_store_tasks.py
+++ b/backend/tests/unit/test_feature_store_tasks.py
@@ -59,6 +59,7 @@ class _FakeUseCase:
             duration_seconds=12.5,
             dq_passed=True,
             warnings=(),
+            failure_diagnostics={},
         )
 
 
@@ -115,6 +116,51 @@ def test_build_daily_snapshot_normalizes_default_active_universe():
     assert fake_use_case.received_cmd is not None
     assert fake_use_case.received_cmd.universe_def.type == UniverseType.MARKET
     assert fake_use_case.received_cmd.universe_def.market.value == "US"
+
+
+def test_build_daily_snapshot_returns_failure_diagnostics(monkeypatch):
+    class _FakeUseCase:
+        def execute(self, *_args, **_kwargs):
+            return SimpleNamespace(
+                run_id=7,
+                status="quarantined",
+                total_symbols=3,
+                processed_symbols=3,
+                failed_symbols=1,
+                skipped_symbols=0,
+                row_count=2,
+                duration_seconds=1.25,
+                dq_passed=False,
+                warnings=("Row count ratio 66.67% below threshold",),
+                failure_diagnostics={
+                    "reason_counts": {"scanner_error_result": 1},
+                    "samples": [{"symbol": "MSFT", "reason": "scanner_error_result"}],
+                    "sample_limit": 50,
+                },
+            )
+
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_build_daily_snapshot_use_case",
+        lambda: _FakeUseCase(),
+    )
+    monkeypatch.setattr(
+        "app.use_cases.feature_store.build_daily_snapshot._is_us_trading_day",
+        lambda *_args, **_kwargs: True,
+    )
+
+    payload = _TASK_BODY(
+        _FakeTask(),
+        as_of_date_str="2026-06-04",
+        screener_names=["custom"],
+        universe_name="market:IN",
+        market="IN",
+        static_daily_mode=True,
+        ignore_runtime_market_gate=True,
+    )
+
+    assert payload["failure_diagnostics"]["reason_counts"] == {
+        "scanner_error_result": 1
+    }
 
 
 def test_bootstrap_coverage_total_preserves_zero_price_total():
@@ -1443,6 +1489,15 @@ def test_create_auto_scan_uses_saved_run_universe_count_for_total_stocks():
     universe_def = SimpleNamespace(
         label=lambda: "All Active Stocks",
         key=lambda: "all",
+        storage_projection=lambda: SimpleNamespace(
+            label="All Active Stocks",
+            key="all",
+            type="all",
+            market=None,
+            exchange=None,
+            index=None,
+            symbols=None,
+        ),
         type=SimpleNamespace(value="all"),
         exchange=None,
         index=None,

--- a/backend/tests/unit/test_static_daily_price_refresh_service.py
+++ b/backend/tests/unit/test_static_daily_price_refresh_service.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models.stock import StockPrice
+from app.models.stock_universe import StockUniverse
+from app.services.static_daily_price_refresh_service import (
+    STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+    STATIC_DAILY_PRICE_REFRESH_PERIOD,
+    STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE,
+    STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
+    STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS,
+    StaticDailyPriceRefreshService,
+    static_daily_price_refresh_batch_size,
+)
+
+
+def _sqlite_session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=[StockUniverse.__table__, StockPrice.__table__],
+    )
+    return sessionmaker(
+        bind=engine,
+        autocommit=False,
+        autoflush=False,
+        expire_on_commit=False,
+    )
+
+
+def test_static_daily_price_refresh_service_fetches_stale_and_no_history_groups() -> None:
+    session_factory = _sqlite_session_factory()
+
+    with session_factory() as db:
+        db.add_all(
+            [
+                StockUniverse(symbol="OLD.NS", market="IN", is_active=True, market_cap=100.0),
+                StockUniverse(symbol="NEW.NS", market="IN", is_active=True, market_cap=90.0),
+            ]
+        )
+        db.add(
+            StockPrice(
+                symbol="OLD.NS",
+                date=date(2026, 6, 3),
+                open=1.0,
+                high=1.0,
+                low=1.0,
+                close=1.0,
+                volume=1000,
+            )
+        )
+        db.commit()
+
+    fetch_calls: list[dict] = []
+    stored_batches: list[dict] = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append(
+                {
+                    "symbols": list(symbols),
+                    "period": period,
+                    "start_batch_size": start_batch_size,
+                    "market": market,
+                }
+            )
+            return {
+                symbol: {"price_data": SimpleNamespace(empty=False), "has_error": False}
+                for symbol in symbols
+            }
+
+    service = StaticDailyPriceRefreshService(
+        session_factory=session_factory,
+        price_cache=SimpleNamespace(
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
+            )
+        ),
+        fetcher=_FakeFetcher(),
+        batch_size_for_market=lambda market: 25,
+        sleep=lambda _seconds: None,
+    )
+
+    result = service.refresh(as_of_date=date(2026, 6, 4), market="IN")
+
+    assert fetch_calls == [
+        {
+            "symbols": ["OLD.NS"],
+            "period": STATIC_DAILY_PRICE_REFRESH_PERIOD,
+            "start_batch_size": 25,
+            "market": "IN",
+        },
+        {
+            "symbols": ["NEW.NS"],
+            "period": STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+            "start_batch_size": 25,
+            "market": "IN",
+        },
+    ]
+    assert stored_batches == [
+        {"symbols": ["OLD.NS"], "also_store_db": True, "market": "IN"},
+        {"symbols": ["NEW.NS"], "also_store_db": True, "market": "IN"},
+    ]
+    assert result["stale_symbols"] == 1
+    assert result["no_history_symbols"] == 1
+    assert result["yahoo_fetched_symbols"] == 2
+
+
+def test_static_daily_price_refresh_service_filters_to_selected_market() -> None:
+    session_factory = _sqlite_session_factory()
+
+    with session_factory() as db:
+        db.add_all(
+            [
+                StockUniverse(symbol="0700.HK", market="HK", is_active=True, market_cap=100.0),
+                StockUniverse(symbol="9988.HK", market="HK", is_active=True, market_cap=90.0),
+                StockUniverse(symbol="AAPL", market="US", is_active=True, market_cap=120.0),
+                StockUniverse(symbol="BAD-W", market="HK", is_active=True, market_cap=80.0),
+            ]
+        )
+        for symbol in ("0700.HK", "AAPL"):
+            db.add(
+                StockPrice(
+                    symbol=symbol,
+                    date=date(2026, 4, 1),
+                    open=1.0,
+                    high=1.0,
+                    low=1.0,
+                    close=1.0,
+                    volume=1000,
+                )
+            )
+        db.commit()
+
+    fetch_calls: list[dict] = []
+    stored_batches: list[dict] = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append(
+                {
+                    "symbols": list(symbols),
+                    "period": period,
+                    "start_batch_size": start_batch_size,
+                    "market": market,
+                }
+            )
+            return {
+                symbol: {"price_data": SimpleNamespace(empty=False), "has_error": False}
+                for symbol in symbols
+            }
+
+    service = StaticDailyPriceRefreshService(
+        session_factory=session_factory,
+        price_cache=SimpleNamespace(
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
+            )
+        ),
+        fetcher=_FakeFetcher(),
+        batch_size_for_market=lambda _market: 25,
+        sleep=lambda _seconds: None,
+    )
+
+    result = service.refresh(as_of_date=date(2026, 4, 2), market="HK")
+
+    assert result["market"] == "HK"
+    assert result["total_active_symbols"] == 3
+    assert result["supported_symbols"] == 2
+    assert result["skipped_unsupported_symbols"] == 1
+    assert fetch_calls == [
+        {
+            "symbols": ["0700.HK"],
+            "period": STATIC_DAILY_PRICE_REFRESH_PERIOD,
+            "start_batch_size": 25,
+            "market": "HK",
+        },
+        {
+            "symbols": ["9988.HK"],
+            "period": STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+            "start_batch_size": 25,
+            "market": "HK",
+        },
+    ]
+    assert stored_batches == [
+        {"symbols": ["0700.HK"], "also_store_db": True, "market": "HK"},
+        {"symbols": ["9988.HK"], "also_store_db": True, "market": "HK"},
+    ]
+
+
+def test_static_daily_price_refresh_batch_size_uses_market_policy(monkeypatch) -> None:
+    import app.services.rate_budget_policy as rate_budget_policy
+
+    calls = []
+
+    class _FakePolicy:
+        def get_batch_size(self, provider, market):
+            calls.append((provider, market))
+            return 31
+
+    monkeypatch.setattr(rate_budget_policy, "get_rate_budget_policy", lambda: _FakePolicy())
+
+    assert static_daily_price_refresh_batch_size("IN") == 31
+    assert calls == [("yfinance", "IN")]
+    assert static_daily_price_refresh_batch_size(None) == STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE
+
+
+def _seed_in_universe(session_factory) -> None:
+    with session_factory() as db:
+        db.add_all(
+            [
+                StockUniverse(symbol="RELIANCE.NS", market="IN", is_active=True, market_cap=300.0),
+                StockUniverse(symbol="TCS.NS", market="IN", is_active=True, market_cap=200.0),
+                StockUniverse(symbol="INFY.NS", market="IN", is_active=True, market_cap=100.0),
+            ]
+        )
+        for symbol in ("RELIANCE.NS", "TCS.NS", "INFY.NS"):
+            db.add(
+                StockPrice(
+                    symbol=symbol,
+                    date=date(2026, 4, 1),
+                    open=1.0,
+                    high=1.0,
+                    low=1.0,
+                    close=1.0,
+                    volume=1000,
+                )
+            )
+        db.commit()
+
+
+def test_static_daily_price_refresh_retries_rate_limited_failures() -> None:
+    session_factory = _sqlite_session_factory()
+    _seed_in_universe(session_factory)
+
+    fetch_calls: list[dict] = []
+    stored_batches: list[dict] = []
+    sleeps: list[float] = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append(
+                {
+                    "symbols": list(symbols),
+                    "period": period,
+                    "start_batch_size": start_batch_size,
+                    "market": market,
+                }
+            )
+            if len(fetch_calls) == 1:
+                return {
+                    "RELIANCE.NS": {
+                        "price_data": SimpleNamespace(empty=False),
+                        "has_error": False,
+                    },
+                    "TCS.NS": {
+                        "price_data": None,
+                        "has_error": True,
+                        "error": "Too Many Requests (429)",
+                    },
+                    "INFY.NS": {
+                        "price_data": None,
+                        "has_error": True,
+                        "error": "delisted: no price data",
+                    },
+                }
+            return {
+                "TCS.NS": {
+                    "price_data": SimpleNamespace(empty=False),
+                    "has_error": False,
+                },
+            }
+
+    service = StaticDailyPriceRefreshService(
+        session_factory=session_factory,
+        price_cache=SimpleNamespace(
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
+            )
+        ),
+        fetcher=_FakeFetcher(),
+        sleep=lambda seconds: sleeps.append(seconds),
+    )
+
+    result = service.refresh(as_of_date=date(2026, 4, 2), market="IN")
+
+    assert sleeps == [STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS]
+    assert len(fetch_calls) == 2
+    assert fetch_calls[1]["symbols"] == ["TCS.NS"]
+    assert fetch_calls[1]["start_batch_size"] == STATIC_RATE_LIMITED_RETRY_BATCH_SIZE
+    assert fetch_calls[1]["market"] == "IN"
+    stored_symbols = {symbol for batch in stored_batches for symbol in batch["symbols"]}
+    assert stored_symbols == {"RELIANCE.NS", "TCS.NS"}
+    assert result["rate_limited_retry"] == {
+        "attempted": 1,
+        "recovered": 1,
+        "still_failed": 0,
+        "wait_seconds": STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS,
+        "batch_size": STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
+    }
+    assert result["yahoo_fetched_symbols"] == 2
+    assert result["yahoo_failed_symbols"] == 1
+
+
+def test_static_daily_price_refresh_retries_no_history_rate_limits_with_bootstrap_period() -> None:
+    session_factory = _sqlite_session_factory()
+
+    with session_factory() as db:
+        db.add(StockUniverse(symbol="NEW.NS", market="IN", is_active=True, market_cap=100.0))
+        db.commit()
+
+    fetch_calls: list[dict] = []
+    stored_batches: list[dict] = []
+    sleeps: list[float] = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append(
+                {
+                    "symbols": list(symbols),
+                    "period": period,
+                    "start_batch_size": start_batch_size,
+                    "market": market,
+                }
+            )
+            if len(fetch_calls) == 1:
+                return {
+                    "NEW.NS": {
+                        "price_data": None,
+                        "has_error": True,
+                        "error": "Too Many Requests (429)",
+                    },
+                }
+            return {
+                "NEW.NS": {
+                    "price_data": SimpleNamespace(empty=False),
+                    "has_error": False,
+                },
+            }
+
+    service = StaticDailyPriceRefreshService(
+        session_factory=session_factory,
+        price_cache=SimpleNamespace(
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
+            )
+        ),
+        fetcher=_FakeFetcher(),
+        batch_size_for_market=lambda _market: 25,
+        sleep=lambda seconds: sleeps.append(seconds),
+    )
+
+    result = service.refresh(as_of_date=date(2026, 6, 4), market="IN")
+
+    assert sleeps == [STATIC_RATE_LIMITED_RETRY_WAIT_SECONDS]
+    assert fetch_calls == [
+        {
+            "symbols": ["NEW.NS"],
+            "period": STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+            "start_batch_size": 25,
+            "market": "IN",
+        },
+        {
+            "symbols": ["NEW.NS"],
+            "period": STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+            "start_batch_size": STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
+            "market": "IN",
+        },
+    ]
+    assert stored_batches == [
+        {"symbols": ["NEW.NS"], "also_store_db": True, "market": "IN"},
+    ]
+    assert result["rate_limited_retry"]["recovered"] == 1
+    assert result["yahoo_fetched_symbols"] == 1
+    assert result["yahoo_failed_symbols"] == 0
+
+
+def test_static_daily_price_refresh_skips_retry_for_non_in_markets() -> None:
+    session_factory = _sqlite_session_factory()
+
+    with session_factory() as db:
+        db.add(StockUniverse(symbol="0700.HK", market="HK", is_active=True, market_cap=100.0))
+        db.add(
+            StockPrice(
+                symbol="0700.HK",
+                date=date(2026, 4, 1),
+                open=1.0,
+                high=1.0,
+                low=1.0,
+                close=1.0,
+                volume=1000,
+            )
+        )
+        db.commit()
+
+    fetch_calls: list[dict] = []
+    sleeps: list[float] = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append({"symbols": list(symbols), "market": market})
+            return {
+                symbol: {
+                    "price_data": None,
+                    "has_error": True,
+                    "error": "429 rate limited",
+                }
+                for symbol in symbols
+            }
+
+    service = StaticDailyPriceRefreshService(
+        session_factory=session_factory,
+        price_cache=SimpleNamespace(store_batch_in_cache=lambda *_args, **_kwargs: None),
+        fetcher=_FakeFetcher(),
+        sleep=lambda seconds: sleeps.append(seconds),
+    )
+
+    result = service.refresh(as_of_date=date(2026, 4, 2), market="HK")
+
+    assert len(fetch_calls) == 1
+    assert sleeps == []
+    assert result["rate_limited_retry"] == {
+        "attempted": 0,
+        "recovered": 0,
+        "still_failed": 0,
+        "wait_seconds": 0,
+        "batch_size": STATIC_RATE_LIMITED_RETRY_BATCH_SIZE,
+    }
+
+
+def test_static_daily_price_refresh_skips_retry_when_no_rate_limited_failures() -> None:
+    session_factory = _sqlite_session_factory()
+    _seed_in_universe(session_factory)
+
+    fetch_calls: list[dict] = []
+    sleeps: list[float] = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append({"symbols": list(symbols)})
+            return {
+                symbol: {
+                    "price_data": None,
+                    "has_error": True,
+                    "error": "delisted: no price data",
+                }
+                for symbol in symbols
+            }
+
+    service = StaticDailyPriceRefreshService(
+        session_factory=session_factory,
+        price_cache=SimpleNamespace(store_batch_in_cache=lambda *_args, **_kwargs: None),
+        fetcher=_FakeFetcher(),
+        sleep=lambda seconds: sleeps.append(seconds),
+    )
+
+    result = service.refresh(as_of_date=date(2026, 4, 2), market="IN")
+
+    assert len(fetch_calls) == 1
+    assert sleeps == []
+    assert result["rate_limited_retry"]["attempted"] == 0
+    assert result["yahoo_failed_symbols"] == 3

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -16,6 +16,7 @@ from app.database import Base
 from app.infra.db.models.feature_store import FeatureRun, FeatureRunPointer
 from app.models.stock import StockPrice
 from app.services.static_site_export_service import (
+    NoPublishedStaticMarketArtifact,
     STATIC_DEFAULT_SCAN_FILTERS_BY_MARKET,
     STATIC_DEFAULT_SCAN_FILTERS_FALLBACK,
     STATIC_MARKET_METADATA_FILENAME,
@@ -1449,8 +1450,11 @@ def test_export_rejects_legacy_unscoped_run_for_market_bundle(
         pointer_run_id=21,
     )
 
-    with pytest.raises(RuntimeError, match="No market-scoped published feature runs"):
-        service.export(tmp_path / "static-data")
+    with pytest.raises(NoPublishedStaticMarketArtifact) as exc_info:
+        service.export(tmp_path / "static-data", markets=("IN",))
+
+    assert exc_info.value.markets == ("IN",)
+    assert "No market-scoped published feature runs" in str(exc_info.value)
 
 
 def test_serialize_history_bars_clamps_to_end_date_and_skips_nan_rows(service_and_session_factory):

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -39,8 +39,12 @@ def _fallback_download_script() -> str:
 
 def test_static_site_market_build_failures_are_not_marked_continue_on_error() -> None:
     build_market_job = _build_market_job()
+    export_step = build_market_job.split("      - name: Export market static data bundle\n", 1)[1].split(
+        "\n      - name: Upload market diagnostics",
+        1,
+    )[0]
 
-    assert "continue-on-error: true" not in build_market_job
+    assert "continue-on-error: true" not in export_step
 
 
 def test_static_site_daily_price_seed_allows_stale_bootstrap() -> None:
@@ -80,6 +84,33 @@ def test_static_site_market_export_skips_artifact_steps_for_closed_market() -> N
     assert "steps.export-market.outputs.has_artifact == 'true'" in build_price_step
     assert "steps.export-market.outputs.has_artifact == 'true'" in upload_price_step
     assert "steps.export-market.outputs.has_artifact == 'true'" in upload_market_step
+
+
+def test_static_site_market_export_soft_skips_no_current_artifact_exit_code() -> None:
+    build_market_job = _build_market_job()
+    export_step = build_market_job.split("      - name: Export market static data bundle\n", 1)[1].split(
+        "\n      - name: Upload market diagnostics",
+        1,
+    )[0]
+
+    assert 'if [ "$status" -eq 79 ]; then' in export_step
+    assert "has_artifact=false" in export_step
+    assert "fallback artifacts" in export_step
+    assert "no current market artifact will be uploaded" in export_step
+
+
+def test_static_site_uploads_market_diagnostics_after_export() -> None:
+    build_market_job = _build_market_job()
+    diagnostics_step = build_market_job.split("      - name: Upload market diagnostics\n", 1)[1].split(
+        "\n      - name: Build daily price bundle",
+        1,
+    )[0]
+
+    assert "if: ${{ always() }}" in diagnostics_step
+    assert "uses: actions/upload-artifact@v4" in diagnostics_step
+    assert "name: static-market-diagnostics-${{ matrix.market }}" in diagnostics_step
+    assert "path: /tmp/static-data/diagnostics/${{ env.MARKET_LOWER }}" in diagnostics_step
+    assert "if-no-files-found: ignore" in diagnostics_step
 
 
 def test_static_site_combine_downloads_current_and_per_market_fallback_artifacts() -> None:

--- a/backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
+++ b/backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
@@ -745,6 +745,81 @@ class TestBulkDataPreparation:
         assert uow.feature_store._universe[result.run_id] == ["AAPL", "MSFT"]
 
     @_PATCH_TRADING_DAY
+    def test_bulk_prefetch_missing_records_failure_diagnostics_in_parallel(self, _mock_td):
+        uow, _ = _make_uow(symbols=["AAPL", "MSFT", "GOOGL"])
+
+        class PartialProvider(FakeStockDataProvider):
+            def prepare_data_bulk(
+                self,
+                symbols: list[str],
+                requirements: object,
+                *,
+                allow_partial: bool = True,
+                batch_only_prices: bool = False,
+                batch_only_fundamentals: bool = False,
+            ) -> dict[str, object]:
+                return {
+                    symbol: self._make_stock_data(symbol)
+                    for symbol in symbols
+                    if symbol == "AAPL"
+                }
+
+        class BulkAwareScanner:
+            def __init__(self) -> None:
+                self.calls: list[str] = []
+
+            def get_merged_requirements(self, screener_names, criteria=None):
+                return {"needs": "price+fundamentals"}
+
+            def scan_stock_multi(self, symbol: str, **_kwargs) -> dict:
+                self.calls.append(symbol)
+                return {
+                    "composite_score": 75.0,
+                    "rating": "Buy",
+                    "passes_template": True,
+                    "current_price": 100.0,
+                }
+
+        scanner = BulkAwareScanner()
+        use_case = BuildDailyFeatureSnapshotUseCase(
+            scanner=scanner,
+            data_provider=PartialProvider(),
+        )
+
+        result = use_case.execute(
+            uow,
+            _make_cmd(
+                chunk_size=3,
+                require_bulk_prefetch=True,
+                batch_only_prices=True,
+                batch_only_fundamentals=True,
+                static_parallel_workers=2,
+            ),
+            FakeProgressSink(),
+            FakeCancellationToken(),
+        )
+
+        assert result.failed_symbols == 2
+        assert scanner.calls == ["AAPL"]
+        assert result.failure_diagnostics["reason_counts"] == {
+            "bulk_prefetch_missing": 2
+        }
+        assert result.failure_diagnostics["samples"] == [
+            {
+                "symbol": "MSFT",
+                "reason": "bulk_prefetch_missing",
+                "error": None,
+                "data_errors": {},
+            },
+            {
+                "symbol": "GOOGL",
+                "reason": "bulk_prefetch_missing",
+                "error": None,
+                "data_errors": {},
+            },
+        ]
+
+    @_PATCH_TRADING_DAY
     def test_bootstrap_gate_fail_raises_before_live_fallback(self, _mock_td):
         uow, _ = _make_uow(symbols=["AAPL", "MSFT", "BAD-WT"])
 
@@ -1166,6 +1241,61 @@ class TestPartialFailures:
                 "data_errors": {},
             }
         ]
+
+    @_PATCH_TRADING_DAY
+    def test_error_result_diagnostics_coerce_non_string_error(self, _mock_td):
+        results = {
+            "AAPL": {
+                "result_status": "error",
+                "error": {"reason": "bad setup", "code": 42},
+            },
+        }
+        uow, scanner = _make_uow(symbols=["AAPL"], scanner_results=results)
+        use_case = BuildDailyFeatureSnapshotUseCase(scanner=scanner)
+
+        result = use_case.execute(
+            uow, _make_cmd(), FakeProgressSink(), FakeCancellationToken()
+        )
+
+        assert result.failed_symbols == 1
+        assert result.failure_diagnostics["samples"] == [
+            {
+                "symbol": "AAPL",
+                "reason": "scanner_error_result",
+                "error": "{'reason': 'bad setup', 'code': 42}",
+                "data_errors": {},
+            }
+        ]
+
+    @_PATCH_TRADING_DAY
+    def test_failure_diagnostic_samples_are_capped(self, _mock_td):
+        symbols = [f"SYM{i:03d}" for i in range(55)]
+        results = {
+            symbol: {
+                "result_status": "error",
+                "error": f"failed {symbol}",
+            }
+            for symbol in symbols
+        }
+        uow, scanner = _make_uow(symbols=symbols, scanner_results=results)
+        use_case = BuildDailyFeatureSnapshotUseCase(scanner=scanner)
+
+        result = use_case.execute(
+            uow,
+            _make_cmd(chunk_size=55),
+            FakeProgressSink(),
+            FakeCancellationToken(),
+        )
+
+        samples = result.failure_diagnostics["samples"]
+        assert result.failed_symbols == 55
+        assert result.failure_diagnostics["reason_counts"] == {
+            "scanner_error_result": 55
+        }
+        assert result.failure_diagnostics["sample_limit"] == 50
+        assert len(samples) == 50
+        assert samples[0]["symbol"] == "SYM000"
+        assert samples[-1]["symbol"] == "SYM049"
 
     @_PATCH_TRADING_DAY
     def test_insufficient_history_rows_are_persisted_without_counting_as_failures(self, _mock_td):

--- a/backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
+++ b/backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
@@ -1093,6 +1093,81 @@ class TestPartialFailures:
         assert result.failed_symbols == 1
 
     @_PATCH_TRADING_DAY
+    def test_error_result_is_reported_in_failure_diagnostics(self, _mock_td):
+        results = {
+            "AAPL": {
+                "composite_score": 85.0,
+                "rating": "Strong Buy",
+                "screeners_passed": 1,
+            },
+            "MSFT": {
+                "result_status": "error",
+                "error": "Screener execution failed: setup_engine",
+                "details": {
+                    "data_errors": {
+                        "price_data": "No price data returned from batch-only price path"
+                    }
+                },
+            },
+            "GOOGL": {
+                "composite_score": 70.0,
+                "rating": "Buy",
+                "screeners_passed": 1,
+            },
+        }
+        uow, scanner = _make_uow(scanner_results=results)
+        use_case = BuildDailyFeatureSnapshotUseCase(scanner=scanner)
+
+        result = use_case.execute(
+            uow, _make_cmd(), FakeProgressSink(), FakeCancellationToken()
+        )
+
+        assert result.failed_symbols == 1
+        assert result.failure_diagnostics["reason_counts"] == {
+            "scanner_error_result": 1
+        }
+        assert result.failure_diagnostics["samples"] == [
+            {
+                "symbol": "MSFT",
+                "reason": "scanner_error_result",
+                "error": "Screener execution failed: setup_engine",
+                "data_errors": {
+                    "price_data": "No price data returned from batch-only price path"
+                },
+            }
+        ]
+
+    @_PATCH_TRADING_DAY
+    def test_scanner_exception_is_reported_in_failure_diagnostics(self, _mock_td):
+        class ExplodingScanner:
+            def scan_stock_multi(self, symbol, screener_names, **kw):
+                if symbol == "BOOM":
+                    raise RuntimeError("kaboom")
+                return {
+                    "composite_score": 75.0,
+                    "rating": "Buy",
+                    "screeners_passed": 1,
+                }
+
+        uow, _ = _make_uow(symbols=["AAPL", "BOOM", "GOOGL"])
+        use_case = BuildDailyFeatureSnapshotUseCase(scanner=ExplodingScanner())
+
+        result = use_case.execute(
+            uow, _make_cmd(), FakeProgressSink(), FakeCancellationToken()
+        )
+
+        assert result.failed_symbols == 1
+        assert result.failure_diagnostics["reason_counts"] == {"scan_exception": 1}
+        assert result.failure_diagnostics["samples"] == [
+            {
+                "symbol": "BOOM",
+                "reason": "scan_exception",
+                "error": "RuntimeError: kaboom",
+                "data_errors": {},
+            }
+        ]
+
+    @_PATCH_TRADING_DAY
     def test_insufficient_history_rows_are_persisted_without_counting_as_failures(self, _mock_td):
         results = {
             "AAPL": {

--- a/docs/superpowers/plans/2026-06-05-in-static-site-daily-run-robustness.md
+++ b/docs/superpowers/plans/2026-06-05-in-static-site-daily-run-robustness.md
@@ -1,0 +1,916 @@
+# IN Static Site Daily Run Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the IN static-site daily run explain snapshot row loss, recover safely with prior artifacts when a fresh snapshot is quarantined, and reduce refresh gaps that can trigger repeated failures.
+
+**Architecture:** First make per-symbol snapshot failures observable without changing publish semantics. Then harden the static daily price refresh so stale and no-history symbols are handled explicitly with market-scoped provider/batch settings. Finally adjust the workflow so a quarantined market build uploads diagnostics and lets the combine job use its existing fallback artifact path instead of marking the whole static-site run failed.
+
+**Tech Stack:** Python 3.11, SQLAlchemy repositories, Celery task interface, pytest, GitHub Actions YAML.
+
+---
+
+## File Structure
+
+- Modify `backend/app/use_cases/feature_store/build_daily_snapshot.py`
+  - Add bounded per-symbol failure diagnostics to `BuildDailySnapshotResult`.
+  - Record diagnostic samples and aggregate counters where rows are currently dropped.
+- Modify `backend/app/interfaces/tasks/feature_store_tasks.py`
+  - Include `failure_diagnostics` in the task return dict and log a compact summary.
+- Modify `backend/app/scripts/export_static_site.py`
+  - Fetch no-history symbols separately.
+  - Use a market-aware static price batch size.
+  - Store refreshed price data with `market=market`.
+  - Return a skipped/no-artifact exit code when the selected market snapshot is quarantined and no current artifact can be exported.
+- Modify `.github/workflows/static-site.yml`
+  - Treat the new no-current-market-artifact exit code like the existing closed-market skip.
+  - Upload diagnostics for failed/quarantined market builds with `if: always()`.
+- Modify `backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py`
+  - Add regression tests for scanner error-result diagnostics, scanner exception diagnostics, and cache-prefetch miss diagnostics.
+- Modify `backend/tests/unit/test_feature_store_tasks.py`
+  - Add a test that task return payload includes `failure_diagnostics`.
+- Modify `backend/tests/unit/test_export_static_site_script.py`
+  - Add tests for no-history fetch, market-scoped cache storage, market-aware batch sizing, and quarantined snapshot skip.
+- Modify `backend/tests/unit/test_static_site_workflow.py`
+  - Add tests that the workflow handles the new skip code and uploads diagnostics.
+
+## Task 1: Snapshot Failure Diagnostics
+
+**Files:**
+- Modify: `backend/app/use_cases/feature_store/build_daily_snapshot.py`
+- Test: `backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py`
+
+- [ ] **Step 1: Write failing tests for scanner error-result diagnostics**
+
+Add this test to `TestPartialFailures` in `backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py`:
+
+```python
+    @_PATCH_TRADING_DAY
+    def test_error_result_is_reported_in_failure_diagnostics(self, _mock_td):
+        results = {
+            "AAPL": {
+                "composite_score": 85.0,
+                "rating": "Strong Buy",
+                "screeners_passed": 1,
+            },
+            "MSFT": {
+                "result_status": "error",
+                "error": "Screener execution failed: setup_engine",
+                "details": {
+                    "data_errors": {
+                        "price_data": "No price data returned from batch-only price path"
+                    }
+                },
+            },
+            "GOOGL": {
+                "composite_score": 70.0,
+                "rating": "Buy",
+                "screeners_passed": 1,
+            },
+        }
+        uow, scanner = _make_uow(scanner_results=results)
+        use_case = BuildDailyFeatureSnapshotUseCase(scanner=scanner)
+
+        result = use_case.execute(
+            uow, _make_cmd(), FakeProgressSink(), FakeCancellationToken()
+        )
+
+        assert result.failed_symbols == 1
+        assert result.failure_diagnostics["reason_counts"] == {
+            "scanner_error_result": 1
+        }
+        assert result.failure_diagnostics["samples"] == [
+            {
+                "symbol": "MSFT",
+                "reason": "scanner_error_result",
+                "error": "Screener execution failed: setup_engine",
+                "data_errors": {
+                    "price_data": "No price data returned from batch-only price path"
+                },
+            }
+        ]
+```
+
+- [ ] **Step 2: Write failing tests for scanner exception diagnostics**
+
+Add this test to `TestPartialFailures`:
+
+```python
+    @_PATCH_TRADING_DAY
+    def test_scanner_exception_is_reported_in_failure_diagnostics(self, _mock_td):
+        class ExplodingScanner:
+            def scan_stock_multi(self, symbol, screener_names, **kw):
+                if symbol == "BOOM":
+                    raise RuntimeError("kaboom")
+                return {
+                    "composite_score": 75.0,
+                    "rating": "Buy",
+                    "screeners_passed": 1,
+                }
+
+        uow, _ = _make_uow(symbols=["AAPL", "BOOM", "GOOGL"])
+        use_case = BuildDailyFeatureSnapshotUseCase(scanner=ExplodingScanner())
+
+        result = use_case.execute(
+            uow, _make_cmd(), FakeProgressSink(), FakeCancellationToken()
+        )
+
+        assert result.failed_symbols == 1
+        assert result.failure_diagnostics["reason_counts"] == {"scan_exception": 1}
+        assert result.failure_diagnostics["samples"] == [
+            {
+                "symbol": "BOOM",
+                "reason": "scan_exception",
+                "error": "RuntimeError: kaboom",
+                "data_errors": {},
+            }
+        ]
+```
+
+- [ ] **Step 3: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+cd backend
+source venv/bin/activate
+pytest backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py::TestPartialFailures::test_error_result_is_reported_in_failure_diagnostics backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py::TestPartialFailures::test_scanner_exception_is_reported_in_failure_diagnostics -q
+```
+
+Expected: both tests fail because `BuildDailySnapshotResult` does not expose `failure_diagnostics`.
+
+- [ ] **Step 4: Add diagnostic helpers and result field**
+
+In `backend/app/use_cases/feature_store/build_daily_snapshot.py`, add imports:
+
+```python
+from collections import Counter
+```
+
+Add helpers near `RunProgressState`:
+
+```python
+MAX_FAILURE_DIAGNOSTIC_SAMPLES = 50
+
+
+def _extract_data_errors(result: object) -> dict[str, str]:
+    if not isinstance(result, dict):
+        return {}
+    details = result.get("details")
+    if not isinstance(details, dict):
+        return {}
+    data_errors = details.get("data_errors")
+    if not isinstance(data_errors, dict):
+        return {}
+    return {str(key): str(value) for key, value in data_errors.items()}
+
+
+def _format_exception(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+@dataclass
+class FailureDiagnosticsCollector:
+    reason_counts: Counter[str] = field(default_factory=Counter)
+    samples: list[dict[str, object]] = field(default_factory=list)
+
+    def record(
+        self,
+        *,
+        symbol: str,
+        reason: str,
+        error: str | None = None,
+        data_errors: dict[str, str] | None = None,
+    ) -> None:
+        self.reason_counts[reason] += 1
+        if len(self.samples) >= MAX_FAILURE_DIAGNOSTIC_SAMPLES:
+            return
+        self.samples.append(
+            {
+                "symbol": symbol,
+                "reason": reason,
+                "error": error,
+                "data_errors": data_errors or {},
+            }
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "reason_counts": dict(self.reason_counts),
+            "samples": list(self.samples),
+            "sample_limit": MAX_FAILURE_DIAGNOSTIC_SAMPLES,
+        }
+```
+
+Extend `BuildDailySnapshotResult`:
+
+```python
+    failure_diagnostics: dict[str, object] = field(default_factory=dict)
+```
+
+- [ ] **Step 5: Record diagnostics in `_scan_symbol`**
+
+Inside `BuildDailyFeatureSnapshotUseCase._execute_scan`, before the chunk loop:
+
+```python
+        failure_diagnostics = FailureDiagnosticsCollector()
+```
+
+Change `_scan_symbol` to return a diagnostic dict:
+
+```python
+            def _scan_symbol(
+                symbol: str,
+            ) -> tuple[str, FeatureRowWrite | None, bool, dict[str, object] | None]:
+                sym = symbol.upper()
+                try:
+                    if cache_only_symbol_data and sym not in pre_fetched_data:
+                        return sym, None, False, {
+                            "symbol": sym,
+                            "reason": "bulk_prefetch_missing",
+                            "error": "Symbol missing from bulk prefetch results",
+                            "data_errors": {},
+                        }
+                    scan_kwargs: dict[str, object] = {}
+                    if merged_requirements is not None:
+                        scan_kwargs["pre_merged_requirements"] = merged_requirements
+                    if sym in pre_fetched_data:
+                        scan_kwargs["pre_fetched_data"] = pre_fetched_data[sym]
+                    result = self._scanner.scan_stock_multi(
+                        symbol=sym,
+                        screener_names=cmd.screener_names,
+                        criteria=cmd.criteria,
+                        composite_method=cmd.composite_method,
+                        **scan_kwargs,
+                    )
+                    result_status = _resolve_result_status(result)
+                    if result and result_status != "error":
+                        row = _map_orchestrator_to_feature_row(
+                            sym, cmd.as_of_date, result
+                        )
+                        return sym, row, bool(result.get("passes_template")), None
+                    return sym, None, False, {
+                        "symbol": sym,
+                        "reason": "scanner_error_result",
+                        "error": result.get("error") if isinstance(result, dict) else None,
+                        "data_errors": _extract_data_errors(result),
+                    }
+                except Exception as exc:
+                    logger.debug(
+                        "Error scanning %s in run %d",
+                        sym,
+                        run_id,
+                        exc_info=True,
+                    )
+                    return sym, None, False, {
+                        "symbol": sym,
+                        "reason": "scan_exception",
+                        "error": _format_exception(exc),
+                        "data_errors": {},
+                    }
+```
+
+Update both sequential and threaded call sites to unpack four values and record diagnostics when `row is None`:
+
+```python
+                sym, row, passed, diagnostic = future.result()
+                outcomes_by_symbol[sym] = (row, passed, diagnostic)
+```
+
+```python
+                sym, row, passed, diagnostic = _scan_symbol(symbol)
+                outcomes_by_symbol[sym] = (row, passed, diagnostic)
+```
+
+```python
+                row, passed, diagnostic = outcomes_by_symbol.get(
+                    symbol.upper(), (None, False, None)
+                )
+                if row is not None:
+                    chunk_rows.append(row)
+                    if passed:
+                        progress_state.passed_symbols += 1
+                else:
+                    progress_state.failed_symbols += 1
+                    if diagnostic is not None:
+                        failure_diagnostics.record(**diagnostic)
+```
+
+- [ ] **Step 6: Include diagnostics in all return paths**
+
+When constructing `BuildDailySnapshotResult`, pass:
+
+```python
+            failure_diagnostics=failure_diagnostics.to_dict(),
+```
+
+For early cancellation and stale-run failure paths that do not have the collector in scope, pass:
+
+```python
+            failure_diagnostics={},
+```
+
+- [ ] **Step 7: Run focused tests and verify they pass**
+
+Run:
+
+```bash
+cd backend
+source venv/bin/activate
+pytest backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py::TestPartialFailures -q
+```
+
+Expected: all `TestPartialFailures` tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/use_cases/feature_store/build_daily_snapshot.py backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
+git commit -m "feat: capture static snapshot failure diagnostics"
+```
+
+## Task 2: Expose Diagnostics Through the Celery Task Payload
+
+**Files:**
+- Modify: `backend/app/interfaces/tasks/feature_store_tasks.py`
+- Test: `backend/tests/unit/test_feature_store_tasks.py`
+
+- [ ] **Step 1: Write the failing task payload test**
+
+Add a fake result with diagnostics in `backend/tests/unit/test_feature_store_tasks.py` and assert the returned dict includes it:
+
+```python
+def test_build_daily_snapshot_returns_failure_diagnostics(monkeypatch):
+    class _FakeUseCase:
+        def execute(self, *_args, **_kwargs):
+            return SimpleNamespace(
+                run_id=7,
+                status="quarantined",
+                total_symbols=3,
+                processed_symbols=3,
+                failed_symbols=1,
+                skipped_symbols=0,
+                row_count=2,
+                duration_seconds=1.25,
+                dq_passed=False,
+                warnings=("Row count ratio 66.67% below threshold",),
+                failure_diagnostics={
+                    "reason_counts": {"scanner_error_result": 1},
+                    "samples": [{"symbol": "MSFT", "reason": "scanner_error_result"}],
+                    "sample_limit": 50,
+                },
+            )
+
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_build_daily_snapshot_use_case",
+        lambda: _FakeUseCase(),
+    )
+    monkeypatch.setattr(
+        "app.use_cases.feature_store.build_daily_snapshot._is_us_trading_day",
+        lambda *_args, **_kwargs: True,
+    )
+
+    payload = _TASK_BODY(
+        as_of_date_str="2026-06-04",
+        screener_names=["custom"],
+        universe_name="market:IN",
+        market="IN",
+        static_daily_mode=True,
+        ignore_runtime_market_gate=True,
+    )
+
+    assert payload["failure_diagnostics"]["reason_counts"] == {
+        "scanner_error_result": 1
+    }
+```
+
+If `SimpleNamespace` is not already imported in that file, add:
+
+```python
+from types import SimpleNamespace
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cd backend
+source venv/bin/activate
+pytest backend/tests/unit/test_feature_store_tasks.py::test_build_daily_snapshot_returns_failure_diagnostics -q
+```
+
+Expected: failure because the task return dict omits `failure_diagnostics`.
+
+- [ ] **Step 3: Add diagnostics to return payload and log**
+
+In `backend/app/interfaces/tasks/feature_store_tasks.py`, update the completion log after line 1047 to include diagnostics counts:
+
+```python
+    failure_diagnostics = dict(result.failure_diagnostics or {})
+    diagnostic_counts = failure_diagnostics.get("reason_counts", {})
+    if diagnostic_counts:
+        logger.warning(
+            "build_daily_snapshot failure diagnostics for %s: %s",
+            effective_market,
+            diagnostic_counts,
+        )
+```
+
+Add to the return dict:
+
+```python
+        "failure_diagnostics": failure_diagnostics,
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run:
+
+```bash
+cd backend
+source venv/bin/activate
+pytest backend/tests/unit/test_feature_store_tasks.py::test_build_daily_snapshot_returns_failure_diagnostics -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/interfaces/tasks/feature_store_tasks.py backend/tests/unit/test_feature_store_tasks.py
+git commit -m "feat: surface snapshot diagnostics in task payload"
+```
+
+## Task 3: Harden Static Daily Price Refresh
+
+**Files:**
+- Modify: `backend/app/scripts/export_static_site.py`
+- Test: `backend/tests/unit/test_export_static_site_script.py`
+
+- [ ] **Step 1: Write failing tests for no-history symbols**
+
+Add a test near `test_refresh_static_daily_prices_filters_to_selected_market`:
+
+```python
+def test_refresh_static_daily_prices_fetches_no_history_symbols_with_full_period(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[StockUniverse.__table__, StockPrice.__table__])
+    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
+
+    with session_factory() as db:
+        db.add_all(
+            [
+                StockUniverse(symbol="OLD.NS", market="IN", is_active=True, market_cap=100.0),
+                StockUniverse(symbol="NEW.NS", market="IN", is_active=True, market_cap=90.0),
+            ]
+        )
+        db.add(
+            StockPrice(
+                symbol="OLD.NS",
+                date=date(2026, 6, 3),
+                open=1.0,
+                high=1.0,
+                low=1.0,
+                close=1.0,
+                volume=1000,
+            )
+        )
+        db.commit()
+
+    fetch_calls = []
+    stored_batches = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(self, symbols, period="2y", start_batch_size=None, market=None):
+            fetch_calls.append(
+                {
+                    "symbols": list(symbols),
+                    "period": period,
+                    "market": market,
+                    "start_batch_size": start_batch_size,
+                }
+            )
+            return {
+                symbol: {"price_data": SimpleNamespace(empty=False), "has_error": False}
+                for symbol in symbols
+            }
+
+    monkeypatch.setattr(export_script, "SessionLocal", session_factory)
+    monkeypatch.setattr(export_script, "BulkDataFetcher", lambda: _FakeFetcher())
+    monkeypatch.setattr(export_script, "_static_daily_price_refresh_batch_size", lambda market: 25)
+    monkeypatch.setattr(
+        export_script,
+        "get_price_cache",
+        lambda: SimpleNamespace(
+            store_batch_in_cache=lambda payload, also_store_db=True, market=None: stored_batches.append(
+                {
+                    "symbols": sorted(payload.keys()),
+                    "also_store_db": also_store_db,
+                    "market": market,
+                }
+            )
+        ),
+    )
+
+    result = export_script._refresh_static_daily_prices(
+        as_of_date=date(2026, 6, 4),
+        market="IN",
+    )
+
+    assert fetch_calls == [
+        {
+            "symbols": ["OLD.NS"],
+            "period": "7d",
+            "market": "IN",
+            "start_batch_size": 25,
+        },
+        {
+            "symbols": ["NEW.NS"],
+            "period": "2y",
+            "market": "IN",
+            "start_batch_size": 25,
+        },
+    ]
+    assert stored_batches == [
+        {"symbols": ["OLD.NS"], "also_store_db": True, "market": "IN"},
+        {"symbols": ["NEW.NS"], "also_store_db": True, "market": "IN"},
+    ]
+    assert result["stale_symbols"] == 1
+    assert result["no_history_symbols"] == 1
+    assert result["yahoo_fetched_symbols"] == 2
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cd backend
+source venv/bin/activate
+pytest backend/tests/unit/test_export_static_site_script.py::test_refresh_static_daily_prices_fetches_no_history_symbols_with_full_period -q
+```
+
+Expected: failure because no-history symbols are not fetched and `store_batch_in_cache` does not receive `market`.
+
+- [ ] **Step 3: Add market-aware batch helper**
+
+In `backend/app/scripts/export_static_site.py`, add:
+
+```python
+STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD = "2y"
+```
+
+Replace the fixed `STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE` usage with:
+
+```python
+def _static_daily_price_refresh_batch_size(market: str | None) -> int:
+    if market:
+        from app.services.rate_budget_policy import get_rate_budget_policy
+
+        return get_rate_budget_policy().get_batch_size("yfinance", market)
+    return STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE
+```
+
+- [ ] **Step 4: Refactor `_refresh_static_daily_prices` to fetch stale and no-history groups**
+
+Inside `_refresh_static_daily_prices`, replace the single stale-symbol loop with a local helper:
+
+```python
+    batch_size = _static_daily_price_refresh_batch_size(market)
+
+    def _fetch_and_store(symbols: list[str], *, period: str) -> tuple[int, int, list[str]]:
+        refreshed_count = 0
+        failed_count = 0
+        rate_limited: list[str] = []
+        total_symbols = len(symbols)
+        if not symbols:
+            return 0, 0, []
+        total_group_batches = (total_symbols + batch_size - 1) // batch_size
+        for batch_index, batch_symbols in enumerate(
+            _iter_chunks(symbols, batch_size),
+            start=1,
+        ):
+            print(
+                f"[static-daily prices] Batch {batch_index}/{total_group_batches}: "
+                f"fetching {len(batch_symbols):,} symbols from Yahoo ({period}).",
+                flush=True,
+            )
+            batch_results = fetcher.fetch_prices_in_batches(
+                batch_symbols,
+                period=period,
+                start_batch_size=batch_size,
+                market=market,
+            )
+            batch_to_store: dict[str, Any] = {}
+            for symbol, payload in batch_results.items():
+                price_data = payload.get("price_data")
+                if not payload.get("has_error") and price_data is not None and not price_data.empty:
+                    batch_to_store[symbol] = price_data
+                    refreshed_count += 1
+                else:
+                    failed_count += 1
+                    if _is_rate_limit_failure(payload):
+                        rate_limited.append(symbol)
+            if batch_to_store:
+                price_cache.store_batch_in_cache(
+                    batch_to_store,
+                    also_store_db=True,
+                    market=market,
+                )
+        return refreshed_count, failed_count, rate_limited
+```
+
+Then call it:
+
+```python
+    stale_refreshed, stale_failed, stale_rate_limited = _fetch_and_store(
+        stale_symbols,
+        period=STATIC_DAILY_PRICE_REFRESH_PERIOD,
+    )
+    bootstrap_refreshed, bootstrap_failed, bootstrap_rate_limited = _fetch_and_store(
+        no_history_symbols,
+        period=STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+    )
+    refreshed = stale_refreshed + bootstrap_refreshed
+    failed = stale_failed + bootstrap_failed
+    rate_limited_symbols = stale_rate_limited + bootstrap_rate_limited
+```
+
+- [ ] **Step 5: Preserve existing retry behavior**
+
+Keep the existing `_retry_rate_limited_failures(...)` call, passing the combined `rate_limited_symbols`.
+
+- [ ] **Step 6: Run static export script tests**
+
+Run:
+
+```bash
+cd backend
+source venv/bin/activate
+pytest backend/tests/unit/test_export_static_site_script.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/scripts/export_static_site.py backend/tests/unit/test_export_static_site_script.py
+git commit -m "fix: refresh static daily no-history symbols"
+```
+
+## Task 4: Make Quarantined Market Builds Soft-Skip With Diagnostics
+
+**Files:**
+- Modify: `backend/app/scripts/export_static_site.py`
+- Modify: `.github/workflows/static-site.yml`
+- Test: `backend/tests/unit/test_export_static_site_script.py`
+- Test: `backend/tests/unit/test_static_site_workflow.py`
+
+- [ ] **Step 1: Write failing export-script test**
+
+Add a test to `backend/tests/unit/test_export_static_site_script.py` that simulates a selected market snapshot returning `quarantined` and no current published run:
+
+```python
+def test_run_daily_refresh_returns_skip_when_selected_market_snapshot_quarantined(monkeypatch, tmp_path):
+    monkeypatch.setattr(export_script, "_resolve_latest_completed_trading_date", lambda market: date(2026, 6, 4))
+    monkeypatch.setattr(export_script, "_refresh_static_daily_prices", lambda **_kwargs: {"status": "completed"})
+    monkeypatch.setattr(export_script.IBDIndustryService, "load_from_csv", lambda db, csv_path=None: 0)
+    monkeypatch.setattr(export_script, "_ensure_group_rank_history", lambda **_kwargs: {"status": "skipped"})
+    monkeypatch.setattr(export_script, "_enrich_feature_run_with_ibd_metadata", lambda **_kwargs: {"updated_rows": 0})
+    monkeypatch.setattr(export_script, "SessionLocal", lambda: SimpleNamespace(__enter__=lambda self: self, __exit__=lambda *args: None))
+
+    class _FakeTask:
+        def run(self, **_kwargs):
+            return {
+                "status": "quarantined",
+                "run_id": 1,
+                "market": "IN",
+                "failed_symbols": 2052,
+                "failure_diagnostics": {
+                    "reason_counts": {"scanner_error_result": 2052},
+                    "samples": [{"symbol": "500000.BO", "reason": "scanner_error_result"}],
+                },
+            }
+
+    monkeypatch.setattr(export_script, "build_daily_snapshot", _FakeTask())
+
+    result = export_script._run_daily_refresh(
+        output_dir=tmp_path,
+        market="IN",
+        refresh_daily=True,
+        build_mode=export_script.STATIC_BUILD_MODE_PRICE_DELTA,
+        skip_universe_refresh=True,
+        skip_fundamentals_refresh=True,
+    )
+
+    assert result["feature_snapshots"]["IN"]["status"] == "quarantined"
+    diagnostic_path = tmp_path / "diagnostics" / "in" / "snapshot-failure.json"
+    assert diagnostic_path.exists()
+    payload = json.loads(diagnostic_path.read_text())
+    assert payload["market"] == "IN"
+    assert payload["failure_diagnostics"]["reason_counts"] == {
+        "scanner_error_result": 2052
+    }
+```
+
+Import `json` if needed.
+
+- [ ] **Step 2: Add diagnostics writer**
+
+In `backend/app/scripts/export_static_site.py`, add:
+
+```python
+def _write_market_diagnostics(
+    *,
+    output_dir: Path,
+    market: str,
+    snapshot: dict[str, Any],
+) -> None:
+    diagnostics_dir = output_dir / "diagnostics" / market.lower()
+    diagnostics_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "market": market.upper(),
+        "status": snapshot.get("status"),
+        "run_id": snapshot.get("run_id"),
+        "failed_symbols": snapshot.get("failed_symbols"),
+        "row_count": snapshot.get("row_count"),
+        "warnings": snapshot.get("warnings", []),
+        "failure_diagnostics": snapshot.get("failure_diagnostics", {}),
+    }
+    (diagnostics_dir / "snapshot-failure.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+```
+
+Call it when `_snapshot_ready(snapshot)` is false:
+
+```python
+            if not _snapshot_ready(snapshot):
+                _write_market_diagnostics(
+                    output_dir=Path(output_dir),
+                    market=selected_market,
+                    snapshot=snapshot,
+                )
+```
+
+- [ ] **Step 3: Add explicit skip exit code for no current artifact**
+
+Add near the existing exit code:
+
+```python
+STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE = 79
+```
+
+In `main()`, when selected market daily refresh finishes but `StaticSiteExportService.export(...)` raises `RuntimeError("No published feature run is available...")` and diagnostics exist, return `79` instead of `1`.
+
+- [ ] **Step 4: Write workflow tests**
+
+Add to `backend/tests/unit/test_static_site_workflow.py`:
+
+```python
+def test_static_site_market_export_soft_skips_no_current_artifact() -> None:
+    build_market_job = _build_market_job()
+    export_step = build_market_job.split("      - name: Export market static data bundle\n", 1)[1].split(
+        "\n      - name: Build daily price bundle",
+        1,
+    )[0]
+
+    assert 'if [ "$status" -eq 79 ]; then' in export_step
+    assert "has_artifact=false" in export_step
+
+
+def test_static_site_uploads_market_diagnostics_on_failure_or_skip() -> None:
+    build_market_job = _build_market_job()
+
+    assert "Upload market diagnostics" in build_market_job
+    diagnostics_step = build_market_job.split("      - name: Upload market diagnostics\n", 1)[1].split(
+        "\n      - name: Build daily price bundle",
+        1,
+    )[0]
+    assert "if: always()" in diagnostics_step
+    assert "static-market-diagnostics-${{ matrix.market }}" in diagnostics_step
+```
+
+- [ ] **Step 5: Update workflow**
+
+In `.github/workflows/static-site.yml`, update the export step:
+
+```bash
+          if [ "$status" -eq 78 ]; then
+            echo "Market ${{ matrix.market }} is not a trading day; no current static artifact will be uploaded."
+            echo "has_artifact=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$status" -eq 79 ]; then
+            echo "Market ${{ matrix.market }} did not produce a publishable current snapshot; fallback artifact will be used if available."
+            echo "has_artifact=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+```
+
+Add a diagnostics upload step immediately after export:
+
+```yaml
+      - name: Upload market diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-market-diagnostics-${{ matrix.market }}
+          path: /tmp/static-data/diagnostics/${{ env.MARKET_LOWER }}
+          if-no-files-found: ignore
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+cd backend
+source venv/bin/activate
+pytest backend/tests/unit/test_export_static_site_script.py::test_run_daily_refresh_returns_skip_when_selected_market_snapshot_quarantined backend/tests/unit/test_static_site_workflow.py::test_static_site_market_export_soft_skips_no_current_artifact backend/tests/unit/test_static_site_workflow.py::test_static_site_uploads_market_diagnostics_on_failure_or_skip -q
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/scripts/export_static_site.py .github/workflows/static-site.yml backend/tests/unit/test_export_static_site_script.py backend/tests/unit/test_static_site_workflow.py
+git commit -m "fix: preserve static site fallback on quarantined markets"
+```
+
+## Task 5: Quality Gates and Operational Check
+
+**Files:**
+- No code changes.
+
+- [ ] **Step 1: Run backend unit tests for touched areas**
+
+Run:
+
+```bash
+cd backend
+source venv/bin/activate
+pytest \
+  backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py \
+  backend/tests/unit/test_feature_store_tasks.py \
+  backend/tests/unit/test_export_static_site_script.py \
+  backend/tests/unit/test_static_site_workflow.py \
+  -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run a local deterministic IN diagnostic smoke test**
+
+Use the same harness shape from the investigation, but only as a manual smoke command after unit tests:
+
+```bash
+cd backend
+DATABASE_URL='postgresql://stockscanner:stockscanner@localhost:55432/stockscanner' \
+REDIS_ENABLED=false \
+venv/bin/python -m app.scripts.export_static_site \
+  --output-dir /tmp/static-data-in-smoke \
+  --refresh-daily \
+  --build-mode price_delta \
+  --skip-universe-refresh \
+  --skip-fundamentals-refresh \
+  --market IN
+```
+
+Expected: either a publishable IN artifact is exported, or `/tmp/static-data-in-smoke/diagnostics/in/snapshot-failure.json` exists and includes `failure_diagnostics.reason_counts`.
+
+- [ ] **Step 3: Inspect Git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean after commits.
+
+- [ ] **Step 4: Push**
+
+Run:
+
+```bash
+git pull --rebase
+bd sync
+git push
+git status
+```
+
+Expected:
+- `bd sync` may fail with `Error: no beads database found` unless beads has been initialized before execution.
+- `git push` succeeds.
+- `git status` reports the branch is up to date with origin.
+
+## Self-Review
+
+- Spec coverage: diagnostics, no-history refresh, market-scoped price storage, batch-size hardening, workflow fallback, and tests are each covered by a task.
+- Placeholder scan: no banned placeholder phrases remain; every task has concrete test or implementation content.
+- Type consistency: `failure_diagnostics` is a dict on `BuildDailySnapshotResult`, is passed through `feature_store_tasks`, and is written into static diagnostics JSON.


### PR DESCRIPTION
## Summary
- Add daily snapshot failure diagnostics and preserve diagnostics artifacts for failed selected-market static exports.
- Harden the static daily price refresh path with a dedicated service, bootstrap fetch period for no-history symbols, and an IN-specific rate-limit retry.
- Replace brittle static-export RuntimeError message matching with a typed no-artifact exception.
- Keep static combine jobs able to reuse fallback artifacts when a market snapshot is quarantined or missing.
- Add the implementation plan for the IN static-site daily run robustness work.

## Verification
- `pytest tests/unit/test_export_static_site_script.py tests/unit/test_static_daily_price_refresh_service.py tests/unit/test_static_site_export_service.py -q` → 75 passed.
- `pytest tests/unit/use_cases/feature_store/test_build_daily_snapshot.py tests/unit/test_feature_store_tasks.py tests/unit/test_static_site_workflow.py -q` → 95 passed.
- `make gate-check` → passed.
- `git diff --check` → passed.
- Simulated merge of `origin/feat/leaders-leading-groups-v1` into latest `origin/main` (`22d5c884e`) completed with no textual conflicts.

## Notes
- Focused static tests in the simulated merged tree hit an existing `origin/main` RRG fixture issue: `sqlite3.OperationalError: no such table: ibd_group_ranks`. I reproduced the representative failure on pure `origin/main`, so it is not introduced by this branch.