### PR TITLE
feat(groups): RRG enhancements — direction arrows, dated tails, rank/name filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ StockBee-style advance/decline analysis with SPY overlay, daily movers (stocks u
 ![Group Rankings](docs/screenshots/group-rankings.png)
 *Industry group rankings with movers panel*
 
+#### Relative Rotation Graph (RRG)
+
+A MarketSmith/Bloomberg-style quadrant view of the same 197-group dataset: every industry group (or GICS-sector roll-up) is plotted by **RS-Ratio** vs **RS-Momentum**, with a weekly tail and direction arrow tracing its path through **Leading → Weakening → Lagging → Improving**. One screen answers *"what's rotating in, what's rolling over."* Filter by name or current rank to focus on the groups you care about, and click any dot to drill into its constituents.
+
+![Relative Rotation Graph](docs/screenshots/rrg-rotation.svg)
+*RRG: industry-group rotation with direction-arrowed weekly tails*
+
 ### Watchlists with Sparklines
 
 Visual performance tracking with RS and price sparklines (30-day trends), price change bars across 7 time periods, drag-and-drop organization with folders, and full-screen chart navigation.

--- a/docs/screenshots/rrg-rotation.svg
+++ b/docs/screenshots/rrg-rotation.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 580" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1b1d22"/>
+      <stop offset="1" stop-color="#121317"/>
+    </linearGradient>
+  </defs>
+
+  <!-- card -->
+  <rect x="0" y="0" width="800" height="580" rx="14" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="799" height="579" rx="14" fill="none" stroke="#2c2f36"/>
+
+  <!-- title -->
+  <text x="32" y="42" fill="#e7e9ee" font-size="20" font-weight="700">Relative Rotation Graph</text>
+  <text x="32" y="64" fill="#8a909b" font-size="13">IBD industry groups · RS-Ratio vs RS-Momentum · weekly tails</text>
+  <text x="768" y="44" text-anchor="end" fill="#8a909b" font-size="12">as of 2026-06-05</text>
+
+  <!-- plot quadrants: center cross at (420, 300) -->
+  <g>
+    <rect x="80"  y="86"  width="340" height="214" fill="#2196f3" fill-opacity="0.10"/>  <!-- Improving  TL -->
+    <rect x="420" y="86"  width="348" height="214" fill="#4caf50" fill-opacity="0.12"/>  <!-- Leading    TR -->
+    <rect x="80"  y="300" width="340" height="200" fill="#f44336" fill-opacity="0.10"/>  <!-- Lagging    BL -->
+    <rect x="420" y="300" width="348" height="200" fill="#ff9800" fill-opacity="0.10"/>  <!-- Weakening  BR -->
+    <rect x="80" y="86" width="688" height="414" fill="none" stroke="#2c2f36"/>
+    <line x1="420" y1="86" x2="420" y2="500" stroke="#5b616c" stroke-dasharray="5 5"/>
+    <line x1="80" y1="300" x2="768" y2="300" stroke="#5b616c" stroke-dasharray="5 5"/>
+  </g>
+
+  <!-- quadrant captions -->
+  <text x="760" y="108" text-anchor="end" fill="#4caf50" font-size="13" font-weight="700" letter-spacing="1">LEADING</text>
+  <text x="88"  y="108" fill="#2196f3" font-size="13" font-weight="700" letter-spacing="1">IMPROVING</text>
+  <text x="760" y="488" text-anchor="end" fill="#ff9800" font-size="13" font-weight="700" letter-spacing="1">WEAKENING</text>
+  <text x="88"  y="488" fill="#f44336" font-size="13" font-weight="700" letter-spacing="1">LAGGING</text>
+
+  <!-- axis labels -->
+  <text x="424" y="525" text-anchor="middle" fill="#aab0bb" font-size="13">RS-Ratio  (relative strength) →</text>
+  <text x="36" y="296" transform="rotate(-90 36 296)" text-anchor="middle" fill="#aab0bb" font-size="13">RS-Momentum →</text>
+
+  <!-- ===== traces ===== -->
+  <!-- Semiconductors: Improving -> Leading, accelerating up-right (rank #1) -->
+  <g>
+    <polyline points="452,322 505,262 556,210 606,168" fill="none" stroke="#4caf50" stroke-width="2" stroke-opacity="0.55"/>
+    <circle cx="452" cy="322" r="2.5" fill="#4caf50" fill-opacity="0.35"/>
+    <circle cx="505" cy="262" r="3.4" fill="#4caf50" fill-opacity="0.5"/>
+    <circle cx="556" cy="210" r="4.2" fill="#4caf50" fill-opacity="0.7"/>
+    <polygon points="-7,-4 7,0 -7,4" fill="#4caf50" transform="translate(581,189) rotate(-45.6)"/>
+    <circle cx="606" cy="168" r="9" fill="#4caf50" stroke="#0c0d10" stroke-width="1.5"/>
+    <text x="618" y="164" fill="#e7e9ee" font-size="12.5" font-weight="600">Semiconductors</text>
+    <text x="618" y="179" fill="#8a909b" font-size="11">rank #1</text>
+  </g>
+
+  <!-- Software: settled in Leading, mild drift -->
+  <g>
+    <polyline points="470,250 512,228 548,212 586,206" fill="none" stroke="#4caf50" stroke-width="2" stroke-opacity="0.55"/>
+    <circle cx="470" cy="250" r="2.5" fill="#4caf50" fill-opacity="0.35"/>
+    <circle cx="512" cy="228" r="3.4" fill="#4caf50" fill-opacity="0.5"/>
+    <circle cx="548" cy="212" r="4.2" fill="#4caf50" fill-opacity="0.7"/>
+    <polygon points="-7,-4 7,0 -7,4" fill="#4caf50" transform="translate(567,209) rotate(-9.5)"/>
+    <circle cx="586" cy="206" r="7.5" fill="#4caf50" stroke="#0c0d10" stroke-width="1.5"/>
+    <text x="598" y="210" fill="#e7e9ee" font-size="12.5" font-weight="600">Software</text>
+  </g>
+
+  <!-- Aerospace/Defense: Lagging -> Improving, turning up -->
+  <g>
+    <polyline points="332,372 350,338 366,302 380,256" fill="none" stroke="#2196f3" stroke-width="2" stroke-opacity="0.55"/>
+    <circle cx="332" cy="372" r="2.5" fill="#2196f3" fill-opacity="0.35"/>
+    <circle cx="350" cy="338" r="3.4" fill="#2196f3" fill-opacity="0.5"/>
+    <circle cx="366" cy="302" r="4.2" fill="#2196f3" fill-opacity="0.7"/>
+    <polygon points="-7,-4 7,0 -7,4" fill="#2196f3" transform="translate(373,279) rotate(-73)"/>
+    <circle cx="380" cy="256" r="7.5" fill="#2196f3" stroke="#0c0d10" stroke-width="1.5"/>
+    <text x="300" y="246" fill="#e7e9ee" font-size="12.5" font-weight="600">Aerospace/Defense</text>
+  </g>
+
+  <!-- Oil &amp; Gas: Leading -> Weakening, rolling over -->
+  <g>
+    <polyline points="556,256 576,292 592,326 604,360" fill="none" stroke="#ff9800" stroke-width="2" stroke-opacity="0.55"/>
+    <circle cx="556" cy="256" r="2.5" fill="#ff9800" fill-opacity="0.35"/>
+    <circle cx="576" cy="292" r="3.4" fill="#ff9800" fill-opacity="0.5"/>
+    <circle cx="592" cy="326" r="4.2" fill="#ff9800" fill-opacity="0.7"/>
+    <polygon points="-7,-4 7,0 -7,4" fill="#ff9800" transform="translate(598,343) rotate(70.6)"/>
+    <circle cx="604" cy="360" r="7.5" fill="#ff9800" stroke="#0c0d10" stroke-width="1.5"/>
+    <text x="616" y="364" fill="#e7e9ee" font-size="12.5" font-weight="600">Oil &amp; Gas</text>
+  </g>
+
+  <!-- Banks: drifting deeper into Lagging -->
+  <g>
+    <polyline points="346,344 322,372 304,398 292,422" fill="none" stroke="#f44336" stroke-width="2" stroke-opacity="0.55"/>
+    <circle cx="346" cy="344" r="2.5" fill="#f44336" fill-opacity="0.35"/>
+    <circle cx="322" cy="372" r="3.4" fill="#f44336" fill-opacity="0.5"/>
+    <circle cx="304" cy="398" r="4.2" fill="#f44336" fill-opacity="0.7"/>
+    <polygon points="-7,-4 7,0 -7,4" fill="#f44336" transform="translate(298,410) rotate(116.6)"/>
+    <circle cx="292" cy="422" r="7.5" fill="#f44336" stroke="#0c0d10" stroke-width="1.5"/>
+    <text x="306" y="430" fill="#e7e9ee" font-size="12.5" font-weight="600">Banks</text>
+  </g>
+
+  <!-- footer legend -->
+  <text x="32" y="558" fill="#6f757f" font-size="11.5">Dot size = constituents · arrow = direction of travel (oldest → newest) · filter by name or current rank</text>
+</svg>

--- a/frontend/src/components/Charts/RRGChart.jsx
+++ b/frontend/src/components/Charts/RRGChart.jsx
@@ -17,7 +17,7 @@
  * component is purely presentational. It is shared by the live Group Rankings
  * page and the static-site Groups page — both pass the same `{ groups: [...] }`.
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   ScatterChart,
   Scatter,
@@ -33,9 +33,6 @@ import {
   Customized,
 } from 'recharts';
 import {
-  Autocomplete,
-  TextField,
-  Slider,
   Box,
   Card,
   CardContent,
@@ -44,7 +41,9 @@ import {
   Alert,
 } from '@mui/material';
 import { QUADRANT_COLORS, QUADRANT_FILLS, quadrantColor } from './rrgColors';
-import { buildTailPoints, filterGroups } from './rrgTrace';
+import { buildTailPoints } from './rrgTrace';
+import { useRRGFilters } from './useRRGFilters';
+import RRGFilters from './RRGFilters';
 
 // Below this many series shown, the plot renders the full per-week detail:
 // graduated, hoverable tail dots + per-segment direction arrows. Above it (e.g.
@@ -176,28 +175,9 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
   const asOf = data?.date ?? null;
   const scopeLabel = data?.scope === 'sectors' ? 'Sectors' : 'Groups';
 
-  const [selected, setSelected] = useState([]);
-  const [rankRange, setRankRange] = useState(null); // null = full range (inactive)
-  // Clear filters when the dataset identity changes (scope/market switch), since
-  // the option names and rank extent no longer apply.
-  useEffect(() => {
-    setSelected([]);
-    setRankRange(null);
-  }, [data?.scope, data?.market]);
+  const { shown, filter } = useRRGFilters(groups, { scope: data?.scope, market: data?.market });
 
-  const allNames = useMemo(() => groups.map((g) => g.industry_group), [groups]);
-  const maxRank = useMemo(
-    () => groups.reduce((m, g) => (g.rank != null && g.rank > m ? g.rank : m), 1),
-    [groups],
-  );
-  const sliderValue = rankRange ?? [1, maxRank];
-  const rankActive = rankRange != null && (rankRange[0] > 1 || rankRange[1] < maxRank);
-  const shown = useMemo(
-    () => filterGroups(groups, { names: selected, rankRange: rankActive ? rankRange : null }),
-    [groups, selected, rankActive, rankRange],
-  );
-
-  const bound = useMemo(() => computeBound(shown.length ? shown : groups), [shown, groups]);
+  const bound = useMemo(() => computeBound(shown), [shown]);
   const lo = 100 - bound;
   const hi = 100 + bound;
 
@@ -258,39 +238,14 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
             {asOf ? ` · ${asOf}` : ''}
           </Typography>
           <Box sx={{ flexGrow: 1 }} />
-          {maxRank > 1 && (
-            <Box sx={{ width: 200 }}>
-              <Typography variant="caption" color="text.secondary">
-                Rank {sliderValue[0]}–{sliderValue[1]}
-              </Typography>
-              <Slider
-                size="small"
-                min={1}
-                max={maxRank}
-                value={sliderValue}
-                onChange={(_e, v) => setRankRange(v)}
-                valueLabelDisplay="auto"
-                disableSwap
-                sx={{ mt: -0.5 }}
-              />
-            </Box>
-          )}
-          <Autocomplete
-            multiple
-            size="small"
-            options={allNames}
-            value={selected}
-            onChange={(_e, v) => setSelected(v)}
-            limitTags={3}
-            disableCloseOnSelect
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label={`Filter ${scopeLabel.toLowerCase()}`}
-                placeholder={selected.length ? '' : 'All shown'}
-              />
-            )}
-            sx={{ width: 360, maxWidth: '100%' }}
+          <RRGFilters
+            scopeLabel={scopeLabel}
+            names={filter.names}
+            selected={filter.selected}
+            onSelected={filter.setSelected}
+            maxRank={filter.maxRank}
+            rankValue={filter.rankValue}
+            onRankChange={filter.setRankRange}
           />
         </Box>
 

--- a/frontend/src/components/Charts/RRGChart.jsx
+++ b/frontend/src/components/Charts/RRGChart.jsx
@@ -9,11 +9,15 @@
  *     Lagging   (x<100,  y<100)   red
  *     Improving (x<100,  y>=100)  blue
  *
+ * Each tail vertex is a hoverable dot (date + weeks-ago), the trace is graduated
+ * oldest->newest, and direction arrows point the way each series is travelling.
+ * A filter narrows the plot to the groups/sectors of interest.
+ *
  * Coordinates are pre-computed server-side (see backend rrg_service.py), so this
  * component is purely presentational. It is shared by the live Group Rankings
  * page and the static-site Groups page — both pass the same `{ groups: [...] }`.
  */
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   ScatterChart,
   Scatter,
@@ -26,8 +30,11 @@ import {
   ReferenceLine,
   ReferenceArea,
   ResponsiveContainer,
+  Customized,
 } from 'recharts';
 import {
+  Autocomplete,
+  TextField,
   Box,
   Card,
   CardContent,
@@ -36,6 +43,12 @@ import {
   Alert,
 } from '@mui/material';
 import { QUADRANT_COLORS, QUADRANT_FILLS, quadrantColor } from './rrgColors';
+import { buildTailPoints } from './rrgTrace';
+
+// Per-segment arrows render when at most this many series are shown; above it
+// (e.g. the unfiltered ~197-group view) only the most-recent segment gets one,
+// to keep the plot readable. Filter down to see the full per-week direction.
+const ARROW_DETAIL_LIMIT = 20;
 
 /** Symmetric axis bounds around the 100/100 cross, padded to the data extent. */
 const computeBound = (groups) => {
@@ -47,6 +60,70 @@ const computeBound = (groups) => {
     }
   }
   return Math.min(20, Math.ceil(maxAbs) + 1);
+};
+
+/** Graduated tail vertex: faint/small when old, brighter toward the head. The
+ *  head itself is drawn by the larger "current" dot, so it's skipped here. */
+const TailDot = ({ cx, cy, payload }) => {
+  if (cx == null || cy == null || payload?.isHead) return null;
+  const t = payload.t ?? 0.5;
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={2 + 2.5 * t}
+      fill={quadrantColor(payload.quadrant)}
+      fillOpacity={0.25 + 0.5 * t}
+    />
+  );
+};
+
+const ArrowHead = ({ x, y, angle, color }) => {
+  const size = 5;
+  return (
+    <polygon
+      points={`${-size},${-size * 0.6} ${size},0 ${-size},${size * 0.6}`}
+      transform={`translate(${x},${y}) rotate(${(angle * 180) / Math.PI})`}
+      fill={color}
+      fillOpacity={0.9}
+    />
+  );
+};
+
+/** Recharts <Customized> child: draws direction arrows in pixel space using the
+ *  axis scales. Degrades to nothing if scales aren't ready (e.g. SSR/jsdom). */
+const TailArrows = ({ shown, perSegment, xAxisMap, yAxisMap }) => {
+  const xAxis = xAxisMap && xAxisMap[Object.keys(xAxisMap)[0]];
+  const yAxis = yAxisMap && yAxisMap[Object.keys(yAxisMap)[0]];
+  const xScale = xAxis?.scale;
+  const yScale = yAxis?.scale;
+  if (typeof xScale !== 'function' || typeof yScale !== 'function') return null;
+
+  const arrows = [];
+  shown.forEach((g) => {
+    const tail = g.tail || [];
+    if (tail.length < 2) return;
+    const from = perSegment ? 1 : tail.length - 1;
+    for (let i = from; i < tail.length; i += 1) {
+      const a = tail[i - 1];
+      const b = tail[i];
+      const x1 = xScale(a.x);
+      const y1 = yScale(a.y);
+      const x2 = xScale(b.x);
+      const y2 = yScale(b.y);
+      if ([x1, y1, x2, y2].some((v) => v == null || Number.isNaN(v))) continue;
+      arrows.push(
+        <ArrowHead
+          key={`${g.industry_group}-${i}`}
+          x={(x1 + x2) / 2}
+          y={(y1 + y2) / 2}
+          angle={Math.atan2(y2 - y1, x2 - x1)}
+          color={quadrantColor(g.quadrant)}
+        />,
+      );
+    }
+  });
+  return <g>{arrows}</g>;
 };
 
 const RRGTooltip = ({ active, payload }) => {
@@ -72,9 +149,16 @@ const RRGTooltip = ({ active, payload }) => {
         {g.quadrant}
         {g.is_provisional ? ' · provisional' : ''}
       </Typography>
-      <Typography variant="body2" sx={{ mt: 0.5 }}>
-        Rank: {g.rank ?? '—'} · RS: {g.avg_rs_rating != null ? g.avg_rs_rating.toFixed(1) : '—'}
-      </Typography>
+      {g.isCurrent ? (
+        <Typography variant="body2" sx={{ mt: 0.5 }}>
+          Rank: {g.rank ?? '—'} · RS: {g.avg_rs_rating != null ? g.avg_rs_rating.toFixed(1) : '—'}
+        </Typography>
+      ) : (
+        <Typography variant="body2" sx={{ mt: 0.5, color: 'text.secondary' }}>
+          {g.weeksAgo === 0 ? 'Current' : `${g.weeksAgo}w ago`}
+          {g.date ? ` · ${g.date}` : ''}
+        </Typography>
+      )}
       <Typography variant="body2" sx={{ color: 'text.secondary' }}>
         Ratio {g.x?.toFixed(1)} · Momentum {g.y?.toFixed(1)}
       </Typography>
@@ -87,15 +171,34 @@ const RRGTooltip = ({ active, payload }) => {
  */
 export default function RRGChart({ data, isLoading, error, onSelectGroup, height = 560 }) {
   const groups = useMemo(() => (data?.groups ?? []), [data]);
+  const asOf = data?.date ?? null;
+  const scopeLabel = data?.scope === 'sectors' ? 'Sectors' : 'Groups';
 
-  const bound = useMemo(() => computeBound(groups), [groups]);
+  const [selected, setSelected] = useState([]);
+  // Clear the filter when the dataset identity changes (scope/market switch),
+  // since the option names no longer apply.
+  useEffect(() => {
+    setSelected([]);
+  }, [data?.scope, data?.market]);
+
+  const allNames = useMemo(() => groups.map((g) => g.industry_group), [groups]);
+  const shown = useMemo(() => {
+    if (!selected.length) return groups;
+    const set = new Set(selected);
+    return groups.filter((g) => set.has(g.industry_group));
+  }, [groups, selected]);
+
+  const bound = useMemo(() => computeBound(shown.length ? shown : groups), [shown, groups]);
   const lo = 100 - bound;
   const hi = 100 + bound;
 
-  // Flatten current points (each carries the full group for tooltip/click).
   const currentPoints = useMemo(
-    () => groups.map((g) => ({ ...g, ...g.current })),
-    [groups],
+    () => shown.map((g) => ({ ...g, ...g.current, isCurrent: true })),
+    [shown],
+  );
+  const tails = useMemo(
+    () => shown.map((g) => ({ name: g.industry_group, color: quadrantColor(g.quadrant), points: buildTailPoints(g, asOf) })),
+    [shown, asOf],
   );
 
   if (isLoading) {
@@ -135,77 +238,109 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
   return (
     <Card>
       <CardContent>
-        <Typography variant="subtitle2" sx={{ mb: 1 }}>
-          Relative Rotation Graph — {data?.scope === 'sectors' ? 'Sectors' : 'Groups'}
-          {data?.date ? ` · ${data.date}` : ''}
-        </Typography>
-        <ResponsiveContainer width="100%" height={height}>
-          <ScatterChart margin={{ top: 20, right: 30, bottom: 20, left: 10 }}>
-            <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
-
-            {/* Quadrant backdrops */}
-            <ReferenceArea x1={100} x2={hi} y1={100} y2={hi} fill={QUADRANT_FILLS.Leading} fillOpacity={1}
-              label={{ value: 'Leading', position: 'insideTopRight', fill: QUADRANT_COLORS.Leading, fontSize: 12 }} />
-            <ReferenceArea x1={100} x2={hi} y1={lo} y2={100} fill={QUADRANT_FILLS.Weakening} fillOpacity={1}
-              label={{ value: 'Weakening', position: 'insideBottomRight', fill: QUADRANT_COLORS.Weakening, fontSize: 12 }} />
-            <ReferenceArea x1={lo} x2={100} y1={lo} y2={100} fill={QUADRANT_FILLS.Lagging} fillOpacity={1}
-              label={{ value: 'Lagging', position: 'insideBottomLeft', fill: QUADRANT_COLORS.Lagging, fontSize: 12 }} />
-            <ReferenceArea x1={lo} x2={100} y1={100} y2={hi} fill={QUADRANT_FILLS.Improving} fillOpacity={1}
-              label={{ value: 'Improving', position: 'insideTopLeft', fill: QUADRANT_COLORS.Improving, fontSize: 12 }} />
-
-            <ReferenceLine x={100} stroke="#9e9e9e" strokeDasharray="4 4" />
-            <ReferenceLine y={100} stroke="#9e9e9e" strokeDasharray="4 4" />
-
-            <XAxis
-              type="number"
-              dataKey="x"
-              name="RS-Ratio"
-              domain={[lo, hi]}
-              tickCount={5}
-              label={{ value: 'RS-Ratio', position: 'insideBottom', offset: -10, fontSize: 12 }}
-            />
-            <YAxis
-              type="number"
-              dataKey="y"
-              name="RS-Momentum"
-              domain={[lo, hi]}
-              tickCount={5}
-              label={{ value: 'RS-Momentum', angle: -90, position: 'insideLeft', fontSize: 12 }}
-            />
-            <ZAxis type="number" dataKey="num_stocks" range={[60, 500]} name="Constituents" />
-            <Tooltip content={<RRGTooltip />} cursor={{ strokeDasharray: '3 3' }} />
-
-            {/* Tails: one connected polyline per group, dots hidden. */}
-            {groups.map((g) => (
-              <Scatter
-                key={`tail-${g.industry_group}`}
-                data={g.tail}
-                line={{ stroke: quadrantColor(g.quadrant), strokeWidth: 1.25, strokeOpacity: 0.5 }}
-                lineType="joint"
-                shape={() => null}
-                isAnimationActive={false}
-                legendType="none"
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+          <Typography variant="subtitle2">
+            Relative Rotation Graph — {scopeLabel}
+            {asOf ? ` · ${asOf}` : ''}
+          </Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          <Autocomplete
+            multiple
+            size="small"
+            options={allNames}
+            value={selected}
+            onChange={(_e, v) => setSelected(v)}
+            limitTags={3}
+            disableCloseOnSelect
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={`Filter ${scopeLabel.toLowerCase()}`}
+                placeholder={selected.length ? '' : 'All shown'}
               />
-            ))}
+            )}
+            sx={{ width: 360, maxWidth: '100%' }}
+          />
+        </Box>
 
-            {/* Current dots — colored by quadrant, clickable. */}
-            <Scatter
-              data={currentPoints}
-              isAnimationActive={false}
-              onClick={(pt) => onSelectGroup?.(pt?.industry_group)}
-              cursor="pointer"
-            >
-              {currentPoints.map((p) => (
-                <Cell
-                  key={`dot-${p.industry_group}`}
-                  fill={quadrantColor(p.quadrant)}
-                  fillOpacity={p.is_provisional ? 0.35 : 0.9}
-                  stroke={quadrantColor(p.quadrant)}
+        {shown.length === 0 ? (
+          <Alert severity="info">No {scopeLabel.toLowerCase()} match the current filter.</Alert>
+        ) : (
+          <ResponsiveContainer width="100%" height={height}>
+            <ScatterChart margin={{ top: 20, right: 30, bottom: 20, left: 10 }}>
+              <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+
+              {/* Quadrant backdrops */}
+              <ReferenceArea x1={100} x2={hi} y1={100} y2={hi} fill={QUADRANT_FILLS.Leading} fillOpacity={1}
+                label={{ value: 'Leading', position: 'insideTopRight', fill: QUADRANT_COLORS.Leading, fontSize: 12 }} />
+              <ReferenceArea x1={100} x2={hi} y1={lo} y2={100} fill={QUADRANT_FILLS.Weakening} fillOpacity={1}
+                label={{ value: 'Weakening', position: 'insideBottomRight', fill: QUADRANT_COLORS.Weakening, fontSize: 12 }} />
+              <ReferenceArea x1={lo} x2={100} y1={lo} y2={100} fill={QUADRANT_FILLS.Lagging} fillOpacity={1}
+                label={{ value: 'Lagging', position: 'insideBottomLeft', fill: QUADRANT_COLORS.Lagging, fontSize: 12 }} />
+              <ReferenceArea x1={lo} x2={100} y1={100} y2={hi} fill={QUADRANT_FILLS.Improving} fillOpacity={1}
+                label={{ value: 'Improving', position: 'insideTopLeft', fill: QUADRANT_COLORS.Improving, fontSize: 12 }} />
+
+              <ReferenceLine x={100} stroke="#9e9e9e" strokeDasharray="4 4" />
+              <ReferenceLine y={100} stroke="#9e9e9e" strokeDasharray="4 4" />
+
+              <XAxis
+                type="number"
+                dataKey="x"
+                name="RS-Ratio"
+                domain={[lo, hi]}
+                tickCount={5}
+                label={{ value: 'RS-Ratio', position: 'insideBottom', offset: -10, fontSize: 12 }}
+              />
+              <YAxis
+                type="number"
+                dataKey="y"
+                name="RS-Momentum"
+                domain={[lo, hi]}
+                tickCount={5}
+                label={{ value: 'RS-Momentum', angle: -90, position: 'insideLeft', fontSize: 12 }}
+              />
+              <ZAxis type="number" dataKey="num_stocks" range={[60, 500]} name="Constituents" />
+              <Tooltip content={<RRGTooltip />} cursor={{ strokeDasharray: '3 3' }} />
+
+              {/* Tails: connecting line + graduated, hoverable per-week dots. */}
+              {tails.map((t) => (
+                <Scatter
+                  key={`tail-${t.name}`}
+                  data={t.points}
+                  line={{ stroke: t.color, strokeWidth: 1.25, strokeOpacity: 0.45 }}
+                  lineType="joint"
+                  shape={<TailDot />}
+                  isAnimationActive={false}
+                  legendType="none"
                 />
               ))}
-            </Scatter>
-          </ScatterChart>
-        </ResponsiveContainer>
+
+              {/* Direction arrows along each trace. */}
+              <Customized
+                component={(props) => (
+                  <TailArrows shown={shown} perSegment={shown.length <= ARROW_DETAIL_LIMIT} {...props} />
+                )}
+              />
+
+              {/* Current head dots — sized by constituents, colored by quadrant, clickable. */}
+              <Scatter
+                data={currentPoints}
+                isAnimationActive={false}
+                onClick={(pt) => onSelectGroup?.(pt?.industry_group)}
+                cursor="pointer"
+              >
+                {currentPoints.map((p) => (
+                  <Cell
+                    key={`dot-${p.industry_group}`}
+                    fill={quadrantColor(p.quadrant)}
+                    fillOpacity={p.is_provisional ? 0.35 : 0.9}
+                    stroke={quadrantColor(p.quadrant)}
+                  />
+                ))}
+              </Scatter>
+            </ScatterChart>
+          </ResponsiveContainer>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/Charts/RRGChart.jsx
+++ b/frontend/src/components/Charts/RRGChart.jsx
@@ -45,10 +45,11 @@ import {
 import { QUADRANT_COLORS, QUADRANT_FILLS, quadrantColor } from './rrgColors';
 import { buildTailPoints } from './rrgTrace';
 
-// Per-segment arrows render when at most this many series are shown; above it
-// (e.g. the unfiltered ~197-group view) only the most-recent segment gets one,
-// to keep the plot readable. Filter down to see the full per-week direction.
-const ARROW_DETAIL_LIMIT = 20;
+// Below this many series shown, the plot renders the full per-week detail:
+// graduated, hoverable tail dots + per-segment direction arrows. Above it (e.g.
+// the unfiltered ~197-series view) tails are line-only with a single most-recent
+// arrow per series, to stay light and readable. Filter down to get the detail.
+const DETAIL_LIMIT = 20;
 
 /** Symmetric axis bounds around the 100/100 cross, padded to the data extent. */
 const computeBound = (groups) => {
@@ -192,6 +193,11 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
   const lo = 100 - bound;
   const hi = 100 + bound;
 
+  // Single "detail level" driving both tail-dot richness and arrow density, so
+  // the default (all-series) view stays light and the filtered view gets the
+  // full per-week detail.
+  const detailed = shown.length <= DETAIL_LIMIT;
+
   const currentPoints = useMemo(
     () => shown.map((g) => ({ ...g, ...g.current, isCurrent: true })),
     [shown],
@@ -302,23 +308,24 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
               <ZAxis type="number" dataKey="num_stocks" range={[60, 500]} name="Constituents" />
               <Tooltip content={<RRGTooltip />} cursor={{ strokeDasharray: '3 3' }} />
 
-              {/* Tails: connecting line + graduated, hoverable per-week dots. */}
+              {/* Tails: connecting line, plus graduated hoverable per-week dots
+                  in the detailed (filtered) view; line-only when many series. */}
               {tails.map((t) => (
                 <Scatter
                   key={`tail-${t.name}`}
                   data={t.points}
                   line={{ stroke: t.color, strokeWidth: 1.25, strokeOpacity: 0.45 }}
                   lineType="joint"
-                  shape={<TailDot />}
+                  shape={detailed ? <TailDot /> : () => null}
                   isAnimationActive={false}
                   legendType="none"
                 />
               ))}
 
-              {/* Direction arrows along each trace. */}
+              {/* Direction arrows along each trace (per-segment when detailed). */}
               <Customized
                 component={(props) => (
-                  <TailArrows shown={shown} perSegment={shown.length <= ARROW_DETAIL_LIMIT} {...props} />
+                  <TailArrows shown={shown} perSegment={detailed} {...props} />
                 )}
               />
 

--- a/frontend/src/components/Charts/RRGChart.jsx
+++ b/frontend/src/components/Charts/RRGChart.jsx
@@ -35,6 +35,7 @@ import {
 import {
   Autocomplete,
   TextField,
+  Slider,
   Box,
   Card,
   CardContent,
@@ -43,7 +44,7 @@ import {
   Alert,
 } from '@mui/material';
 import { QUADRANT_COLORS, QUADRANT_FILLS, quadrantColor } from './rrgColors';
-import { buildTailPoints } from './rrgTrace';
+import { buildTailPoints, filterGroups } from './rrgTrace';
 
 // Below this many series shown, the plot renders the full per-week detail:
 // graduated, hoverable tail dots + per-segment direction arrows. Above it (e.g.
@@ -176,18 +177,25 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
   const scopeLabel = data?.scope === 'sectors' ? 'Sectors' : 'Groups';
 
   const [selected, setSelected] = useState([]);
-  // Clear the filter when the dataset identity changes (scope/market switch),
-  // since the option names no longer apply.
+  const [rankRange, setRankRange] = useState(null); // null = full range (inactive)
+  // Clear filters when the dataset identity changes (scope/market switch), since
+  // the option names and rank extent no longer apply.
   useEffect(() => {
     setSelected([]);
+    setRankRange(null);
   }, [data?.scope, data?.market]);
 
   const allNames = useMemo(() => groups.map((g) => g.industry_group), [groups]);
-  const shown = useMemo(() => {
-    if (!selected.length) return groups;
-    const set = new Set(selected);
-    return groups.filter((g) => set.has(g.industry_group));
-  }, [groups, selected]);
+  const maxRank = useMemo(
+    () => groups.reduce((m, g) => (g.rank != null && g.rank > m ? g.rank : m), 1),
+    [groups],
+  );
+  const sliderValue = rankRange ?? [1, maxRank];
+  const rankActive = rankRange != null && (rankRange[0] > 1 || rankRange[1] < maxRank);
+  const shown = useMemo(
+    () => filterGroups(groups, { names: selected, rankRange: rankActive ? rankRange : null }),
+    [groups, selected, rankActive, rankRange],
+  );
 
   const bound = useMemo(() => computeBound(shown.length ? shown : groups), [shown, groups]);
   const lo = 100 - bound;
@@ -250,6 +258,23 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
             {asOf ? ` · ${asOf}` : ''}
           </Typography>
           <Box sx={{ flexGrow: 1 }} />
+          {maxRank > 1 && (
+            <Box sx={{ width: 200 }}>
+              <Typography variant="caption" color="text.secondary">
+                Rank {sliderValue[0]}–{sliderValue[1]}
+              </Typography>
+              <Slider
+                size="small"
+                min={1}
+                max={maxRank}
+                value={sliderValue}
+                onChange={(_e, v) => setRankRange(v)}
+                valueLabelDisplay="auto"
+                disableSwap
+                sx={{ mt: -0.5 }}
+              />
+            </Box>
+          )}
           <Autocomplete
             multiple
             size="small"

--- a/frontend/src/components/Charts/RRGChart.test.jsx
+++ b/frontend/src/components/Charts/RRGChart.test.jsx
@@ -51,6 +51,13 @@ describe('RRGChart', () => {
     expect(screen.getByText(/Sectors/)).toBeInTheDocument();
   });
 
+  it('renders a scope-aware filter control', () => {
+    const { rerender } = renderWithProviders(<RRGChart data={sampleData} />);
+    expect(screen.getByLabelText(/Filter groups/i)).toBeInTheDocument();
+    rerender(<RRGChart data={{ ...sampleData, scope: 'sectors' }} />);
+    expect(screen.getByLabelText(/Filter sectors/i)).toBeInTheDocument();
+  });
+
   it('shows a spinner while loading', () => {
     renderWithProviders(<RRGChart data={null} isLoading />);
     expect(screen.getByRole('progressbar')).toBeInTheDocument();

--- a/frontend/src/components/Charts/RRGChart.test.jsx
+++ b/frontend/src/components/Charts/RRGChart.test.jsx
@@ -51,6 +51,12 @@ describe('RRGChart', () => {
     expect(screen.getByText(/Sectors/)).toBeInTheDocument();
   });
 
+  it('renders a current-rank range slider (two thumbs)', () => {
+    renderWithProviders(<RRGChart data={sampleData} />);
+    expect(screen.getByText(/Rank 1/)).toBeInTheDocument();
+    expect(screen.getAllByRole('slider')).toHaveLength(2);
+  });
+
   it('renders a scope-aware filter control', () => {
     const { rerender } = renderWithProviders(<RRGChart data={sampleData} />);
     expect(screen.getByLabelText(/Filter groups/i)).toBeInTheDocument();

--- a/frontend/src/components/Charts/RRGFilters.jsx
+++ b/frontend/src/components/Charts/RRGFilters.jsx
@@ -1,0 +1,55 @@
+/**
+ * RRG filter controls: a current-rank range slider + a name multi-select.
+ * Presentational only — state lives in useRRGFilters. Shared by the live and
+ * static Group Rankings pages via RRGChart.
+ */
+import { Autocomplete, TextField, Slider, Box, Typography } from '@mui/material';
+
+export default function RRGFilters({
+  scopeLabel,
+  names,
+  selected,
+  onSelected,
+  maxRank,
+  rankValue,
+  onRankChange,
+}) {
+  return (
+    <>
+      {maxRank > 1 && (
+        <Box sx={{ width: 200 }}>
+          <Typography variant="caption" color="text.secondary">
+            Rank {rankValue[0]}–{rankValue[1]}
+          </Typography>
+          <Slider
+            size="small"
+            min={1}
+            max={maxRank}
+            value={rankValue}
+            onChange={(_e, v) => onRankChange(v)}
+            valueLabelDisplay="auto"
+            disableSwap
+            sx={{ mt: -0.5 }}
+          />
+        </Box>
+      )}
+      <Autocomplete
+        multiple
+        size="small"
+        options={names}
+        value={selected}
+        onChange={(_e, v) => onSelected(v)}
+        limitTags={3}
+        disableCloseOnSelect
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={`Filter ${scopeLabel.toLowerCase()}`}
+            placeholder={selected.length ? '' : 'All shown'}
+          />
+        )}
+        sx={{ width: 360, maxWidth: '100%' }}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/Charts/rrgTrace.js
+++ b/frontend/src/components/Charts/rrgTrace.js
@@ -1,0 +1,34 @@
+/**
+ * Pure helpers for RRG tail rendering (kept out of the component file so they
+ * are unit-testable and don't trip react-refresh).
+ */
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Whole weeks between the as-of date and a tail point's date (>= 0, or null). */
+export const weeksAgo = (asOfISO, pointISO) => {
+  const asOf = Date.parse(asOfISO);
+  const point = Date.parse(pointISO);
+  if (Number.isNaN(asOf) || Number.isNaN(point)) return null;
+  return Math.max(0, Math.round((asOf - point) / WEEK_MS));
+};
+
+/**
+ * Enrich a group's weekly tail (oldest -> newest) with per-point metadata used
+ * for hover tooltips and graduated styling:
+ *   - weeksAgo: how far back the point is from the as-of date
+ *   - isHead:   the most-recent point (the current position)
+ *   - t:        0 (oldest) -> 1 (newest), for size/opacity gradients
+ */
+export const buildTailPoints = (group, asOfISO) => {
+  const tail = group?.tail ?? [];
+  const last = tail.length - 1;
+  return tail.map((p, i) => ({
+    ...p,
+    industry_group: group.industry_group,
+    quadrant: group.quadrant,
+    weeksAgo: weeksAgo(asOfISO, p.date),
+    isHead: i === last,
+    t: last > 0 ? i / last : 1,
+  }));
+};

--- a/frontend/src/components/Charts/rrgTrace.js
+++ b/frontend/src/components/Charts/rrgTrace.js
@@ -20,6 +20,23 @@ export const weeksAgo = (asOfISO, pointISO) => {
  *   - isHead:   the most-recent point (the current position)
  *   - t:        0 (oldest) -> 1 (newest), for size/opacity gradients
  */
+/**
+ * Filter RRG series by selected names and/or an inclusive current-rank range.
+ * Both filters compose with AND; pass `rankRange = null` to disable rank
+ * filtering (when set, series with no rank are excluded).
+ */
+export const filterGroups = (groups, { names = [], rankRange = null } = {}) => {
+  const nameSet = names.length ? new Set(names) : null;
+  return (groups ?? []).filter((g) => {
+    if (nameSet && !nameSet.has(g.industry_group)) return false;
+    if (rankRange) {
+      const [lo, hi] = rankRange;
+      if (g.rank == null || g.rank < lo || g.rank > hi) return false;
+    }
+    return true;
+  });
+};
+
 export const buildTailPoints = (group, asOfISO) => {
   const tail = group?.tail ?? [];
   const last = tail.length - 1;

--- a/frontend/src/components/Charts/rrgTrace.test.js
+++ b/frontend/src/components/Charts/rrgTrace.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { weeksAgo, buildTailPoints } from './rrgTrace';
+
+describe('weeksAgo', () => {
+  it('is 0 for the as-of date itself', () => {
+    expect(weeksAgo('2024-09-29', '2024-09-29')).toBe(0);
+  });
+
+  it('rounds the day gap to whole weeks', () => {
+    expect(weeksAgo('2024-09-29', '2024-09-22')).toBe(1); // 7 days
+    expect(weeksAgo('2024-09-29', '2024-08-11')).toBe(7); // 49 days
+  });
+
+  it('never returns negative (future point clamps to 0)', () => {
+    expect(weeksAgo('2024-09-29', '2024-10-06')).toBe(0);
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(weeksAgo('2024-09-29', 'nope')).toBeNull();
+    expect(weeksAgo(undefined, '2024-09-29')).toBeNull();
+  });
+});
+
+describe('buildTailPoints', () => {
+  const group = {
+    industry_group: 'AlphaTech',
+    quadrant: 'Leading',
+    tail: [
+      { date: '2024-08-11', x: 104.0, y: 98.0 },
+      { date: '2024-09-01', x: 106.0, y: 101.0 },
+      { date: '2024-09-29', x: 108.3, y: 106.1 },
+    ],
+  };
+
+  it('enriches every tail point with hover + styling metadata', () => {
+    const pts = buildTailPoints(group, '2024-09-29');
+    expect(pts).toHaveLength(3);
+    expect(pts[0]).toMatchObject({
+      industry_group: 'AlphaTech',
+      quadrant: 'Leading',
+      x: 104.0,
+      y: 98.0,
+      date: '2024-08-11',
+      weeksAgo: 7,
+      isHead: false,
+      t: 0, // oldest -> 0
+    });
+    expect(pts[2]).toMatchObject({ isHead: true, weeksAgo: 0, t: 1 }); // newest -> head
+    expect(pts[1].t).toBeCloseTo(0.5, 5);
+  });
+
+  it('handles a single-point tail (head, t=1)', () => {
+    const pts = buildTailPoints({ ...group, tail: [{ date: '2024-09-29', x: 100, y: 100 }] }, '2024-09-29');
+    expect(pts).toHaveLength(1);
+    expect(pts[0]).toMatchObject({ isHead: true, t: 1, weeksAgo: 0 });
+  });
+
+  it('returns an empty array when there is no tail', () => {
+    expect(buildTailPoints({ industry_group: 'X', quadrant: 'Lagging' }, '2024-09-29')).toEqual([]);
+  });
+});

--- a/frontend/src/components/Charts/rrgTrace.test.js
+++ b/frontend/src/components/Charts/rrgTrace.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { weeksAgo, buildTailPoints } from './rrgTrace';
+import { weeksAgo, buildTailPoints, filterGroups } from './rrgTrace';
 
 describe('weeksAgo', () => {
   it('is 0 for the as-of date itself', () => {
@@ -57,5 +57,32 @@ describe('buildTailPoints', () => {
 
   it('returns an empty array when there is no tail', () => {
     expect(buildTailPoints({ industry_group: 'X', quadrant: 'Lagging' }, '2024-09-29')).toEqual([]);
+  });
+});
+
+describe('filterGroups', () => {
+  const groups = [
+    { industry_group: 'A', rank: 1 },
+    { industry_group: 'B', rank: 10 },
+    { industry_group: 'C', rank: 50 },
+    { industry_group: 'D', rank: null },
+  ];
+
+  it('returns everything when no filters are active', () => {
+    expect(filterGroups(groups)).toHaveLength(4);
+    expect(filterGroups(groups, {})).toHaveLength(4);
+  });
+
+  it('filters by selected names', () => {
+    expect(filterGroups(groups, { names: ['A', 'C'] }).map((g) => g.industry_group)).toEqual(['A', 'C']);
+  });
+
+  it('filters by inclusive current-rank range and drops null ranks', () => {
+    expect(filterGroups(groups, { rankRange: [1, 10] }).map((g) => g.industry_group)).toEqual(['A', 'B']);
+    expect(filterGroups(groups, { rankRange: [10, 50] }).map((g) => g.industry_group)).toEqual(['B', 'C']);
+  });
+
+  it('combines name and rank filters with AND', () => {
+    expect(filterGroups(groups, { names: ['A', 'C'], rankRange: [1, 10] }).map((g) => g.industry_group)).toEqual(['A']);
   });
 });

--- a/frontend/src/components/Charts/useRRGFilters.js
+++ b/frontend/src/components/Charts/useRRGFilters.js
@@ -1,0 +1,41 @@
+import { useEffect, useMemo, useState } from 'react';
+import { filterGroups } from './rrgTrace';
+
+/**
+ * Owns the RRG filtering concern (name multi-select + current-rank range) and
+ * returns the resolved `shown` series plus the props the `RRGFilters` controls
+ * need. Kept out of RRGChart so the chart stays a pure visualization and the
+ * filter logic is testable in isolation.
+ *
+ * `rankRange === null` means the range is inactive (full extent) — null-rank
+ * series are only dropped once the user actually constrains the range.
+ */
+export function useRRGFilters(groups, { scope, market } = {}) {
+  const [selected, setSelected] = useState([]);
+  const [rankRange, setRankRange] = useState(null);
+
+  // Reset when the dataset identity changes (scope/market switch), since the
+  // option names and rank extent no longer apply.
+  useEffect(() => {
+    setSelected([]);
+    setRankRange(null);
+  }, [scope, market]);
+
+  const names = useMemo(() => groups.map((g) => g.industry_group), [groups]);
+  const maxRank = useMemo(
+    () => groups.reduce((m, g) => (g.rank != null && g.rank > m ? g.rank : m), 1),
+    [groups],
+  );
+  const rankValue = rankRange ?? [1, maxRank];
+  const rankActive = rankRange != null && (rankRange[0] > 1 || rankRange[1] < maxRank);
+
+  const shown = useMemo(
+    () => filterGroups(groups, { names: selected, rankRange: rankActive ? rankRange : null }),
+    [groups, selected, rankActive, rankRange],
+  );
+
+  return {
+    shown,
+    filter: { names, selected, setSelected, maxRank, rankValue, setRankRange },
+  };
+}

--- a/frontend/src/components/Charts/useRRGFilters.js
+++ b/frontend/src/components/Charts/useRRGFilters.js
@@ -26,12 +26,17 @@ export function useRRGFilters(groups, { scope, market } = {}) {
     () => groups.reduce((m, g) => (g.rank != null && g.rank > m ? g.rank : m), 1),
     [groups],
   );
-  const rankValue = rankRange ?? [1, maxRank];
-  const rankActive = rankRange != null && (rankRange[0] > 1 || rankRange[1] < maxRank);
+  // Clamp the stored range to the current [1, maxRank] at derivation time, so a
+  // stale range from a prior data refresh (where maxRank shrank) can never feed
+  // the slider an out-of-range value or filter to nothing.
+  const rankLo = rankRange ? Math.min(Math.max(1, rankRange[0]), maxRank) : 1;
+  const rankHi = rankRange ? Math.min(Math.max(1, rankRange[1]), maxRank) : maxRank;
+  const rankValue = [rankLo, rankHi];
+  const rankActive = rankLo > 1 || rankHi < maxRank;
 
   const shown = useMemo(
-    () => filterGroups(groups, { names: selected, rankRange: rankActive ? rankRange : null }),
-    [groups, selected, rankActive, rankRange],
+    () => filterGroups(groups, { names: selected, rankRange: rankActive ? [rankLo, rankHi] : null }),
+    [groups, selected, rankActive, rankLo, rankHi],
   );
 
   return {

--- a/frontend/src/components/Charts/useRRGFilters.test.js
+++ b/frontend/src/components/Charts/useRRGFilters.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useRRGFilters } from './useRRGFilters';
+
+const groups = [
+  { industry_group: 'A', rank: 1 },
+  { industry_group: 'B', rank: 10 },
+  { industry_group: 'C', rank: 50 },
+];
+
+describe('useRRGFilters', () => {
+  it('shows all groups by default and reports the rank extent', () => {
+    const { result } = renderHook(() => useRRGFilters(groups, { scope: 'groups', market: 'US' }));
+    expect(result.current.shown).toHaveLength(3);
+    expect(result.current.filter.maxRank).toBe(50);
+    expect(result.current.filter.rankValue).toEqual([1, 50]);
+  });
+
+  it('filters by current-rank range', () => {
+    const { result } = renderHook(() => useRRGFilters(groups, { scope: 'groups', market: 'US' }));
+    act(() => result.current.filter.setRankRange([1, 10]));
+    expect(result.current.shown.map((g) => g.industry_group)).toEqual(['A', 'B']);
+  });
+
+  it('filters by selected names', () => {
+    const { result } = renderHook(() => useRRGFilters(groups, { scope: 'groups', market: 'US' }));
+    act(() => result.current.filter.setSelected(['C']));
+    expect(result.current.shown.map((g) => g.industry_group)).toEqual(['C']);
+  });
+
+  it('resets filters when the scope changes', () => {
+    const { result, rerender } = renderHook(
+      ({ scope }) => useRRGFilters(groups, { scope, market: 'US' }),
+      { initialProps: { scope: 'groups' } },
+    );
+    act(() => result.current.filter.setSelected(['C']));
+    expect(result.current.shown).toHaveLength(1);
+    rerender({ scope: 'sectors' });
+    expect(result.current.shown).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/Charts/useRRGFilters.test.js
+++ b/frontend/src/components/Charts/useRRGFilters.test.js
@@ -28,6 +28,28 @@ describe('useRRGFilters', () => {
     expect(result.current.shown.map((g) => g.industry_group)).toEqual(['C']);
   });
 
+  it('clamps a stale rank range when maxRank shrinks on a same-scope refresh', () => {
+    const big = [
+      { industry_group: 'A', rank: 1 },
+      { industry_group: 'B', rank: 40 },
+      { industry_group: 'C', rank: 50 },
+    ];
+    const small = [
+      { industry_group: 'A', rank: 1 },
+      { industry_group: 'B', rank: 10 },
+    ]; // maxRank drops 50 -> 10, same scope/market (no reset)
+    const { result, rerender } = renderHook(
+      ({ g }) => useRRGFilters(g, { scope: 'groups', market: 'US' }),
+      { initialProps: { g: big } },
+    );
+    act(() => result.current.filter.setRankRange([40, 50]));
+    expect(result.current.shown.map((x) => x.industry_group)).toEqual(['B', 'C']);
+
+    rerender({ g: small });
+    expect(result.current.filter.rankValue).toEqual([10, 10]); // clamped into [1, 10]
+    expect(result.current.shown.map((x) => x.industry_group)).toEqual(['B']);
+  });
+
   it('resets filters when the scope changes', () => {
     const { result, rerender } = renderHook(
       ({ scope }) => useRRGFilters(groups, { scope, market: 'US' }),


### PR DESCRIPTION
Follow-up to #218 (merged), which shipped the base Relative Rotation Graph. This adds the interaction/readability improvements requested after first use. All changes are client-side on the shared `RRGChart` (live + static both benefit) plus a README graphic — no backend or static-export change.

## What's new
- **Direction arrows along each trace** — per-segment arrowheads (Recharts `<Customized>`, oriented by segment angle in pixel space) show which way each series is rotating, oldest→newest.
- **Hoverable, dated trace points** — every weekly tail vertex is a graduated dot (faint/old → bright/new) with a tooltip showing its date and how many weeks back it is. The head stays the larger clickable "current" dot.
- **Filters** — a name multi-select **and** a current-rank range slider (compose with AND). The slider extent adapts to scope (197 groups vs ~11 sectors) and resets on scope/market switch.
- **Adaptive detail** — a single `detailed = shown.length <= DETAIL_LIMIT` flag drives both dot richness and arrow density, so the full ~197-series overview stays light and a filtered view gets the per-week detail.
- **README** — documents the RRG under *IBD Industry Group Rankings* with a hand-authored, dark-theme SVG (quadrants, direction-arrowed sample rotation), verified by rendering it.

## Structure
The filtering concern is a `useRRGFilters` hook + a presentational `RRGFilters` component; pure helpers (`weeksAgo`, `buildTailPoints`, `filterGroups`) live in `rrgTrace.js`; colors in `rrgColors.js`. `RRGChart` stays a focused visualization (334 lines).

## Tests
Pure helpers + the filter hook are unit-tested (`rrgTrace.test.js`, `useRRGFilters.test.js`); the chart/page tests cover the filter + slider controls. Local: 41/41 charts+pages green, lint 0/0. (SVG-layout-dependent visuals — arrow orientation — need a browser eyeball; the arrow code degrades to nothing if axis scales aren't ready.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Relative Rotation Graph (RRG) visualization with quadrant-based rotation tracking.
  * New filtering UI: rank-range slider (two-thumb) and multi-select group filter; chart shows an informational message when filters yield no matches.
  * Detailed tail mode: per-week markers, graduated tail visuals, directional arrows; tooltips show current rank/RS and historical timing.

* **Documentation**
  * README updated with RRG description, RS‑Ratio/RS‑Momentum guidance, filtering/drill‑down notes, and a screenshot.

* **Tests**
  * Added/expanded tests covering filters, tail helpers, and timing calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->