### PR TITLE
ci(static-site): split daily run into Asian and US-close groups

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -2,9 +2,23 @@ name: Static Site
 
 on:
   schedule:
+    # US/EU/Americas group — after US close (unchanged).
     - cron: '10 16 * * 1-6'
       timezone: 'America/New_York'
+    # Asian group — 6:30pm SGT, after all Asian markets close (incl. India,
+    # which closes 3:30pm IST = 6:00pm SGT; the 30-min buffer lets prices settle).
+    - cron: '30 18 * * 1-5'
+      timezone: 'Asia/Singapore'
   workflow_dispatch:
+    inputs:
+      market_group:
+        description: 'Which market group to build'
+        type: choice
+        default: all
+        options:
+          - all
+          - asia
+          - us
 
 concurrency:
   group: static-site-${{ github.ref }}
@@ -17,6 +31,43 @@ permissions:
   id-token: write
 
 jobs:
+  select-markets:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    runs-on: ubuntu-latest
+    outputs:
+      markets: ${{ steps.pick.outputs.markets }}
+    steps:
+      # Resolve which markets this run builds. The schedule that fired
+      # (github.event.schedule) selects the group; manual dispatch uses the
+      # market_group input. The combine job back-fills every market that is NOT
+      # built here from the last good artifact of a previous run, so a partial
+      # group still publishes a complete site.
+      - id: pick
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
+          MARKET_GROUP: ${{ github.event.inputs.market_group }}
+        run: |
+          ASIA='["HK","IN","JP","KR","TW","CN","SG","MY","AU"]'
+          US='["US","CA","DE"]'
+          ALL='["US","HK","IN","JP","KR","TW","CN","CA","DE","SG","AU","MY"]'
+
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            case "$SCHEDULE" in
+              '30 18 * * 1-5') markets="$ASIA" ;;   # 6:30pm SGT (Asia/Singapore)
+              *)               markets="$US" ;;     # 4:10pm ET (America/New_York)
+            esac
+          else
+            case "$MARKET_GROUP" in
+              asia) markets="$ASIA" ;;
+              us)   markets="$US" ;;
+              *)    markets="$ALL" ;;
+            esac
+          fi
+
+          echo "markets=$markets" >> "$GITHUB_OUTPUT"
+          echo "Building markets: $markets"
+
   ensure_daily_price_release:
     if: ${{ github.event_name == 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
@@ -34,12 +85,12 @@ jobs:
 
   build-market:
     if: ${{ github.event_name == 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-    needs: ensure_daily_price_release
+    needs: [select-markets, ensure_daily_price_release]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        market: [US, HK, IN, JP, KR, TW, CN, CA, DE, SG, AU, MY]
+        market: ${{ fromJSON(needs.select-markets.outputs.markets) }}
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -2,9 +2,10 @@ name: Static Site
 
 on:
   schedule:
-    # US/EU/Americas group — after US close. 21:10 UTC stays past the 4pm ET
-    # close in both DST states (4:10pm EST in winter, 5:10pm EDT in summer).
-    - cron: '10 21 * * 1-6'
+    # US/EU/Americas group — 4:10pm ET, after US close. Uses the New York
+    # timezone so it tracks DST automatically.
+    - cron: '10 16 * * 1-6'
+      timezone: 'America/New_York'
     # Asian group — 6:30pm SGT, after all Asian markets close (incl. India,
     # which closes 3:30pm IST = 6:00pm SGT; the 30-min buffer lets prices
     # settle). Singapore has no DST, so 6:30pm SGT == 10:30 UTC year-round.
@@ -55,7 +56,7 @@ jobs:
           if [ "$EVENT_NAME" = "schedule" ]; then
             case "$SCHEDULE" in
               '30 10 * * 1-5') markets="$ASIA" ;;   # 10:30 UTC = 6:30pm SGT
-              *)               markets="$US" ;;     # 21:10 UTC = after US close
+              *)               markets="$US" ;;     # 4:10pm ET (America/New_York)
             esac
           else
             case "$MARKET_GROUP" in

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -646,11 +646,49 @@ jobs:
       - name: Validate market artifacts
         run: |
           mkdir -p /tmp/static-market-artifacts-current /tmp/static-market-artifacts-fallback
-          find /tmp/static-market-artifacts-current /tmp/static-market-artifacts-fallback -type f -name 'manifest.market.json'
-          if ! find /tmp/static-market-artifacts-current /tmp/static-market-artifacts-fallback -type f -name 'manifest.market.json' | grep -q .; then
-            echo "No current or fallback market artifacts are available." >&2
-            exit 1
-          fi
+          cd backend
+          python - <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          from app.domain.markets import market_registry
+
+          # Every scheduled run builds only one market group; the rest must be
+          # back-filled from a previous run's artifacts. Publishing is all-or-
+          # nothing: refuse to deploy unless every supported market is present
+          # across current + fallback artifacts, so a partial group run (or a
+          # failed fallback download) can never ship an incomplete static site.
+          expected = {code.upper() for code in market_registry.supported_market_codes()}
+          present = set()
+          for base in (
+              "/tmp/static-market-artifacts-current",
+              "/tmp/static-market-artifacts-fallback",
+          ):
+              for manifest in Path(base).rglob("manifest.market.json"):
+                  try:
+                      market = str(
+                          json.loads(manifest.read_text(encoding="utf-8")).get("market", "")
+                      ).upper()
+                  except (OSError, json.JSONDecodeError, TypeError) as exc:
+                      print(f"::warning::Could not read {manifest}: {exc}", flush=True)
+                      continue
+                  if market:
+                      present.add(market)
+
+          print(f"Expected markets: {', '.join(sorted(expected))}")
+          print(f"Present markets:  {', '.join(sorted(present)) or '(none)'}")
+
+          missing = sorted(expected - present)
+          if missing:
+              print(
+                  "::error::Refusing to publish an incomplete static site. No current "
+                  f"build and no fallback artifact for: {', '.join(missing)}.",
+                  flush=True,
+              )
+              sys.exit(1)
+          print("All supported markets present; static site is complete.")
+          PY
 
       - name: Combine static data bundle
         run: |

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -2,13 +2,13 @@ name: Static Site
 
 on:
   schedule:
-    # US/EU/Americas group — after US close (unchanged).
-    - cron: '10 16 * * 1-6'
-      timezone: 'America/New_York'
+    # US/EU/Americas group — after US close. 21:10 UTC stays past the 4pm ET
+    # close in both DST states (4:10pm EST in winter, 5:10pm EDT in summer).
+    - cron: '10 21 * * 1-6'
     # Asian group — 6:30pm SGT, after all Asian markets close (incl. India,
-    # which closes 3:30pm IST = 6:00pm SGT; the 30-min buffer lets prices settle).
-    - cron: '30 18 * * 1-5'
-      timezone: 'Asia/Singapore'
+    # which closes 3:30pm IST = 6:00pm SGT; the 30-min buffer lets prices
+    # settle). Singapore has no DST, so 6:30pm SGT == 10:30 UTC year-round.
+    - cron: '30 10 * * 1-5'
   workflow_dispatch:
     inputs:
       market_group:
@@ -54,8 +54,8 @@ jobs:
 
           if [ "$EVENT_NAME" = "schedule" ]; then
             case "$SCHEDULE" in
-              '30 18 * * 1-5') markets="$ASIA" ;;   # 6:30pm SGT (Asia/Singapore)
-              *)               markets="$US" ;;     # 4:10pm ET (America/New_York)
+              '30 10 * * 1-5') markets="$ASIA" ;;   # 10:30 UTC = 6:30pm SGT
+              *)               markets="$US" ;;     # 21:10 UTC = after US close
             esac
           else
             case "$MARKET_GROUP" in

