### PR TITLE
fix(scripts): add mapfile fallback for macOS Bash 3.2

### DIFF
--- a/scripts/docker-compose-enabled-markets.sh
+++ b/scripts/docker-compose-enabled-markets.sh
@@ -109,11 +109,23 @@ is_down_command() {
   return 1
 }
 
-mapfile -t PROVIDED_ENV_FILES < <(env_files_from_args "$@")
+# mapfile -t PROVIDED_ENV_FILES < <(env_files_from_args "$@")
+PROVIDED_ENV_FILES=()
+
+if type mapfile >/dev/null 2>&1; then
+    mapfile -t PROVIDED_ENV_FILES < <(env_files_from_args "$@")
+else
+    while IFS= read -r line; do
+        PROVIDED_ENV_FILES+=("$line")
+    done < <(env_files_from_args "$@")
+fi
+
 RESOLVED_ENV_FILES=()
-for ENV_FILE in "${PROVIDED_ENV_FILES[@]}"; do
-  RESOLVED_ENV_FILES+=("$(env_file_path "$ENV_FILE")")
-done
+if [[ ${#PROVIDED_ENV_FILES[@]} -gt 0 ]]; then
+  for ENV_FILE in "${PROVIDED_ENV_FILES[@]}"; do
+    RESOLVED_ENV_FILES+=("$(env_file_path "$ENV_FILE")")
+  done
+fi
 
 ENV_FILE_TO_FORWARD=""
 if [[ "${#RESOLVED_ENV_FILES[@]}" -eq 0 ]]; then


### PR DESCRIPTION
Replace the unconditional mapfile usage with feature detection and a portable while-read fallback for environments where mapfile is unavailable.

Also fix wrapper script behavior under Bash 3.2 with set -u enabled, allowing docker-compose-enabled-markets.sh to run on default macOS installations without requiring Homebrew Bash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker Compose script compatibility by enhancing environment file processing with better fallback support for different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->