### PR TITLE
Add quadrant filter and group labels toggle to RRG chart

### DIFF
--- a/frontend/src/components/Charts/RRGChart.jsx
+++ b/frontend/src/components/Charts/RRGChart.jsx
@@ -17,7 +17,7 @@
  * component is purely presentational. It is shared by the live Group Rankings
  * page and the static-site Groups page — both pass the same `{ groups: [...] }`.
  */
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
   ScatterChart,
   Scatter,
@@ -39,6 +39,8 @@ import {
   Typography,
   CircularProgress,
   Alert,
+  FormControlLabel,
+  Switch,
 } from '@mui/material';
 import { QUADRANT_COLORS, QUADRANT_FILLS, quadrantColor } from './rrgColors';
 import { buildTailPoints } from './rrgTrace';
@@ -127,6 +129,42 @@ const TailArrows = ({ shown, perSegment, xAxisMap, yAxisMap }) => {
   return <g>{arrows}</g>;
 };
 
+/** Recharts <Customized> child: draws the group/sector name next to each current
+ *  head dot, tinted by quadrant. Uses the axis scales like TailArrows, and
+ *  degrades to nothing if scales aren't ready (e.g. SSR/jsdom). */
+const GroupLabels = ({ shown, xAxisMap, yAxisMap }) => {
+  const xAxis = xAxisMap && xAxisMap[Object.keys(xAxisMap)[0]];
+  const yAxis = yAxisMap && yAxisMap[Object.keys(yAxisMap)[0]];
+  const xScale = xAxis?.scale;
+  const yScale = yAxis?.scale;
+  if (typeof xScale !== 'function' || typeof yScale !== 'function') return null;
+
+  return (
+    <g>
+      {shown.map((g) => {
+        const cur = g.current;
+        if (!cur) return null;
+        const cx = xScale(cur.x);
+        const cy = yScale(cur.y);
+        if ([cx, cy].some((v) => v == null || Number.isNaN(v))) return null;
+        return (
+          <text
+            key={`label-${g.industry_group}`}
+            x={cx + 7}
+            y={cy - 7}
+            fontSize={10}
+            fontWeight={600}
+            fill={quadrantColor(g.quadrant)}
+            pointerEvents="none"
+          >
+            {g.industry_group}
+          </text>
+        );
+      })}
+    </g>
+  );
+};
+
 const RRGTooltip = ({ active, payload }) => {
   if (!active || !payload || !payload.length) return null;
   const g = payload[0]?.payload;
@@ -176,6 +214,10 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
   const scopeLabel = data?.scope === 'sectors' ? 'Sectors' : 'Groups';
 
   const { shown, filter } = useRRGFilters(groups, { scope: data?.scope, market: data?.market });
+
+  // Display preference (not a filter) — kept local so it persists across
+  // scope/market switches, unlike the filters in useRRGFilters.
+  const [showLabels, setShowLabels] = useState(false);
 
   const bound = useMemo(() => computeBound(shown), [shown]);
   const lo = 100 - bound;
@@ -238,11 +280,24 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
             {asOf ? ` · ${asOf}` : ''}
           </Typography>
           <Box sx={{ flexGrow: 1 }} />
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={showLabels}
+                onChange={(e) => setShowLabels(e.target.checked)}
+              />
+            }
+            label="Labels"
+            sx={{ mr: 0 }}
+          />
           <RRGFilters
             scopeLabel={scopeLabel}
             names={filter.names}
             selected={filter.selected}
             onSelected={filter.setSelected}
+            quadrants={filter.quadrants}
+            onQuadrants={filter.setQuadrants}
             maxRank={filter.maxRank}
             rankValue={filter.rankValue}
             onRankChange={filter.setRankRange}
@@ -308,6 +363,13 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
                   <TailArrows shown={shown} perSegment={detailed} {...props} />
                 )}
               />
+
+              {/* Group/sector name labels next to each head dot (toggle). */}
+              {showLabels && (
+                <Customized
+                  component={(props) => <GroupLabels shown={shown} {...props} />}
+                />
+              )}
 
               {/* Current head dots — sized by constituents, colored by quadrant, clickable. */}
               <Scatter

--- a/frontend/src/components/Charts/RRGChart.test.jsx
+++ b/frontend/src/components/Charts/RRGChart.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import RRGChart from './RRGChart';
 import { QUADRANT_COLORS } from './rrgColors';