--- a/backend/tests/unit/test_static_workflow_markets.py
+++ b/backend/tests/unit/test_static_workflow_markets.py
@@ -12,22 +12,50 @@ from app.domain.markets import market_registry
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _workflow_matrix_markets(path: str) -> list[str]:
+def _weekly_reference_matrix_markets(path: str) -> list[str]:
+    """Parse the weekly-reference matrix from its ``|| '[...]'`` dispatch form."""
     content = (_PROJECT_ROOT / path).read_text(encoding="utf-8")
-    match = re.search(r"market:\s*\[([^\]]+)\]", content)
-    if match is not None:
-        return [market.strip() for market in match.group(1).split(",")]
-
-    dispatch_matrix_match = re.search(r"\|\|\s*'(\[[^']+\])'", content)
-    assert dispatch_matrix_match is not None, f"{path} does not declare a market matrix"
-    return list(json.loads(dispatch_matrix_match.group(1)))
+    match = re.search(r"\|\|\s*'(\[[^']+\])'", content)
+    assert match is not None, f"{path} does not declare a market matrix"
+    return list(json.loads(match.group(1)))
 
 
-def test_static_and_weekly_reference_workflows_cover_supported_markets():
+def _static_site_market_group(name: str) -> list[str]:
+    """Parse a market-group JSON array assigned in the select-markets job.
+
+    The static-site workflow no longer uses a literal matrix; build-market
+    consumes ``fromJSON(needs.select-markets.outputs.markets)`` and the
+    select-markets job derives the group from shell vars like ``ASIA='[...]'``.
+    """
+    content = (_PROJECT_ROOT / ".github/workflows/static-site.yml").read_text(encoding="utf-8")
+    match = re.search(rf"^\s*{name}='(\[[^']*\])'", content, re.MULTILINE)
+    assert match is not None, f"static-site.yml does not define a {name} market group"
+    return list(json.loads(match.group(1)))
+
+
+def test_static_site_all_group_and_weekly_reference_cover_supported_markets():
     expected = list(market_registry.supported_market_codes())
 
-    assert _workflow_matrix_markets(".github/workflows/static-site.yml") == expected
-    assert _workflow_matrix_markets(".github/workflows/weekly-reference-data.yml") == expected
+    # The dispatch "all" group must stay in lockstep with the registry so a
+    # manual full rebuild covers every supported market in the canonical order.
+    assert _static_site_market_group("ALL") == expected
+    assert _weekly_reference_matrix_markets(".github/workflows/weekly-reference-data.yml") == expected
+
+
+def test_static_site_schedule_groups_partition_supported_markets():
+    asia = _static_site_market_group("ASIA")
+    us = _static_site_market_group("US")
+    all_markets = _static_site_market_group("ALL")
+
+    # The two scheduled groups must contain the intended exact markets...
+    assert asia == ["HK", "IN", "JP", "KR", "TW", "CN", "SG", "MY", "AU"]
+    assert us == ["US", "CA", "DE"]
+
+    # ...and together partition the full market set (disjoint + exhaustive), so
+    # every supported market is published by exactly one scheduled run.
+    assert set(asia).isdisjoint(us)
+    assert set(asia) | set(us) == set(all_markets)
+    assert set(all_markets) == set(market_registry.supported_market_codes())
 
 
 def test_static_workflow_legacy_weekly_reference_manifest_is_us_only():


### PR DESCRIPTION
Add a second schedule at 6:30pm SGT (Asia/Singapore) so Asian markets
(HK, IN, JP, KR, TW, CN, SG, MY, AU) publish right after their close,
while US/EU/Americas markets (US, CA, DE) keep the 4:10pm ET run. India
is grouped with Asia with a 30-min buffer past its 6:00pm SGT close.

A new select-markets job resolves the matrix from the firing schedule
(github.event.schedule) or the workflow_dispatch market_group input, and
build-market consumes it via fromJSON. combine-and-build and deploy are
unchanged: the existing per-market fallback back-fills every market not
built in the current run from the last good artifact, so each run still
publishes one complete static site. Kept as a single workflow file so the
fallback's static-site.yml run query continues to see both groups.