@@ -55,6 +55,21 @@ describe('RRGChart', () => {
     renderWithProviders(<RRGChart data={sampleData} />);
     expect(screen.getByText(/Rank 1/)).toBeInTheDocument();
     expect(screen.getAllByRole('slider')).toHaveLength(2);
+  });
+
+  it('renders a multi-select quadrant filter (one toggle per quadrant)', () => {
+    renderWithProviders(<RRGChart data={sampleData} />);
+    ['Improving', 'Leading', 'Weakening', 'Lagging'].forEach((q) => {
+      expect(screen.getByRole('button', { name: q })).toBeInTheDocument();
+    });
+  });
+
+  it('renders a Labels toggle that starts off and can be turned on', () => {
+    renderWithProviders(<RRGChart data={sampleData} />);
+    const toggle = screen.getByRole('checkbox', { name: /labels/i });
+    expect(toggle).not.toBeChecked();
+    fireEvent.click(toggle);
+    expect(toggle).toBeChecked();
   });
 
   it('renders a scope-aware filter control', () => {

--- a/frontend/src/components/Charts/RRGFilters.jsx
+++ b/frontend/src/components/Charts/RRGFilters.jsx
@@ -1,21 +1,57 @@
 /**
- * RRG filter controls: a current-rank range slider + a name multi-select.
- * Presentational only — state lives in useRRGFilters. Shared by the live and
- * static Group Rankings pages via RRGChart.
+ * RRG filter controls: a quadrant multi-select + a current-rank range slider +
+ * a name multi-select. Presentational only — state lives in useRRGFilters.
+ * Shared by the live and static Group Rankings pages via RRGChart.
  */
-import { Autocomplete, TextField, Slider, Box, Typography } from '@mui/material';
+import {
+  Autocomplete,
+  TextField,
+  Slider,
+  Box,
+  Typography,
+  ToggleButton,
+  ToggleButtonGroup,
+} from '@mui/material';
+import { QUADRANTS, QUADRANT_COLORS } from './rrgColors';
 
 export default function RRGFilters({
   scopeLabel,
   names,
   selected,
   onSelected,
+  quadrants,
+  onQuadrants,
   maxRank,
   rankValue,
   onRankChange,
 }) {
   return (
     <>
+      {/* Quadrant multi-select — empty selection means "all shown". Each button
+          is tinted with its quadrant color when active. */}
+      <ToggleButtonGroup
+        size="small"
+        value={quadrants}
+        onChange={(_e, v) => onQuadrants(v)}
+        aria-label="Filter by quadrant"
+      >
+        {QUADRANTS.map((q) => (
+          <ToggleButton
+            key={q}
+            value={q}
+            sx={{
+              textTransform: 'none',
+              '&.Mui-selected': {
+                color: QUADRANT_COLORS[q],
+                borderColor: QUADRANT_COLORS[q],
+                fontWeight: 700,
+              },
+            }}
+          >
+            {q}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
       {maxRank > 1 && (
         <Box sx={{ width: 200 }}>
           <Typography variant="caption" color="text.secondary">

--- a/frontend/src/components/Charts/rrgColors.js
+++ b/frontend/src/components/Charts/rrgColors.js
@@ -17,3 +17,9 @@ export const QUADRANT_FILLS = {
 };
 
 export const quadrantColor = (q) => QUADRANT_COLORS[q] || '#9e9e9e';
+
+/**
+ * Canonical quadrant order (clockwise rotation cycle) — single source of truth
+ * for the quadrant filter buttons so they stay consistent with the colors above.
+ */
+export const QUADRANTS = ['Improving', 'Leading', 'Weakening', 'Lagging'];

--- a/frontend/src/components/Charts/rrgTrace.js
+++ b/frontend/src/components/Charts/rrgTrace.js
@@ -21,14 +21,17 @@ export const weeksAgo = (asOfISO, pointISO) => {
  *   - t:        0 (oldest) -> 1 (newest), for size/opacity gradients
  */
 /**
- * Filter RRG series by selected names and/or an inclusive current-rank range.
- * Both filters compose with AND; pass `rankRange = null` to disable rank
- * filtering (when set, series with no rank are excluded).
+ * Filter RRG series by selected names, quadrants, and/or an inclusive
+ * current-rank range. All filters compose with AND; an empty `names`/`quadrants`
+ * array disables that filter, and `rankRange = null` disables rank filtering
+ * (when set, series with no rank are excluded).
  */
-export const filterGroups = (groups, { names = [], rankRange = null } = {}) => {
+export const filterGroups = (groups, { names = [], quadrants = [], rankRange = null } = {}) => {
   const nameSet = names.length ? new Set(names) : null;
+  const quadSet = quadrants.length ? new Set(quadrants) : null;
   return (groups ?? []).filter((g) => {
     if (nameSet && !nameSet.has(g.industry_group)) return false;
+    if (quadSet && !quadSet.has(g.quadrant)) return false;
     if (rankRange) {
       const [lo, hi] = rankRange;
       if (g.rank == null || g.rank < lo || g.rank > hi) return false;

--- a/frontend/src/components/Charts/rrgTrace.test.js
+++ b/frontend/src/components/Charts/rrgTrace.test.js
@@ -62,10 +62,10 @@ describe('buildTailPoints', () => {
 
 describe('filterGroups', () => {
   const groups = [
-    { industry_group: 'A', rank: 1 },
-    { industry_group: 'B', rank: 10 },
-    { industry_group: 'C', rank: 50 },
-    { industry_group: 'D', rank: null },
+    { industry_group: 'A', rank: 1, quadrant: 'Leading' },
+    { industry_group: 'B', rank: 10, quadrant: 'Improving' },
+    { industry_group: 'C', rank: 50, quadrant: 'Lagging' },
+    { industry_group: 'D', rank: null, quadrant: 'Leading' },
   ];
 
   it('returns everything when no filters are active', () => {
@@ -77,12 +77,18 @@ describe('filterGroups', () => {
     expect(filterGroups(groups, { names: ['A', 'C'] }).map((g) => g.industry_group)).toEqual(['A', 'C']);
   });
 
+  it('filters by selected quadrants', () => {
+    expect(filterGroups(groups, { quadrants: ['Leading'] }).map((g) => g.industry_group)).toEqual(['A', 'D']);
+    expect(filterGroups(groups, { quadrants: ['Improving', 'Lagging'] }).map((g) => g.industry_group)).toEqual(['B', 'C']);
+  });
+
   it('filters by inclusive current-rank range and drops null ranks', () => {
     expect(filterGroups(groups, { rankRange: [1, 10] }).map((g) => g.industry_group)).toEqual(['A', 'B']);
     expect(filterGroups(groups, { rankRange: [10, 50] }).map((g) => g.industry_group)).toEqual(['B', 'C']);
   });
 
-  it('combines name and rank filters with AND', () => {
+  it('combines name, quadrant, and rank filters with AND', () => {
     expect(filterGroups(groups, { names: ['A', 'C'], rankRange: [1, 10] }).map((g) => g.industry_group)).toEqual(['A']);
+    expect(filterGroups(groups, { quadrants: ['Leading'], rankRange: [1, 10] }).map((g) => g.industry_group)).toEqual(['A']);
   });
 });

--- a/frontend/src/components/Charts/useRRGFilters.js
+++ b/frontend/src/components/Charts/useRRGFilters.js
@@ -12,12 +12,14 @@ import { filterGroups } from './rrgTrace';
  */
 export function useRRGFilters(groups, { scope, market } = {}) {
   const [selected, setSelected] = useState([]);
+  const [selectedQuadrants, setSelectedQuadrants] = useState([]);
   const [rankRange, setRankRange] = useState(null);
 
   // Reset when the dataset identity changes (scope/market switch), since the
   // option names and rank extent no longer apply.
   useEffect(() => {
     setSelected([]);
+    setSelectedQuadrants([]);
     setRankRange(null);
   }, [scope, market]);
 
@@ -35,12 +37,25 @@ export function useRRGFilters(groups, { scope, market } = {}) {
   const rankActive = rankLo > 1 || rankHi < maxRank;
 
   const shown = useMemo(
-    () => filterGroups(groups, { names: selected, rankRange: rankActive ? [rankLo, rankHi] : null }),
-    [groups, selected, rankActive, rankLo, rankHi],
+    () => filterGroups(groups, {
+      names: selected,
+      quadrants: selectedQuadrants,
+      rankRange: rankActive ? [rankLo, rankHi] : null,
+    }),
+    [groups, selected, selectedQuadrants, rankActive, rankLo, rankHi],
   );
 
   return {
     shown,
-    filter: { names, selected, setSelected, maxRank, rankValue, setRankRange },
+    filter: {
+      names,
+      selected,
+      setSelected,
+      quadrants: selectedQuadrants,
+      setQuadrants: setSelectedQuadrants,
+      maxRank,
+      rankValue,
+      setRankRange,
+    },
   };
 }

--- a/frontend/src/components/Charts/useRRGFilters.test.js
+++ b/frontend/src/components/Charts/useRRGFilters.test.js
@@ -3,9 +3,9 @@ import { act, renderHook } from '@testing-library/react';
 import { useRRGFilters } from './useRRGFilters';
 
 const groups = [
-  { industry_group: 'A', rank: 1 },
-  { industry_group: 'B', rank: 10 },
-  { industry_group: 'C', rank: 50 },
+  { industry_group: 'A', rank: 1, quadrant: 'Leading' },
+  { industry_group: 'B', rank: 10, quadrant: 'Improving' },
+  { industry_group: 'C', rank: 50, quadrant: 'Lagging' },
 ];
 
 describe('useRRGFilters', () => {
@@ -26,6 +26,12 @@ describe('useRRGFilters', () => {
     const { result } = renderHook(() => useRRGFilters(groups, { scope: 'groups', market: 'US' }));
     act(() => result.current.filter.setSelected(['C']));
     expect(result.current.shown.map((g) => g.industry_group)).toEqual(['C']);
+  });
+
+  it('filters by selected quadrants', () => {
+    const { result } = renderHook(() => useRRGFilters(groups, { scope: 'groups', market: 'US' }));
+    act(() => result.current.filter.setQuadrants(['Leading', 'Lagging']));
+    expect(result.current.shown.map((g) => g.industry_group)).toEqual(['A', 'C']);
   });
 
   it('clamps a stale rank range when maxRank shrinks on a same-scope refresh', () => {
@@ -56,8 +62,10 @@ describe('useRRGFilters', () => {
       { initialProps: { scope: 'groups' } },
     );
     act(() => result.current.filter.setSelected(['C']));
+    act(() => result.current.filter.setQuadrants(['Lagging']));
     expect(result.current.shown).toHaveLength(1);
     rerender({ scope: 'sectors' });
     expect(result.current.shown).toHaveLength(3);
+    expect(result.current.filter.quadrants).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
Enhances the Relative Rotation Graph (RRG) chart with two new features: a quadrant-based filter control and an optional labels toggle that displays group/sector names next to current head dots.

## Key Changes

- **Quadrant Filter**: Added a multi-select toggle button group in `RRGFilters` that allows users to filter groups by their quadrant (Improving, Leading, Weakening, Lagging). The filter composes with existing name and rank filters using AND logic.

- **Group Labels Toggle**: Added a switch control in the RRG chart header that toggles the display of group/sector name labels positioned next to each current head dot, tinted by quadrant color.

- **New `GroupLabels` Component**: Implemented a Recharts `<Customized>` child component that renders text labels using the chart's axis scales, with graceful degradation for SSR/jsdom environments.

- **Filter State Management**: Extended `useRRGFilters` hook to manage quadrant selection state alongside existing name and rank filters. Quadrant selection resets when scope/market changes (consistent with other filters).

- **Updated `filterGroups` Function**: Modified the filter logic in `rrgTrace.js` to support quadrant filtering with the same AND composition pattern as existing filters.

- **Test Coverage**: Added tests for the quadrant filter button rendering, labels toggle behavior, and quadrant filtering logic in both unit and integration test suites.

## Implementation Details

- The labels toggle state is kept local to `RRGChart` (not in `useRRGFilters`) so it persists across scope/market switches, unlike the filters which reset on dataset changes.
- Quadrant order is defined in a new `QUADRANTS` constant in `rrgColors.js` to serve as the single source of truth for filter button ordering.
- The `GroupLabels` component safely handles missing or invalid axis scales by returning `null`, preventing errors in SSR or test environments.
- Toggle buttons use quadrant colors for visual feedback when selected, maintaining consistency with the chart's color scheme.

https://claude.ai/code/session_01YTUmSptbwnzXF23kxWpPin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional label display toggle to show group names directly on the chart visualization.
  * Introduced quadrant multi-select filter allowing users to filter groups by quadrant (Improving, Leading, Weakening, Lagging).

* **Tests**
  * Added tests for label toggle and quadrant filter UI behavior.
  * Expanded filter testing to cover quadrant-based filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->