### PR TITLE
Fix bootstrap review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ On first launch the app boots into a setup screen — no pre-seeded database req
 The orchestrator runs a staged Celery pipeline for the primary market:
 
 1. **Universe refresh** — seeds the market's symbol list (S&P 500 / Russell / NDX for US via `refresh_stock_universe`; official exchange feeds for HK / IN / JP / KR / TW / CN / CA / DE / SG / MY / AU via `refresh_official_market_universe`).
-2. **Benchmark + price refresh** — 5y OHLCV cached in Redis with PostgreSQL fallback.
+2. **Benchmark + price refresh** — imports the GitHub daily price bundle first, accepts recent stale bundles during bootstrap, then live-fetches only missing/current-session gaps (`7d` top-up for stale symbols, `2y` only for no-history symbols).
 3. **Fundamentals refresh** — quarterly and annual financials.
 4. **Breadth calculation** — StockBee-style advance/decline with gap-fill.
 5. **Group rankings** — IBD-style relative strength across 197 industry groups.
@@ -167,7 +167,7 @@ The orchestrator runs a staged Celery pipeline for the primary market:
 
 *Per-stage progress with per-market queue status while the pipeline is running*
 
-The workspace opens as soon as the primary market reaches `ready`. Secondary markets keep hydrating in the background on their own queues (`data_fetch_{us,hk,in,jp,kr,tw,cn,de,ca,sg,my,au}`) so you can start scanning immediately. Scans against a market that's still refreshing return HTTP 409 `market_refresh_active` — the UI surfaces this as a wait indicator rather than a failure.
+The workspace opens as soon as the primary market reaches `ready`. Secondary markets keep hydrating in the background on their own queues (`data_fetch_{us,hk,in,jp,kr,tw,cn,de,ca,sg,my,au}`) so you can start scanning immediately. Scans against a market that's still refreshing return HTTP 409 `market_refresh_active`, and scans against a market whose data is not current yet return the usual stale-data response instead of triggering a first-run block.
 
 State is persisted in `AppSetting` under `runtime.primary_market`, `runtime.enabled_markets`, and `runtime.bootstrap_state` (`not_started` → `running` → `ready`). To re-run the wizard, reset `runtime.bootstrap_state` to `not_started`.
 

--- a/backend/app/api/v1/app_runtime.py
+++ b/backend/app/api/v1/app_runtime.py
@@ -26,6 +26,7 @@ from ...services.runtime_preferences_service import (
 )
 from ...services.runtime_universe_options import build_runtime_universe_options_payload
 from ...services.market_activity_service import get_runtime_activity_status
+from ...services.runtime_activity_contract import bootstrap_stage_metadata
 from ...tasks.runtime_bootstrap_tasks import queue_local_runtime_bootstrap
 
 router = APIRouter()
@@ -40,6 +41,7 @@ def _bootstrap_status_payload(status: object) -> dict[str, object]:
         "enabled_markets": list(getattr(status, "enabled_markets")),
         "bootstrap_state": str(getattr(status, "bootstrap_state")),
         "supported_markets": list(getattr(status, "supported_markets")),
+        "bootstrap_stages": bootstrap_stage_metadata(),
     }
 
 
@@ -65,6 +67,7 @@ async def get_app_capabilities(
         enabled_markets=bootstrap_status.enabled_markets,
         bootstrap_state=bootstrap_status.bootstrap_state,
         supported_markets=market_catalog.supported_market_codes(),
+        bootstrap_stages=bootstrap_stage_metadata(),
         market_catalog=market_catalog.as_runtime_payload(),
         universe_options=build_runtime_universe_options_payload(
             enabled_markets=bootstrap_status.enabled_markets,

--- a/backend/app/api/v1/app_runtime.py
+++ b/backend/app/api/v1/app_runtime.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
@@ -27,9 +29,10 @@ from ...services.runtime_preferences_service import (
 from ...services.runtime_universe_options import build_runtime_universe_options_payload
 from ...services.market_activity_service import get_runtime_activity_status
 from ...services.runtime_activity_contract import bootstrap_stage_metadata
-from ...tasks.runtime_bootstrap_tasks import queue_local_runtime_bootstrap
+from ...tasks.runtime_bootstrap_tasks import BootstrapDispatchError, queue_local_runtime_bootstrap
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def _bootstrap_status_payload(status: object) -> dict[str, object]:
@@ -127,6 +130,31 @@ async def start_runtime_bootstrap(
             primary_market=prefs.primary_market,
             enabled_markets=prefs.enabled_markets,
         )
+    except BootstrapDispatchError as exc:
+        if not exc.dispatched_any:
+            save_runtime_preferences(
+                db,
+                primary_market=prefs.primary_market,
+                enabled_markets=prefs.enabled_markets,
+                bootstrap_state=current_status.bootstrap_state,
+            )
+            raise
+        logger.warning(
+            "Bootstrap dispatch failed after queueing one or more market workflows",
+            extra={
+                "primary_market": exc.primary_market,
+                "enabled_markets": exc.enabled_markets,
+                "primary_task_id": exc.primary_task_id,
+                "market_task_ids": exc.market_task_ids,
+            },
+            exc_info=True,
+        )
+        status = get_runtime_bootstrap_status(db)
+        payload = {
+            **_bootstrap_status_payload(status),
+            "task_id": exc.primary_task_id,
+        }
+        return RuntimeBootstrapStartResponse(**payload)
     except Exception:
         save_runtime_preferences(
             db,

--- a/backend/app/domain/bootstrap/plan.py
+++ b/backend/app/domain/bootstrap/plan.py
@@ -96,7 +96,7 @@ def _build_market_plan(market: str) -> MarketBootstrapPlan:
                 task_name="smart_refresh_cache",
                 queue_kind=BootstrapQueueKind.DATA_FETCH,
                 market=market,
-                mode="full",
+                mode="bootstrap",
             ),
             _stage(
                 key="fundamentals",

--- a/backend/app/domain/bootstrap/plan.py
+++ b/backend/app/domain/bootstrap/plan.py
@@ -14,10 +14,21 @@ class BootstrapQueueKind(str, Enum):
     MARKET_JOBS = "market_jobs"
 
 
+class BootstrapOperation(str, Enum):
+    REFRESH_STOCK_UNIVERSE = "refresh_stock_universe"
+    REFRESH_OFFICIAL_MARKET_UNIVERSE = "refresh_official_market_universe"
+    LOAD_TRACKED_IBD_INDUSTRY_GROUPS = "load_tracked_ibd_industry_groups"
+    SMART_REFRESH_CACHE = "smart_refresh_cache"
+    REFRESH_ALL_FUNDAMENTALS = "refresh_all_fundamentals"
+    CALCULATE_DAILY_BREADTH_WITH_GAPFILL = "calculate_daily_breadth_with_gapfill"
+    CALCULATE_DAILY_GROUP_RANKINGS_WITH_GAPFILL = "calculate_daily_group_rankings_with_gapfill"
+    BUILD_DAILY_SNAPSHOT = "build_daily_snapshot"
+
+
 @dataclass(frozen=True)
 class BootstrapStage:
     key: str
-    task_name: str
+    operation: BootstrapOperation
     queue_kind: BootstrapQueueKind
     kwargs: dict[str, Any]
 
@@ -52,14 +63,14 @@ def _normalize_markets(
 def _stage(
     *,
     key: str,
-    task_name: str,
+    operation: BootstrapOperation,
     queue_kind: BootstrapQueueKind,
     market: str,
     **kwargs: Any,
 ) -> BootstrapStage:
     return BootstrapStage(
         key=key,
-        task_name=task_name,
+        operation=operation,
         queue_kind=queue_kind,
         kwargs={"market": market, "activity_lifecycle": "bootstrap", **kwargs},
     )
@@ -69,10 +80,10 @@ def _build_market_plan(market: str) -> MarketBootstrapPlan:
     stages = [
         _stage(
             key="universe",
-            task_name=(
-                "refresh_stock_universe"
+            operation=(
+                BootstrapOperation.REFRESH_STOCK_UNIVERSE
                 if market == "US"
-                else "refresh_official_market_universe"
+                else BootstrapOperation.REFRESH_OFFICIAL_MARKET_UNIVERSE
             ),
             queue_kind=BootstrapQueueKind.DATA_FETCH,
             market=market,
@@ -83,7 +94,7 @@ def _build_market_plan(market: str) -> MarketBootstrapPlan:
         stages.append(
             _stage(
                 key="industry_groups",
-                task_name="load_tracked_ibd_industry_groups",
+                operation=BootstrapOperation.LOAD_TRACKED_IBD_INDUSTRY_GROUPS,
                 queue_kind=BootstrapQueueKind.MARKET_JOBS,
                 market=market,
             )
@@ -93,32 +104,32 @@ def _build_market_plan(market: str) -> MarketBootstrapPlan:
         [
             _stage(
                 key="prices",
-                task_name="smart_refresh_cache",
+                operation=BootstrapOperation.SMART_REFRESH_CACHE,
                 queue_kind=BootstrapQueueKind.DATA_FETCH,
                 market=market,
                 mode="bootstrap",
             ),
             _stage(
                 key="fundamentals",
-                task_name="refresh_all_fundamentals",
+                operation=BootstrapOperation.REFRESH_ALL_FUNDAMENTALS,
                 queue_kind=BootstrapQueueKind.DATA_FETCH,
                 market=market,
             ),
             _stage(
                 key="breadth",
-                task_name="calculate_daily_breadth_with_gapfill",
+                operation=BootstrapOperation.CALCULATE_DAILY_BREADTH_WITH_GAPFILL,
                 queue_kind=BootstrapQueueKind.MARKET_JOBS,
                 market=market,
             ),
             _stage(
                 key="groups",
-                task_name="calculate_daily_group_rankings_with_gapfill",
+                operation=BootstrapOperation.CALCULATE_DAILY_GROUP_RANKINGS_WITH_GAPFILL,
                 queue_kind=BootstrapQueueKind.MARKET_JOBS,
                 market=market,
             ),
             _stage(
                 key="snapshot",
-                task_name="build_daily_snapshot",
+                operation=BootstrapOperation.BUILD_DAILY_SNAPSHOT,
                 queue_kind=BootstrapQueueKind.MARKET_JOBS,
                 market=market,
                 universe_name=f"market:{market}",

--- a/backend/app/schemas/app_runtime.py
+++ b/backend/app/schemas/app_runtime.py
@@ -203,6 +203,8 @@ class RuntimeActivityBootstrapResponse(BaseModel):
     current_stage: str | None = None
     progress_mode: str = "indeterminate"
     percent: float | None = None
+    current: int | None = None
+    total: int | None = None
     message: str | None = None
     background_warning: str | None = None
 

--- a/backend/app/schemas/app_runtime.py
+++ b/backend/app/schemas/app_runtime.py
@@ -200,6 +200,7 @@ class RuntimeActivityBootstrapResponse(BaseModel):
     app_ready: bool
     primary_market: str
     enabled_markets: list[str] = Field(default_factory=list)
+    queue_state: str | None = None
     task_id: str | None = None
     market_task_ids: dict[str, str | None] = Field(default_factory=dict)
     current_stage: str | None = None

--- a/backend/app/schemas/app_runtime.py
+++ b/backend/app/schemas/app_runtime.py
@@ -152,6 +152,13 @@ class RuntimeUniverseOptionsResponse(BaseModel):
     markets: list[RuntimeUniverseMarketOptionsResponse]
 
 
+class BootstrapStageResponse(BaseModel):
+    """Canonical local bootstrap stage metadata."""
+
+    key: str
+    label: str
+
+
 class AppCapabilitiesResponse(BaseModel):
     """Feature/capability flags exposed to the frontend."""
 
@@ -163,6 +170,7 @@ class AppCapabilitiesResponse(BaseModel):
     enabled_markets: list[str] = Field(default_factory=lambda: ["US"])
     bootstrap_state: str = "not_started"
     supported_markets: list[str] = Field(default_factory=_supported_market_codes)
+    bootstrap_stages: list[BootstrapStageResponse] = Field(default_factory=list)
     market_catalog: MarketCatalogResponse
     universe_options: RuntimeUniverseOptionsResponse
     api_base_path: str = "/api"
@@ -178,6 +186,7 @@ class RuntimeBootstrapStatusResponse(BaseModel):
     enabled_markets: list[str]
     bootstrap_state: str
     supported_markets: list[str] = Field(default_factory=_supported_market_codes)
+    bootstrap_stages: list[BootstrapStageResponse] = Field(default_factory=list)
 
 
 class RuntimeBootstrapRequest(BaseModel):
@@ -210,6 +219,7 @@ class RuntimeActivityBootstrapResponse(BaseModel):
     total: int | None = None
     message: str | None = None
     background_warning: str | None = None
+    stages: list[BootstrapStageResponse] = Field(default_factory=list)
 
 
 class RuntimeActivitySummaryResponse(BaseModel):

--- a/backend/app/schemas/app_runtime.py
+++ b/backend/app/schemas/app_runtime.py
@@ -200,6 +200,8 @@ class RuntimeActivityBootstrapResponse(BaseModel):
     app_ready: bool
     primary_market: str
     enabled_markets: list[str] = Field(default_factory=list)
+    task_id: str | None = None
+    market_task_ids: dict[str, str] = Field(default_factory=dict)
     current_stage: str | None = None
     progress_mode: str = "indeterminate"
     percent: float | None = None

--- a/backend/app/schemas/app_runtime.py
+++ b/backend/app/schemas/app_runtime.py
@@ -201,7 +201,7 @@ class RuntimeActivityBootstrapResponse(BaseModel):
     primary_market: str
     enabled_markets: list[str] = Field(default_factory=list)
     task_id: str | None = None
-    market_task_ids: dict[str, str] = Field(default_factory=dict)
+    market_task_ids: dict[str, str | None] = Field(default_factory=dict)
     current_stage: str | None = None
     progress_mode: str = "indeterminate"
     percent: float | None = None

--- a/backend/app/scripts/bootstrap_cn_daily_price_shard.py
+++ b/backend/app/scripts/bootstrap_cn_daily_price_shard.py
@@ -13,6 +13,7 @@ from app.database import SessionLocal
 from app.models.stock_universe import StockUniverse
 from app.scripts._runtime import prepare_runtime, repo_root
 from app.services.bulk_data_fetcher import BulkDataFetcher
+from app.services.price_refresh_planning import classify_price_history
 from app.wiring.bootstrap import get_daily_price_bundle_service
 
 
@@ -160,11 +161,12 @@ def bootstrap_cn_daily_price_shard(
     if not shard_symbols:
         raise RuntimeError(f"CN shard {shard_index}/{shard_count} resolved to zero symbols")
 
-    missing_symbols = service.symbols_missing_as_of(
+    coverage = classify_price_history(
         db,
         symbols=shard_symbols,
         as_of_date=as_of_date,
     )
+    missing_symbols = list(coverage.refresh_symbols)
     refreshed_symbols = 0
     failed_symbols = 0
     export_stats: dict[str, Any] | None = None

--- a/backend/app/scripts/bootstrap_cn_daily_price_shard.py
+++ b/backend/app/scripts/bootstrap_cn_daily_price_shard.py
@@ -13,7 +13,7 @@ from app.database import SessionLocal
 from app.models.stock_universe import StockUniverse
 from app.scripts._runtime import prepare_runtime, repo_root
 from app.services.bulk_data_fetcher import BulkDataFetcher
-from app.services.price_refresh_planning import classify_price_history
+from app.services.price_history_coverage import classify_price_history
 from app.wiring.bootstrap import get_daily_price_bundle_service
 
 

--- a/backend/app/services/bootstrap_run_manifest.py
+++ b/backend/app/services/bootstrap_run_manifest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -16,13 +17,28 @@ RUNTIME_ACTIVITY_CATEGORY = "runtime_activity"
 BOOTSTRAP_RUN_DESCRIPTION = "Latest local runtime bootstrap run task manifest."
 
 
+class BootstrapQueueState(str, Enum):
+    QUEUEING = "queueing"
+    PARTIAL = "partial"
+    QUEUED = "queued"
+
+    @classmethod
+    def parse(cls, value: "BootstrapQueueState | str") -> "BootstrapQueueState":
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(str(value))
+        except ValueError as exc:
+            raise ValueError(f"invalid bootstrap queue_state: {value}") from exc
+
+
 @dataclass(frozen=True)
 class BootstrapRunManifest:
     primary_market: str
     enabled_markets: tuple[str, ...]
     primary_task_id: str | None = None
     market_task_ids: Mapping[str, str | None] = field(default_factory=dict)
-    queue_state: str = "queued"
+    queue_state: BootstrapQueueState | str = BootstrapQueueState.QUEUED
     queued_at: str | None = None
 
     def __post_init__(self) -> None:
@@ -40,7 +56,7 @@ class BootstrapRunManifest:
                 for market, task_id in self.market_task_ids.items()
             },
         )
-        object.__setattr__(self, "queue_state", str(self.queue_state))
+        object.__setattr__(self, "queue_state", BootstrapQueueState.parse(self.queue_state))
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "BootstrapRunManifest":
@@ -53,7 +69,9 @@ class BootstrapRunManifest:
                 else None
             ),
             market_task_ids=dict(payload.get("market_task_ids") or {}),
-            queue_state=str(payload.get("queue_state") or "queued"),
+            queue_state=BootstrapQueueState.parse(
+                payload.get("queue_state") or BootstrapQueueState.QUEUED
+            ),
             queued_at=(
                 str(payload["queued_at"])
                 if payload.get("queued_at") is not None
@@ -69,7 +87,7 @@ class BootstrapRunManifest:
         enabled_markets: Iterable[str],
         primary_task_id: str | None = None,
         market_task_ids: Mapping[str, str | None] | None = None,
-        queue_state: str = "queued",
+        queue_state: BootstrapQueueState | str = BootstrapQueueState.QUEUED,
         queued_at: str | None = None,
     ) -> "BootstrapRunManifest":
         return cls(
@@ -87,7 +105,7 @@ class BootstrapRunManifest:
             "enabled_markets": list(self.enabled_markets),
             "primary_task_id": self.primary_task_id,
             "market_task_ids": dict(self.market_task_ids),
-            "queue_state": self.queue_state,
+            "queue_state": self.queue_state.value,
         }
         if self.queued_at is not None:
             payload["queued_at"] = self.queued_at

--- a/backend/app/services/bootstrap_run_manifest.py
+++ b/backend/app/services/bootstrap_run_manifest.py
@@ -1,0 +1,120 @@
+"""Persistence boundary for local runtime bootstrap task manifests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ..models.app_settings import AppSetting
+
+BOOTSTRAP_RUN_KEY = "runtime.activity.bootstrap_run"
+RUNTIME_ACTIVITY_CATEGORY = "runtime_activity"
+BOOTSTRAP_RUN_DESCRIPTION = "Latest local runtime bootstrap run task manifest."
+
+
+@dataclass(frozen=True)
+class BootstrapRunManifest:
+    primary_market: str
+    enabled_markets: tuple[str, ...]
+    primary_task_id: str
+    market_task_ids: Mapping[str, str]
+    queued_at: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "primary_market", str(self.primary_market).upper())
+        object.__setattr__(
+            self,
+            "enabled_markets",
+            tuple(str(market).upper() for market in self.enabled_markets),
+        )
+        object.__setattr__(
+            self,
+            "market_task_ids",
+            {
+                str(market).upper(): task_id
+                for market, task_id in self.market_task_ids.items()
+            },
+        )
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "BootstrapRunManifest":
+        return cls(
+            primary_market=str(payload["primary_market"]),
+            enabled_markets=tuple(payload.get("enabled_markets") or ()),
+            primary_task_id=str(payload["primary_task_id"]),
+            market_task_ids=dict(payload.get("market_task_ids") or {}),
+            queued_at=(
+                str(payload["queued_at"])
+                if payload.get("queued_at") is not None
+                else None
+            ),
+        )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        primary_market: str,
+        enabled_markets: Iterable[str],
+        primary_task_id: str,
+        market_task_ids: Mapping[str, str],
+        queued_at: str | None = None,
+    ) -> "BootstrapRunManifest":
+        return cls(
+            primary_market=primary_market,
+            enabled_markets=tuple(enabled_markets),
+            primary_task_id=primary_task_id,
+            market_task_ids=dict(market_task_ids),
+            queued_at=queued_at,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "primary_market": self.primary_market,
+            "enabled_markets": list(self.enabled_markets),
+            "primary_task_id": self.primary_task_id,
+            "market_task_ids": dict(self.market_task_ids),
+        }
+        if self.queued_at is not None:
+            payload["queued_at"] = self.queued_at
+        return payload
+
+
+class BootstrapRunManifestRepository:
+    def load(self, db: Session) -> BootstrapRunManifest | None:
+        setting = db.query(AppSetting).filter(AppSetting.key == BOOTSTRAP_RUN_KEY).first()
+        if setting is None:
+            return None
+        try:
+            payload = json.loads(setting.value)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        return BootstrapRunManifest.from_payload(payload)
+
+    def save(
+        self,
+        db: Session,
+        manifest: BootstrapRunManifest,
+    ) -> dict[str, Any]:
+        encoded = json.dumps(manifest.to_payload())
+        setting = db.query(AppSetting).filter(AppSetting.key == BOOTSTRAP_RUN_KEY).first()
+        if setting is None:
+            setting = AppSetting(
+                key=BOOTSTRAP_RUN_KEY,
+                value=encoded,
+                category=RUNTIME_ACTIVITY_CATEGORY,
+                description=BOOTSTRAP_RUN_DESCRIPTION,
+            )
+            db.add(setting)
+        else:
+            setting.value = encoded
+            setting.category = RUNTIME_ACTIVITY_CATEGORY
+            setting.description = BOOTSTRAP_RUN_DESCRIPTION
+        db.commit()
+        return manifest.to_payload()

--- a/backend/app/services/bootstrap_run_manifest.py
+++ b/backend/app/services/bootstrap_run_manifest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -20,8 +20,9 @@ BOOTSTRAP_RUN_DESCRIPTION = "Latest local runtime bootstrap run task manifest."
 class BootstrapRunManifest:
     primary_market: str
     enabled_markets: tuple[str, ...]
-    primary_task_id: str
-    market_task_ids: Mapping[str, str]
+    primary_task_id: str | None = None
+    market_task_ids: Mapping[str, str | None] = field(default_factory=dict)
+    queue_state: str = "queued"
     queued_at: str | None = None
 
     def __post_init__(self) -> None:
@@ -35,18 +36,24 @@ class BootstrapRunManifest:
             self,
             "market_task_ids",
             {
-                str(market).upper(): task_id
+                str(market).upper(): str(task_id) if task_id is not None else None
                 for market, task_id in self.market_task_ids.items()
             },
         )
+        object.__setattr__(self, "queue_state", str(self.queue_state))
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "BootstrapRunManifest":
         return cls(
             primary_market=str(payload["primary_market"]),
             enabled_markets=tuple(payload.get("enabled_markets") or ()),
-            primary_task_id=str(payload["primary_task_id"]),
+            primary_task_id=(
+                str(payload["primary_task_id"])
+                if payload.get("primary_task_id") is not None
+                else None
+            ),
             market_task_ids=dict(payload.get("market_task_ids") or {}),
+            queue_state=str(payload.get("queue_state") or "queued"),
             queued_at=(
                 str(payload["queued_at"])
                 if payload.get("queued_at") is not None
@@ -60,15 +67,17 @@ class BootstrapRunManifest:
         *,
         primary_market: str,
         enabled_markets: Iterable[str],
-        primary_task_id: str,
-        market_task_ids: Mapping[str, str],
+        primary_task_id: str | None = None,
+        market_task_ids: Mapping[str, str | None] | None = None,
+        queue_state: str = "queued",
         queued_at: str | None = None,
     ) -> "BootstrapRunManifest":
         return cls(
             primary_market=primary_market,
             enabled_markets=tuple(enabled_markets),
             primary_task_id=primary_task_id,
-            market_task_ids=dict(market_task_ids),
+            market_task_ids=dict(market_task_ids or {}),
+            queue_state=queue_state,
             queued_at=queued_at,
         )
 
@@ -78,6 +87,7 @@ class BootstrapRunManifest:
             "enabled_markets": list(self.enabled_markets),
             "primary_task_id": self.primary_task_id,
             "market_task_ids": dict(self.market_task_ids),
+            "queue_state": self.queue_state,
         }
         if self.queued_at is not None:
             payload["queued_at"] = self.queued_at

--- a/backend/app/services/bootstrap_run_manifest.py
+++ b/backend/app/services/bootstrap_run_manifest.py
@@ -21,6 +21,7 @@ class BootstrapQueueState(str, Enum):
     QUEUEING = "queueing"
     PARTIAL = "partial"
     QUEUED = "queued"
+    DISPATCH_FAILED = "dispatch_failed"
 
     @classmethod
     def parse(cls, value: "BootstrapQueueState | str") -> "BootstrapQueueState":

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -20,6 +20,12 @@ import time
 
 from ..config import settings
 from .growth_cadence_service import compute_cadence_aware_growth
+from .price_fetch_failures import (
+    classify_price_fetch_error,
+    is_no_data_price_failure,
+    is_rate_limit_error,
+    normalize_price_fetch_failure_kind,
+)
 
 if TYPE_CHECKING:
     from .eps_rating_service import EPSRatingService
@@ -66,16 +72,6 @@ def _new_yf_tickers(symbols_str: str):
             # Older yfinance: no session kwarg on Tickers; fall through.
             pass
     return yf.Tickers(symbols_str)
-
-
-_NO_PRICE_DATA_ERROR_INDICATORS = (
-    "yfpricesmissingerror",
-    "possibly delisted",
-    "no price data",
-    "no data found, symbol may be delisted",
-    "symbol may be delisted",
-    "no data after filtering",
-)
 
 
 class BulkDataFetcher:
@@ -146,26 +142,16 @@ class BulkDataFetcher:
 
     @staticmethod
     def _is_rate_limit_error(error: str) -> bool:
-        lower = (error or "").lower()
-        return any(indicator in lower for indicator in ("rate", "429", "too many", "limit", "throttl"))
+        return is_rate_limit_error(error)
 
     @staticmethod
     def _is_permanent_missing_price_error(error: str) -> bool:
-        lower = (error or "").lower()
-        if BulkDataFetcher._is_rate_limit_error(lower):
-            return False
-        return any(indicator in lower for indicator in _NO_PRICE_DATA_ERROR_INDICATORS)
+        return is_no_data_price_failure(error)
 
     @staticmethod
     def _price_error_kind(error: str) -> Optional[str]:
-        lower = (error or "").lower()
-        if BulkDataFetcher._is_permanent_missing_price_error(lower):
-            return "no_price_data"
-        if BulkDataFetcher._is_rate_limit_error(lower):
-            return "rate_limit"
-        if "empty" in lower or "batch download error" in lower:
-            return "transient"
-        return None
+        kind = classify_price_fetch_error(error)
+        return kind.value if kind is not None else None
 
     @staticmethod
     def _yfinance_download_errors(symbols: List[str]) -> Dict[str, str]:
@@ -188,11 +174,13 @@ class BulkDataFetcher:
             if not data.get("has_error"):
                 continue
             error = data.get("error", "")
-            error_kind = data.get("error_kind")
-            if error_kind == "no_price_data" or self._is_permanent_missing_price_error(error):
+            error_kind = normalize_price_fetch_failure_kind(data.get("error_kind"))
+            if error_kind is not None and error_kind.value == "no_price_data":
+                continue
+            if error_kind is None and self._is_permanent_missing_price_error(error):
                 continue
             if (
-                error_kind in {"rate_limit", "transient"}
+                (error_kind is not None and error_kind.value in {"rate_limit", "transient"})
                 or self._is_rate_limit_error(error)
                 or "empty" in error.lower()
             ):

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -68,6 +68,16 @@ def _new_yf_tickers(symbols_str: str):
     return yf.Tickers(symbols_str)
 
 
+_NO_PRICE_DATA_ERROR_INDICATORS = (
+    "yfpricesmissingerror",
+    "possibly delisted",
+    "no price data",
+    "no data found, symbol may be delisted",
+    "symbol may be delisted",
+    "no data after filtering",
+)
+
+
 class BulkDataFetcher:
     """
     Fetch data for multiple stocks efficiently using ``yf.download()``.
@@ -116,8 +126,13 @@ class BulkDataFetcher:
         return EPSRatingService()
 
     @staticmethod
-    def _build_error_result(symbol: str, error: str) -> Dict[str, Any]:
-        return {
+    def _build_error_result(
+        symbol: str,
+        error: str,
+        *,
+        error_kind: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        result = {
             'symbol': symbol,
             'price_data': None,
             'info': None,
@@ -125,11 +140,44 @@ class BulkDataFetcher:
             'has_error': True,
             'error': error,
         }
+        if error_kind:
+            result["error_kind"] = error_kind
+        return result
 
     @staticmethod
     def _is_rate_limit_error(error: str) -> bool:
         lower = (error or "").lower()
         return any(indicator in lower for indicator in ("rate", "429", "too many", "limit", "throttl"))
+
+    @staticmethod
+    def _is_permanent_missing_price_error(error: str) -> bool:
+        lower = (error or "").lower()
+        if BulkDataFetcher._is_rate_limit_error(lower):
+            return False
+        return any(indicator in lower for indicator in _NO_PRICE_DATA_ERROR_INDICATORS)
+
+    @staticmethod
+    def _price_error_kind(error: str) -> Optional[str]:
+        lower = (error or "").lower()
+        if BulkDataFetcher._is_permanent_missing_price_error(lower):
+            return "no_price_data"
+        if BulkDataFetcher._is_rate_limit_error(lower):
+            return "rate_limit"
+        if "empty" in lower or "batch download error" in lower:
+            return "transient"
+        return None
+
+    @staticmethod
+    def _yfinance_download_errors(symbols: List[str]) -> Dict[str, str]:
+        shared = getattr(yf, "shared", None)
+        errors = getattr(shared, "_ERRORS", None)
+        if not isinstance(errors, dict):
+            return {}
+        return {
+            symbol: str(errors[symbol])
+            for symbol in symbols
+            if symbol in errors and errors[symbol]
+        }
 
     def _transient_failure_rate(self, results: Dict[str, Dict[str, Any]]) -> float:
         if not results:
@@ -140,7 +188,14 @@ class BulkDataFetcher:
             if not data.get("has_error"):
                 continue
             error = data.get("error", "")
-            if self._is_rate_limit_error(error) or "empty" in error.lower():
+            error_kind = data.get("error_kind")
+            if error_kind == "no_price_data" or self._is_permanent_missing_price_error(error):
+                continue
+            if (
+                error_kind in {"rate_limit", "transient"}
+                or self._is_rate_limit_error(error)
+                or "empty" in error.lower()
+            ):
                 transient_failures += 1
         return transient_failures / len(results)
 
@@ -459,11 +514,17 @@ class BulkDataFetcher:
             if session is not None:
                 download_kwargs["session"] = session
             raw = yf.download(**download_kwargs)
+            download_errors = self._yfinance_download_errors(symbols)
 
             if raw is None or raw.empty:
                 logger.warning("yf.download returned empty DataFrame")
                 for symbol in symbols:
-                    results[symbol] = self._build_error_result(symbol, 'yf.download returned empty')
+                    error = download_errors.get(symbol) or 'yf.download returned empty'
+                    results[symbol] = self._build_error_result(
+                        symbol,
+                        error,
+                        error_kind=self._price_error_kind(error),
+                    )
                 return results
 
             # Single symbol: yf.download returns flat columns (Open, High, etc.)
@@ -477,7 +538,12 @@ class BulkDataFetcher:
                         'fundamentals': None, 'has_error': False, 'error': None
                     }
                 else:
-                    results[symbol] = self._build_error_result(symbol, 'No data returned')
+                    error = download_errors.get(symbol) or 'No data returned'
+                    results[symbol] = self._build_error_result(
+                        symbol,
+                        error,
+                        error_kind=self._price_error_kind(error),
+                    )
             else:
                 # Multi-symbol: split by ticker
                 for symbol in symbols:
@@ -492,12 +558,27 @@ class BulkDataFetcher:
                                     'fundamentals': None, 'has_error': False, 'error': None
                                 }
                             else:
-                                results[symbol] = self._build_error_result(symbol, 'No data after filtering NaN rows')
+                                error = download_errors.get(symbol) or 'No data after filtering NaN rows'
+                                results[symbol] = self._build_error_result(
+                                    symbol,
+                                    error,
+                                    error_kind=self._price_error_kind(error),
+                                )
                         else:
-                            results[symbol] = self._build_error_result(symbol, 'Symbol not in download results')
+                            error = download_errors.get(symbol) or 'Symbol not in download results'
+                            results[symbol] = self._build_error_result(
+                                symbol,
+                                error,
+                                error_kind=self._price_error_kind(error),
+                            )
                     except Exception as e:
                         logger.warning(f"Error extracting {symbol} from download: {e}")
-                        results[symbol] = self._build_error_result(symbol, str(e))
+                        error = str(e)
+                        results[symbol] = self._build_error_result(
+                            symbol,
+                            error,
+                            error_kind=self._price_error_kind(error),
+                        )
 
             success = len([r for r in results.values() if not r['has_error']])
             failed = len(results) - success
@@ -506,14 +587,24 @@ class BulkDataFetcher:
             # Add missing symbols as errors
             for symbol in symbols:
                 if symbol not in results:
-                    results[symbol] = self._build_error_result(symbol, 'Missing from results')
+                    error = download_errors.get(symbol) or 'Missing from results'
+                    results[symbol] = self._build_error_result(
+                        symbol,
+                        error,
+                        error_kind=self._price_error_kind(error),
+                    )
 
             return results
 
         except Exception as e:
             logger.error(f"yf.download batch failed: {e}", exc_info=True)
+            error = f"Batch download error: {str(e)}"
             return {
-                symbol: self._build_error_result(symbol, f"Batch download error: {str(e)}")
+                symbol: self._build_error_result(
+                    symbol,
+                    error,
+                    error_kind=self._price_error_kind(error),
+                )
                 for symbol in symbols
             }
 

--- a/backend/app/services/daily_price_bundle_service.py
+++ b/backend/app/services/daily_price_bundle_service.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ..config import settings
@@ -455,34 +454,6 @@ class DailyPriceBundleService:
             "imported_rows": imported_rows,
             "redis_warmed_symbols": redis_warmed_symbols,
         }
-
-    def symbols_missing_as_of(
-        self,
-        db: Session,
-        *,
-        symbols: list[str],
-        as_of_date: str | date,
-    ) -> list[str]:
-        if not symbols:
-            return []
-        expected_date = (
-            as_of_date if isinstance(as_of_date, date) else date.fromisoformat(str(as_of_date))
-        )
-        latest_by_symbol: dict[str, date | None] = {}
-        for chunk_start in range(0, len(symbols), 500):
-            chunk_symbols = symbols[chunk_start:chunk_start + 500]
-            rows = (
-                db.query(StockPrice.symbol, func.max(StockPrice.date))
-                .filter(StockPrice.symbol.in_(chunk_symbols))
-                .group_by(StockPrice.symbol)
-                .all()
-            )
-            for symbol, latest_date in rows:
-                latest_by_symbol[str(symbol)] = latest_date
-        return [
-            symbol for symbol in symbols
-            if latest_by_symbol.get(symbol) is None or latest_by_symbol[symbol] < expected_date
-        ]
 
     def sync_from_github(
         self,

--- a/backend/app/services/fx_service.py
+++ b/backend/app/services/fx_service.py
@@ -240,9 +240,6 @@ class FXService:
             return memoed
         if memoed is not None:
             stale_quote = memoed
-            suppressed_quote = self._retry_suppressed_stale_quote(currency, latest_close)
-            if suppressed_quote is not None:
-                return suppressed_quote
 
         # 2. Redis
         quote = self._read_redis(currency)
@@ -271,6 +268,11 @@ class FXService:
                 return quote
             if stale_quote is None or quote.as_of_date > stale_quote.as_of_date:
                 stale_quote = quote
+
+        if stale_quote is not None:
+            suppressed_quote = self._retry_suppressed_stale_quote(currency, latest_close)
+            if suppressed_quote is not None:
+                return suppressed_quote
 
         # 4. Upstream fetch
         fetched = self._rate_fetcher(currency)

--- a/backend/app/services/fx_service.py
+++ b/backend/app/services/fx_service.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple
@@ -168,6 +169,7 @@ class FXService:
 
     REDIS_KEY_FORMAT = "fx:{source_currency}:USD"
     REDIS_TTL_SECONDS = 24 * 60 * 60  # 24h — FX rates are slow-moving
+    STALE_FETCH_RETRY_COOLDOWN_SECONDS = 15 * 60
 
     SOURCE_IDENTITY = "identity"
     SOURCE_YFINANCE = "yfinance"
@@ -198,6 +200,7 @@ class FXService:
         # In-process cache: avoids re-hitting Redis for the same currency
         # within a single batch refresh.
         self._memo: Dict[str, FXQuote] = {}
+        self._stale_fallback_retry_after: Dict[str, Tuple[FXQuote, float, date]] = {}
 
     # --- Public API --------------------------------------------------------
 
@@ -233,9 +236,13 @@ class FXService:
             today=today,
             latest_close=latest_close,
         ):
+            self._stale_fallback_retry_after.pop(currency, None)
             return memoed
         if memoed is not None:
             stale_quote = memoed
+            suppressed_quote = self._retry_suppressed_stale_quote(currency, latest_close)
+            if suppressed_quote is not None:
+                return suppressed_quote
 
         # 2. Redis
         quote = self._read_redis(currency)
@@ -246,6 +253,7 @@ class FXService:
                 latest_close=latest_close,
             ):
                 self._memo[currency] = quote
+                self._stale_fallback_retry_after.pop(currency, None)
                 return quote
             stale_quote = quote
 
@@ -258,6 +266,7 @@ class FXService:
                 latest_close=latest_close,
             ):
                 self._memo[currency] = quote
+                self._stale_fallback_retry_after.pop(currency, None)
                 self._write_redis(quote)
                 return quote
             if stale_quote is None or quote.as_of_date > stale_quote.as_of_date:
@@ -275,6 +284,11 @@ class FXService:
                     stale_quote.as_of_date,
                 )
                 self._memo[currency] = stale_quote
+                self._stale_fallback_retry_after[currency] = (
+                    stale_quote,
+                    time.monotonic() + self.STALE_FETCH_RETRY_COOLDOWN_SECONDS,
+                    latest_close,
+                )
                 self._write_redis(stale_quote)
                 return stale_quote
             logger.warning(
@@ -285,6 +299,7 @@ class FXService:
         self._persist_database(quote)
         self._write_redis(quote)
         self._memo[currency] = quote
+        self._stale_fallback_retry_after.pop(currency, None)
         return quote
 
     @staticmethod
@@ -302,8 +317,28 @@ class FXService:
         today: date,
         latest_close: date,
     ) -> bool:
-        """Treat either today's quote or latest trading close as fresh."""
-        return quote_date == today or quote_date == latest_close
+        """Treat the latest close, today's quote, or a near-future local-market date as fresh."""
+        if quote_date == today or quote_date == latest_close:
+            return True
+        # Celery containers may run in UTC while Asian market data providers
+        # stamp quotes in local exchange dates. A quote one calendar day ahead
+        # of the process date is fresh for the bootstrap; refetching it for
+        # every row only burns Yahoo quota.
+        return latest_close <= quote_date <= today + timedelta(days=1)
+
+    def _retry_suppressed_stale_quote(
+        self,
+        currency: str,
+        latest_close: date,
+    ) -> Optional[FXQuote]:
+        entry = self._stale_fallback_retry_after.get(currency)
+        if entry is None:
+            return None
+        quote, retry_after, retry_close = entry
+        if retry_close != latest_close or time.monotonic() >= retry_after:
+            self._stale_fallback_retry_after.pop(currency, None)
+            return None
+        return quote
 
     def convert_to_usd(
         self,

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -621,8 +621,28 @@ def get_runtime_activity_status(db: Session) -> dict[str, Any]:
         for payload in market_payloads
         if payload["market"] != primary_market and payload.get("status") in ACTIVE_STATUSES
     ]
+    secondary_active_payload = next(
+        (
+            payload
+            for payload in market_payloads
+            if payload["market"] != primary_market and payload.get("status") in ACTIVE_STATUSES
+        ),
+        None,
+    )
+    bootstrap_current = None
+    bootstrap_total = None
 
-    if bootstrap_status.bootstrap_state == "ready":
+    if bootstrap_status.bootstrap_state == "ready" and secondary_active_payload:
+        bootstrap_progress_mode = secondary_active_payload.get("progress_mode") or "indeterminate"
+        bootstrap_percent = secondary_active_payload.get("percent")
+        bootstrap_stage = secondary_active_payload.get("stage_label")
+        bootstrap_message = (
+            secondary_active_payload.get("message")
+            or "Additional market loading continues."
+        )
+        bootstrap_current = secondary_active_payload.get("current")
+        bootstrap_total = secondary_active_payload.get("total")
+    elif bootstrap_status.bootstrap_state == "ready":
         bootstrap_progress_mode = "determinate"
         bootstrap_percent = 100.0
         bootstrap_stage = primary_payload.get("stage_label") if primary_payload else None
@@ -671,6 +691,8 @@ def get_runtime_activity_status(db: Session) -> dict[str, Any]:
             "current_stage": bootstrap_stage,
             "progress_mode": bootstrap_progress_mode,
             "percent": bootstrap_percent,
+            "current": bootstrap_current,
+            "total": bootstrap_total,
             "message": bootstrap_message,
             "background_warning": background_warning,
         },

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -14,41 +14,18 @@ from ..services.bootstrap_run_manifest import (
     BootstrapRunManifest,
     BootstrapRunManifestRepository,
 )
+from ..services.runtime_activity_contract import (
+    RuntimeActivityRecord,
+    progress_mode,
+    resolve_progress_percent,
+    stage_index,
+)
 from ..services.runtime_activity_presenter import build_runtime_activity_status
 from ..services.runtime_preferences_service import get_runtime_bootstrap_status
 from ..wiring.bootstrap import get_data_fetch_lock
 
 RUNTIME_ACTIVITY_CATEGORY = "runtime_activity"
 MARKET_ACTIVITY_KEY_PREFIX = "runtime.activity.market."
-
-STAGE_SEQUENCE = (
-    "universe",
-    "prices",
-    "fundamentals",
-    "breadth",
-    "groups",
-    "scan",
-)
-
-STAGE_LABELS = {
-    "universe": "Universe Refresh",
-    "prices": "Price Refresh",
-    "fundamentals": "Fundamentals Refresh",
-    "breadth": "Breadth Calculation",
-    "groups": "Group Rankings",
-    "snapshot": "Feature Snapshot",
-    "scan": "Scan",
-}
-
-DEFAULT_LIFECYCLE_BY_STAGE = {
-    "universe": "weekly_refresh",
-    "prices": "daily_refresh",
-    "fundamentals": "weekly_refresh",
-    "breadth": "daily_refresh",
-    "groups": "daily_refresh",
-    "snapshot": "daily_refresh",
-    "scan": "daily_refresh",
-}
 
 _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
 
@@ -59,18 +36,6 @@ def _utcnow_iso() -> str:
 
 def _activity_key(market: str) -> str:
     return f"{MARKET_ACTIVITY_KEY_PREFIX}{str(market).upper()}"
-
-
-def _stage_label(stage_key: str | None) -> str | None:
-    if stage_key is None:
-        return None
-    return STAGE_LABELS.get(stage_key, str(stage_key).replace("_", " ").title())
-
-
-def _default_lifecycle(stage_key: str | None) -> str:
-    if stage_key is None:
-        return "daily_refresh"
-    return DEFAULT_LIFECYCLE_BY_STAGE.get(stage_key, "daily_refresh")
 
 
 def _get_setting(db: Session, key: str) -> AppSetting | None:
@@ -146,7 +111,7 @@ def _should_supersede_failed_activity(
         return False
     if payload.get("lifecycle") != "bootstrap":
         return False
-    return _stage_index(payload.get("stage_key")) > _stage_index(existing_payload.get("stage_key"))
+    return stage_index(payload.get("stage_key")) > stage_index(existing_payload.get("stage_key"))
 
 
 def _save_market_activity(
@@ -193,8 +158,8 @@ def _save_market_activity(
                 )
                 incoming_new_cycle = payload_status in {"queued", "running"} and not same_owner
                 if incoming_new_cycle:
-                    existing_stage_index = _stage_index(existing_payload.get("stage_key"))
-                    payload_stage_index = _stage_index(payload.get("stage_key"))
+                    existing_stage_index = stage_index(existing_payload.get("stage_key"))
+                    payload_stage_index = stage_index(payload.get("stage_key"))
                     lifecycle_changed = existing_payload.get("lifecycle") != payload.get("lifecycle")
                     incoming_new_cycle = lifecycle_changed or payload_stage_index <= existing_stage_index
                 if supersedes_failed_activity:
@@ -221,35 +186,6 @@ def _save_market_activity(
     return payload
 
 
-def _resolve_progress_percent(
-    percent: float | None,
-    current: int | None,
-    total: int | None,
-) -> float | None:
-    if percent is not None:
-        return float(percent)
-    if current is None or total in (None, 0):
-        return None
-    return round((float(current) / float(total)) * 100.0, 1)
-
-
-def _progress_mode(
-    status: str | None,
-    percent: float | None,
-    current: int | None = None,
-    total: int | None = None,
-) -> str:
-    if _resolve_progress_percent(percent, current, total) is not None or status in {"completed", "idle"}:
-        return "determinate"
-    return "indeterminate"
-
-
-def _stage_index(stage_key: str | None) -> int:
-    if stage_key in STAGE_SEQUENCE:
-        return STAGE_SEQUENCE.index(stage_key)
-    return len(STAGE_SEQUENCE)
-
-
 def _activity_payload(
     *,
     market: str,
@@ -263,33 +199,19 @@ def _activity_payload(
     total: int | None = None,
     message: str | None = None,
 ) -> dict[str, Any]:
-    stage_label = _stage_label(stage_key)
-    resolved_lifecycle = lifecycle or _default_lifecycle(stage_key)
-    resolved_message = message
-    resolved_percent = _resolve_progress_percent(percent, current, total)
-    if not resolved_message and stage_label:
-        action = {
-            "queued": "Queued",
-            "running": "Running",
-            "completed": "Completed",
-            "failed": "Failed",
-        }.get(status, "Updated")
-        resolved_message = f"{action} {stage_label.lower()}"
-    return {
-        "market": str(market).upper(),
-        "lifecycle": resolved_lifecycle,
-        "stage_key": stage_key,
-        "stage_label": stage_label,
-        "status": status,
-        "progress_mode": _progress_mode(status, resolved_percent, current, total),
-        "percent": resolved_percent,
-        "current": current,
-        "total": total,
-        "message": resolved_message,
-        "task_name": task_name,
-        "task_id": task_id,
-        "updated_at": _utcnow_iso(),
-    }
+    return RuntimeActivityRecord.create(
+        market=market,
+        stage_key=stage_key,
+        lifecycle=lifecycle,
+        status=status,
+        task_name=task_name,
+        task_id=task_id,
+        percent=percent,
+        current=current,
+        total=total,
+        message=message,
+        updated_at=_utcnow_iso(),
+    ).to_payload()
 
 
 def mark_market_activity_queued(
@@ -514,12 +436,12 @@ def _overlay_live_progress(record: dict[str, Any], market: str) -> dict[str, Any
         merged["total"] = current_task["total"]
     if current_task.get("last_heartbeat") is not None:
         merged["updated_at"] = current_task["last_heartbeat"]
-    merged["percent"] = _resolve_progress_percent(
+    merged["percent"] = resolve_progress_percent(
         merged.get("percent"),
         merged.get("current"),
         merged.get("total"),
     )
-    merged["progress_mode"] = _progress_mode(
+    merged["progress_mode"] = progress_mode(
         merged.get("status"),
         merged.get("percent"),
         merged.get("current"),
@@ -534,49 +456,34 @@ def _queued_bootstrap_market_payload(
     *,
     task_id: str | None = None,
 ) -> dict[str, Any]:
-    return {
-        "market": str(market).upper(),
-        "lifecycle": "bootstrap",
-        "stage_key": "universe",
-        "stage_label": _stage_label("universe"),
-        "status": "queued",
-        "progress_mode": "indeterminate",
-        "percent": None,
-        "current": None,
-        "total": None,
-        "message": "Bootstrap queued.",
-        "task_name": None,
-        "task_id": task_id,
-        "updated_at": None,
-    }
+    return RuntimeActivityRecord.create(
+        market=market,
+        lifecycle="bootstrap",
+        stage_key="universe",
+        status="queued",
+        message="Bootstrap queued.",
+        task_id=task_id,
+    ).to_payload()
 
 
 def _idle_market_payload(market: str, record: dict[str, Any] | None) -> dict[str, Any]:
     if record is None:
-        return {
-            "market": str(market).upper(),
-            "lifecycle": "idle",
-            "stage_key": None,
-            "stage_label": None,
-            "status": "idle",
-            "progress_mode": "determinate",
-            "percent": None,
-            "current": None,
-            "total": None,
-            "message": "Idle",
-            "task_name": None,
-            "task_id": None,
-            "updated_at": None,
-        }
+        return RuntimeActivityRecord.create(
+            market=market,
+            lifecycle="idle",
+            stage_key=None,
+            status="idle",
+            message="Idle",
+        ).to_payload()
     payload = dict(record)
     if payload.get("status") == "completed":
         payload["lifecycle"] = "idle"
-    payload["percent"] = _resolve_progress_percent(
+    payload["percent"] = resolve_progress_percent(
         payload.get("percent"),
         payload.get("current"),
         payload.get("total"),
     )
-    payload["progress_mode"] = _progress_mode(
+    payload["progress_mode"] = progress_mode(
         payload.get("status"),
         payload.get("percent"),
         payload.get("current"),

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -89,8 +89,6 @@ def _save_market_activity(
     db: Session,
     market: str,
     payload: dict[str, Any],
-    *,
-    preserve_existing_statuses: set[str] | None = None,
 ) -> dict[str, Any]:
     key = _activity_key(market)
     setting = _get_setting(db, key)
@@ -104,13 +102,12 @@ def _save_market_activity(
     transition = reduce_market_activity(
         existing_payload if isinstance(existing_payload, dict) else None,
         payload,
-        preserve_existing_statuses=preserve_existing_statuses,
     )
     if not transition.should_persist:
         return transition.payload
-    payload = transition.payload
+    record = transition.record
 
-    encoded = json.dumps(payload)
+    encoded = json.dumps(record.to_persisted_payload())
     if setting is None:
         setting = AppSetting(
             key=key,
@@ -124,7 +121,7 @@ def _save_market_activity(
         setting.category = RUNTIME_ACTIVITY_CATEGORY
         setting.description = f"Latest runtime activity state for {market.upper()}"
     db.commit()
-    return payload
+    return record.to_payload()
 
 
 def _activity_payload(
@@ -177,7 +174,6 @@ def mark_market_activity_queued(
             task_id=task_id,
             message=message,
         ),
-        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 
@@ -209,7 +205,6 @@ def mark_market_activity_started(
             total=total,
             message=message,
         ),
-        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 
@@ -231,17 +226,17 @@ def mark_market_activity_progress(
         existing_task_id = existing.get("task_id")
         existing_stage_key = existing.get("stage_key")
         existing_status = existing.get("status")
-        if existing_status in {"completed", "failed"}:
-            return existing
-        if existing_task_id and task_id and existing_task_id != task_id:
-            return existing
-        if existing_stage_key and existing_stage_key != stage_key:
-            return existing
-        stage_key = existing_stage_key or stage_key
-        lifecycle = lifecycle or existing.get("lifecycle")
-        task_name = task_name or existing.get("task_name")
-        task_id = task_id or existing_task_id
-        message = message or existing.get("message")
+        can_inherit_existing_metadata = (
+            existing_status in {"queued", "running"}
+            and (not existing_task_id or not task_id or existing_task_id == task_id)
+            and (not existing_stage_key or existing_stage_key == stage_key)
+        )
+        if can_inherit_existing_metadata:
+            stage_key = existing_stage_key or stage_key
+            lifecycle = lifecycle or existing.get("lifecycle")
+            task_name = task_name or existing.get("task_name")
+            task_id = task_id or existing_task_id
+            message = message or existing.get("message")
 
     return _save_market_activity(
         db,
@@ -258,7 +253,6 @@ def mark_market_activity_progress(
             total=total,
             message=message,
         ),
-        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 
@@ -290,7 +284,6 @@ def mark_market_activity_completed(
             total=total,
             message=message,
         ),
-        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 
@@ -322,7 +315,6 @@ def mark_market_activity_failed(
             total=total,
             message=message,
         ),
-        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
 

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -659,7 +659,7 @@ def get_runtime_activity_status(db: Session) -> dict[str, Any]:
         bootstrap_status.bootstrap_state == "running" or bool(secondary_active)
     ):
         background_warning = (
-            "Bootstrap remains active until every enabled market has a published scan."
+            "Additional enabled markets are still loading in the background."
         )
 
     return {

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -312,25 +312,18 @@ def mark_current_market_activity_failed(
     task_id: str | None = None,
     message: str | None = None,
 ) -> dict[str, Any]:
-    existing = _load_market_activity(db, market)
-    stage_key = "scan"
-    resolved_task_name = task_name
-    resolved_task_id = task_id
-    if isinstance(existing, dict) and existing.get("status") in {"queued", "running"}:
-        existing_lifecycle = existing.get("lifecycle")
-        if lifecycle is None or lifecycle == existing_lifecycle:
-            stage_key = existing.get("stage_key") or stage_key
-            lifecycle = lifecycle or existing_lifecycle
-            resolved_task_name = resolved_task_name or existing.get("task_name")
-            resolved_task_id = resolved_task_id or existing.get("task_id")
-    return mark_market_activity_failed(
+    return _save_market_activity(
         db,
-        market=market,
-        stage_key=stage_key,
-        lifecycle=lifecycle,
-        task_name=resolved_task_name,
-        task_id=resolved_task_id,
-        message=message,
+        market,
+        _activity_payload(
+            market=market,
+            stage_key=None,
+            lifecycle=lifecycle,
+            status="failed",
+            task_name=task_name,
+            task_id=task_id,
+            message=message,
+        ),
     )
 
 

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -67,8 +67,9 @@ def save_runtime_bootstrap_run(
     *,
     primary_market: str,
     enabled_markets: list[str],
-    primary_task_id: str,
-    market_task_ids: dict[str, str],
+    primary_task_id: str | None = None,
+    market_task_ids: dict[str, str | None] | None = None,
+    queue_state: str = "queued",
 ) -> dict[str, Any]:
     return BootstrapRunManifestRepository().save(
         db,
@@ -76,7 +77,8 @@ def save_runtime_bootstrap_run(
             primary_market=primary_market,
             enabled_markets=enabled_markets,
             primary_task_id=primary_task_id,
-            market_task_ids=market_task_ids,
+            market_task_ids=market_task_ids or {},
+            queue_state=queue_state,
             queued_at=_utcnow_iso(),
         ),
     )

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -9,12 +9,17 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from ..models.app_settings import AppSetting
+from ..services.bootstrap_run_manifest import (
+    BOOTSTRAP_RUN_KEY,
+    BootstrapRunManifest,
+    BootstrapRunManifestRepository,
+)
+from ..services.runtime_activity_presenter import build_runtime_activity_status
 from ..services.runtime_preferences_service import get_runtime_bootstrap_status
 from ..wiring.bootstrap import get_data_fetch_lock
 
 RUNTIME_ACTIVITY_CATEGORY = "runtime_activity"
 MARKET_ACTIVITY_KEY_PREFIX = "runtime.activity.market."
-BOOTSTRAP_RUN_KEY = "runtime.activity.bootstrap_run"
 
 STAGE_SEQUENCE = (
     "universe",
@@ -45,7 +50,6 @@ DEFAULT_LIFECYCLE_BY_STAGE = {
     "scan": "daily_refresh",
 }
 
-ACTIVE_STATUSES = {"queued", "running"}
 _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
 
 
@@ -87,16 +91,10 @@ def _load_market_activity(db: Session, market: str) -> dict[str, Any] | None:
 
 
 def _load_runtime_bootstrap_run(db: Session) -> dict[str, Any] | None:
-    setting = _get_setting(db, BOOTSTRAP_RUN_KEY)
-    if setting is None:
+    manifest = BootstrapRunManifestRepository().load(db)
+    if manifest is None:
         return None
-    try:
-        payload = json.loads(setting.value)
-    except (json.JSONDecodeError, TypeError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-    return payload
+    return manifest.to_payload()
 
 
 def save_runtime_bootstrap_run(
@@ -107,32 +105,16 @@ def save_runtime_bootstrap_run(
     primary_task_id: str,
     market_task_ids: dict[str, str],
 ) -> dict[str, Any]:
-    payload = {
-        "primary_market": str(primary_market).upper(),
-        "enabled_markets": [str(market).upper() for market in enabled_markets],
-        "primary_task_id": primary_task_id,
-        "market_task_ids": {
-            str(market).upper(): task_id
-            for market, task_id in market_task_ids.items()
-        },
-        "queued_at": _utcnow_iso(),
-    }
-    encoded = json.dumps(payload)
-    setting = _get_setting(db, BOOTSTRAP_RUN_KEY)
-    if setting is None:
-        setting = AppSetting(
-            key=BOOTSTRAP_RUN_KEY,
-            value=encoded,
-            category=RUNTIME_ACTIVITY_CATEGORY,
-            description="Latest local runtime bootstrap run task manifest.",
-        )
-        db.add(setting)
-    else:
-        setting.value = encoded
-        setting.category = RUNTIME_ACTIVITY_CATEGORY
-        setting.description = "Latest local runtime bootstrap run task manifest."
-    db.commit()
-    return payload
+    return BootstrapRunManifestRepository().save(
+        db,
+        BootstrapRunManifest.create(
+            primary_market=primary_market,
+            enabled_markets=enabled_markets,
+            primary_task_id=primary_task_id,
+            market_task_ids=market_task_ids,
+            queued_at=_utcnow_iso(),
+        ),
+    )
 
 
 def _should_preserve_existing_failed_message(
@@ -546,30 +528,6 @@ def _overlay_live_progress(record: dict[str, Any], market: str) -> dict[str, Any
     return merged
 
 
-def _bootstrap_progress_percent(record: dict[str, Any] | None) -> float:
-    if record is None:
-        return 0.0
-    stage_key = record.get("stage_key")
-    if stage_key not in STAGE_SEQUENCE:
-        return 0.0
-    stage_index = STAGE_SEQUENCE.index(stage_key)
-    raw_percent = record.get("percent")
-    if raw_percent is not None:
-        stage_fraction = max(0.0, min(float(raw_percent), 100.0)) / 100.0
-    elif record.get("status") == "completed":
-        stage_fraction = 1.0
-    else:
-        stage_fraction = 0.0
-    return round(((stage_index + stage_fraction) / len(STAGE_SEQUENCE)) * 100.0, 2)
-
-
-def _is_active_bootstrap_payload(payload: dict[str, Any]) -> bool:
-    return (
-        payload.get("lifecycle") == "bootstrap"
-        and payload.get("status") in ACTIVE_STATUSES
-    )
-
-
 def _queued_bootstrap_market_payload(
     market: str,
     _primary_market: str,
@@ -668,104 +626,8 @@ def get_runtime_activity_status(db: Session) -> dict[str, Any]:
             )
         )
 
-    active_markets = [
-        payload["market"]
-        for payload in market_payloads
-        if payload.get("status") in ACTIVE_STATUSES
-    ]
-    has_failed = any(payload.get("status") == "failed" for payload in market_payloads)
-    summary_status = "warning" if has_failed else ("active" if active_markets else "idle")
-
-    primary_payload = next(
-        (payload for payload in market_payloads if payload["market"] == primary_market),
-        None,
+    return build_runtime_activity_status(
+        bootstrap_status=bootstrap_status,
+        bootstrap_run=bootstrap_run,
+        market_payloads=market_payloads,
     )
-    secondary_active = [
-        payload["market"]
-        for payload in market_payloads
-        if payload["market"] != primary_market and _is_active_bootstrap_payload(payload)
-    ]
-    secondary_active_payload = next(
-        (
-            payload
-            for payload in market_payloads
-            if payload["market"] != primary_market and _is_active_bootstrap_payload(payload)
-        ),
-        None,
-    )
-    bootstrap_current = None
-    bootstrap_total = None
-
-    if bootstrap_status.bootstrap_state == "ready" and secondary_active_payload:
-        bootstrap_progress_mode = secondary_active_payload.get("progress_mode") or "indeterminate"
-        bootstrap_percent = secondary_active_payload.get("percent")
-        bootstrap_stage = secondary_active_payload.get("stage_label")
-        bootstrap_message = (
-            secondary_active_payload.get("message")
-            or "Additional market loading continues."
-        )
-        bootstrap_current = secondary_active_payload.get("current")
-        bootstrap_total = secondary_active_payload.get("total")
-    elif bootstrap_status.bootstrap_state == "ready":
-        bootstrap_progress_mode = "determinate"
-        bootstrap_percent = 100.0
-        bootstrap_stage = primary_payload.get("stage_label") if primary_payload else None
-        bootstrap_message = (
-            "Primary market is ready."
-            if not secondary_active
-            else "Primary market is ready while additional market loading continues."
-        )
-    elif any(payload.get("progress_mode") == "determinate" for payload in market_payloads):
-        focus_payload = next(
-            (payload for payload in market_payloads if payload.get("status") in ACTIVE_STATUSES),
-            primary_payload,
-        )
-        bootstrap_progress_mode = "determinate"
-        bootstrap_percent = round(
-            sum(_bootstrap_progress_percent(payload) for payload in market_payloads)
-            / max(len(market_payloads), 1),
-            2,
-        )
-        bootstrap_stage = focus_payload.get("stage_label") if focus_payload else None
-        bootstrap_message = focus_payload.get("message") if focus_payload else "Bootstrap queued."
-    else:
-        bootstrap_progress_mode = "indeterminate"
-        bootstrap_percent = None
-        bootstrap_stage = primary_payload.get("stage_label") if primary_payload else None
-        bootstrap_message = (
-            primary_payload.get("message")
-            if primary_payload is not None
-            else "Bootstrap queued."
-        )
-
-    background_warning = None
-    if len(enabled_markets) > 1 and (
-        bootstrap_status.bootstrap_state == "running" or bool(secondary_active)
-    ):
-        background_warning = (
-            "Additional enabled markets are still loading in the background."
-        )
-
-    return {
-        "bootstrap": {
-            "state": bootstrap_status.bootstrap_state,
-            "app_ready": not bootstrap_status.bootstrap_required,
-            "primary_market": primary_market,
-            "enabled_markets": enabled_markets,
-            "task_id": bootstrap_run.get("primary_task_id"),
-            "market_task_ids": bootstrap_run.get("market_task_ids") or {},
-            "current_stage": bootstrap_stage,
-            "progress_mode": bootstrap_progress_mode,
-            "percent": bootstrap_percent,
-            "current": bootstrap_current,
-            "total": bootstrap_total,
-            "message": bootstrap_message,
-            "background_warning": background_warning,
-        },
-        "summary": {
-            "active_market_count": len(active_markets),
-            "active_markets": active_markets,
-            "status": summary_status,
-        },
-        "markets": market_payloads,
-    }

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -15,7 +15,9 @@ from ..services.bootstrap_run_manifest import (
     BootstrapRunManifestRepository,
 )
 from ..services.runtime_activity_contract import (
+    PersistedRuntimeActivity,
     RuntimeActivityRecord,
+    RuntimeActivityUpdate,
     progress_mode,
     resolve_progress_percent,
 )
@@ -51,7 +53,7 @@ def _load_market_activity(db: Session, market: str) -> dict[str, Any] | None:
     if not isinstance(payload, dict):
         return None
     try:
-        return RuntimeActivityRecord.from_payload(payload).to_payload()
+        return PersistedRuntimeActivity.from_payload(payload).to_record().to_payload()
     except ValueError:
         return None
 
@@ -88,7 +90,7 @@ def save_runtime_bootstrap_run(
 def _save_market_activity(
     db: Session,
     market: str,
-    payload: dict[str, Any],
+    payload: RuntimeActivityUpdate | RuntimeActivityRecord | dict[str, Any],
 ) -> dict[str, Any]:
     key = _activity_key(market)
     setting = _get_setting(db, key)
@@ -107,7 +109,7 @@ def _save_market_activity(
         return transition.payload
     record = transition.record
 
-    encoded = json.dumps(record.to_persisted_payload())
+    encoded = json.dumps(PersistedRuntimeActivity.from_record(record).to_payload())
     if setting is None:
         setting = AppSetting(
             key=key,
@@ -136,8 +138,8 @@ def _activity_payload(
     current: int | None = None,
     total: int | None = None,
     message: str | None = None,
-) -> dict[str, Any]:
-    return RuntimeActivityRecord.create(
+) -> RuntimeActivityUpdate:
+    return RuntimeActivityUpdate(
         market=market,
         stage_key=stage_key,
         lifecycle=lifecycle,
@@ -149,7 +151,7 @@ def _activity_payload(
         total=total,
         message=message,
         updated_at=_utcnow_iso(),
-    ).to_payload()
+    )
 
 
 def mark_market_activity_queued(
@@ -221,23 +223,6 @@ def mark_market_activity_progress(
     total: int | None = None,
     message: str | None = None,
 ) -> dict[str, Any]:
-    existing = _load_market_activity(db, market)
-    if isinstance(existing, dict):
-        existing_task_id = existing.get("task_id")
-        existing_stage_key = existing.get("stage_key")
-        existing_status = existing.get("status")
-        can_inherit_existing_metadata = (
-            existing_status in {"queued", "running"}
-            and (not existing_task_id or not task_id or existing_task_id == task_id)
-            and (not existing_stage_key or existing_stage_key == stage_key)
-        )
-        if can_inherit_existing_metadata:
-            stage_key = existing_stage_key or stage_key
-            lifecycle = lifecycle or existing.get("lifecycle")
-            task_name = task_name or existing.get("task_name")
-            task_id = task_id or existing_task_id
-            message = message or existing.get("message")
-
     return _save_market_activity(
         db,
         market,

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -18,16 +18,14 @@ from ..services.runtime_activity_contract import (
     RuntimeActivityRecord,
     progress_mode,
     resolve_progress_percent,
-    stage_index,
 )
 from ..services.runtime_activity_presenter import build_runtime_activity_status
+from ..services.runtime_activity_reducer import reduce_market_activity
 from ..services.runtime_preferences_service import get_runtime_bootstrap_status
 from ..wiring.bootstrap import get_data_fetch_lock
 
 RUNTIME_ACTIVITY_CATEGORY = "runtime_activity"
 MARKET_ACTIVITY_KEY_PREFIX = "runtime.activity.market."
-
-_OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
 
 
 def _utcnow_iso() -> str:
@@ -52,7 +50,10 @@ def _load_market_activity(db: Session, market: str) -> dict[str, Any] | None:
         return None
     if not isinstance(payload, dict):
         return None
-    return payload
+    try:
+        return RuntimeActivityRecord.from_payload(payload).to_payload()
+    except ValueError:
+        return None
 
 
 def _load_runtime_bootstrap_run(db: Session) -> dict[str, Any] | None:
@@ -84,38 +85,6 @@ def save_runtime_bootstrap_run(
     )
 
 
-def _should_preserve_existing_failed_message(
-    existing_payload: dict[str, Any],
-    payload: dict[str, Any],
-) -> bool:
-    existing_message = str(existing_payload.get("message") or "").strip()
-    incoming_message = str(payload.get("message") or "").strip()
-    return bool(
-        existing_message
-        and incoming_message
-        and existing_message != incoming_message
-        and len(existing_message) >= len(incoming_message)
-    )
-
-
-def _should_supersede_failed_activity(
-    existing_payload: dict[str, Any],
-    payload: dict[str, Any],
-) -> bool:
-    """Allow a real scan stage to replace stale optional-stage failures."""
-    if existing_payload.get("stage_key") not in _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES:
-        return False
-    if payload.get("status") not in {"running", "completed"}:
-        return False
-    if payload.get("stage_key") != "scan":
-        return False
-    if existing_payload.get("lifecycle") != payload.get("lifecycle"):
-        return False
-    if payload.get("lifecycle") != "bootstrap":
-        return False
-    return stage_index(payload.get("stage_key")) > stage_index(existing_payload.get("stage_key"))
-
-
 def _save_market_activity(
     db: Session,
     market: str,
@@ -131,46 +100,16 @@ def _save_market_activity(
             existing_payload = json.loads(setting.value)
         except (json.JSONDecodeError, TypeError):
             existing_payload = None
-    if preserve_existing_statuses and isinstance(existing_payload, dict):
-        existing_status = existing_payload.get("status")
-        if existing_status in preserve_existing_statuses:
-            payload_status = payload.get("status")
-            same_task = existing_payload.get("task_id") == payload.get("task_id")
-            same_stage = existing_payload.get("stage_key") == payload.get("stage_key")
-            same_owner = same_task and same_stage
 
-            if existing_status == "running":
-                if payload_status == "queued" or (
-                    payload_status != "failed" and not same_owner
-                ):
-                    return existing_payload
-                if payload_status == "failed" and not same_owner:
-                    return existing_payload
-            elif existing_status == "completed":
-                if payload_status == "failed":
-                    pass
-                else:
-                    incoming_new_cycle = payload_status in {"queued", "running"} and not same_owner
-                    if not incoming_new_cycle:
-                        return existing_payload
-            elif existing_status == "failed":
-                supersedes_failed_activity = _should_supersede_failed_activity(
-                    existing_payload,
-                    payload,
-                )
-                incoming_new_cycle = payload_status in {"queued", "running"} and not same_owner
-                if incoming_new_cycle:
-                    existing_stage_index = stage_index(existing_payload.get("stage_key"))
-                    payload_stage_index = stage_index(payload.get("stage_key"))
-                    lifecycle_changed = existing_payload.get("lifecycle") != payload.get("lifecycle")
-                    incoming_new_cycle = lifecycle_changed or payload_stage_index <= existing_stage_index
-                if supersedes_failed_activity:
-                    pass
-                elif payload_status == "failed" and same_owner:
-                    if _should_preserve_existing_failed_message(existing_payload, payload):
-                        return existing_payload
-                elif not incoming_new_cycle:
-                    return existing_payload
+    transition = reduce_market_activity(
+        existing_payload if isinstance(existing_payload, dict) else None,
+        payload,
+        preserve_existing_statuses=preserve_existing_statuses,
+    )
+    if not transition.should_persist:
+        return transition.payload
+    payload = transition.payload
+
     encoded = json.dumps(payload)
     if setting is None:
         setting = AppSetting(

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -14,6 +14,7 @@ from ..wiring.bootstrap import get_data_fetch_lock
 
 RUNTIME_ACTIVITY_CATEGORY = "runtime_activity"
 MARKET_ACTIVITY_KEY_PREFIX = "runtime.activity.market."
+BOOTSTRAP_RUN_KEY = "runtime.activity.bootstrap_run"
 
 STAGE_SEQUENCE = (
     "universe",
@@ -82,6 +83,55 @@ def _load_market_activity(db: Session, market: str) -> dict[str, Any] | None:
         return None
     if not isinstance(payload, dict):
         return None
+    return payload
+
+
+def _load_runtime_bootstrap_run(db: Session) -> dict[str, Any] | None:
+    setting = _get_setting(db, BOOTSTRAP_RUN_KEY)
+    if setting is None:
+        return None
+    try:
+        payload = json.loads(setting.value)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def save_runtime_bootstrap_run(
+    db: Session,
+    *,
+    primary_market: str,
+    enabled_markets: list[str],
+    primary_task_id: str,
+    market_task_ids: dict[str, str],
+) -> dict[str, Any]:
+    payload = {
+        "primary_market": str(primary_market).upper(),
+        "enabled_markets": [str(market).upper() for market in enabled_markets],
+        "primary_task_id": primary_task_id,
+        "market_task_ids": {
+            str(market).upper(): task_id
+            for market, task_id in market_task_ids.items()
+        },
+        "queued_at": _utcnow_iso(),
+    }
+    encoded = json.dumps(payload)
+    setting = _get_setting(db, BOOTSTRAP_RUN_KEY)
+    if setting is None:
+        setting = AppSetting(
+            key=BOOTSTRAP_RUN_KEY,
+            value=encoded,
+            category=RUNTIME_ACTIVITY_CATEGORY,
+            description="Latest local runtime bootstrap run task manifest.",
+        )
+        db.add(setting)
+    else:
+        setting.value = encoded
+        setting.category = RUNTIME_ACTIVITY_CATEGORY
+        setting.description = "Latest local runtime bootstrap run task manifest."
+    db.commit()
     return payload
 
 
@@ -520,7 +570,12 @@ def _is_active_bootstrap_payload(payload: dict[str, Any]) -> bool:
     )
 
 
-def _queued_bootstrap_market_payload(market: str, _primary_market: str) -> dict[str, Any]:
+def _queued_bootstrap_market_payload(
+    market: str,
+    _primary_market: str,
+    *,
+    task_id: str | None = None,
+) -> dict[str, Any]:
     return {
         "market": str(market).upper(),
         "lifecycle": "bootstrap",
@@ -533,7 +588,7 @@ def _queued_bootstrap_market_payload(market: str, _primary_market: str) -> dict[
         "total": None,
         "message": "Bootstrap queued.",
         "task_name": None,
-        "task_id": None,
+        "task_id": task_id,
         "updated_at": None,
     }
 
@@ -579,9 +634,15 @@ def _market_payload(
     bootstrap_state: str,
     bootstrap_required: bool,
     primary_market: str,
+    bootstrap_run: dict[str, Any],
 ) -> dict[str, Any]:
     if record is None and bootstrap_state == "running" and bootstrap_required:
-        return _queued_bootstrap_market_payload(market, primary_market)
+        market_task_ids = bootstrap_run.get("market_task_ids") or {}
+        return _queued_bootstrap_market_payload(
+            market,
+            primary_market,
+            task_id=market_task_ids.get(str(market).upper()),
+        )
     if record is None:
         return _idle_market_payload(market, None)
     return _idle_market_payload(market, _overlay_live_progress(record, market))
@@ -591,6 +652,7 @@ def get_runtime_activity_status(db: Session) -> dict[str, Any]:
     bootstrap_status = get_runtime_bootstrap_status(db)
     enabled_markets = list(bootstrap_status.enabled_markets)
     primary_market = bootstrap_status.primary_market
+    bootstrap_run = _load_runtime_bootstrap_run(db) or {}
 
     market_payloads = []
     for market in enabled_markets:
@@ -602,6 +664,7 @@ def get_runtime_activity_status(db: Session) -> dict[str, Any]:
                 bootstrap_state=bootstrap_status.bootstrap_state,
                 bootstrap_required=bootstrap_status.bootstrap_required,
                 primary_market=primary_market,
+                bootstrap_run=bootstrap_run,
             )
         )
 
@@ -689,6 +752,8 @@ def get_runtime_activity_status(db: Session) -> dict[str, Any]:
             "app_ready": not bootstrap_status.bootstrap_required,
             "primary_market": primary_market,
             "enabled_markets": enabled_markets,
+            "task_id": bootstrap_run.get("primary_task_id"),
+            "market_task_ids": bootstrap_run.get("market_task_ids") or {},
             "current_stage": bootstrap_stage,
             "progress_mode": bootstrap_progress_mode,
             "percent": bootstrap_percent,

--- a/backend/app/services/market_activity_service.py
+++ b/backend/app/services/market_activity_service.py
@@ -513,13 +513,14 @@ def _bootstrap_progress_percent(record: dict[str, Any] | None) -> float:
     return round(((stage_index + stage_fraction) / len(STAGE_SEQUENCE)) * 100.0, 2)
 
 
-def _queued_bootstrap_market_payload(market: str, primary_market: str) -> dict[str, Any]:
-    queued_for_primary = str(market).upper() != str(primary_market).upper()
-    message = (
-        f"Queued until {primary_market.upper()} is ready."
-        if queued_for_primary
-        else "Bootstrap queued."
+def _is_active_bootstrap_payload(payload: dict[str, Any]) -> bool:
+    return (
+        payload.get("lifecycle") == "bootstrap"
+        and payload.get("status") in ACTIVE_STATUSES
     )
+
+
+def _queued_bootstrap_market_payload(market: str, _primary_market: str) -> dict[str, Any]:
     return {
         "market": str(market).upper(),
         "lifecycle": "bootstrap",
@@ -530,7 +531,7 @@ def _queued_bootstrap_market_payload(market: str, primary_market: str) -> dict[s
         "percent": None,
         "current": None,
         "total": None,
-        "message": message,
+        "message": "Bootstrap queued.",
         "task_name": None,
         "task_id": None,
         "updated_at": None,
@@ -619,13 +620,13 @@ def get_runtime_activity_status(db: Session) -> dict[str, Any]:
     secondary_active = [
         payload["market"]
         for payload in market_payloads
-        if payload["market"] != primary_market and payload.get("status") in ACTIVE_STATUSES
+        if payload["market"] != primary_market and _is_active_bootstrap_payload(payload)
     ]
     secondary_active_payload = next(
         (
             payload
             for payload in market_payloads
-            if payload["market"] != primary_market and payload.get("status") in ACTIVE_STATUSES
+            if payload["market"] != primary_market and _is_active_bootstrap_payload(payload)
         ),
         None,
     )

--- a/backend/app/services/operations_job_service.py
+++ b/backend/app/services/operations_job_service.py
@@ -208,7 +208,19 @@ def _cancel_strategy_for(record: _JobRecord) -> str:
     return "unsupported"
 
 
-def _progress_mode(percent: float | None, current: int | None, total: int | None) -> str:
+def _progress_mode(
+    percent: float | None,
+    current: int | None,
+    total: int | None,
+    *,
+    state: str | None = None,
+) -> str:
+    resolved_percent = percent
+    if resolved_percent is None and current is not None and total not in (None, 0):
+        resolved_percent = (float(current) / float(total)) * 100.0
+    if state in {"queued", "running", "reserved", "waiting", "stale", "stuck"}:
+        if resolved_percent is not None and resolved_percent >= 100.0:
+            return "indeterminate"
     if percent is not None:
         return "determinate"
     if current is not None and total is not None:
@@ -501,7 +513,12 @@ class OperationsJobService:
             wait_reason=None,
             heartbeat_lag_seconds=heartbeat_lag,
             cancel_strategy="force_cancel_refresh" if state == "stuck" else "unsupported",
-            progress_mode=_progress_mode(current_task.get("progress"), current_task.get("current"), current_task.get("total")),
+            progress_mode=_progress_mode(
+                current_task.get("progress"),
+                current_task.get("current"),
+                current_task.get("total"),
+                state=state,
+            ),
             percent=current_task.get("progress"),
             current=current_task.get("current"),
             total=current_task.get("total"),
@@ -544,7 +561,12 @@ class OperationsJobService:
             wait_reason=None,
             heartbeat_lag_seconds=None,
             cancel_strategy="unsupported",
-            progress_mode=_progress_mode(runtime_record.get("percent"), runtime_record.get("current"), runtime_record.get("total")),
+            progress_mode=_progress_mode(
+                runtime_record.get("percent"),
+                runtime_record.get("current"),
+                runtime_record.get("total"),
+                state=state,
+            ),
             percent=runtime_record.get("percent"),
             current=runtime_record.get("current"),
             total=runtime_record.get("total"),
@@ -569,6 +591,7 @@ class OperationsJobService:
             record.percent,
             record.current,
             record.total,
+            state=record.state,
         )
 
     def _apply_job_backend_progress(self, record: _JobRecord) -> None:
@@ -589,7 +612,12 @@ class OperationsJobService:
             record.current = snapshot.current
         if record.total is None and getattr(snapshot, "total", None) is not None:
             record.total = snapshot.total
-        record.progress_mode = _progress_mode(record.percent, record.current, record.total)
+        record.progress_mode = _progress_mode(
+            record.percent,
+            record.current,
+            record.total,
+            state=record.state,
+        )
 
     def _apply_heartbeat_progress(self, record: _JobRecord) -> None:
         if _queue_family(record.queue) != "data_fetch" or record.market is None:
@@ -606,7 +634,12 @@ class OperationsJobService:
             record.current = current_task.get("current")
         if record.total is None and current_task.get("total") is not None:
             record.total = current_task.get("total")
-        record.progress_mode = _progress_mode(record.percent, record.current, record.total)
+        record.progress_mode = _progress_mode(
+            record.percent,
+            record.current,
+            record.total,
+            state=record.state,
+        )
 
     def _augment_with_runtime_activity(
         self,
@@ -681,7 +714,12 @@ class OperationsJobService:
                 wait_reason=None,
                 heartbeat_lag_seconds=None,
                 cancel_strategy="unsupported",
-                progress_mode=_progress_mode(runtime_record.get("percent"), runtime_record.get("current"), runtime_record.get("total")),
+                progress_mode=_progress_mode(
+                    runtime_record.get("percent"),
+                    runtime_record.get("current"),
+                    runtime_record.get("total"),
+                    state=state,
+                ),
                 percent=runtime_record.get("percent"),
                 current=runtime_record.get("current"),
                 total=runtime_record.get("total"),

--- a/backend/app/services/operations_job_service.py
+++ b/backend/app/services/operations_job_service.py
@@ -25,6 +25,7 @@ from app.services.market_activity_service import (
     MARKET_ACTIVITY_KEY_PREFIX,
     RUNTIME_ACTIVITY_CATEGORY,
 )
+from app.services.runtime_activity_contract import progress_mode
 from app.services.ui_snapshot_service import safe_publish_scan_bootstrap
 from app.tasks.market_queues import (
     SHARED_DATA_FETCH_QUEUE,
@@ -206,26 +207,6 @@ def _cancel_strategy_for(record: _JobRecord) -> str:
     ):
         return "force_release_market_lease"
     return "unsupported"
-
-
-def _progress_mode(
-    percent: float | None,
-    current: int | None,
-    total: int | None,
-    *,
-    state: str | None = None,
-) -> str:
-    resolved_percent = percent
-    if resolved_percent is None and current is not None and total not in (None, 0):
-        resolved_percent = (float(current) / float(total)) * 100.0
-    if state in {"queued", "running", "reserved", "waiting", "stale", "stuck"}:
-        if resolved_percent is not None and resolved_percent >= 100.0:
-            return "indeterminate"
-    if percent is not None:
-        return "determinate"
-    if current is not None and total is not None:
-        return "determinate"
-    return "indeterminate"
 
 
 def _market_lease_state(holder: dict[str, Any]) -> tuple[str, float | None]:
@@ -513,11 +494,11 @@ class OperationsJobService:
             wait_reason=None,
             heartbeat_lag_seconds=heartbeat_lag,
             cancel_strategy="force_cancel_refresh" if state == "stuck" else "unsupported",
-            progress_mode=_progress_mode(
+            progress_mode=progress_mode(
+                state,
                 current_task.get("progress"),
                 current_task.get("current"),
                 current_task.get("total"),
-                state=state,
             ),
             percent=current_task.get("progress"),
             current=current_task.get("current"),
@@ -561,11 +542,11 @@ class OperationsJobService:
             wait_reason=None,
             heartbeat_lag_seconds=None,
             cancel_strategy="unsupported",
-            progress_mode=_progress_mode(
+            progress_mode=progress_mode(
+                state,
                 runtime_record.get("percent"),
                 runtime_record.get("current"),
                 runtime_record.get("total"),
-                state=state,
             ),
             percent=runtime_record.get("percent"),
             current=runtime_record.get("current"),
@@ -587,11 +568,11 @@ class OperationsJobService:
             record.current = runtime_record.get("current")
         if runtime_record.get("total") is not None:
             record.total = runtime_record.get("total")
-        record.progress_mode = _progress_mode(
+        record.progress_mode = progress_mode(
+            record.state,
             record.percent,
             record.current,
             record.total,
-            state=record.state,
         )
 
     def _apply_job_backend_progress(self, record: _JobRecord) -> None:
@@ -612,11 +593,11 @@ class OperationsJobService:
             record.current = snapshot.current
         if record.total is None and getattr(snapshot, "total", None) is not None:
             record.total = snapshot.total
-        record.progress_mode = _progress_mode(
+        record.progress_mode = progress_mode(
+            record.state,
             record.percent,
             record.current,
             record.total,
-            state=record.state,
         )
 
     def _apply_heartbeat_progress(self, record: _JobRecord) -> None:
@@ -634,11 +615,11 @@ class OperationsJobService:
             record.current = current_task.get("current")
         if record.total is None and current_task.get("total") is not None:
             record.total = current_task.get("total")
-        record.progress_mode = _progress_mode(
+        record.progress_mode = progress_mode(
+            record.state,
             record.percent,
             record.current,
             record.total,
-            state=record.state,
         )
 
     def _augment_with_runtime_activity(
@@ -714,11 +695,11 @@ class OperationsJobService:
                 wait_reason=None,
                 heartbeat_lag_seconds=None,
                 cancel_strategy="unsupported",
-                progress_mode=_progress_mode(
+                progress_mode=progress_mode(
+                    state,
                     runtime_record.get("percent"),
                     runtime_record.get("current"),
                     runtime_record.get("total"),
-                    state=state,
                 ),
                 percent=runtime_record.get("percent"),
                 current=runtime_record.get("current"),

--- a/backend/app/services/price_fetch_failures.py
+++ b/backend/app/services/price_fetch_failures.py
@@ -1,0 +1,84 @@
+"""Shared price-provider failure classification."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class PriceFetchFailureKind(str, Enum):
+    NO_PRICE_DATA = "no_price_data"
+    RATE_LIMIT = "rate_limit"
+    TRANSIENT = "transient"
+    CIRCUIT_OPEN = "circuit_open"
+
+
+_RATE_LIMIT_INDICATORS = ("rate", "429", "too many", "limit", "throttl")
+_NO_PRICE_DATA_INDICATORS = (
+    "yfpricesmissingerror",
+    "possibly delisted",
+    "delisted",
+    "no price data",
+    "no data found",
+    "symbol may be delisted",
+    "no data after filtering",
+)
+_TRANSIENT_INDICATORS = (
+    "empty",
+    "batch download error",
+    "missing from results",
+    "symbol not in download results",
+)
+
+
+def normalize_price_fetch_failure_kind(value: Any) -> PriceFetchFailureKind | None:
+    if isinstance(value, PriceFetchFailureKind):
+        return value
+    if value is None:
+        return None
+    try:
+        return PriceFetchFailureKind(str(value))
+    except ValueError:
+        return None
+
+
+def is_rate_limit_error(error: str | None) -> bool:
+    lower = (error or "").lower()
+    return any(indicator in lower for indicator in _RATE_LIMIT_INDICATORS)
+
+
+def classify_price_fetch_error(error: str | None) -> PriceFetchFailureKind | None:
+    lower = (error or "").lower()
+    if not lower:
+        return None
+    if lower == PriceFetchFailureKind.CIRCUIT_OPEN.value:
+        return PriceFetchFailureKind.CIRCUIT_OPEN
+    if is_rate_limit_error(lower):
+        return PriceFetchFailureKind.RATE_LIMIT
+    if any(indicator in lower for indicator in _NO_PRICE_DATA_INDICATORS):
+        return PriceFetchFailureKind.NO_PRICE_DATA
+    if any(indicator in lower for indicator in _TRANSIENT_INDICATORS):
+        return PriceFetchFailureKind.TRANSIENT
+    return None
+
+
+def is_no_data_price_failure(error: str | None) -> bool:
+    return classify_price_fetch_error(error) is PriceFetchFailureKind.NO_PRICE_DATA
+
+
+def is_retryable_price_failure_kind(
+    kind: PriceFetchFailureKind | str | None,
+) -> bool:
+    normalized = normalize_price_fetch_failure_kind(kind)
+    return normalized is not PriceFetchFailureKind.NO_PRICE_DATA
+
+
+def is_retryable_price_failure(
+    *,
+    kind: PriceFetchFailureKind | str | None = None,
+    error: str | None = None,
+) -> bool:
+    normalized = normalize_price_fetch_failure_kind(kind)
+    if normalized is None:
+        normalized = classify_price_fetch_error(error)
+    return is_retryable_price_failure_kind(normalized)

--- a/backend/app/services/price_history_coverage.py
+++ b/backend/app/services/price_history_coverage.py
@@ -1,0 +1,67 @@
+"""Coverage classification for persisted daily price history."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..models.stock import StockPrice
+
+
+@dataclass(frozen=True)
+class PriceHistoryCoverage:
+    fresh: tuple[str, ...] = ()
+    stale: tuple[str, ...] = ()
+    no_history: tuple[str, ...] = ()
+
+    @property
+    def refresh_symbols(self) -> tuple[str, ...]:
+        return self.stale + self.no_history
+
+
+def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
+    return tuple(str(symbol).upper() for symbol in symbols)
+
+
+def classify_price_history(
+    db: Session,
+    *,
+    symbols: Sequence[str],
+    as_of_date: date,
+) -> PriceHistoryCoverage:
+    """Split symbols by whether persisted prices already cover ``as_of_date``."""
+    normalized_symbols = _normalize_symbols(symbols)
+    latest_by_symbol: dict[str, date | None] = {}
+    for chunk_start in range(0, len(normalized_symbols), 500):
+        chunk_symbols = normalized_symbols[chunk_start:chunk_start + 500]
+        rows = (
+            db.query(StockPrice.symbol, func.max(StockPrice.date))
+            .filter(StockPrice.symbol.in_(chunk_symbols))
+            .group_by(StockPrice.symbol)
+            .all()
+        )
+        latest_by_symbol.update(
+            {str(symbol).upper(): latest_date for symbol, latest_date in rows}
+        )
+
+    fresh_symbols: list[str] = []
+    stale_symbols: list[str] = []
+    no_history_symbols: list[str] = []
+    for symbol in normalized_symbols:
+        latest_date = latest_by_symbol.get(symbol)
+        if latest_date is None:
+            no_history_symbols.append(symbol)
+        elif latest_date < as_of_date:
+            stale_symbols.append(symbol)
+        else:
+            fresh_symbols.append(symbol)
+
+    return PriceHistoryCoverage(
+        fresh=tuple(fresh_symbols),
+        stale=tuple(stale_symbols),
+        no_history=tuple(no_history_symbols),
+    )

--- a/backend/app/services/price_refresh_actions.py
+++ b/backend/app/services/price_refresh_actions.py
@@ -48,20 +48,6 @@ class PriceRefreshTerminalCompletion:
     finalization: PriceRefreshFinalization
 
 
-@dataclass(frozen=True)
-class LivePriceRefreshAction:
-    preparation: PriceRefreshPreparation
-
-
-@dataclass(frozen=True)
-class TerminalPriceRefreshAction:
-    preparation: PriceRefreshPreparation
-    completion: PriceRefreshTerminalCompletion
-
-
-PriceRefreshAction = LivePriceRefreshAction | TerminalPriceRefreshAction
-
-
 class PriceRefreshActionFactory:
     def __init__(
         self,
@@ -70,23 +56,20 @@ class PriceRefreshActionFactory:
     ) -> None:
         self._last_completed_trading_day = last_completed_trading_day
 
-    def build(
+    def build_terminal_completion(
         self,
         *,
         mode: PriceRefreshMode,
         effective_market: str,
         preparation: PriceRefreshPreparation,
-    ) -> PriceRefreshAction:
+    ) -> PriceRefreshTerminalCompletion | None:
         if preparation.symbols:
-            return LivePriceRefreshAction(preparation=preparation)
+            return None
 
-        return TerminalPriceRefreshAction(
+        return self._terminal_completion(
+            mode=mode,
+            effective_market=effective_market,
             preparation=preparation,
-            completion=self._terminal_completion(
-                mode=mode,
-                effective_market=effective_market,
-                preparation=preparation,
-            ),
         )
 
     def _terminal_completion(

--- a/backend/app/services/price_refresh_actions.py
+++ b/backend/app/services/price_refresh_actions.py
@@ -1,0 +1,145 @@
+"""Executable action planning for market price refreshes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .price_refresh_activity import (
+    PriceRefreshFinalization,
+    PriceRefreshOutcome,
+)
+from .price_refresh_planning import (
+    GitHubSeedOutcome,
+    PriceRefreshJob,
+    PriceRefreshMode,
+    PriceRefreshPlan,
+    PriceRefreshSource,
+)
+
+
+@dataclass(frozen=True)
+class PriceRefreshPreparation:
+    all_symbols: list[str]
+    symbol_markets: dict[str, str]
+    github_seed: GitHubSeedOutcome | None
+    refresh_plan: PriceRefreshPlan
+    refresh_source: PriceRefreshSource
+    symbols: list[str]
+    live_refresh_jobs: list[PriceRefreshJob]
+
+
+@dataclass(frozen=True)
+class PriceRefreshTerminalCompletion:
+    outcome: PriceRefreshOutcome
+    finalization: PriceRefreshFinalization
+
+
+@dataclass(frozen=True)
+class PriceRefreshAction:
+    preparation: PriceRefreshPreparation
+    terminal_completion: PriceRefreshTerminalCompletion | None = None
+
+    @property
+    def requires_live_fetch(self) -> bool:
+        return self.terminal_completion is None
+
+
+class PriceRefreshActionFactory:
+    def __init__(
+        self,
+        *,
+        last_completed_trading_day: Callable[[str], Any],
+    ) -> None:
+        self._last_completed_trading_day = last_completed_trading_day
+
+    def build(
+        self,
+        *,
+        mode: PriceRefreshMode,
+        effective_market: str,
+        preparation: PriceRefreshPreparation,
+    ) -> PriceRefreshAction:
+        if preparation.symbols:
+            return PriceRefreshAction(preparation=preparation)
+
+        return PriceRefreshAction(
+            preparation=preparation,
+            terminal_completion=self._terminal_completion(
+                mode=mode,
+                effective_market=effective_market,
+                preparation=preparation,
+            ),
+        )
+
+    def _terminal_completion(
+        self,
+        *,
+        mode: PriceRefreshMode,
+        effective_market: str,
+        preparation: PriceRefreshPreparation,
+    ) -> PriceRefreshTerminalCompletion:
+        if preparation.refresh_source is PriceRefreshSource.GITHUB:
+            message = (
+                preparation.refresh_plan.completion_message
+                or "GitHub daily price bundle is current - no live fetch needed"
+            )
+            symbol_count = len(preparation.all_symbols)
+            trading_day = self._completion_trading_day(
+                preparation.github_seed,
+                effective_market,
+            )
+            finalization = PriceRefreshFinalization(
+                metadata_status="completed",
+                metadata_refreshed=symbol_count,
+                metadata_total=symbol_count,
+                activity_current=symbol_count,
+                activity_total=symbol_count,
+                message=message,
+                market_success_rates={effective_market: (trading_day, 1.0)},
+            )
+        else:
+            message = _empty_refresh_message(preparation.refresh_plan, mode)
+            finalization = PriceRefreshFinalization(
+                metadata_status="completed",
+                metadata_refreshed=0,
+                metadata_total=0,
+                activity_current=0,
+                activity_total=0,
+                message=message,
+                heartbeat_status=None,
+            )
+
+        return PriceRefreshTerminalCompletion(
+            outcome=PriceRefreshOutcome(
+                status="completed",
+                source=preparation.refresh_source,
+                mode=mode,
+                message=message,
+                github_seed=preparation.github_seed,
+            ),
+            finalization=finalization,
+        )
+
+    def _completion_trading_day(
+        self,
+        github_seed: GitHubSeedOutcome | None,
+        effective_market: str,
+    ) -> Any:
+        if github_seed and github_seed.as_of_date is not None:
+            return github_seed.as_of_date
+        return self._last_completed_trading_day(effective_market)
+
+
+def _empty_refresh_message(
+    refresh_plan: PriceRefreshPlan,
+    mode: PriceRefreshMode,
+) -> str:
+    if refresh_plan.completion_message:
+        return refresh_plan.completion_message
+    if mode is PriceRefreshMode.AUTO:
+        return "All symbols recently refreshed - nothing to do"
+    if mode in {PriceRefreshMode.BOOTSTRAP, PriceRefreshMode.DELTA}:
+        return "All symbols already fresh - no live fetch needed"
+    return "No active symbols found in universe"

--- a/backend/app/services/price_refresh_actions.py
+++ b/backend/app/services/price_refresh_actions.py
@@ -1,4 +1,4 @@
-"""Executable action planning for market price refreshes."""
+"""Terminal completion helpers for market price refreshes."""
 
 from __future__ import annotations
 
@@ -12,34 +12,10 @@ from .price_refresh_activity import (
 )
 from .price_refresh_planning import (
     GitHubSeedOutcome,
-    PriceRefreshJob,
     PriceRefreshMode,
     PriceRefreshPlan,
     PriceRefreshSource,
 )
-
-
-@dataclass(frozen=True)
-class PriceRefreshPreparation:
-    all_symbols: list[str]
-    symbol_markets: dict[str, str]
-    refresh_plan: PriceRefreshPlan
-
-    @property
-    def github_seed(self) -> GitHubSeedOutcome | None:
-        return self.refresh_plan.github_seed
-
-    @property
-    def refresh_source(self) -> PriceRefreshSource:
-        return self.refresh_plan.source
-
-    @property
-    def symbols(self) -> tuple[str, ...]:
-        return self.refresh_plan.symbols
-
-    @property
-    def live_refresh_jobs(self) -> tuple[PriceRefreshJob, ...]:
-        return self.refresh_plan.jobs
 
 
 @dataclass(frozen=True)
@@ -48,87 +24,68 @@ class PriceRefreshTerminalCompletion:
     finalization: PriceRefreshFinalization
 
 
-class PriceRefreshActionFactory:
-    def __init__(
-        self,
-        *,
-        last_completed_trading_day: Callable[[str], Any],
-    ) -> None:
-        self._last_completed_trading_day = last_completed_trading_day
+def build_terminal_completion(
+    *,
+    mode: PriceRefreshMode,
+    effective_market: str,
+    plan: PriceRefreshPlan,
+    last_completed_trading_day: Callable[[str], Any],
+) -> PriceRefreshTerminalCompletion | None:
+    if plan.symbols:
+        return None
+    if plan.source is PriceRefreshSource.GITHUB:
+        message = (
+            plan.completion_message
+            or "GitHub daily price bundle is current - no live fetch needed"
+        )
+        symbol_count = len(plan.all_symbols)
+        trading_day = _completion_trading_day(
+            plan.github_seed,
+            effective_market,
+            last_completed_trading_day=last_completed_trading_day,
+        )
+        finalization = PriceRefreshFinalization(
+            metadata_status="completed",
+            metadata_refreshed=symbol_count,
+            metadata_total=symbol_count,
+            activity_current=symbol_count,
+            activity_total=symbol_count,
+            message=message,
+            market_success_rates={effective_market: (trading_day, 1.0)},
+        )
+    else:
+        message = _empty_refresh_message(plan, mode)
+        finalization = PriceRefreshFinalization(
+            metadata_status="completed",
+            metadata_refreshed=0,
+            metadata_total=0,
+            activity_current=0,
+            activity_total=0,
+            message=message,
+            heartbeat_status=None,
+        )
 
-    def build_terminal_completion(
-        self,
-        *,
-        mode: PriceRefreshMode,
-        effective_market: str,
-        preparation: PriceRefreshPreparation,
-    ) -> PriceRefreshTerminalCompletion | None:
-        if preparation.symbols:
-            return None
-
-        return self._terminal_completion(
+    return PriceRefreshTerminalCompletion(
+        outcome=PriceRefreshOutcome(
+            status="completed",
+            source=plan.source,
             mode=mode,
-            effective_market=effective_market,
-            preparation=preparation,
-        )
+            message=message,
+            github_seed=plan.github_seed,
+        ),
+        finalization=finalization,
+    )
 
-    def _terminal_completion(
-        self,
-        *,
-        mode: PriceRefreshMode,
-        effective_market: str,
-        preparation: PriceRefreshPreparation,
-    ) -> PriceRefreshTerminalCompletion:
-        if preparation.refresh_source is PriceRefreshSource.GITHUB:
-            message = (
-                preparation.refresh_plan.completion_message
-                or "GitHub daily price bundle is current - no live fetch needed"
-            )
-            symbol_count = len(preparation.all_symbols)
-            trading_day = self._completion_trading_day(
-                preparation.github_seed,
-                effective_market,
-            )
-            finalization = PriceRefreshFinalization(
-                metadata_status="completed",
-                metadata_refreshed=symbol_count,
-                metadata_total=symbol_count,
-                activity_current=symbol_count,
-                activity_total=symbol_count,
-                message=message,
-                market_success_rates={effective_market: (trading_day, 1.0)},
-            )
-        else:
-            message = _empty_refresh_message(preparation.refresh_plan, mode)
-            finalization = PriceRefreshFinalization(
-                metadata_status="completed",
-                metadata_refreshed=0,
-                metadata_total=0,
-                activity_current=0,
-                activity_total=0,
-                message=message,
-                heartbeat_status=None,
-            )
 
-        return PriceRefreshTerminalCompletion(
-            outcome=PriceRefreshOutcome(
-                status="completed",
-                source=preparation.refresh_source,
-                mode=mode,
-                message=message,
-                github_seed=preparation.github_seed,
-            ),
-            finalization=finalization,
-        )
-
-    def _completion_trading_day(
-        self,
-        github_seed: GitHubSeedOutcome | None,
-        effective_market: str,
-    ) -> Any:
-        if github_seed and github_seed.as_of_date is not None:
-            return github_seed.as_of_date
-        return self._last_completed_trading_day(effective_market)
+def _completion_trading_day(
+    github_seed: GitHubSeedOutcome | None,
+    effective_market: str,
+    *,
+    last_completed_trading_day: Callable[[str], Any],
+) -> Any:
+    if github_seed and github_seed.as_of_date is not None:
+        return github_seed.as_of_date
+    return last_completed_trading_day(effective_market)
 
 
 def _empty_refresh_message(

--- a/backend/app/services/price_refresh_actions.py
+++ b/backend/app/services/price_refresh_actions.py
@@ -23,11 +23,23 @@ from .price_refresh_planning import (
 class PriceRefreshPreparation:
     all_symbols: list[str]
     symbol_markets: dict[str, str]
-    github_seed: GitHubSeedOutcome | None
     refresh_plan: PriceRefreshPlan
-    refresh_source: PriceRefreshSource
-    symbols: list[str]
-    live_refresh_jobs: list[PriceRefreshJob]
+
+    @property
+    def github_seed(self) -> GitHubSeedOutcome | None:
+        return self.refresh_plan.github_seed
+
+    @property
+    def refresh_source(self) -> PriceRefreshSource:
+        return self.refresh_plan.source
+
+    @property
+    def symbols(self) -> tuple[str, ...]:
+        return self.refresh_plan.symbols
+
+    @property
+    def live_refresh_jobs(self) -> tuple[PriceRefreshJob, ...]:
+        return self.refresh_plan.jobs
 
 
 @dataclass(frozen=True)
@@ -37,13 +49,17 @@ class PriceRefreshTerminalCompletion:
 
 
 @dataclass(frozen=True)
-class PriceRefreshAction:
+class LivePriceRefreshAction:
     preparation: PriceRefreshPreparation
-    terminal_completion: PriceRefreshTerminalCompletion | None = None
 
-    @property
-    def requires_live_fetch(self) -> bool:
-        return self.terminal_completion is None
+
+@dataclass(frozen=True)
+class TerminalPriceRefreshAction:
+    preparation: PriceRefreshPreparation
+    completion: PriceRefreshTerminalCompletion
+
+
+PriceRefreshAction = LivePriceRefreshAction | TerminalPriceRefreshAction
 
 
 class PriceRefreshActionFactory:
@@ -62,11 +78,11 @@ class PriceRefreshActionFactory:
         preparation: PriceRefreshPreparation,
     ) -> PriceRefreshAction:
         if preparation.symbols:
-            return PriceRefreshAction(preparation=preparation)
+            return LivePriceRefreshAction(preparation=preparation)
 
-        return PriceRefreshAction(
+        return TerminalPriceRefreshAction(
             preparation=preparation,
-            terminal_completion=self._terminal_completion(
+            completion=self._terminal_completion(
                 mode=mode,
                 effective_market=effective_market,
                 preparation=preparation,

--- a/backend/app/services/price_refresh_activity.py
+++ b/backend/app/services/price_refresh_activity.py
@@ -1,0 +1,246 @@
+"""Activity publication for smart price refresh workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Protocol
+
+from .price_refresh_planning import (
+    GitHubSeedOutcome,
+    PriceRefreshMode,
+    PriceRefreshSource,
+)
+
+
+class CeleryTaskLike(Protocol):
+    name: str
+    request: Any
+
+    def update_state(self, *args, **kwargs) -> None:
+        ...
+
+
+def task_name(task: CeleryTaskLike) -> str:
+    return getattr(task, "name", "smart_refresh_cache")
+
+
+def task_id(task: CeleryTaskLike) -> str | None:
+    return getattr(getattr(task, "request", None), "id", None)
+
+
+@dataclass(frozen=True)
+class PriceRefreshOutcome:
+    status: str
+    mode: PriceRefreshMode
+    source: PriceRefreshSource
+    message: str | None = None
+    refreshed: int = 0
+    failed: int = 0
+    total: int = 0
+    failed_symbols: list[str] = field(default_factory=list)
+    completed_at: datetime = field(default_factory=datetime.now)
+    github_seed: GitHubSeedOutcome | None = None
+
+    def to_task_result(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "status": self.status,
+            "source": self.source.value,
+            "refreshed": self.refreshed,
+            "failed": self.failed,
+            "total": self.total,
+            "mode": self.mode.value,
+            "completed_at": self.completed_at.isoformat(),
+        }
+        if self.github_seed is not None:
+            result["github_sync_status"] = self.github_seed.status_value
+            result["source_revision"] = self.github_seed.source_revision
+        if self.message is not None:
+            result["message"] = self.message
+        if self.failed_symbols:
+            result["failed_symbols"] = self.failed_symbols[:20]
+        return result
+
+
+@dataclass(frozen=True)
+class PriceRefreshFinalization:
+    metadata_status: str
+    metadata_refreshed: int
+    metadata_total: int
+    activity_current: int
+    activity_total: int
+    message: str
+    heartbeat_status: str | None = "completed"
+    market_success_rates: Mapping[str, tuple[Any, float]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PriceRefreshActivityDependencies:
+    record_market_refresh_success: Callable[..., None]
+    mark_market_activity_started: Callable[..., None]
+    mark_market_activity_completed: Callable[..., None]
+    mark_market_activity_progress_safely: Callable[..., None]
+    mark_market_activity_failed_safely: Callable[..., None]
+
+
+class PriceRefreshActivityReporter:
+    def __init__(self, dependencies: PriceRefreshActivityDependencies) -> None:
+        self._deps = dependencies
+
+    def start_prices(
+        self,
+        db,
+        *,
+        task: CeleryTaskLike,
+        market: str,
+        lifecycle: str,
+        message: str,
+    ) -> None:
+        self._deps.mark_market_activity_started(
+            db,
+            market=market,
+            stage_key="prices",
+            lifecycle=lifecycle,
+            task_name=task_name(task),
+            task_id=task_id(task),
+            message=message,
+        )
+
+    def publish_github_seed_fallback(
+        self,
+        db,
+        *,
+        task: CeleryTaskLike,
+        market: str,
+        lifecycle: str,
+        total: int,
+        status_value: str,
+    ) -> None:
+        self._deps.mark_market_activity_progress_safely(
+            db,
+            market=market,
+            stage_key="prices",
+            lifecycle=lifecycle,
+            task_name=task_name(task),
+            task_id=task_id(task),
+            current=0,
+            total=total,
+            percent=0,
+            message=f"GitHub price bundle {status_value}; using live price refresh",
+        )
+
+    def publish_progress(
+        self,
+        db,
+        price_cache,
+        *,
+        task: CeleryTaskLike,
+        market: str | None,
+        effective_market: str,
+        lifecycle: str,
+        current: int,
+        total: int,
+        percent: float,
+        message: str,
+        refreshed: int,
+        failed: int,
+    ) -> None:
+        task.update_state(
+            state="PROGRESS",
+            meta={
+                "current": current,
+                "total": total,
+                "percent": percent,
+                "refreshed": refreshed,
+                "failed": failed,
+            },
+        )
+        price_cache.update_warmup_heartbeat(current, total, percent, market=market)
+        self._deps.mark_market_activity_progress_safely(
+            db,
+            market=effective_market,
+            stage_key="prices",
+            lifecycle=lifecycle,
+            task_name=task_name(task),
+            task_id=task_id(task),
+            current=current,
+            total=total,
+            percent=round(percent, 1),
+            message=message,
+        )
+
+    def finalize_success(
+        self,
+        db,
+        price_cache,
+        *,
+        task: CeleryTaskLike,
+        market: str | None,
+        effective_market: str,
+        lifecycle: str,
+        finalization: PriceRefreshFinalization,
+    ) -> None:
+        price_cache.save_warmup_metadata(
+            finalization.metadata_status,
+            finalization.metadata_refreshed,
+            finalization.metadata_total,
+            market=market,
+        )
+        if finalization.heartbeat_status is not None:
+            price_cache.complete_warmup_heartbeat(
+                finalization.heartbeat_status,
+                market=market,
+            )
+        self._deps.mark_market_activity_completed(
+            db,
+            market=effective_market,
+            stage_key="prices",
+            lifecycle=lifecycle,
+            task_name=task_name(task),
+            task_id=task_id(task),
+            current=finalization.activity_current,
+            total=finalization.activity_total,
+            message=finalization.message,
+        )
+        for refresh_market, (trading_day, success_rate) in finalization.market_success_rates.items():
+            self._deps.record_market_refresh_success(
+                db,
+                market=refresh_market,
+                trading_day=trading_day,
+                success_rate=success_rate,
+            )
+
+    def record_failure(
+        self,
+        db,
+        price_cache,
+        *,
+        task: CeleryTaskLike,
+        market: str | None,
+        effective_market: str,
+        lifecycle: str,
+        refreshed: int,
+        total: int,
+        current: int,
+        message: str,
+    ) -> None:
+        price_cache.save_warmup_metadata(
+            "failed",
+            refreshed,
+            total,
+            message,
+            market=market,
+        )
+        price_cache.complete_warmup_heartbeat("failed", market=market)
+        self._deps.mark_market_activity_failed_safely(
+            db,
+            market=effective_market,
+            stage_key="prices",
+            lifecycle=lifecycle,
+            task_name=task_name(task),
+            task_id=task_id(task),
+            current=current,
+            total=total,
+            message=message,
+        )

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -50,6 +50,34 @@ class PriceRefreshExecutionSummary:
     processed: int = 0
 
 
+@dataclass
+class PriceRefreshExecutionAccumulator:
+    refreshed: int = 0
+    failed: int = 0
+    processed: int = 0
+    failed_symbols: list[str] = field(default_factory=list)
+    refreshed_by_market: Counter[str] = field(default_factory=Counter)
+    failed_by_market: Counter[str] = field(default_factory=Counter)
+
+    def add(self, batch: PriceRefreshBatchOutcome) -> None:
+        self.processed += len(batch.symbols)
+        self.refreshed += batch.refreshed
+        self.failed += batch.failed
+        self.failed_symbols.extend(batch.failures)
+        self.refreshed_by_market.update(batch.refreshed_by_market)
+        self.failed_by_market.update(batch.failed_by_market)
+
+    def summary(self) -> PriceRefreshExecutionSummary:
+        return PriceRefreshExecutionSummary(
+            refreshed=self.refreshed,
+            failed=self.failed,
+            failed_symbols=list(self.failed_symbols),
+            refreshed_by_market=Counter(self.refreshed_by_market),
+            failed_by_market=Counter(self.failed_by_market),
+            processed=self.processed,
+        )
+
+
 def _total_batches(jobs: Sequence[PriceRefreshJob], batch_size: int) -> int:
     return sum(
         (len(job.symbols) + batch_size - 1) // batch_size
@@ -225,25 +253,7 @@ def iter_price_refresh_batches(
 def summarize_price_refresh_batches(
     batches: Sequence[PriceRefreshBatchOutcome],
 ) -> PriceRefreshExecutionSummary:
-    refreshed_by_market: Counter[str] = Counter()
-    failed_by_market: Counter[str] = Counter()
-    failed_symbols: list[str] = []
-    refreshed = 0
-    failed = 0
-    processed = 0
+    accumulator = PriceRefreshExecutionAccumulator()
     for batch in batches:
-        processed += len(batch.symbols)
-        refreshed += batch.refreshed
-        failed += batch.failed
-        failed_symbols.extend(batch.failures)
-        refreshed_by_market.update(batch.refreshed_by_market)
-        failed_by_market.update(batch.failed_by_market)
-
-    return PriceRefreshExecutionSummary(
-        refreshed=refreshed,
-        failed=failed,
-        failed_symbols=failed_symbols,
-        refreshed_by_market=refreshed_by_market,
-        failed_by_market=failed_by_market,
-        processed=processed,
-    )
+        accumulator.add(batch)
+    return accumulator.summary()

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -1,12 +1,12 @@
-"""Live execution helpers for planned price refresh jobs."""
+"""Live fetch execution helpers for planned price refresh jobs."""
 
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 import logging
-from typing import Any, Protocol
+from typing import Any
 
 from celery.exceptions import SoftTimeLimitExceeded
 
@@ -19,59 +19,35 @@ MappingResult = Mapping[str, Mapping[str, Any]]
 
 
 @dataclass(frozen=True)
-class PriceRefreshExecutionResult:
+class PriceRefreshBatchOutcome:
+    batch_number: int
+    total_batches: int
+    job: PriceRefreshJob
+    symbols: tuple[str, ...]
+    price_data_by_symbol: Mapping[str, Any]
+    successes: tuple[str, ...]
+    failures: tuple[str, ...]
+    failure_details: Mapping[str, str]
+    refreshed_by_market: Counter[str] = field(default_factory=Counter)
+    failed_by_market: Counter[str] = field(default_factory=Counter)
+
+    @property
+    def refreshed(self) -> int:
+        return len(self.successes)
+
+    @property
+    def failed(self) -> int:
+        return len(self.failures)
+
+
+@dataclass(frozen=True)
+class PriceRefreshExecutionSummary:
     refreshed: int
     failed: int
     failed_symbols: list[str]
     refreshed_by_market: Counter[str] = field(default_factory=Counter)
     failed_by_market: Counter[str] = field(default_factory=Counter)
-
-
-class PriceRefreshExecutionContext(Protocol):
-    def fetch_batch(
-        self,
-        symbols: Sequence[str],
-        *,
-        period: str,
-        market: str | None,
-    ) -> MappingResult:
-        ...
-
-    def store_prices(self, price_data_by_symbol: Mapping[str, Any]) -> None:
-        ...
-
-    def track_symbol_failures(
-        self,
-        successes: Sequence[str],
-        failures: Sequence[str],
-        *,
-        failure_details: Mapping[str, str],
-    ) -> None:
-        ...
-
-    def market_for_symbol(self, symbol: str) -> str:
-        ...
-
-    def publish_progress(
-        self,
-        current: int,
-        total: int,
-        percent: float,
-        message: str,
-        *,
-        refreshed: int,
-        failed: int,
-    ) -> None:
-        ...
-
-    def extend_lock(self) -> None:
-        ...
-
-    def wait_between_batches(self) -> None:
-        ...
-
-    def raise_if_transient_database_error(self, exc: Exception) -> None:
-        ...
+    processed: int = 0
 
 
 def _total_batches(jobs: Sequence[PriceRefreshJob], batch_size: int) -> int:
@@ -98,145 +74,176 @@ def _record_failure(
     *,
     symbol: str,
     reason: str,
-    failed_symbols: list[str],
+    failures: list[str],
     failed_by_market: Counter[str],
-    batch_failures: list[str],
     failure_details: dict[str, str],
-    context: PriceRefreshExecutionContext,
+    market_for_symbol: Callable[[str], str],
 ) -> None:
-    failed_symbols.append(symbol)
-    failed_by_market[context.market_for_symbol(symbol)] += 1
-    batch_failures.append(symbol)
+    failures.append(symbol)
+    failed_by_market[market_for_symbol(symbol)] += 1
     failure_details[symbol] = reason
 
 
-def run_price_refresh_jobs(
+def _classify_batch_results(
     *,
-    jobs: Sequence[PriceRefreshJob],
-    total: int,
-    batch_size: int,
-    market: str | None,
-    context: PriceRefreshExecutionContext,
-) -> PriceRefreshExecutionResult:
-    total_batches = _total_batches(jobs, batch_size)
-    refreshed = 0
-    failed = 0
-    failed_symbols: list[str] = []
+    symbols: Sequence[str],
+    batch_results: MappingResult,
+    market_for_symbol: Callable[[str], str],
+) -> tuple[
+    dict[str, Any],
+    tuple[str, ...],
+    tuple[str, ...],
+    dict[str, str],
+    Counter[str],
+    Counter[str],
+]:
+    price_data_by_symbol: dict[str, Any] = {}
+    successes: list[str] = []
+    failures: list[str] = []
+    failure_details: dict[str, str] = {}
     refreshed_by_market: Counter[str] = Counter()
     failed_by_market: Counter[str] = Counter()
-    processed_count = 0
-    batch_num = 0
 
+    for symbol in symbols:
+        data = _result_for_symbol(batch_results, symbol)
+        if data is None:
+            _record_failure(
+                symbol=symbol,
+                reason="No data returned",
+                failures=failures,
+                failed_by_market=failed_by_market,
+                failure_details=failure_details,
+                market_for_symbol=market_for_symbol,
+            )
+            continue
+        if not data.get("has_error") and data.get("price_data") is not None:
+            price_df = data["price_data"]
+            if not price_df.empty:
+                price_data_by_symbol[symbol] = price_df
+                successes.append(symbol)
+                refreshed_by_market[market_for_symbol(symbol)] += 1
+                continue
+            _record_failure(
+                symbol=symbol,
+                reason="Empty data returned",
+                failures=failures,
+                failed_by_market=failed_by_market,
+                failure_details=failure_details,
+                market_for_symbol=market_for_symbol,
+            )
+            continue
+        _record_failure(
+            symbol=symbol,
+            reason=str(data.get("error", "Unknown error")),
+            failures=failures,
+            failed_by_market=failed_by_market,
+            failure_details=failure_details,
+            market_for_symbol=market_for_symbol,
+        )
+
+    return (
+        price_data_by_symbol,
+        tuple(successes),
+        tuple(failures),
+        failure_details,
+        refreshed_by_market,
+        failed_by_market,
+    )
+
+
+def iter_price_refresh_batches(
+    *,
+    jobs: Sequence[PriceRefreshJob],
+    batch_size: int,
+    market: str | None,
+    fetch_batch: Callable[..., MappingResult],
+    market_for_symbol: Callable[[str], str],
+    raise_if_transient_database_error: Callable[[Exception], None],
+) -> Iterator[PriceRefreshBatchOutcome]:
+    total_batches = _total_batches(jobs, batch_size)
+    batch_number = 0
     for job in jobs:
-        job_symbols = list(job.symbols)
+        job_symbols = tuple(job.symbols)
         for batch_start in range(0, len(job_symbols), batch_size):
             batch_symbols = job_symbols[batch_start:batch_start + batch_size]
-            batch_num += 1
-
+            batch_number += 1
             logger.info(
                 "Batch %d/%d: Fetching %d symbols (%s, period=%s)",
-                batch_num,
+                batch_number,
                 total_batches,
                 len(batch_symbols),
-                job.kind,
+                job.kind.value,
                 job.period,
             )
 
-            batch_successes: list[str] = []
-            batch_failures: list[str] = []
-            failure_details: dict[str, str] = {}
-
             try:
-                batch_results = context.fetch_batch(
+                batch_results = fetch_batch(
                     batch_symbols,
                     period=job.period,
                     market=market,
                 )
-                batch_to_store = {}
-                for symbol in batch_symbols:
-                    data = _result_for_symbol(batch_results, symbol)
-                    if data is None:
-                        failed += 1
-                        _record_failure(
-                            symbol=symbol,
-                            reason="No data returned",
-                            failed_symbols=failed_symbols,
-                            failed_by_market=failed_by_market,
-                            batch_failures=batch_failures,
-                            failure_details=failure_details,
-                            context=context,
-                        )
-                        continue
-                    if not data.get("has_error") and data.get("price_data") is not None:
-                        price_df = data["price_data"]
-                        if not price_df.empty:
-                            batch_to_store[symbol] = price_df
-                            refreshed += 1
-                            refreshed_by_market[context.market_for_symbol(symbol)] += 1
-                            batch_successes.append(symbol)
-                        else:
-                            failed += 1
-                            _record_failure(
-                                symbol=symbol,
-                                reason="Empty data returned",
-                                failed_symbols=failed_symbols,
-                                failed_by_market=failed_by_market,
-                                batch_failures=batch_failures,
-                                failure_details=failure_details,
-                                context=context,
-                            )
-                    else:
-                        failed += 1
-                        _record_failure(
-                            symbol=symbol,
-                            reason=str(data.get("error", "Unknown error")),
-                            failed_symbols=failed_symbols,
-                            failed_by_market=failed_by_market,
-                            batch_failures=batch_failures,
-                            failure_details=failure_details,
-                            context=context,
-                        )
-
-                if batch_to_store:
-                    context.store_prices(batch_to_store)
-
+                (
+                    price_data_by_symbol,
+                    successes,
+                    failures,
+                    failure_details,
+                    refreshed_by_market,
+                    failed_by_market,
+                ) = _classify_batch_results(
+                    symbols=batch_symbols,
+                    batch_results=batch_results,
+                    market_for_symbol=market_for_symbol,
+                )
             except SoftTimeLimitExceeded:
                 raise
             except Exception as exc:
-                context.raise_if_transient_database_error(exc)
-                logger.error("Batch %d error: %s", batch_num, exc)
-                failed += len(batch_symbols)
-                failed_symbols.extend(batch_symbols)
-                failed_by_market.update(context.market_for_symbol(symbol) for symbol in batch_symbols)
-                batch_failures.extend(batch_symbols)
-                failure_details.update({symbol: str(exc) for symbol in batch_symbols})
+                raise_if_transient_database_error(exc)
+                logger.error("Batch %d error: %s", batch_number, exc)
+                price_data_by_symbol = {}
+                successes = ()
+                failures = batch_symbols
+                failure_details = {symbol: str(exc) for symbol in batch_symbols}
+                refreshed_by_market = Counter()
+                failed_by_market = Counter(
+                    market_for_symbol(symbol) for symbol in batch_symbols
+                )
 
-            context.track_symbol_failures(
-                batch_successes,
-                batch_failures,
+            yield PriceRefreshBatchOutcome(
+                batch_number=batch_number,
+                total_batches=total_batches,
+                job=job,
+                symbols=batch_symbols,
+                price_data_by_symbol=price_data_by_symbol,
+                successes=successes,
+                failures=failures,
                 failure_details=failure_details,
+                refreshed_by_market=refreshed_by_market,
+                failed_by_market=failed_by_market,
             )
 
-            processed_count += len(batch_symbols)
-            progress = min(processed_count, total)
-            percent = (progress / total) * 100 if total else 100.0
-            context.publish_progress(
-                progress,
-                total,
-                percent,
-                f"Batch {batch_num}/{total_batches} · refreshing prices",
-                refreshed=refreshed,
-                failed=failed,
-            )
-            context.extend_lock()
 
-            if processed_count < total:
-                context.wait_between_batches()
+def summarize_price_refresh_batches(
+    batches: Sequence[PriceRefreshBatchOutcome],
+) -> PriceRefreshExecutionSummary:
+    refreshed_by_market: Counter[str] = Counter()
+    failed_by_market: Counter[str] = Counter()
+    failed_symbols: list[str] = []
+    refreshed = 0
+    failed = 0
+    processed = 0
+    for batch in batches:
+        processed += len(batch.symbols)
+        refreshed += batch.refreshed
+        failed += batch.failed
+        failed_symbols.extend(batch.failures)
+        refreshed_by_market.update(batch.refreshed_by_market)
+        failed_by_market.update(batch.failed_by_market)
 
-    return PriceRefreshExecutionResult(
+    return PriceRefreshExecutionSummary(
         refreshed=refreshed,
         failed=failed,
         failed_symbols=failed_symbols,
         refreshed_by_market=refreshed_by_market,
         failed_by_market=failed_by_market,
+        processed=processed,
     )

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -10,6 +10,10 @@ from typing import Any
 
 from celery.exceptions import SoftTimeLimitExceeded
 
+from .price_fetch_failures import (
+    classify_price_fetch_error,
+    normalize_price_fetch_failure_kind,
+)
 from .price_refresh_planning import PriceRefreshJob
 
 
@@ -28,6 +32,7 @@ class PriceRefreshBatchOutcome:
     successes: tuple[str, ...]
     failures: tuple[str, ...]
     failure_details: Mapping[str, str]
+    failure_kinds: Mapping[str, str] = field(default_factory=dict)
     refreshed_by_market: Counter[str] = field(default_factory=Counter)
     failed_by_market: Counter[str] = field(default_factory=Counter)
 
@@ -45,6 +50,7 @@ class PriceRefreshExecutionSummary:
     refreshed: int
     failed: int
     failed_symbols: list[str]
+    failure_kinds: Mapping[str, str] = field(default_factory=dict)
     refreshed_by_market: Counter[str] = field(default_factory=Counter)
     failed_by_market: Counter[str] = field(default_factory=Counter)
     processed: int = 0
@@ -56,6 +62,7 @@ class PriceRefreshExecutionSummary:
             refreshed=0,
             failed=0,
             failed_symbols=[],
+            failure_kinds={},
             processed=0,
             total=total,
         )
@@ -68,6 +75,7 @@ class PriceRefreshExecutionAccumulator:
     failed: int = 0
     processed: int = 0
     failed_symbols: list[str] = field(default_factory=list)
+    failure_kinds: dict[str, str] = field(default_factory=dict)
     refreshed_by_market: Counter[str] = field(default_factory=Counter)
     failed_by_market: Counter[str] = field(default_factory=Counter)
 
@@ -76,6 +84,7 @@ class PriceRefreshExecutionAccumulator:
         self.refreshed += batch.refreshed
         self.failed += batch.failed
         self.failed_symbols.extend(batch.failures)
+        self.failure_kinds.update(batch.failure_kinds)
         self.refreshed_by_market.update(batch.refreshed_by_market)
         self.failed_by_market.update(batch.failed_by_market)
 
@@ -84,6 +93,7 @@ class PriceRefreshExecutionAccumulator:
             refreshed=self.refreshed,
             failed=self.failed,
             failed_symbols=list(self.failed_symbols),
+            failure_kinds=dict(self.failure_kinds),
             refreshed_by_market=Counter(self.refreshed_by_market),
             failed_by_market=Counter(self.failed_by_market),
             processed=self.processed,
@@ -91,11 +101,23 @@ class PriceRefreshExecutionAccumulator:
         )
 
 
-def _total_batches(jobs: Sequence[PriceRefreshJob], batch_size: int) -> int:
-    return sum(
-        (len(job.symbols) + batch_size - 1) // batch_size
-        for job in jobs
-    )
+def _total_batches(jobs: Sequence[PriceRefreshJob], batch_size: int | None) -> int:
+    if batch_size is None:
+        return sum(1 for job in jobs if job.symbols)
+    return sum((len(job.symbols) + batch_size - 1) // batch_size for job in jobs)
+
+
+def _iter_job_symbol_batches(
+    symbols: tuple[str, ...],
+    batch_size: int | None,
+) -> Iterator[tuple[str, ...]]:
+    if not symbols:
+        return
+    if batch_size is None:
+        yield symbols
+        return
+    for batch_start in range(0, len(symbols), batch_size):
+        yield symbols[batch_start:batch_start + batch_size]
 
 
 def _result_for_symbol(
@@ -118,11 +140,18 @@ def _record_failure(
     failures: list[str],
     failed_by_market: Counter[str],
     failure_details: dict[str, str],
+    failure_kinds: dict[str, str],
     market_for_symbol: Callable[[str], str],
+    kind: str | None = None,
 ) -> None:
     failures.append(symbol)
     failed_by_market[market_for_symbol(symbol)] += 1
     failure_details[symbol] = reason
+    resolved_kind = normalize_price_fetch_failure_kind(kind)
+    if resolved_kind is None:
+        resolved_kind = classify_price_fetch_error(reason)
+    if resolved_kind is not None:
+        failure_kinds[symbol] = resolved_kind.value
 
 
 def _classify_batch_results(
@@ -135,6 +164,7 @@ def _classify_batch_results(
     tuple[str, ...],
     tuple[str, ...],
     dict[str, str],
+    dict[str, str],
     Counter[str],
     Counter[str],
 ]:
@@ -142,6 +172,7 @@ def _classify_batch_results(
     successes: list[str] = []
     failures: list[str] = []
     failure_details: dict[str, str] = {}
+    failure_kinds: dict[str, str] = {}
     refreshed_by_market: Counter[str] = Counter()
     failed_by_market: Counter[str] = Counter()
 
@@ -154,6 +185,7 @@ def _classify_batch_results(
                 failures=failures,
                 failed_by_market=failed_by_market,
                 failure_details=failure_details,
+                failure_kinds=failure_kinds,
                 market_for_symbol=market_for_symbol,
             )
             continue
@@ -170,6 +202,7 @@ def _classify_batch_results(
                 failures=failures,
                 failed_by_market=failed_by_market,
                 failure_details=failure_details,
+                failure_kinds=failure_kinds,
                 market_for_symbol=market_for_symbol,
             )
             continue
@@ -179,7 +212,9 @@ def _classify_batch_results(
             failures=failures,
             failed_by_market=failed_by_market,
             failure_details=failure_details,
+            failure_kinds=failure_kinds,
             market_for_symbol=market_for_symbol,
+            kind=data.get("error_kind"),
         )
 
     return (
@@ -187,6 +222,7 @@ def _classify_batch_results(
         tuple(successes),
         tuple(failures),
         failure_details,
+        failure_kinds,
         refreshed_by_market,
         failed_by_market,
     )
@@ -195,7 +231,7 @@ def _classify_batch_results(
 def iter_price_refresh_batches(
     *,
     jobs: Sequence[PriceRefreshJob],
-    batch_size: int,
+    batch_size: int | None,
     market: str | None,
     fetch_batch: Callable[..., MappingResult],
     market_for_symbol: Callable[[str], str],
@@ -205,8 +241,7 @@ def iter_price_refresh_batches(
     batch_number = 0
     for job in jobs:
         job_symbols = tuple(job.symbols)
-        for batch_start in range(0, len(job_symbols), batch_size):
-            batch_symbols = job_symbols[batch_start:batch_start + batch_size]
+        for batch_symbols in _iter_job_symbol_batches(job_symbols, batch_size):
             batch_number += 1
             logger.info(
                 "Batch %d/%d: Fetching %d symbols (%s, period=%s)",
@@ -228,6 +263,7 @@ def iter_price_refresh_batches(
                     successes,
                     failures,
                     failure_details,
+                    failure_kinds,
                     refreshed_by_market,
                     failed_by_market,
                 ) = _classify_batch_results(
@@ -244,6 +280,12 @@ def iter_price_refresh_batches(
                 successes = ()
                 failures = batch_symbols
                 failure_details = {symbol: str(exc) for symbol in batch_symbols}
+                resolved_kind = classify_price_fetch_error(str(exc))
+                failure_kinds = (
+                    {symbol: resolved_kind.value for symbol in batch_symbols}
+                    if resolved_kind is not None
+                    else {}
+                )
                 refreshed_by_market = Counter()
                 failed_by_market = Counter(
                     market_for_symbol(symbol) for symbol in batch_symbols
@@ -258,6 +300,7 @@ def iter_price_refresh_batches(
                 successes=successes,
                 failures=failures,
                 failure_details=failure_details,
+                failure_kinds=failure_kinds,
                 refreshed_by_market=refreshed_by_market,
                 failed_by_market=failed_by_market,
             )

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -48,10 +48,22 @@ class PriceRefreshExecutionSummary:
     refreshed_by_market: Counter[str] = field(default_factory=Counter)
     failed_by_market: Counter[str] = field(default_factory=Counter)
     processed: int = 0
+    total: int = 0
+
+    @classmethod
+    def empty(cls, *, total: int = 0) -> "PriceRefreshExecutionSummary":
+        return cls(
+            refreshed=0,
+            failed=0,
+            failed_symbols=[],
+            processed=0,
+            total=total,
+        )
 
 
 @dataclass
 class PriceRefreshExecutionAccumulator:
+    total: int = 0
     refreshed: int = 0
     failed: int = 0
     processed: int = 0
@@ -75,6 +87,7 @@ class PriceRefreshExecutionAccumulator:
             refreshed_by_market=Counter(self.refreshed_by_market),
             failed_by_market=Counter(self.failed_by_market),
             processed=self.processed,
+            total=self.total,
         )
 
 

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -266,7 +266,9 @@ def iter_price_refresh_batches(
 def summarize_price_refresh_batches(
     batches: Sequence[PriceRefreshBatchOutcome],
 ) -> PriceRefreshExecutionSummary:
-    accumulator = PriceRefreshExecutionAccumulator()
+    accumulator = PriceRefreshExecutionAccumulator(
+        total=sum(len(batch.symbols) for batch in batches),
+    )
     for batch in batches:
         accumulator.add(batch)
     return accumulator.summary()

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Callable, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 import logging
-from typing import Any
+from typing import Any, Protocol
 
 from celery.exceptions import SoftTimeLimitExceeded
 
@@ -15,7 +15,7 @@ from .price_refresh_planning import PriceRefreshJob
 
 logger = logging.getLogger(__name__)
 
-MappingResult = dict[str, dict[str, Any]]
+MappingResult = Mapping[str, Mapping[str, Any]]
 
 
 @dataclass(frozen=True)
@@ -27,6 +27,53 @@ class PriceRefreshExecutionResult:
     failed_by_market: Counter[str] = field(default_factory=Counter)
 
 
+class PriceRefreshExecutionContext(Protocol):
+    def fetch_batch(
+        self,
+        symbols: Sequence[str],
+        *,
+        period: str,
+        market: str | None,
+    ) -> MappingResult:
+        ...
+
+    def store_prices(self, price_data_by_symbol: Mapping[str, Any]) -> None:
+        ...
+
+    def track_symbol_failures(
+        self,
+        successes: Sequence[str],
+        failures: Sequence[str],
+        *,
+        failure_details: Mapping[str, str],
+    ) -> None:
+        ...
+
+    def market_for_symbol(self, symbol: str) -> str:
+        ...
+
+    def publish_progress(
+        self,
+        current: int,
+        total: int,
+        percent: float,
+        message: str,
+        *,
+        refreshed: int,
+        failed: int,
+    ) -> None:
+        ...
+
+    def extend_lock(self) -> None:
+        ...
+
+    def wait_between_batches(self) -> None:
+        ...
+
+    def raise_if_transient_database_error(self, exc: Exception) -> None:
+        ...
+
+
 def _total_batches(jobs: Sequence[PriceRefreshJob], batch_size: int) -> int:
     return sum(
         (len(job.symbols) + batch_size - 1) // batch_size
@@ -34,23 +81,42 @@ def _total_batches(jobs: Sequence[PriceRefreshJob], batch_size: int) -> int:
     )
 
 
+def _result_for_symbol(
+    batch_results: MappingResult,
+    symbol: str,
+) -> Mapping[str, Any] | None:
+    if symbol in batch_results:
+        return batch_results[symbol]
+    normalized_symbol = str(symbol).upper()
+    for result_symbol, result in batch_results.items():
+        if str(result_symbol).upper() == normalized_symbol:
+            return result
+    return None
+
+
+def _record_failure(
+    *,
+    symbol: str,
+    reason: str,
+    failed_symbols: list[str],
+    failed_by_market: Counter[str],
+    batch_failures: list[str],
+    failure_details: dict[str, str],
+    context: PriceRefreshExecutionContext,
+) -> None:
+    failed_symbols.append(symbol)
+    failed_by_market[context.market_for_symbol(symbol)] += 1
+    batch_failures.append(symbol)
+    failure_details[symbol] = reason
+
+
 def run_price_refresh_jobs(
     *,
     jobs: Sequence[PriceRefreshJob],
     total: int,
     batch_size: int,
-    bulk_fetcher,
-    price_cache,
-    db,
     market: str | None,
-    fetch_with_backoff: Callable[..., MappingResult],
-    track_symbol_failures: Callable[..., None],
-    market_for_symbol: Callable[[str], str],
-    mark_progress: Callable[[int, int, float, str], None],
-    update_task_state: Callable[[int, int, float, int, int], None],
-    extend_lock: Callable[[], None],
-    wait_between_batches: Callable[[], None],
-    raise_if_transient_database_error: Callable[[Exception], None],
+    context: PriceRefreshExecutionContext,
 ) -> PriceRefreshExecutionResult:
     total_batches = _total_batches(jobs, batch_size)
     refreshed = 0
@@ -81,70 +147,91 @@ def run_price_refresh_jobs(
             failure_details: dict[str, str] = {}
 
             try:
-                batch_results = fetch_with_backoff(
-                    bulk_fetcher,
+                batch_results = context.fetch_batch(
                     batch_symbols,
                     period=job.period,
                     market=market,
                 )
                 batch_to_store = {}
-                for symbol, data in batch_results.items():
+                for symbol in batch_symbols:
+                    data = _result_for_symbol(batch_results, symbol)
+                    if data is None:
+                        failed += 1
+                        _record_failure(
+                            symbol=symbol,
+                            reason="No data returned",
+                            failed_symbols=failed_symbols,
+                            failed_by_market=failed_by_market,
+                            batch_failures=batch_failures,
+                            failure_details=failure_details,
+                            context=context,
+                        )
+                        continue
                     if not data.get("has_error") and data.get("price_data") is not None:
                         price_df = data["price_data"]
                         if not price_df.empty:
                             batch_to_store[symbol] = price_df
                             refreshed += 1
-                            refreshed_by_market[market_for_symbol(symbol)] += 1
+                            refreshed_by_market[context.market_for_symbol(symbol)] += 1
                             batch_successes.append(symbol)
                         else:
                             failed += 1
-                            failed_symbols.append(symbol)
-                            failed_by_market[market_for_symbol(symbol)] += 1
-                            batch_failures.append(symbol)
-                            failure_details[symbol] = "Empty data returned"
+                            _record_failure(
+                                symbol=symbol,
+                                reason="Empty data returned",
+                                failed_symbols=failed_symbols,
+                                failed_by_market=failed_by_market,
+                                batch_failures=batch_failures,
+                                failure_details=failure_details,
+                                context=context,
+                            )
                     else:
                         failed += 1
-                        failed_symbols.append(symbol)
-                        failed_by_market[market_for_symbol(symbol)] += 1
-                        batch_failures.append(symbol)
-                        failure_details[symbol] = data.get("error", "Unknown error")
+                        _record_failure(
+                            symbol=symbol,
+                            reason=str(data.get("error", "Unknown error")),
+                            failed_symbols=failed_symbols,
+                            failed_by_market=failed_by_market,
+                            batch_failures=batch_failures,
+                            failure_details=failure_details,
+                            context=context,
+                        )
 
                 if batch_to_store:
-                    price_cache.store_batch_in_cache(batch_to_store, also_store_db=True)
+                    context.store_prices(batch_to_store)
 
             except SoftTimeLimitExceeded:
                 raise
             except Exception as exc:
-                raise_if_transient_database_error(exc)
+                context.raise_if_transient_database_error(exc)
                 logger.error("Batch %d error: %s", batch_num, exc)
                 failed += len(batch_symbols)
                 failed_symbols.extend(batch_symbols)
-                failed_by_market.update(market_for_symbol(symbol) for symbol in batch_symbols)
+                failed_by_market.update(context.market_for_symbol(symbol) for symbol in batch_symbols)
                 batch_failures.extend(batch_symbols)
                 failure_details.update({symbol: str(exc) for symbol in batch_symbols})
 
-            track_symbol_failures(
-                price_cache,
+            context.track_symbol_failures(
                 batch_successes,
                 batch_failures,
-                db,
                 failure_details=failure_details,
             )
 
             processed_count += len(batch_symbols)
             progress = min(processed_count, total)
             percent = (progress / total) * 100 if total else 100.0
-            update_task_state(progress, total, percent, refreshed, failed)
-            mark_progress(
+            context.publish_progress(
                 progress,
                 total,
                 percent,
                 f"Batch {batch_num}/{total_batches} · refreshing prices",
+                refreshed=refreshed,
+                failed=failed,
             )
-            extend_lock()
+            context.extend_lock()
 
             if processed_count < total:
-                wait_between_batches()
+                context.wait_between_batches()
 
     return PriceRefreshExecutionResult(
         refreshed=refreshed,

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -1,0 +1,155 @@
+"""Live execution helpers for planned price refresh jobs."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+import logging
+from typing import Any
+
+from celery.exceptions import SoftTimeLimitExceeded
+
+from .price_refresh_planning import PriceRefreshJob
+
+
+logger = logging.getLogger(__name__)
+
+MappingResult = dict[str, dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class PriceRefreshExecutionResult:
+    refreshed: int
+    failed: int
+    failed_symbols: list[str]
+    refreshed_by_market: Counter[str] = field(default_factory=Counter)
+    failed_by_market: Counter[str] = field(default_factory=Counter)
+
+
+def _total_batches(jobs: Sequence[PriceRefreshJob], batch_size: int) -> int:
+    return sum(
+        (len(job.symbols) + batch_size - 1) // batch_size
+        for job in jobs
+    )
+
+
+def run_price_refresh_jobs(
+    *,
+    jobs: Sequence[PriceRefreshJob],
+    total: int,
+    batch_size: int,
+    bulk_fetcher,
+    price_cache,
+    db,
+    market: str | None,
+    fetch_with_backoff: Callable[..., MappingResult],
+    track_symbol_failures: Callable[..., None],
+    market_for_symbol: Callable[[str], str],
+    mark_progress: Callable[[int, int, float, str], None],
+    update_task_state: Callable[[int, int, float, int, int], None],
+    extend_lock: Callable[[], None],
+    wait_between_batches: Callable[[], None],
+    raise_if_transient_database_error: Callable[[Exception], None],
+) -> PriceRefreshExecutionResult:
+    total_batches = _total_batches(jobs, batch_size)
+    refreshed = 0
+    failed = 0
+    failed_symbols: list[str] = []
+    refreshed_by_market: Counter[str] = Counter()
+    failed_by_market: Counter[str] = Counter()
+    processed_count = 0
+    batch_num = 0
+
+    for job in jobs:
+        job_symbols = list(job.symbols)
+        for batch_start in range(0, len(job_symbols), batch_size):
+            batch_symbols = job_symbols[batch_start:batch_start + batch_size]
+            batch_num += 1
+
+            logger.info(
+                "Batch %d/%d: Fetching %d symbols (%s, period=%s)",
+                batch_num,
+                total_batches,
+                len(batch_symbols),
+                job.kind,
+                job.period,
+            )
+
+            batch_successes: list[str] = []
+            batch_failures: list[str] = []
+            failure_details: dict[str, str] = {}
+
+            try:
+                batch_results = fetch_with_backoff(
+                    bulk_fetcher,
+                    batch_symbols,
+                    period=job.period,
+                    market=market,
+                )
+                batch_to_store = {}
+                for symbol, data in batch_results.items():
+                    if not data.get("has_error") and data.get("price_data") is not None:
+                        price_df = data["price_data"]
+                        if not price_df.empty:
+                            batch_to_store[symbol] = price_df
+                            refreshed += 1
+                            refreshed_by_market[market_for_symbol(symbol)] += 1
+                            batch_successes.append(symbol)
+                        else:
+                            failed += 1
+                            failed_symbols.append(symbol)
+                            failed_by_market[market_for_symbol(symbol)] += 1
+                            batch_failures.append(symbol)
+                            failure_details[symbol] = "Empty data returned"
+                    else:
+                        failed += 1
+                        failed_symbols.append(symbol)
+                        failed_by_market[market_for_symbol(symbol)] += 1
+                        batch_failures.append(symbol)
+                        failure_details[symbol] = data.get("error", "Unknown error")
+
+                if batch_to_store:
+                    price_cache.store_batch_in_cache(batch_to_store, also_store_db=True)
+
+            except SoftTimeLimitExceeded:
+                raise
+            except Exception as exc:
+                raise_if_transient_database_error(exc)
+                logger.error("Batch %d error: %s", batch_num, exc)
+                failed += len(batch_symbols)
+                failed_symbols.extend(batch_symbols)
+                failed_by_market.update(market_for_symbol(symbol) for symbol in batch_symbols)
+                batch_failures.extend(batch_symbols)
+                failure_details.update({symbol: str(exc) for symbol in batch_symbols})
+
+            track_symbol_failures(
+                price_cache,
+                batch_successes,
+                batch_failures,
+                db,
+                failure_details=failure_details,
+            )
+
+            processed_count += len(batch_symbols)
+            progress = min(processed_count, total)
+            percent = (progress / total) * 100 if total else 100.0
+            update_task_state(progress, total, percent, refreshed, failed)
+            mark_progress(
+                progress,
+                total,
+                percent,
+                f"Batch {batch_num}/{total_batches} · refreshing prices",
+            )
+            extend_lock()
+
+            if processed_count < total:
+                wait_between_batches()
+
+    return PriceRefreshExecutionResult(
+        refreshed=refreshed,
+        failed=failed,
+        failed_symbols=failed_symbols,
+        refreshed_by_market=refreshed_by_market,
+        failed_by_market=failed_by_market,
+    )

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -228,6 +228,43 @@ def _classify_batch_results(
     )
 
 
+def classify_price_refresh_batch(
+    *,
+    batch_number: int,
+    total_batches: int,
+    job: PriceRefreshJob,
+    symbols: Sequence[str],
+    batch_results: MappingResult,
+    market_for_symbol: Callable[[str], str],
+) -> PriceRefreshBatchOutcome:
+    (
+        price_data_by_symbol,
+        successes,
+        failures,
+        failure_details,
+        failure_kinds,
+        refreshed_by_market,
+        failed_by_market,
+    ) = _classify_batch_results(
+        symbols=symbols,
+        batch_results=batch_results,
+        market_for_symbol=market_for_symbol,
+    )
+    return PriceRefreshBatchOutcome(
+        batch_number=batch_number,
+        total_batches=total_batches,
+        job=job,
+        symbols=tuple(symbols),
+        price_data_by_symbol=price_data_by_symbol,
+        successes=successes,
+        failures=failures,
+        failure_details=failure_details,
+        failure_kinds=failure_kinds,
+        refreshed_by_market=refreshed_by_market,
+        failed_by_market=failed_by_market,
+    )
+
+
 def iter_price_refresh_batches(
     *,
     jobs: Sequence[PriceRefreshJob],
@@ -258,19 +295,15 @@ def iter_price_refresh_batches(
                     period=job.period,
                     market=market,
                 )
-                (
-                    price_data_by_symbol,
-                    successes,
-                    failures,
-                    failure_details,
-                    failure_kinds,
-                    refreshed_by_market,
-                    failed_by_market,
-                ) = _classify_batch_results(
+                yield classify_price_refresh_batch(
+                    batch_number=batch_number,
+                    total_batches=total_batches,
+                    job=job,
                     symbols=batch_symbols,
                     batch_results=batch_results,
                     market_for_symbol=market_for_symbol,
                 )
+                continue
             except SoftTimeLimitExceeded:
                 raise
             except Exception as exc:

--- a/backend/app/services/price_refresh_live_runner.py
+++ b/backend/app/services/price_refresh_live_runner.py
@@ -9,9 +9,9 @@ from typing import Any
 from ..config import settings
 from .price_refresh_activity import CeleryTaskLike, PriceRefreshActivityReporter, task_id
 from .price_refresh_execution import (
+    PriceRefreshExecutionAccumulator,
     PriceRefreshExecutionSummary,
     iter_price_refresh_batches,
-    summarize_price_refresh_batches,
 )
 from .price_refresh_planning import PriceRefreshJob
 
@@ -44,11 +44,9 @@ class LivePriceRefreshRunner:
         activity_lifecycle: str,
         symbol_markets: Mapping[str, str],
         activity_reporter: PriceRefreshActivityReporter,
+        progress_recorder: Callable[[PriceRefreshExecutionSummary], None] | None = None,
     ) -> PriceRefreshExecutionSummary:
-        batches = []
-        processed = 0
-        refreshed = 0
-        failed = 0
+        accumulator = PriceRefreshExecutionAccumulator()
 
         def market_for_symbol(symbol: str) -> str:
             return symbol_markets.get(str(symbol).upper(), effective_market)
@@ -69,7 +67,6 @@ class LivePriceRefreshRunner:
             market_for_symbol=market_for_symbol,
             raise_if_transient_database_error=self._deps.raise_if_transient_database_error,
         ):
-            batches.append(batch)
             if batch.price_data_by_symbol:
                 price_cache.store_batch_in_cache(
                     dict(batch.price_data_by_symbol),
@@ -80,13 +77,14 @@ class LivePriceRefreshRunner:
                 list(batch.successes),
                 list(batch.failures),
                 db,
-                failure_details=dict(batch.failure_details),
-            )
+                    failure_details=dict(batch.failure_details),
+                )
 
-            processed += len(batch.symbols)
-            refreshed += batch.refreshed
-            failed += batch.failed
-            percent = (processed / total) * 100 if total else 100.0
+            accumulator.add(batch)
+            summary = accumulator.summary()
+            if progress_recorder is not None:
+                progress_recorder(summary)
+            percent = (summary.processed / total) * 100 if total else 100.0
             activity_reporter.publish_progress(
                 db,
                 price_cache,
@@ -94,26 +92,18 @@ class LivePriceRefreshRunner:
                 market=market,
                 effective_market=effective_market,
                 lifecycle=activity_lifecycle,
-                current=processed,
+                current=summary.processed,
                 total=total,
                 percent=percent,
                 message=f"Batch {batch.batch_number}/{batch.total_batches} · refreshing prices",
-                refreshed=refreshed,
-                failed=failed,
+                refreshed=summary.refreshed,
+                failed=summary.failed,
             )
             self._extend_lock(task, market=market)
-            if processed < total:
+            if summary.processed < total:
                 self._wait_between_batches(market)
 
-        summary = summarize_price_refresh_batches(batches)
-        return PriceRefreshExecutionSummary(
-            refreshed=summary.refreshed,
-            failed=summary.failed,
-            failed_symbols=summary.failed_symbols,
-            refreshed_by_market=summary.refreshed_by_market,
-            failed_by_market=summary.failed_by_market,
-            processed=processed,
-        )
+        return accumulator.summary()
 
     def _extend_lock(self, task: CeleryTaskLike, *, market: str | None) -> None:
         self._deps.data_fetch_lock_factory().extend_lock(

--- a/backend/app/services/price_refresh_live_runner.py
+++ b/backend/app/services/price_refresh_live_runner.py
@@ -25,6 +25,20 @@ class LivePriceRefreshRunnerDependencies:
     raise_if_transient_database_error: Callable[[Exception], None]
 
 
+class PriceRefreshExecutionError(Exception):
+    def __init__(
+        self,
+        summary: PriceRefreshExecutionSummary,
+        cause: Exception,
+    ) -> None:
+        super().__init__(str(cause))
+        self.summary = summary
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return str(self.cause)
+
+
 class LivePriceRefreshRunner:
     def __init__(self, dependencies: LivePriceRefreshRunnerDependencies) -> None:
         self._deps = dependencies
@@ -44,9 +58,8 @@ class LivePriceRefreshRunner:
         activity_lifecycle: str,
         symbol_markets: Mapping[str, str],
         activity_reporter: PriceRefreshActivityReporter,
-        progress_recorder: Callable[[PriceRefreshExecutionSummary], None] | None = None,
     ) -> PriceRefreshExecutionSummary:
-        accumulator = PriceRefreshExecutionAccumulator()
+        accumulator = PriceRefreshExecutionAccumulator(total=total)
 
         def market_for_symbol(symbol: str) -> str:
             return symbol_markets.get(str(symbol).upper(), effective_market)
@@ -59,49 +72,50 @@ class LivePriceRefreshRunner:
                 market=market,
             )
 
-        for batch in iter_price_refresh_batches(
-            jobs=jobs,
-            batch_size=batch_size,
-            market=market,
-            fetch_batch=fetch_batch,
-            market_for_symbol=market_for_symbol,
-            raise_if_transient_database_error=self._deps.raise_if_transient_database_error,
-        ):
-            if batch.price_data_by_symbol:
-                price_cache.store_batch_in_cache(
-                    dict(batch.price_data_by_symbol),
-                    also_store_db=True,
-                )
-            self._deps.track_symbol_failures(
-                price_cache,
-                list(batch.successes),
-                list(batch.failures),
-                db,
+        try:
+            for batch in iter_price_refresh_batches(
+                jobs=jobs,
+                batch_size=batch_size,
+                market=market,
+                fetch_batch=fetch_batch,
+                market_for_symbol=market_for_symbol,
+                raise_if_transient_database_error=self._deps.raise_if_transient_database_error,
+            ):
+                if batch.price_data_by_symbol:
+                    price_cache.store_batch_in_cache(
+                        dict(batch.price_data_by_symbol),
+                        also_store_db=True,
+                    )
+                self._deps.track_symbol_failures(
+                    price_cache,
+                    list(batch.successes),
+                    list(batch.failures),
+                    db,
                     failure_details=dict(batch.failure_details),
                 )
 
-            accumulator.add(batch)
-            summary = accumulator.summary()
-            if progress_recorder is not None:
-                progress_recorder(summary)
-            percent = (summary.processed / total) * 100 if total else 100.0
-            activity_reporter.publish_progress(
-                db,
-                price_cache,
-                task=task,
-                market=market,
-                effective_market=effective_market,
-                lifecycle=activity_lifecycle,
-                current=summary.processed,
-                total=total,
-                percent=percent,
-                message=f"Batch {batch.batch_number}/{batch.total_batches} · refreshing prices",
-                refreshed=summary.refreshed,
-                failed=summary.failed,
-            )
-            self._extend_lock(task, market=market)
-            if summary.processed < total:
-                self._wait_between_batches(market)
+                accumulator.add(batch)
+                summary = accumulator.summary()
+                percent = (summary.processed / total) * 100 if total else 100.0
+                activity_reporter.publish_progress(
+                    db,
+                    price_cache,
+                    task=task,
+                    market=market,
+                    effective_market=effective_market,
+                    lifecycle=activity_lifecycle,
+                    current=summary.processed,
+                    total=total,
+                    percent=percent,
+                    message=f"Batch {batch.batch_number}/{batch.total_batches} · refreshing prices",
+                    refreshed=summary.refreshed,
+                    failed=summary.failed,
+                )
+                self._extend_lock(task, market=market)
+                if summary.processed < total:
+                    self._wait_between_batches(market)
+        except Exception as exc:
+            raise PriceRefreshExecutionError(accumulator.summary(), exc) from exc
 
         return accumulator.summary()
 

--- a/backend/app/services/price_refresh_live_runner.py
+++ b/backend/app/services/price_refresh_live_runner.py
@@ -1,0 +1,164 @@
+"""Side-effect runner for live price refresh batches."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ..config import settings
+from .price_refresh_activity import CeleryTaskLike, PriceRefreshActivityReporter, task_id
+from .price_refresh_execution import (
+    PriceRefreshExecutionSummary,
+    iter_price_refresh_batches,
+    summarize_price_refresh_batches,
+)
+from .price_refresh_planning import PriceRefreshJob
+
+
+@dataclass(frozen=True)
+class LivePriceRefreshRunnerDependencies:
+    fetch_with_backoff: Callable[..., Mapping[str, Mapping[str, Any]]]
+    track_symbol_failures: Callable[..., None]
+    rate_limiter_factory: Callable[[], Any]
+    data_fetch_lock_factory: Callable[[], Any]
+    raise_if_transient_database_error: Callable[[Exception], None]
+
+
+class LivePriceRefreshRunner:
+    def __init__(self, dependencies: LivePriceRefreshRunnerDependencies) -> None:
+        self._deps = dependencies
+
+    def run(
+        self,
+        *,
+        task: CeleryTaskLike,
+        bulk_fetcher: Any,
+        price_cache: Any,
+        db: Any,
+        jobs: Sequence[PriceRefreshJob],
+        total: int,
+        batch_size: int,
+        market: str | None,
+        effective_market: str,
+        activity_lifecycle: str,
+        symbol_markets: Mapping[str, str],
+        activity_reporter: PriceRefreshActivityReporter,
+    ) -> PriceRefreshExecutionSummary:
+        batches = []
+        processed = 0
+        refreshed = 0
+        failed = 0
+
+        def market_for_symbol(symbol: str) -> str:
+            return symbol_markets.get(str(symbol).upper(), effective_market)
+
+        def fetch_batch(symbols: Sequence[str], *, period: str, market: str | None):
+            return self._deps.fetch_with_backoff(
+                bulk_fetcher,
+                list(symbols),
+                period=period,
+                market=market,
+            )
+
+        for batch in iter_price_refresh_batches(
+            jobs=jobs,
+            batch_size=batch_size,
+            market=market,
+            fetch_batch=fetch_batch,
+            market_for_symbol=market_for_symbol,
+            raise_if_transient_database_error=self._deps.raise_if_transient_database_error,
+        ):
+            batches.append(batch)
+            if batch.price_data_by_symbol:
+                price_cache.store_batch_in_cache(
+                    dict(batch.price_data_by_symbol),
+                    also_store_db=True,
+                )
+            self._deps.track_symbol_failures(
+                price_cache,
+                list(batch.successes),
+                list(batch.failures),
+                db,
+                failure_details=dict(batch.failure_details),
+            )
+
+            processed += len(batch.symbols)
+            refreshed += batch.refreshed
+            failed += batch.failed
+            percent = (processed / total) * 100 if total else 100.0
+            activity_reporter.publish_progress(
+                db,
+                price_cache,
+                task=task,
+                market=market,
+                effective_market=effective_market,
+                lifecycle=activity_lifecycle,
+                current=processed,
+                total=total,
+                percent=percent,
+                message=f"Batch {batch.batch_number}/{batch.total_batches} · refreshing prices",
+                refreshed=refreshed,
+                failed=failed,
+            )
+            self._extend_lock(task, market=market)
+            if processed < total:
+                self._wait_between_batches(market)
+
+        summary = summarize_price_refresh_batches(batches)
+        return PriceRefreshExecutionSummary(
+            refreshed=summary.refreshed,
+            failed=summary.failed,
+            failed_symbols=summary.failed_symbols,
+            refreshed_by_market=summary.refreshed_by_market,
+            failed_by_market=summary.failed_by_market,
+            processed=processed,
+        )
+
+    def _extend_lock(self, task: CeleryTaskLike, *, market: str | None) -> None:
+        self._deps.data_fetch_lock_factory().extend_lock(
+            task_id(task) or "unknown",
+            300,
+            market=market,
+        )
+
+    def _wait_between_batches(self, market: str | None) -> None:
+        rate_limiter = self._deps.rate_limiter_factory()
+        if market is not None:
+            rate_limiter.wait_for_market("yfinance:batch", market)
+            return
+        rate_limiter.wait(
+            "yfinance:batch",
+            min_interval_s=settings.yfinance_batch_rate_limit_interval,
+        )
+
+
+@dataclass(frozen=True)
+class PriceRefreshRetryScheduler:
+    schedule_failed_symbol_retry: Callable[..., None]
+
+    def schedule(
+        self,
+        failed_symbols: Sequence[str],
+        *,
+        effective_market: str,
+        symbol_markets: Mapping[str, str],
+        activity_lifecycle: str,
+    ) -> None:
+        if not failed_symbols:
+            return
+        failed_symbols_by_market: dict[str, list[str]] = {}
+        for symbol in failed_symbols:
+            failed_symbols_by_market.setdefault(
+                symbol_markets.get(str(symbol).upper(), effective_market),
+                [],
+            ).append(symbol)
+        for retry_market, retry_symbols in failed_symbols_by_market.items():
+            kwargs = {
+                "symbols": retry_symbols,
+                "market": retry_market,
+                "attempt": 1,
+            }
+            if activity_lifecycle == "bootstrap":
+                kwargs["countdown"] = 30
+            self.schedule_failed_symbol_retry(**kwargs)

--- a/backend/app/services/price_refresh_live_runner.py
+++ b/backend/app/services/price_refresh_live_runner.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from ..config import settings
+from .price_fetch_failures import is_retryable_price_failure_kind
 from .price_refresh_activity import CeleryTaskLike, PriceRefreshActivityReporter, task_id
 from .price_refresh_execution import (
     PriceRefreshExecutionAccumulator,
@@ -20,7 +20,6 @@ from .price_refresh_planning import PriceRefreshJob
 class LivePriceRefreshRunnerDependencies:
     fetch_with_backoff: Callable[..., Mapping[str, Mapping[str, Any]]]
     track_symbol_failures: Callable[..., None]
-    rate_limiter_factory: Callable[[], Any]
     data_fetch_lock_factory: Callable[[], Any]
     raise_if_transient_database_error: Callable[[Exception], None]
 
@@ -52,7 +51,7 @@ class LivePriceRefreshRunner:
         db: Any,
         jobs: Sequence[PriceRefreshJob],
         total: int,
-        batch_size: int,
+        batch_size: int | None,
         market: str | None,
         effective_market: str,
         activity_lifecycle: str,
@@ -112,8 +111,6 @@ class LivePriceRefreshRunner:
                     failed=summary.failed,
                 )
                 self._extend_lock(task, market=market)
-                if summary.processed < total:
-                    self._wait_between_batches(market)
         except Exception as exc:
             raise PriceRefreshExecutionError(accumulator.summary(), exc) from exc
 
@@ -126,16 +123,6 @@ class LivePriceRefreshRunner:
             market=market,
         )
 
-    def _wait_between_batches(self, market: str | None) -> None:
-        rate_limiter = self._deps.rate_limiter_factory()
-        if market is not None:
-            rate_limiter.wait_for_market("yfinance:batch", market)
-            return
-        rate_limiter.wait(
-            "yfinance:batch",
-            min_interval_s=settings.yfinance_batch_rate_limit_interval,
-        )
-
 
 @dataclass(frozen=True)
 class PriceRefreshRetryScheduler:
@@ -145,14 +132,18 @@ class PriceRefreshRetryScheduler:
         self,
         failed_symbols: Sequence[str],
         *,
+        failure_kinds: Mapping[str, str] | None = None,
         effective_market: str,
         symbol_markets: Mapping[str, str],
         activity_lifecycle: str,
     ) -> None:
         if not failed_symbols:
             return
+        failure_kinds = failure_kinds or {}
         failed_symbols_by_market: dict[str, list[str]] = {}
         for symbol in failed_symbols:
+            if not is_retryable_price_failure_kind(failure_kinds.get(symbol)):
+                continue
             failed_symbols_by_market.setdefault(
                 symbol_markets.get(str(symbol).upper(), effective_market),
                 [],

--- a/backend/app/services/price_refresh_plan_builder.py
+++ b/backend/app/services/price_refresh_plan_builder.py
@@ -1,0 +1,111 @@
+"""I/O boundary that builds price-refresh planner inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from .price_history_coverage import classify_price_history
+from .price_refresh_planning import (
+    GitHubSeedOutcome,
+    LIVE_TOP_UP_MODES,
+    PriceRefreshMode,
+    PriceRefreshPlan,
+    PriceRefreshPlanningInput,
+    plan_price_refresh_from_input,
+)
+
+
+@dataclass(frozen=True)
+class PriceRefreshUniverse:
+    symbols: tuple[str, ...]
+    symbol_markets: dict[str, str]
+
+
+def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
+    return tuple(str(symbol).upper() for symbol in symbols)
+
+
+def load_active_price_refresh_universe(
+    db: Session,
+    *,
+    market: str | None,
+    effective_market: str,
+    normalize_market: Callable[[str], str],
+) -> PriceRefreshUniverse:
+    from ..models.stock_universe import StockUniverse
+
+    query = db.query(StockUniverse.symbol, StockUniverse.market).filter(
+        StockUniverse.is_active == True
+    )
+    if market is not None:
+        query = query.filter(StockUniverse.market == normalize_market(market))
+    query = query.order_by(StockUniverse.market_cap.desc().nullslast())
+    universe_rows = query.all()
+    all_symbols = tuple(row.symbol for row in universe_rows)
+    symbol_markets = {
+        str(row.symbol).upper(): normalize_market(
+            getattr(row, "market", None) or effective_market
+        )
+        for row in universe_rows
+    }
+    return PriceRefreshUniverse(symbols=all_symbols, symbol_markets=symbol_markets)
+
+
+def build_price_refresh_planning_input(
+    db: Session,
+    *,
+    mode: PriceRefreshMode | str,
+    market: str | None,
+    effective_market: str,
+    normalize_market: Callable[[str], str],
+    market_calendar_service,
+    sync_github_seed: Callable[..., Mapping[str, Any]],
+    recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None = None,
+) -> PriceRefreshPlanningInput:
+    parsed_mode = PriceRefreshMode.parse(mode)
+    universe = load_active_price_refresh_universe(
+        db,
+        market=market,
+        effective_market=effective_market,
+        normalize_market=normalize_market,
+    )
+    all_symbols = _normalize_symbols(universe.symbols)
+    github_seed = None
+    if parsed_mode in LIVE_TOP_UP_MODES and all_symbols and market is not None:
+        github_seed = GitHubSeedOutcome.from_mapping(
+            sync_github_seed(db, market=effective_market, allow_stale=True)
+        )
+
+    target_as_of = None
+    coverage = None
+    if parsed_mode in LIVE_TOP_UP_MODES and all_symbols:
+        target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
+        coverage = classify_price_history(db, symbols=all_symbols, as_of_date=target_as_of)
+
+    auto_refresh_symbols = None
+    if parsed_mode is PriceRefreshMode.AUTO and recently_refreshed_filter is not None:
+        auto_refresh_symbols = _normalize_symbols(recently_refreshed_filter(all_symbols))
+
+    return PriceRefreshPlanningInput(
+        all_symbols=all_symbols,
+        mode=parsed_mode,
+        effective_market=effective_market,
+        symbol_markets=universe.symbol_markets,
+        github_seed=github_seed,
+        coverage=coverage,
+        target_as_of=target_as_of,
+        auto_refresh_symbols=auto_refresh_symbols,
+    )
+
+
+def build_market_price_refresh_plan(
+    db: Session,
+    **kwargs,
+) -> PriceRefreshPlan:
+    return plan_price_refresh_from_input(
+        build_price_refresh_planning_input(db, **kwargs)
+    )

--- a/backend/app/services/price_refresh_planning.py
+++ b/backend/app/services/price_refresh_planning.py
@@ -39,18 +39,21 @@ class PriceRefreshJob:
 
 @dataclass(frozen=True)
 class PriceRefreshPlan:
-    source: str
     symbols: tuple[str, ...]
     jobs: tuple[PriceRefreshJob, ...] = ()
     github_sync: Mapping[str, Any] | None = None
+    github_seed_used: bool = False
     completion_message: str | None = None
 
     @property
+    def source(self) -> str:
+        if self.github_seed_used:
+            return "github+live" if self.jobs else "github"
+        return "live"
+
+    @property
     def used_github_seed(self) -> bool:
-        return (
-            self.github_sync is not None
-            and self.github_sync.get("status") in GITHUB_SYNC_SUCCESS_STATUSES
-        )
+        return self.github_seed_used
 
 
 def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
@@ -141,7 +144,7 @@ def _plan_live_full(symbols: tuple[str, ...]) -> PriceRefreshPlan:
             period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         ),
     ) if symbols else ()
-    return PriceRefreshPlan(source="live", symbols=symbols, jobs=jobs)
+    return PriceRefreshPlan(symbols=symbols, jobs=jobs)
 
 
 def _plan_live_auto(
@@ -161,7 +164,7 @@ def _plan_live_auto(
             period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         ),
     ) if refresh_symbols else ()
-    return PriceRefreshPlan(source="live", symbols=refresh_symbols, jobs=jobs)
+    return PriceRefreshPlan(symbols=refresh_symbols, jobs=jobs)
 
 
 def _plan_live_top_up(
@@ -175,9 +178,7 @@ def _plan_live_top_up(
     target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
     coverage = classify_price_history(db, symbols=symbols, as_of_date=target_as_of)
     jobs = build_top_up_jobs(coverage)
-    source = "github+live" if github_sync and jobs else "live"
     return PriceRefreshPlan(
-        source=source,
         symbols=_symbols_from_jobs(jobs),
         jobs=jobs,
         github_sync=github_sync,
@@ -190,25 +191,13 @@ def _plan_github_top_up(
     symbols: tuple[str, ...],
     effective_market: str,
     github_sync: Mapping[str, Any],
-    price_bundle_service,
     market_calendar_service,
 ) -> PriceRefreshPlan:
     target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
     github_as_of = _parse_bundle_date(github_sync.get("as_of_date"))
-
-    if github_as_of == target_as_of:
-        candidates = price_bundle_service.symbols_missing_as_of(
-            db,
-            symbols=list(symbols),
-            as_of_date=target_as_of.isoformat(),
-        )
-    else:
-        candidates = symbols
-
-    coverage = classify_price_history(db, symbols=candidates, as_of_date=target_as_of)
+    coverage = classify_price_history(db, symbols=symbols, as_of_date=target_as_of)
     jobs = build_top_up_jobs(coverage)
     live_symbols = _symbols_from_jobs(jobs)
-    source = "github+live" if live_symbols else "github"
     completion_message = None
     if not live_symbols:
         completion_message = (
@@ -217,10 +206,10 @@ def _plan_github_top_up(
             else "All symbols already fresh - no live fetch needed"
         )
     return PriceRefreshPlan(
-        source=source,
         symbols=live_symbols,
         jobs=jobs,
         github_sync=github_sync,
+        github_seed_used=True,
         completion_message=completion_message,
     )
 
@@ -230,18 +219,15 @@ def plan_price_refresh(
     *,
     all_symbols: Sequence[str],
     mode: str,
-    activity_lifecycle: str,
     effective_market: str,
-    price_bundle_service,
     market_calendar_service,
-    github_seed_allowed: bool = True,
+    github_sync: Mapping[str, Any] | None = None,
     recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None = None,
 ) -> PriceRefreshPlan:
     """Plan live price-fetch work without performing any fetches."""
     normalized_symbols = _normalize_symbols(all_symbols)
     if not normalized_symbols:
         return PriceRefreshPlan(
-            source="live",
             symbols=(),
             jobs=(),
             completion_message="No active symbols found in universe",
@@ -257,21 +243,12 @@ def plan_price_refresh(
     if mode not in LIVE_TOP_UP_MODES:
         raise ValueError(f"Unknown price refresh mode: {mode}")
 
-    github_sync: Mapping[str, Any] | None = None
-    if github_seed_allowed and activity_lifecycle in {"daily_refresh", "bootstrap"}:
-        github_sync = price_bundle_service.sync_from_github(
-            db,
-            market=effective_market,
-            allow_stale=True,
-        )
-
     if github_sync and github_sync.get("status") in GITHUB_SYNC_SUCCESS_STATUSES:
         return _plan_github_top_up(
             db,
             symbols=normalized_symbols,
             effective_market=effective_market,
             github_sync=github_sync,
-            price_bundle_service=price_bundle_service,
             market_calendar_service=market_calendar_service,
         )
 

--- a/backend/app/services/price_refresh_planning.py
+++ b/backend/app/services/price_refresh_planning.py
@@ -74,15 +74,11 @@ class GitHubSeedOutcome:
     reason: str | None = None
     error: str | None = None
     stale_reason: str | None = None
-    raw: Mapping[str, Any] | None = None
 
     @classmethod
     def from_mapping(
-        cls,
-        payload: "GitHubSeedOutcome | Mapping[str, Any] | None",
+        cls, payload: Mapping[str, Any] | None
     ) -> "GitHubSeedOutcome | None":
-        if isinstance(payload, cls):
-            return payload
         if not payload:
             return None
         raw_status = str(payload.get("status")) if payload.get("status") is not None else None
@@ -102,7 +98,6 @@ class GitHubSeedOutcome:
                 if payload.get("stale_reason") is not None
                 else None
             ),
-            raw=dict(payload),
         )
 
     @property
@@ -113,15 +108,8 @@ class GitHubSeedOutcome:
     def is_success(self) -> bool:
         return self.status in GITHUB_SYNC_SUCCESS_STATUSES
 
-    def get(self, key: str, default: Any = None) -> Any:
-        return self.to_mapping().get(key, default)
-
-    def __getitem__(self, key: str) -> Any:
-        return self.to_mapping()[key]
-
     def to_mapping(self) -> dict[str, Any]:
-        payload = dict(self.raw or {})
-        payload["status"] = self.status_value
+        payload: dict[str, Any] = {"status": self.status_value}
         if self.as_of_date is not None:
             payload["as_of_date"] = self.as_of_date.isoformat()
         if self.source_revision is not None:
@@ -160,10 +148,6 @@ class PriceRefreshPlan:
     def used_github_seed(self) -> bool:
         return self.github_seed_used
 
-    @property
-    def github_sync(self) -> Mapping[str, Any] | None:
-        return self.github_seed.to_mapping() if self.github_seed else None
-
 
 def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
     return tuple(str(symbol).upper() for symbol in symbols)
@@ -178,14 +162,6 @@ def _parse_bundle_date(value: Any) -> date | None:
         return datetime.fromisoformat(str(value)).date()
     except (TypeError, ValueError):
         return None
-
-
-def _normalize_github_seed(
-    github_sync: GitHubSeedOutcome | Mapping[str, Any] | None,
-) -> GitHubSeedOutcome | None:
-    if isinstance(github_sync, GitHubSeedOutcome):
-        return github_sync
-    return GitHubSeedOutcome.from_mapping(github_sync)
 
 
 def build_top_up_jobs(coverage: PriceHistoryCoverage) -> tuple[PriceRefreshJob, ...]:
@@ -298,12 +274,11 @@ def plan_price_refresh(
     mode: PriceRefreshMode | str,
     effective_market: str,
     market_calendar_service,
-    github_sync: GitHubSeedOutcome | Mapping[str, Any] | None = None,
+    github_seed: GitHubSeedOutcome | None = None,
     recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None = None,
 ) -> PriceRefreshPlan:
     """Plan live price-fetch work without performing any fetches."""
     parsed_mode = PriceRefreshMode.parse(mode)
-    github_seed = _normalize_github_seed(github_sync)
     normalized_symbols = _normalize_symbols(all_symbols)
     if not normalized_symbols:
         return PriceRefreshPlan(

--- a/backend/app/services/price_refresh_planning.py
+++ b/backend/app/services/price_refresh_planning.py
@@ -1,0 +1,284 @@
+"""Price refresh planning for GitHub-seeded and live market refreshes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..models.stock import StockPrice
+
+
+STALE_PRICE_TOP_UP_PERIOD = "7d"
+NO_HISTORY_PRICE_BOOTSTRAP_PERIOD = "2y"
+LIVE_TOP_UP_MODES = frozenset({"bootstrap", "delta"})
+GITHUB_SYNC_SUCCESS_STATUSES = frozenset({"success", "up_to_date"})
+
+
+@dataclass(frozen=True)
+class PriceHistoryCoverage:
+    fresh: tuple[str, ...] = ()
+    stale: tuple[str, ...] = ()
+    no_history: tuple[str, ...] = ()
+
+    @property
+    def refresh_symbols(self) -> tuple[str, ...]:
+        return self.stale + self.no_history
+
+
+@dataclass(frozen=True)
+class PriceRefreshJob:
+    kind: str
+    symbols: tuple[str, ...]
+    period: str
+
+
+@dataclass(frozen=True)
+class PriceRefreshPlan:
+    source: str
+    symbols: tuple[str, ...]
+    jobs: tuple[PriceRefreshJob, ...] = ()
+    github_sync: Mapping[str, Any] | None = None
+    completion_message: str | None = None
+
+    @property
+    def used_github_seed(self) -> bool:
+        return (
+            self.github_sync is not None
+            and self.github_sync.get("status") in GITHUB_SYNC_SUCCESS_STATUSES
+        )
+
+
+def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
+    return tuple(str(symbol).upper() for symbol in symbols)
+
+
+def _parse_bundle_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    try:
+        return datetime.fromisoformat(str(value)).date()
+    except (TypeError, ValueError):
+        return None
+
+
+def classify_price_history(
+    db: Session,
+    *,
+    symbols: Sequence[str],
+    as_of_date: date,
+) -> PriceHistoryCoverage:
+    """Split symbols by whether persisted prices already cover ``as_of_date``."""
+    normalized_symbols = _normalize_symbols(symbols)
+    latest_by_symbol: dict[str, date | None] = {}
+    for chunk_start in range(0, len(normalized_symbols), 500):
+        chunk_symbols = normalized_symbols[chunk_start:chunk_start + 500]
+        rows = (
+            db.query(StockPrice.symbol, func.max(StockPrice.date))
+            .filter(StockPrice.symbol.in_(chunk_symbols))
+            .group_by(StockPrice.symbol)
+            .all()
+        )
+        latest_by_symbol.update(
+            {str(symbol).upper(): latest_date for symbol, latest_date in rows}
+        )
+
+    fresh_symbols: list[str] = []
+    stale_symbols: list[str] = []
+    no_history_symbols: list[str] = []
+    for symbol in normalized_symbols:
+        latest_date = latest_by_symbol.get(symbol)
+        if latest_date is None:
+            no_history_symbols.append(symbol)
+        elif latest_date < as_of_date:
+            stale_symbols.append(symbol)
+        else:
+            fresh_symbols.append(symbol)
+
+    return PriceHistoryCoverage(
+        fresh=tuple(fresh_symbols),
+        stale=tuple(stale_symbols),
+        no_history=tuple(no_history_symbols),
+    )
+
+
+def build_top_up_jobs(coverage: PriceHistoryCoverage) -> tuple[PriceRefreshJob, ...]:
+    jobs: list[PriceRefreshJob] = []
+    if coverage.stale:
+        jobs.append(
+            PriceRefreshJob(
+                kind="stale",
+                symbols=coverage.stale,
+                period=STALE_PRICE_TOP_UP_PERIOD,
+            )
+        )
+    if coverage.no_history:
+        jobs.append(
+            PriceRefreshJob(
+                kind="no_history",
+                symbols=coverage.no_history,
+                period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+            )
+        )
+    return tuple(jobs)
+
+
+def _symbols_from_jobs(jobs: Sequence[PriceRefreshJob]) -> tuple[str, ...]:
+    return tuple(symbol for job in jobs for symbol in job.symbols)
+
+
+def _plan_live_full(symbols: tuple[str, ...]) -> PriceRefreshPlan:
+    jobs = (
+        PriceRefreshJob(
+            kind="full",
+            symbols=symbols,
+            period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+        ),
+    ) if symbols else ()
+    return PriceRefreshPlan(source="live", symbols=symbols, jobs=jobs)
+
+
+def _plan_live_auto(
+    symbols: tuple[str, ...],
+    *,
+    recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None,
+) -> PriceRefreshPlan:
+    refresh_symbols = (
+        _normalize_symbols(recently_refreshed_filter(symbols))
+        if recently_refreshed_filter is not None
+        else symbols
+    )
+    jobs = (
+        PriceRefreshJob(
+            kind="auto",
+            symbols=refresh_symbols,
+            period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+        ),
+    ) if refresh_symbols else ()
+    return PriceRefreshPlan(source="live", symbols=refresh_symbols, jobs=jobs)
+
+
+def _plan_live_top_up(
+    db: Session,
+    *,
+    symbols: tuple[str, ...],
+    effective_market: str,
+    market_calendar_service,
+    github_sync: Mapping[str, Any] | None = None,
+) -> PriceRefreshPlan:
+    target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
+    coverage = classify_price_history(db, symbols=symbols, as_of_date=target_as_of)
+    jobs = build_top_up_jobs(coverage)
+    source = "github+live" if github_sync and jobs else "live"
+    return PriceRefreshPlan(
+        source=source,
+        symbols=_symbols_from_jobs(jobs),
+        jobs=jobs,
+        github_sync=github_sync,
+    )
+
+
+def _plan_github_top_up(
+    db: Session,
+    *,
+    symbols: tuple[str, ...],
+    effective_market: str,
+    github_sync: Mapping[str, Any],
+    price_bundle_service,
+    market_calendar_service,
+) -> PriceRefreshPlan:
+    target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
+    github_as_of = _parse_bundle_date(github_sync.get("as_of_date"))
+
+    if github_as_of == target_as_of:
+        candidates = price_bundle_service.symbols_missing_as_of(
+            db,
+            symbols=list(symbols),
+            as_of_date=target_as_of.isoformat(),
+        )
+    else:
+        candidates = symbols
+
+    coverage = classify_price_history(db, symbols=candidates, as_of_date=target_as_of)
+    jobs = build_top_up_jobs(coverage)
+    live_symbols = _symbols_from_jobs(jobs)
+    source = "github+live" if live_symbols else "github"
+    completion_message = None
+    if not live_symbols:
+        completion_message = (
+            "GitHub daily price bundle is current - no live fetch needed"
+            if github_as_of == target_as_of
+            else "All symbols already fresh - no live fetch needed"
+        )
+    return PriceRefreshPlan(
+        source=source,
+        symbols=live_symbols,
+        jobs=jobs,
+        github_sync=github_sync,
+        completion_message=completion_message,
+    )
+
+
+def plan_price_refresh(
+    db: Session,
+    *,
+    all_symbols: Sequence[str],
+    mode: str,
+    activity_lifecycle: str,
+    effective_market: str,
+    price_bundle_service,
+    market_calendar_service,
+    github_seed_allowed: bool = True,
+    recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None = None,
+) -> PriceRefreshPlan:
+    """Plan live price-fetch work without performing any fetches."""
+    normalized_symbols = _normalize_symbols(all_symbols)
+    if not normalized_symbols:
+        return PriceRefreshPlan(
+            source="live",
+            symbols=(),
+            jobs=(),
+            completion_message="No active symbols found in universe",
+        )
+
+    if mode == "auto":
+        return _plan_live_auto(
+            normalized_symbols,
+            recently_refreshed_filter=recently_refreshed_filter,
+        )
+    if mode == "full":
+        return _plan_live_full(normalized_symbols)
+    if mode not in LIVE_TOP_UP_MODES:
+        raise ValueError(f"Unknown price refresh mode: {mode}")
+
+    github_sync: Mapping[str, Any] | None = None
+    if github_seed_allowed and activity_lifecycle in {"daily_refresh", "bootstrap"}:
+        github_sync = price_bundle_service.sync_from_github(
+            db,
+            market=effective_market,
+            allow_stale=True,
+        )
+
+    if github_sync and github_sync.get("status") in GITHUB_SYNC_SUCCESS_STATUSES:
+        return _plan_github_top_up(
+            db,
+            symbols=normalized_symbols,
+            effective_market=effective_market,
+            github_sync=github_sync,
+            price_bundle_service=price_bundle_service,
+            market_calendar_service=market_calendar_service,
+        )
+
+    return _plan_live_top_up(
+        db,
+        symbols=normalized_symbols,
+        effective_market=effective_market,
+        market_calendar_service=market_calendar_service,
+        github_sync=github_sync,
+    )

--- a/backend/app/services/price_refresh_planning.py
+++ b/backend/app/services/price_refresh_planning.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from datetime import date, datetime
 from enum import Enum
 from typing import Any
@@ -134,6 +134,8 @@ class PriceRefreshJob:
 class PriceRefreshPlan:
     symbols: tuple[str, ...]
     jobs: tuple[PriceRefreshJob, ...] = ()
+    all_symbols: tuple[str, ...] = ()
+    symbol_markets: Mapping[str, str] = field(default_factory=dict)
     github_seed: GitHubSeedOutcome | None = None
     github_seed_used: bool = False
     completion_message: str | None = None
@@ -147,6 +149,10 @@ class PriceRefreshPlan:
     @property
     def used_github_seed(self) -> bool:
         return self.github_seed_used
+
+    @property
+    def live_refresh_jobs(self) -> tuple[PriceRefreshJob, ...]:
+        return self.jobs
 
 
 def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
@@ -288,26 +294,92 @@ def plan_price_refresh(
         )
 
     if parsed_mode is PriceRefreshMode.AUTO:
-        return _plan_live_auto(
+        plan = _plan_live_auto(
             normalized_symbols,
             recently_refreshed_filter=recently_refreshed_filter,
         )
-    if parsed_mode is PriceRefreshMode.FULL:
-        return _plan_live_full(normalized_symbols)
-
-    if github_seed and github_seed.is_success:
-        return _plan_github_top_up(
+    elif parsed_mode is PriceRefreshMode.FULL:
+        plan = _plan_live_full(normalized_symbols)
+    elif github_seed and github_seed.is_success:
+        plan = _plan_github_top_up(
             db,
             symbols=normalized_symbols,
             effective_market=effective_market,
             github_seed=github_seed,
             market_calendar_service=market_calendar_service,
         )
+    else:
+        plan = _plan_live_top_up(
+            db,
+            symbols=normalized_symbols,
+            effective_market=effective_market,
+            market_calendar_service=market_calendar_service,
+            github_seed=github_seed,
+        )
 
-    return _plan_live_top_up(
+    return replace(plan, all_symbols=normalized_symbols)
+
+
+def load_active_price_refresh_universe(
+    db: Session,
+    *,
+    market: str | None,
+    effective_market: str,
+    normalize_market: Callable[[str], str],
+) -> tuple[tuple[str, ...], dict[str, str]]:
+    from ..models.stock_universe import StockUniverse
+
+    query = db.query(StockUniverse.symbol, StockUniverse.market).filter(
+        StockUniverse.is_active == True
+    )
+    if market is not None:
+        query = query.filter(StockUniverse.market == normalize_market(market))
+    query = query.order_by(StockUniverse.market_cap.desc().nullslast())
+    universe_rows = query.all()
+    all_symbols = tuple(row.symbol for row in universe_rows)
+    symbol_markets = {
+        str(row.symbol).upper(): normalize_market(
+            getattr(row, "market", None) or effective_market
+        )
+        for row in universe_rows
+    }
+    return all_symbols, symbol_markets
+
+
+def build_market_price_refresh_plan(
+    db: Session,
+    *,
+    mode: PriceRefreshMode | str,
+    market: str | None,
+    effective_market: str,
+    normalize_market: Callable[[str], str],
+    market_calendar_service,
+    sync_github_seed: Callable[..., Mapping[str, Any]],
+    recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None = None,
+) -> PriceRefreshPlan:
+    parsed_mode = PriceRefreshMode.parse(mode)
+    all_symbols, symbol_markets = load_active_price_refresh_universe(
         db,
-        symbols=normalized_symbols,
+        market=market,
+        effective_market=effective_market,
+        normalize_market=normalize_market,
+    )
+    github_seed = None
+    if parsed_mode in LIVE_TOP_UP_MODES and all_symbols and market is not None:
+        github_seed = GitHubSeedOutcome.from_mapping(
+            sync_github_seed(db, market=effective_market, allow_stale=True)
+        )
+    plan = plan_price_refresh(
+        db,
+        all_symbols=all_symbols,
+        mode=parsed_mode,
         effective_market=effective_market,
         market_calendar_service=market_calendar_service,
         github_seed=github_seed,
+        recently_refreshed_filter=recently_refreshed_filter,
+    )
+    return replace(
+        plan,
+        all_symbols=all_symbols,
+        symbol_markets=symbol_markets,
     )

--- a/backend/app/services/price_refresh_planning.py
+++ b/backend/app/services/price_refresh_planning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
+from enum import Enum
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -14,13 +15,129 @@ from .price_history_coverage import PriceHistoryCoverage, classify_price_history
 
 STALE_PRICE_TOP_UP_PERIOD = "7d"
 NO_HISTORY_PRICE_BOOTSTRAP_PERIOD = "2y"
-LIVE_TOP_UP_MODES = frozenset({"bootstrap", "delta"})
-GITHUB_SYNC_SUCCESS_STATUSES = frozenset({"success", "up_to_date"})
+
+
+class PriceRefreshMode(str, Enum):
+    AUTO = "auto"
+    FULL = "full"
+    BOOTSTRAP = "bootstrap"
+    DELTA = "delta"
+
+    @classmethod
+    def parse(cls, value: "PriceRefreshMode | str") -> "PriceRefreshMode":
+        if isinstance(value, cls):
+            return value
+        return cls(str(value))
+
+
+class PriceRefreshJobKind(str, Enum):
+    AUTO = "auto"
+    FULL = "full"
+    STALE = "stale"
+    NO_HISTORY = "no_history"
+
+
+class PriceRefreshSource(str, Enum):
+    LIVE = "live"
+    GITHUB = "github"
+    GITHUB_AND_LIVE = "github+live"
+
+
+class GitHubSeedStatus(str, Enum):
+    SUCCESS = "success"
+    UP_TO_DATE = "up_to_date"
+    MISSING = "missing"
+    ERROR = "error"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def parse(cls, value: Any) -> "GitHubSeedStatus":
+        try:
+            return cls(str(value))
+        except ValueError:
+            return cls.UNKNOWN
+
+
+LIVE_TOP_UP_MODES = frozenset({PriceRefreshMode.BOOTSTRAP, PriceRefreshMode.DELTA})
+GITHUB_SYNC_SUCCESS_STATUSES = frozenset({
+    GitHubSeedStatus.SUCCESS,
+    GitHubSeedStatus.UP_TO_DATE,
+})
+
+
+@dataclass(frozen=True)
+class GitHubSeedOutcome:
+    status: GitHubSeedStatus
+    raw_status: str | None = None
+    as_of_date: date | None = None
+    source_revision: str | None = None
+    reason: str | None = None
+    error: str | None = None
+    stale_reason: str | None = None
+    raw: Mapping[str, Any] | None = None
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: "GitHubSeedOutcome | Mapping[str, Any] | None",
+    ) -> "GitHubSeedOutcome | None":
+        if isinstance(payload, cls):
+            return payload
+        if not payload:
+            return None
+        raw_status = str(payload.get("status")) if payload.get("status") is not None else None
+        return cls(
+            status=GitHubSeedStatus.parse(raw_status),
+            raw_status=raw_status,
+            as_of_date=_parse_bundle_date(payload.get("as_of_date")),
+            source_revision=(
+                str(payload["source_revision"])
+                if payload.get("source_revision") is not None
+                else None
+            ),
+            reason=str(payload["reason"]) if payload.get("reason") is not None else None,
+            error=str(payload["error"]) if payload.get("error") is not None else None,
+            stale_reason=(
+                str(payload["stale_reason"])
+                if payload.get("stale_reason") is not None
+                else None
+            ),
+            raw=dict(payload),
+        )
+
+    @property
+    def status_value(self) -> str:
+        return self.raw_status or self.status.value
+
+    @property
+    def is_success(self) -> bool:
+        return self.status in GITHUB_SYNC_SUCCESS_STATUSES
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.to_mapping().get(key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_mapping()[key]
+
+    def to_mapping(self) -> dict[str, Any]:
+        payload = dict(self.raw or {})
+        payload["status"] = self.status_value
+        if self.as_of_date is not None:
+            payload["as_of_date"] = self.as_of_date.isoformat()
+        if self.source_revision is not None:
+            payload["source_revision"] = self.source_revision
+        if self.reason is not None:
+            payload["reason"] = self.reason
+        if self.error is not None:
+            payload["error"] = self.error
+        if self.stale_reason is not None:
+            payload["stale_reason"] = self.stale_reason
+        return payload
 
 
 @dataclass(frozen=True)
 class PriceRefreshJob:
-    kind: str
+    kind: PriceRefreshJobKind
     symbols: tuple[str, ...]
     period: str
 
@@ -29,19 +146,23 @@ class PriceRefreshJob:
 class PriceRefreshPlan:
     symbols: tuple[str, ...]
     jobs: tuple[PriceRefreshJob, ...] = ()
-    github_sync: Mapping[str, Any] | None = None
+    github_seed: GitHubSeedOutcome | None = None
     github_seed_used: bool = False
     completion_message: str | None = None
 
     @property
-    def source(self) -> str:
+    def source(self) -> PriceRefreshSource:
         if self.github_seed_used:
-            return "github+live" if self.jobs else "github"
-        return "live"
+            return PriceRefreshSource.GITHUB_AND_LIVE if self.jobs else PriceRefreshSource.GITHUB
+        return PriceRefreshSource.LIVE
 
     @property
     def used_github_seed(self) -> bool:
         return self.github_seed_used
+
+    @property
+    def github_sync(self) -> Mapping[str, Any] | None:
+        return self.github_seed.to_mapping() if self.github_seed else None
 
 
 def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
@@ -59,12 +180,20 @@ def _parse_bundle_date(value: Any) -> date | None:
         return None
 
 
+def _normalize_github_seed(
+    github_sync: GitHubSeedOutcome | Mapping[str, Any] | None,
+) -> GitHubSeedOutcome | None:
+    if isinstance(github_sync, GitHubSeedOutcome):
+        return github_sync
+    return GitHubSeedOutcome.from_mapping(github_sync)
+
+
 def build_top_up_jobs(coverage: PriceHistoryCoverage) -> tuple[PriceRefreshJob, ...]:
     jobs: list[PriceRefreshJob] = []
     if coverage.stale:
         jobs.append(
             PriceRefreshJob(
-                kind="stale",
+                kind=PriceRefreshJobKind.STALE,
                 symbols=coverage.stale,
                 period=STALE_PRICE_TOP_UP_PERIOD,
             )
@@ -72,7 +201,7 @@ def build_top_up_jobs(coverage: PriceHistoryCoverage) -> tuple[PriceRefreshJob, 
     if coverage.no_history:
         jobs.append(
             PriceRefreshJob(
-                kind="no_history",
+                kind=PriceRefreshJobKind.NO_HISTORY,
                 symbols=coverage.no_history,
                 period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
             )
@@ -87,7 +216,7 @@ def _symbols_from_jobs(jobs: Sequence[PriceRefreshJob]) -> tuple[str, ...]:
 def _plan_live_full(symbols: tuple[str, ...]) -> PriceRefreshPlan:
     jobs = (
         PriceRefreshJob(
-            kind="full",
+            kind=PriceRefreshJobKind.FULL,
             symbols=symbols,
             period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         ),
@@ -107,7 +236,7 @@ def _plan_live_auto(
     )
     jobs = (
         PriceRefreshJob(
-            kind="auto",
+            kind=PriceRefreshJobKind.AUTO,
             symbols=refresh_symbols,
             period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         ),
@@ -121,7 +250,7 @@ def _plan_live_top_up(
     symbols: tuple[str, ...],
     effective_market: str,
     market_calendar_service,
-    github_sync: Mapping[str, Any] | None = None,
+    github_seed: GitHubSeedOutcome | None = None,
 ) -> PriceRefreshPlan:
     target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
     coverage = classify_price_history(db, symbols=symbols, as_of_date=target_as_of)
@@ -129,7 +258,7 @@ def _plan_live_top_up(
     return PriceRefreshPlan(
         symbols=_symbols_from_jobs(jobs),
         jobs=jobs,
-        github_sync=github_sync,
+        github_seed=github_seed,
     )
 
 
@@ -138,11 +267,11 @@ def _plan_github_top_up(
     *,
     symbols: tuple[str, ...],
     effective_market: str,
-    github_sync: Mapping[str, Any],
+    github_seed: GitHubSeedOutcome,
     market_calendar_service,
 ) -> PriceRefreshPlan:
     target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
-    github_as_of = _parse_bundle_date(github_sync.get("as_of_date"))
+    github_as_of = github_seed.as_of_date
     coverage = classify_price_history(db, symbols=symbols, as_of_date=target_as_of)
     jobs = build_top_up_jobs(coverage)
     live_symbols = _symbols_from_jobs(jobs)
@@ -156,7 +285,7 @@ def _plan_github_top_up(
     return PriceRefreshPlan(
         symbols=live_symbols,
         jobs=jobs,
-        github_sync=github_sync,
+        github_seed=github_seed,
         github_seed_used=True,
         completion_message=completion_message,
     )
@@ -166,13 +295,15 @@ def plan_price_refresh(
     db: Session,
     *,
     all_symbols: Sequence[str],
-    mode: str,
+    mode: PriceRefreshMode | str,
     effective_market: str,
     market_calendar_service,
-    github_sync: Mapping[str, Any] | None = None,
+    github_sync: GitHubSeedOutcome | Mapping[str, Any] | None = None,
     recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None = None,
 ) -> PriceRefreshPlan:
     """Plan live price-fetch work without performing any fetches."""
+    parsed_mode = PriceRefreshMode.parse(mode)
+    github_seed = _normalize_github_seed(github_sync)
     normalized_symbols = _normalize_symbols(all_symbols)
     if not normalized_symbols:
         return PriceRefreshPlan(
@@ -181,22 +312,20 @@ def plan_price_refresh(
             completion_message="No active symbols found in universe",
         )
 
-    if mode == "auto":
+    if parsed_mode is PriceRefreshMode.AUTO:
         return _plan_live_auto(
             normalized_symbols,
             recently_refreshed_filter=recently_refreshed_filter,
         )
-    if mode == "full":
+    if parsed_mode is PriceRefreshMode.FULL:
         return _plan_live_full(normalized_symbols)
-    if mode not in LIVE_TOP_UP_MODES:
-        raise ValueError(f"Unknown price refresh mode: {mode}")
 
-    if github_sync and github_sync.get("status") in GITHUB_SYNC_SUCCESS_STATUSES:
+    if github_seed and github_seed.is_success:
         return _plan_github_top_up(
             db,
             symbols=normalized_symbols,
             effective_market=effective_market,
-            github_sync=github_sync,
+            github_seed=github_seed,
             market_calendar_service=market_calendar_service,
         )
 
@@ -205,5 +334,5 @@ def plan_price_refresh(
         symbols=normalized_symbols,
         effective_market=effective_market,
         market_calendar_service=market_calendar_service,
-        github_sync=github_sync,
+        github_seed=github_seed,
     )

--- a/backend/app/services/price_refresh_planning.py
+++ b/backend/app/services/price_refresh_planning.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import date, datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy.orm import Session
-
-from .price_history_coverage import PriceHistoryCoverage, classify_price_history
+from .price_history_coverage import PriceHistoryCoverage
 
 
 STALE_PRICE_TOP_UP_PERIOD = "7d"
@@ -155,6 +153,18 @@ class PriceRefreshPlan:
         return self.jobs
 
 
+@dataclass(frozen=True)
+class PriceRefreshPlanningInput:
+    all_symbols: Sequence[str]
+    mode: PriceRefreshMode | str
+    effective_market: str
+    symbol_markets: Mapping[str, str] = field(default_factory=dict)
+    github_seed: GitHubSeedOutcome | None = None
+    coverage: PriceHistoryCoverage | None = None
+    target_as_of: date | None = None
+    auto_refresh_symbols: Sequence[str] | None = None
+
+
 def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
     return tuple(str(symbol).upper() for symbol in symbols)
 
@@ -206,36 +216,22 @@ def _plan_live_full(symbols: tuple[str, ...]) -> PriceRefreshPlan:
     return PriceRefreshPlan(symbols=symbols, jobs=jobs)
 
 
-def _plan_live_auto(
-    symbols: tuple[str, ...],
-    *,
-    recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None,
-) -> PriceRefreshPlan:
-    refresh_symbols = (
-        _normalize_symbols(recently_refreshed_filter(symbols))
-        if recently_refreshed_filter is not None
-        else symbols
-    )
+def _plan_live_auto(symbols: tuple[str, ...]) -> PriceRefreshPlan:
     jobs = (
         PriceRefreshJob(
             kind=PriceRefreshJobKind.AUTO,
-            symbols=refresh_symbols,
+            symbols=symbols,
             period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         ),
-    ) if refresh_symbols else ()
-    return PriceRefreshPlan(symbols=refresh_symbols, jobs=jobs)
+    ) if symbols else ()
+    return PriceRefreshPlan(symbols=symbols, jobs=jobs)
 
 
 def _plan_live_top_up(
-    db: Session,
+    coverage: PriceHistoryCoverage,
     *,
-    symbols: tuple[str, ...],
-    effective_market: str,
-    market_calendar_service,
     github_seed: GitHubSeedOutcome | None = None,
 ) -> PriceRefreshPlan:
-    target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
-    coverage = classify_price_history(db, symbols=symbols, as_of_date=target_as_of)
     jobs = build_top_up_jobs(coverage)
     return PriceRefreshPlan(
         symbols=_symbols_from_jobs(jobs),
@@ -245,16 +241,12 @@ def _plan_live_top_up(
 
 
 def _plan_github_top_up(
-    db: Session,
+    coverage: PriceHistoryCoverage,
     *,
-    symbols: tuple[str, ...],
-    effective_market: str,
     github_seed: GitHubSeedOutcome,
-    market_calendar_service,
+    target_as_of: date | None,
 ) -> PriceRefreshPlan:
-    target_as_of = market_calendar_service.last_completed_trading_day(effective_market)
     github_as_of = github_seed.as_of_date
-    coverage = classify_price_history(db, symbols=symbols, as_of_date=target_as_of)
     jobs = build_top_up_jobs(coverage)
     live_symbols = _symbols_from_jobs(jobs)
     completion_message = None
@@ -273,19 +265,12 @@ def _plan_github_top_up(
     )
 
 
-def plan_price_refresh(
-    db: Session,
-    *,
-    all_symbols: Sequence[str],
-    mode: PriceRefreshMode | str,
-    effective_market: str,
-    market_calendar_service,
-    github_seed: GitHubSeedOutcome | None = None,
-    recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None = None,
+def plan_price_refresh_from_input(
+    planning_input: PriceRefreshPlanningInput,
 ) -> PriceRefreshPlan:
-    """Plan live price-fetch work without performing any fetches."""
-    parsed_mode = PriceRefreshMode.parse(mode)
-    normalized_symbols = _normalize_symbols(all_symbols)
+    """Plan price-fetch work from precomputed, side-effect-free inputs."""
+    parsed_mode = PriceRefreshMode.parse(planning_input.mode)
+    normalized_symbols = _normalize_symbols(planning_input.all_symbols)
     if not normalized_symbols:
         return PriceRefreshPlan(
             symbols=(),
@@ -295,91 +280,32 @@ def plan_price_refresh(
 
     if parsed_mode is PriceRefreshMode.AUTO:
         plan = _plan_live_auto(
-            normalized_symbols,
-            recently_refreshed_filter=recently_refreshed_filter,
+            _normalize_symbols(planning_input.auto_refresh_symbols)
+            if planning_input.auto_refresh_symbols is not None
+            else normalized_symbols
         )
     elif parsed_mode is PriceRefreshMode.FULL:
         plan = _plan_live_full(normalized_symbols)
-    elif github_seed and github_seed.is_success:
+    elif planning_input.github_seed and planning_input.github_seed.is_success:
         plan = _plan_github_top_up(
-            db,
-            symbols=normalized_symbols,
-            effective_market=effective_market,
-            github_seed=github_seed,
-            market_calendar_service=market_calendar_service,
+            _require_coverage(planning_input),
+            github_seed=planning_input.github_seed,
+            target_as_of=planning_input.target_as_of,
         )
     else:
         plan = _plan_live_top_up(
-            db,
-            symbols=normalized_symbols,
-            effective_market=effective_market,
-            market_calendar_service=market_calendar_service,
-            github_seed=github_seed,
+            _require_coverage(planning_input),
+            github_seed=planning_input.github_seed,
         )
 
-    return replace(plan, all_symbols=normalized_symbols)
-
-
-def load_active_price_refresh_universe(
-    db: Session,
-    *,
-    market: str | None,
-    effective_market: str,
-    normalize_market: Callable[[str], str],
-) -> tuple[tuple[str, ...], dict[str, str]]:
-    from ..models.stock_universe import StockUniverse
-
-    query = db.query(StockUniverse.symbol, StockUniverse.market).filter(
-        StockUniverse.is_active == True
-    )
-    if market is not None:
-        query = query.filter(StockUniverse.market == normalize_market(market))
-    query = query.order_by(StockUniverse.market_cap.desc().nullslast())
-    universe_rows = query.all()
-    all_symbols = tuple(row.symbol for row in universe_rows)
-    symbol_markets = {
-        str(row.symbol).upper(): normalize_market(
-            getattr(row, "market", None) or effective_market
-        )
-        for row in universe_rows
-    }
-    return all_symbols, symbol_markets
-
-
-def build_market_price_refresh_plan(
-    db: Session,
-    *,
-    mode: PriceRefreshMode | str,
-    market: str | None,
-    effective_market: str,
-    normalize_market: Callable[[str], str],
-    market_calendar_service,
-    sync_github_seed: Callable[..., Mapping[str, Any]],
-    recently_refreshed_filter: Callable[[Sequence[str]], Sequence[str]] | None = None,
-) -> PriceRefreshPlan:
-    parsed_mode = PriceRefreshMode.parse(mode)
-    all_symbols, symbol_markets = load_active_price_refresh_universe(
-        db,
-        market=market,
-        effective_market=effective_market,
-        normalize_market=normalize_market,
-    )
-    github_seed = None
-    if parsed_mode in LIVE_TOP_UP_MODES and all_symbols and market is not None:
-        github_seed = GitHubSeedOutcome.from_mapping(
-            sync_github_seed(db, market=effective_market, allow_stale=True)
-        )
-    plan = plan_price_refresh(
-        db,
-        all_symbols=all_symbols,
-        mode=parsed_mode,
-        effective_market=effective_market,
-        market_calendar_service=market_calendar_service,
-        github_seed=github_seed,
-        recently_refreshed_filter=recently_refreshed_filter,
-    )
     return replace(
         plan,
-        all_symbols=all_symbols,
-        symbol_markets=symbol_markets,
+        all_symbols=normalized_symbols,
+        symbol_markets=dict(planning_input.symbol_markets),
     )
+
+
+def _require_coverage(planning_input: PriceRefreshPlanningInput) -> PriceHistoryCoverage:
+    if planning_input.coverage is None:
+        raise ValueError("price refresh top-up planning requires precomputed coverage")
+    return planning_input.coverage

--- a/backend/app/services/price_refresh_planning.py
+++ b/backend/app/services/price_refresh_planning.py
@@ -7,27 +7,15 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Any
 
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from ..models.stock import StockPrice
+from .price_history_coverage import PriceHistoryCoverage, classify_price_history
 
 
 STALE_PRICE_TOP_UP_PERIOD = "7d"
 NO_HISTORY_PRICE_BOOTSTRAP_PERIOD = "2y"
 LIVE_TOP_UP_MODES = frozenset({"bootstrap", "delta"})
 GITHUB_SYNC_SUCCESS_STATUSES = frozenset({"success", "up_to_date"})
-
-
-@dataclass(frozen=True)
-class PriceHistoryCoverage:
-    fresh: tuple[str, ...] = ()
-    stale: tuple[str, ...] = ()
-    no_history: tuple[str, ...] = ()
-
-    @property
-    def refresh_symbols(self) -> tuple[str, ...]:
-        return self.stale + self.no_history
 
 
 @dataclass(frozen=True)
@@ -69,46 +57,6 @@ def _parse_bundle_date(value: Any) -> date | None:
         return datetime.fromisoformat(str(value)).date()
     except (TypeError, ValueError):
         return None
-
-
-def classify_price_history(
-    db: Session,
-    *,
-    symbols: Sequence[str],
-    as_of_date: date,
-) -> PriceHistoryCoverage:
-    """Split symbols by whether persisted prices already cover ``as_of_date``."""
-    normalized_symbols = _normalize_symbols(symbols)
-    latest_by_symbol: dict[str, date | None] = {}
-    for chunk_start in range(0, len(normalized_symbols), 500):
-        chunk_symbols = normalized_symbols[chunk_start:chunk_start + 500]
-        rows = (
-            db.query(StockPrice.symbol, func.max(StockPrice.date))
-            .filter(StockPrice.symbol.in_(chunk_symbols))
-            .group_by(StockPrice.symbol)
-            .all()
-        )
-        latest_by_symbol.update(
-            {str(symbol).upper(): latest_date for symbol, latest_date in rows}
-        )
-
-    fresh_symbols: list[str] = []
-    stale_symbols: list[str] = []
-    no_history_symbols: list[str] = []
-    for symbol in normalized_symbols:
-        latest_date = latest_by_symbol.get(symbol)
-        if latest_date is None:
-            no_history_symbols.append(symbol)
-        elif latest_date < as_of_date:
-            stale_symbols.append(symbol)
-        else:
-            fresh_symbols.append(symbol)
-
-    return PriceHistoryCoverage(
-        fresh=tuple(fresh_symbols),
-        stale=tuple(stale_symbols),
-        no_history=tuple(no_history_symbols),
-    )
 
 
 def build_top_up_jobs(coverage: PriceHistoryCoverage) -> tuple[PriceRefreshJob, ...]:

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -22,6 +22,7 @@ from ..services.price_refresh_live_runner import (
     LivePriceRefreshRunner,
     PriceRefreshRetryScheduler,
 )
+from ..services.price_refresh_execution import PriceRefreshExecutionSummary
 from ..services.price_refresh_planning import (
     GitHubSeedOutcome,
     LIVE_TOP_UP_MODES,
@@ -80,6 +81,11 @@ class PriceRefreshProgressState:
     processed: int = 0
     failed: int = 0
     total: int = 0
+
+    def update_from_summary(self, summary: PriceRefreshExecutionSummary) -> None:
+        self.refreshed = summary.refreshed
+        self.processed = summary.processed
+        self.failed = summary.failed
 
 
 class PriceRefreshWorkflow:
@@ -464,6 +470,7 @@ class PriceRefreshWorkflow:
             activity_lifecycle=activity_lifecycle,
             symbol_markets=preparation.symbol_markets,
             activity_reporter=self._deps.activity_reporter,
+            progress_recorder=progress.update_from_summary,
         )
         progress.processed = execution_result.processed
         progress.refreshed = execution_result.refreshed

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -13,10 +13,9 @@ from celery.exceptions import SoftTimeLimitExceeded
 
 from ..config import settings
 from ..services.price_refresh_actions import (
-    PriceRefreshAction,
     PriceRefreshActionFactory,
     PriceRefreshPreparation,
-    TerminalPriceRefreshAction,
+    PriceRefreshTerminalCompletion,
 )
 from ..services.price_refresh_activity import (
     CeleryTaskLike,
@@ -154,20 +153,20 @@ class PriceRefreshWorkflow:
                 activity_lifecycle=activity_lifecycle,
                 log_extra=log_extra,
             )
-            action = self._build_executable_action(
+            terminal_completion = self._build_terminal_completion(
                 mode=parsed_mode,
                 effective_market=effective_market,
                 preparation=preparation,
             )
-            if isinstance(action, TerminalPriceRefreshAction):
-                return self._complete_terminal_action(
+            if terminal_completion is not None:
+                return self._complete_terminal_refresh(
                     db,
                     price_cache,
                     task=task,
                     market=market,
                     effective_market=effective_market,
                     activity_lifecycle=activity_lifecycle,
-                    action=action,
+                    completion=terminal_completion,
                 )
 
             outcome = self._execute_live_refresh(
@@ -178,7 +177,7 @@ class PriceRefreshWorkflow:
                 market=market,
                 effective_market=effective_market,
                 activity_lifecycle=activity_lifecycle,
-                preparation=action.preparation,
+                preparation=preparation,
             )
             return outcome.to_task_result()
 
@@ -228,9 +227,9 @@ class PriceRefreshWorkflow:
             )
             raise
         except Exception as exc:
+            self._deps.safe_rollback(db)
             self._deps.raise_if_transient_database_error(exc)
             logger.error("Error in smart_refresh_cache task: %s", exc, exc_info=True)
-            self._deps.safe_rollback(db)
             summary = PriceRefreshExecutionSummary.empty()
             self._record_refresh_failure(
                 db,
@@ -380,13 +379,13 @@ class PriceRefreshWorkflow:
         )
         return preparation
 
-    def _build_executable_action(
+    def _build_terminal_completion(
         self,
         *,
         mode: PriceRefreshMode,
         effective_market: str,
         preparation: PriceRefreshPreparation,
-    ) -> PriceRefreshAction:
+    ) -> PriceRefreshTerminalCompletion | None:
         def last_completed_trading_day(action_market: str) -> Any:
             return (
                 self._deps.market_calendar_service_factory()
@@ -395,13 +394,13 @@ class PriceRefreshWorkflow:
 
         return PriceRefreshActionFactory(
             last_completed_trading_day=last_completed_trading_day,
-        ).build(
+        ).build_terminal_completion(
             mode=mode,
             effective_market=effective_market,
             preparation=preparation,
         )
 
-    def _complete_terminal_action(
+    def _complete_terminal_refresh(
         self,
         db,
         price_cache,
@@ -410,7 +409,7 @@ class PriceRefreshWorkflow:
         market: str | None,
         effective_market: str,
         activity_lifecycle: str,
-        action: TerminalPriceRefreshAction,
+        completion: PriceRefreshTerminalCompletion,
     ) -> dict[str, Any]:
         self._deps.activity_reporter.finalize_success(
             db,
@@ -419,9 +418,9 @@ class PriceRefreshWorkflow:
             market=market,
             effective_market=effective_market,
             lifecycle=activity_lifecycle,
-            finalization=action.completion.finalization,
+            finalization=completion.finalization,
         )
-        return action.completion.outcome.to_task_result()
+        return completion.outcome.to_task_result()
 
     def _execute_live_refresh(
         self,

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -4,18 +4,28 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 import logging
-from typing import Any, Protocol
+from typing import Any
 
 from celery.exceptions import SoftTimeLimitExceeded
 
 from ..config import settings
-from ..services.price_refresh_execution import run_price_refresh_jobs
+from ..services.price_refresh_activity import (
+    CeleryTaskLike,
+    PriceRefreshActivityReporter,
+    PriceRefreshFinalization,
+    PriceRefreshOutcome,
+)
+from ..services.price_refresh_live_runner import (
+    LivePriceRefreshRunner,
+    PriceRefreshRetryScheduler,
+)
 from ..services.price_refresh_planning import (
     GitHubSeedOutcome,
     LIVE_TOP_UP_MODES,
+    PriceRefreshJob,
     PriceRefreshMode,
     PriceRefreshPlan,
     PriceRefreshSource,
@@ -24,57 +34,15 @@ from ..services.price_refresh_planning import (
 logger = logging.getLogger(__name__)
 
 
-class CeleryTaskLike(Protocol):
-    name: str
-    request: Any
-
-    def update_state(self, *args, **kwargs) -> None:
-        ...
-
-
 @dataclass(frozen=True)
-class PriceRefreshOutcome:
-    status: str
-    mode: PriceRefreshMode
-    source: PriceRefreshSource
-    message: str | None = None
-    refreshed: int = 0
-    failed: int = 0
-    total: int = 0
-    failed_symbols: list[str] = field(default_factory=list)
-    completed_at: datetime = field(default_factory=datetime.now)
-    github_seed: GitHubSeedOutcome | None = None
-
-    def to_task_result(self) -> dict[str, Any]:
-        result: dict[str, Any] = {
-            "status": self.status,
-            "source": self.source.value,
-            "refreshed": self.refreshed,
-            "failed": self.failed,
-            "total": self.total,
-            "mode": self.mode.value,
-            "completed_at": self.completed_at.isoformat(),
-        }
-        if self.github_seed is not None:
-            result["github_sync_status"] = self.github_seed.status_value
-            result["source_revision"] = self.github_seed.source_revision
-        if self.message is not None:
-            result["message"] = self.message
-        if self.failed_symbols:
-            result["failed_symbols"] = self.failed_symbols[:20]
-        return result
-
-
-@dataclass(frozen=True)
-class PriceRefreshFinalization:
-    metadata_status: str
-    metadata_refreshed: int
-    metadata_total: int
-    activity_current: int
-    activity_total: int
-    message: str
-    heartbeat_status: str | None = "completed"
-    market_success_rates: Mapping[str, tuple[Any, float]] = field(default_factory=dict)
+class PriceRefreshMarketGateway:
+    normalize_market: Callable[[str], str]
+    market_tag: Callable[[str | None], str]
+    log_extra: Callable[[str | None], Mapping[str, Any]]
+    get_eastern_now: Callable[[], Any]
+    is_trading_day: Callable[[Any], bool]
+    format_market_status: Callable[[], str]
+    is_market_enabled_now: Callable[[str], bool]
 
 
 @dataclass(frozen=True)
@@ -84,132 +52,34 @@ class PriceRefreshWorkflowDependencies:
     bulk_fetcher_factory: Callable[[], Any]
     warm_benchmarks: Callable[..., Mapping[str, Any]]
     plan_price_refresh: Callable[..., PriceRefreshPlan]
-    fetch_with_backoff: Callable[..., Mapping[str, Mapping[str, Any]]]
-    track_symbol_failures: Callable[..., None]
-    schedule_failed_symbol_retry: Callable[..., None]
-    record_market_refresh_success: Callable[..., None]
-    mark_market_activity_started: Callable[..., None]
-    mark_market_activity_completed: Callable[..., None]
-    mark_market_activity_progress_safely: Callable[..., None]
-    mark_market_activity_failed_safely: Callable[..., None]
     daily_price_bundle_service_factory: Callable[[], Any]
     market_calendar_service_factory: Callable[[], Any]
-    rate_limiter_factory: Callable[[], Any]
-    normalize_market: Callable[[str], str]
-    market_tag: Callable[[str | None], str]
-    log_extra: Callable[[str | None], Mapping[str, Any]]
-    get_eastern_now: Callable[[], Any]
-    is_trading_day: Callable[[Any], bool]
-    format_market_status: Callable[[], str]
-    is_market_enabled_now: Callable[[str], bool]
+    activity_reporter: PriceRefreshActivityReporter
+    live_runner: LivePriceRefreshRunner
+    retry_scheduler: PriceRefreshRetryScheduler
+    market_gateway: PriceRefreshMarketGateway
     raise_if_transient_database_error: Callable[[Exception], None]
     safe_rollback: Callable[[Any], None]
     time_window_bypass_enabled: Callable[[], bool] = lambda: False
 
 
-@dataclass
-class LivePriceRefreshExecutionContext:
-    task: CeleryTaskLike
-    bulk_fetcher: Any
-    price_cache: Any
-    db: Any
-    market: str | None
-    effective_market: str
-    activity_lifecycle: str
+@dataclass(frozen=True)
+class PriceRefreshPreparation:
+    all_symbols: list[str]
     symbol_markets: dict[str, str]
-    dependencies: PriceRefreshWorkflowDependencies
+    github_seed: GitHubSeedOutcome | None
+    refresh_plan: PriceRefreshPlan
+    refresh_source: PriceRefreshSource
+    symbols: list[str]
+    live_refresh_jobs: list[PriceRefreshJob]
+
+
+@dataclass
+class PriceRefreshProgressState:
+    refreshed: int = 0
     processed: int = 0
-
-    def market_for_symbol(self, symbol: str) -> str:
-        return self.symbol_markets.get(str(symbol).upper(), self.effective_market)
-
-    def fetch_batch(self, symbols: Sequence[str], *, period: str, market: str | None):
-        return self.dependencies.fetch_with_backoff(
-            self.bulk_fetcher,
-            list(symbols),
-            period=period,
-            market=market,
-        )
-
-    def store_prices(self, price_data_by_symbol: Mapping[str, Any]) -> None:
-        self.price_cache.store_batch_in_cache(
-            dict(price_data_by_symbol),
-            also_store_db=True,
-        )
-
-    def track_symbol_failures(
-        self,
-        successes: Sequence[str],
-        failures: Sequence[str],
-        *,
-        failure_details: Mapping[str, str],
-    ) -> None:
-        self.dependencies.track_symbol_failures(
-            self.price_cache,
-            list(successes),
-            list(failures),
-            self.db,
-            failure_details=dict(failure_details),
-        )
-
-    def publish_progress(
-        self,
-        current: int,
-        total: int,
-        percent: float,
-        message: str,
-        *,
-        refreshed: int,
-        failed: int,
-    ) -> None:
-        self.processed = current
-        self.task.update_state(
-            state="PROGRESS",
-            meta={
-                "current": current,
-                "total": total,
-                "percent": percent,
-                "refreshed": refreshed,
-                "failed": failed,
-            },
-        )
-        self.price_cache.update_warmup_heartbeat(
-            current,
-            total,
-            percent,
-            market=self.market,
-        )
-        self.dependencies.mark_market_activity_progress_safely(
-            self.db,
-            market=self.effective_market,
-            stage_key="prices",
-            lifecycle=self.activity_lifecycle,
-            task_name=getattr(self.task, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(self.task, "request", None), "id", None),
-            current=current,
-            total=total,
-            percent=round(percent, 1),
-            message=message,
-        )
-
-    def extend_lock(self) -> None:
-        task_id = getattr(getattr(self.task, "request", None), "id", None) or "unknown"
-        from ..wiring.bootstrap import get_data_fetch_lock
-
-        get_data_fetch_lock().extend_lock(task_id, 300, market=self.market)
-
-    def wait_between_batches(self) -> None:
-        rate_limiter = self.dependencies.rate_limiter_factory()
-        if self.market is not None:
-            rate_limiter.wait_for_market("yfinance:batch", self.market)
-            return
-        rate_limiter.wait(
-            "yfinance:batch",
-            min_interval_s=settings.yfinance_batch_rate_limit_interval,
-        )
-
-    def raise_if_transient_database_error(self, exc: Exception) -> None:
-        self.dependencies.raise_if_transient_database_error(exc)
+    failed: int = 0
+    total: int = 0
 
 
 class PriceRefreshWorkflow:
@@ -225,25 +95,26 @@ class PriceRefreshWorkflow:
         activity_lifecycle: str | None = None,
     ) -> dict[str, Any]:
         parsed_mode = PriceRefreshMode.parse(mode)
+        gateway = self._deps.market_gateway
         effective_market = (
-            self._deps.normalize_market(market) if market is not None else "US"
+            gateway.normalize_market(market) if market is not None else "US"
         )
         activity_lifecycle = activity_lifecycle or "daily_refresh"
-        log_extra = self._deps.log_extra(market)
+        log_extra = gateway.log_extra(market)
 
         logger.info("=" * 80)
         logger.info(
             "TASK: Smart Cache Refresh %s (mode=%s)",
-            self._deps.market_tag(market),
+            gateway.market_tag(market),
             parsed_mode.value,
             extra=log_extra,
         )
-        logger.info("Market status: %s", self._deps.format_market_status(), extra=log_extra)
+        logger.info("Market status: %s", gateway.format_market_status(), extra=log_extra)
         logger.info("Timestamp: %s", datetime.now().strftime("%Y-%m-%d %H:%M:%S"), extra=log_extra)
         logger.info("=" * 80)
 
-        if market is not None and not self._deps.is_market_enabled_now(
-            self._deps.normalize_market(market)
+        if market is not None and not gateway.is_market_enabled_now(
+            gateway.normalize_market(market)
         ):
             logger.info("Skipping smart refresh for disabled market %s", market, extra=log_extra)
             return {
@@ -255,7 +126,7 @@ class PriceRefreshWorkflow:
             }
 
         if self._should_reject_full_refresh(parsed_mode, task, market):
-            now_et = self._deps.get_eastern_now()
+            now_et = gateway.get_eastern_now()
             return {
                 "skipped": True,
                 "reason": f"Outside refresh window (weekday={now_et.weekday()}, hour={now_et.hour})",
@@ -264,8 +135,8 @@ class PriceRefreshWorkflow:
             }
 
         if parsed_mode is PriceRefreshMode.AUTO:
-            today = self._deps.get_eastern_now().date()
-            if not self._deps.is_trading_day(today):
+            today = gateway.get_eastern_now().date()
+            if not gateway.is_trading_day(today):
                 logger.info("Skipping smart refresh (auto) - %s is not a trading day", today)
                 return {
                     "skipped": True,
@@ -276,294 +147,66 @@ class PriceRefreshWorkflow:
 
         price_cache = self._deps.price_cache_factory()
         db = self._deps.session_factory()
-
-        refreshed = 0
-        processed = 0
-        failed = 0
-        github_seed: GitHubSeedOutcome | None = None
-        execution_context: LivePriceRefreshExecutionContext | None = None
+        progress = PriceRefreshProgressState()
 
         try:
-            self._deps.mark_market_activity_started(
+            self._deps.activity_reporter.start_prices(
                 db,
+                task=task,
                 market=effective_market,
-                stage_key="prices",
                 lifecycle=activity_lifecycle,
-                task_name=getattr(task, "name", "smart_refresh_cache"),
-                task_id=getattr(getattr(task, "request", None), "id", None),
                 message="Refreshing market prices",
             )
-
-            logger.info("[1/3] Warming market benchmarks...")
-            benchmark_result = self._deps.warm_benchmarks(market=market)
-            if benchmark_result.get("error"):
-                logger.error("Benchmark warmup failed: %s", benchmark_result.get("error"))
-
-            logger.info("[2/3] Determining symbols to refresh (mode=%s)...", parsed_mode.value)
-            all_symbols, symbol_markets = self._load_active_symbol_universe(
-                db,
-                market=market,
-                effective_market=effective_market,
-            )
-
-            def symbols_needing_auto_refresh(candidate_symbols: Sequence[str]) -> Sequence[str]:
-                logger.info(
-                    "Auto refresh: %d active symbols (full universe, market cap order) %s",
-                    len(candidate_symbols),
-                    self._deps.market_tag(market),
-                    extra=log_extra,
-                )
-                refresh_symbols = price_cache.get_symbols_needing_refresh(
-                    list(candidate_symbols),
-                    max_age_hours=settings.refresh_skip_hours,
-                )
-                skipped = len(candidate_symbols) - len(refresh_symbols)
-                if skipped > 0:
-                    logger.info(
-                        "Skipping %d recently-refreshed symbols (fresh within %sh)",
-                        skipped,
-                        settings.refresh_skip_hours,
-                    )
-                return refresh_symbols
-
-            if (
-                parsed_mode in LIVE_TOP_UP_MODES
-                and all_symbols
-                and market is not None
-            ):
-                github_seed = GitHubSeedOutcome.from_mapping(
-                    self._deps.daily_price_bundle_service_factory().sync_from_github(
-                        db,
-                        market=effective_market,
-                        allow_stale=True,
-                    )
-                )
-
-            refresh_plan = self._deps.plan_price_refresh(
-                db,
-                all_symbols=all_symbols,
-                mode=parsed_mode,
-                effective_market=effective_market,
-                market_calendar_service=self._deps.market_calendar_service_factory(),
-                github_sync=github_seed,
-                recently_refreshed_filter=(
-                    symbols_needing_auto_refresh
-                    if parsed_mode is PriceRefreshMode.AUTO
-                    else None
-                ),
-            )
-            github_seed = self._github_seed_from_plan(refresh_plan)
-            refresh_source = self._source_from_plan(refresh_plan)
-            symbols = list(refresh_plan.symbols)
-            live_refresh_jobs = list(refresh_plan.jobs)
-
-            self._publish_github_seed_log(
-                github_seed=github_seed,
-                refresh_plan=refresh_plan,
-                effective_market=effective_market,
-                all_symbols=all_symbols,
-                activity_lifecycle=activity_lifecycle,
-                db=db,
-                task=task,
-                log_extra=log_extra,
-            )
-            self._log_live_symbol_plan(
-                refresh_plan=refresh_plan,
-                refresh_source=refresh_source,
-                symbols=symbols,
-                mode=parsed_mode,
-                market=market,
-                effective_market=effective_market,
-                log_extra=log_extra,
-            )
-
-            if refresh_source is PriceRefreshSource.GITHUB and not symbols:
-                message = (
-                    refresh_plan.completion_message
-                    or "GitHub daily price bundle is current - no live fetch needed"
-                )
-                trading_day = self._completion_trading_day(github_seed, effective_market)
-                outcome = PriceRefreshOutcome(
-                    status="completed",
-                    source=PriceRefreshSource.GITHUB,
-                    mode=parsed_mode,
-                    message=message,
-                    github_seed=github_seed,
-                )
-                finalization = PriceRefreshFinalization(
-                    metadata_status="completed",
-                    metadata_refreshed=len(all_symbols),
-                    metadata_total=len(all_symbols),
-                    activity_current=len(all_symbols) if all_symbols else 0,
-                    activity_total=len(all_symbols) if all_symbols else 0,
-                    message=message,
-                    market_success_rates={effective_market: (trading_day, 1.0)},
-                )
-                self._finalize_success(
-                    db,
-                    price_cache,
-                    task,
-                    market=market,
-                    effective_market=effective_market,
-                    activity_lifecycle=activity_lifecycle,
-                    finalization=finalization,
-                )
-                return outcome.to_task_result()
-
-            if not symbols:
-                message = self._empty_refresh_message(refresh_plan, parsed_mode)
-                outcome = PriceRefreshOutcome(
-                    status="completed",
-                    source=refresh_source,
-                    mode=parsed_mode,
-                    message=message,
-                    github_seed=github_seed,
-                )
-                finalization = PriceRefreshFinalization(
-                    metadata_status="completed",
-                    metadata_refreshed=0,
-                    metadata_total=0,
-                    activity_current=0,
-                    activity_total=0,
-                    message=message,
-                    heartbeat_status=None,
-                )
-                self._finalize_success(
-                    db,
-                    price_cache,
-                    task,
-                    market=market,
-                    effective_market=effective_market,
-                    activity_lifecycle=activity_lifecycle,
-                    finalization=finalization,
-                )
-                return outcome.to_task_result()
-
-            total = len(symbols)
-            symbol_market_totals = Counter(
-                symbol_markets.get(str(symbol).upper(), effective_market)
-                for symbol in symbols
-            )
-            bulk_fetcher = self._deps.bulk_fetcher_factory()
-            execution_context = LivePriceRefreshExecutionContext(
-                task=task,
-                bulk_fetcher=bulk_fetcher,
-                price_cache=price_cache,
-                db=db,
-                market=market,
-                effective_market=effective_market,
-                activity_lifecycle=activity_lifecycle,
-                symbol_markets=symbol_markets,
-                dependencies=self._deps,
-            )
-
-            price_cache.update_warmup_heartbeat(0, total, 0.0, market=market)
-            self._deps.mark_market_activity_progress_safely(
-                db,
-                market=effective_market,
-                stage_key="prices",
-                lifecycle=activity_lifecycle,
-                task_name=getattr(task, "name", "smart_refresh_cache"),
-                task_id=getattr(getattr(task, "request", None), "id", None),
-                current=0,
-                total=total,
-                percent=0,
-                message="Refreshing market prices",
-            )
-
-            logger.info("[3/3] Fetching %d symbols...", total)
-            execution_result = run_price_refresh_jobs(
-                jobs=live_refresh_jobs,
-                total=total,
-                batch_size=100,
-                market=market,
-                context=execution_context,
-            )
-            processed = execution_context.processed
-            refreshed = execution_result.refreshed
-            failed = execution_result.failed
-
-            success_rate = refreshed / total if total > 0 else 0
-            status = "completed" if success_rate >= 0.95 else "partial"
-            market_success_rates = {}
-            for refresh_market, market_total in symbol_market_totals.items():
-                market_success_rate = (
-                    execution_result.refreshed_by_market[refresh_market] / market_total
-                    if market_total > 0
-                    else 0
-                )
-                if market_success_rate >= 0.95:
-                    market_success_rates[refresh_market] = (
-                        self._deps.market_calendar_service_factory().last_completed_trading_day(
-                            refresh_market
-                        ),
-                        market_success_rate,
-                    )
-
-            self._schedule_failed_retries(
-                execution_result.failed_symbols,
-                execution_context=execution_context,
-                activity_lifecycle=activity_lifecycle,
-            )
-
-            logger.info("=" * 80)
-            logger.info("Smart refresh completed (%s mode):", parsed_mode.value)
-            logger.info("  Refreshed: %s", refreshed)
-            logger.info("  Failed: %s", failed)
-            logger.info("  Total: %s", total)
-            if execution_result.failed_symbols:
-                logger.info("  Failed symbols: %s...", execution_result.failed_symbols[:10])
-            logger.info("=" * 80)
-
-            finalization = PriceRefreshFinalization(
-                metadata_status=status,
-                metadata_refreshed=refreshed,
-                metadata_total=total,
-                activity_current=total,
-                activity_total=total,
-                message=f"Price refresh {status}",
-                market_success_rates=market_success_rates,
-            )
-            self._finalize_success(
+            preparation = self._prepare_refresh(
                 db,
                 price_cache,
-                task,
+                task=task,
+                mode=parsed_mode,
                 market=market,
                 effective_market=effective_market,
                 activity_lifecycle=activity_lifecycle,
-                finalization=finalization,
+                log_extra=log_extra,
             )
 
-            outcome = PriceRefreshOutcome(
-                status=status,
-                source=(
-                    PriceRefreshSource.GITHUB_AND_LIVE
-                    if refresh_plan.used_github_seed
-                    else PriceRefreshSource.LIVE
-                ),
+            no_live_result = self._complete_without_live_fetch(
+                db,
+                price_cache,
+                task=task,
                 mode=parsed_mode,
-                refreshed=refreshed,
-                failed=failed,
-                total=total,
-                failed_symbols=execution_result.failed_symbols,
-                github_seed=github_seed,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                preparation=preparation,
+            )
+            if no_live_result is not None:
+                return no_live_result
+
+            outcome = self._execute_live_refresh(
+                db,
+                price_cache,
+                task=task,
+                mode=parsed_mode,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                preparation=preparation,
+                progress=progress,
             )
             return outcome.to_task_result()
 
         except SoftTimeLimitExceeded:
             logger.error("Soft time limit exceeded in smart_refresh_cache", exc_info=True)
             self._deps.safe_rollback(db)
-            current_progress = getattr(execution_context, "processed", processed)
-            self._record_failure(
+            self._deps.activity_reporter.record_failure(
                 db,
                 price_cache,
-                task,
+                task=task,
                 market=market,
                 effective_market=effective_market,
-                activity_lifecycle=activity_lifecycle,
-                refreshed=refreshed,
-                total=locals().get("total", 0),
-                current=current_progress,
+                lifecycle=activity_lifecycle,
+                refreshed=progress.refreshed,
+                total=progress.total,
+                current=progress.processed,
                 message="Soft time limit exceeded",
             )
             raise
@@ -571,29 +214,339 @@ class PriceRefreshWorkflow:
             self._deps.raise_if_transient_database_error(exc)
             logger.error("Error in smart_refresh_cache task: %s", exc, exc_info=True)
             self._deps.safe_rollback(db)
-            current_progress = getattr(execution_context, "processed", processed)
-            self._record_failure(
+            self._deps.activity_reporter.record_failure(
                 db,
                 price_cache,
-                task,
+                task=task,
                 market=market,
                 effective_market=effective_market,
-                activity_lifecycle=activity_lifecycle,
-                refreshed=refreshed,
-                total=locals().get("total", 0),
-                current=current_progress,
+                lifecycle=activity_lifecycle,
+                refreshed=progress.refreshed,
+                total=progress.total,
+                current=progress.processed,
                 message=str(exc),
             )
             return {
                 "status": "failed",
                 "error": str(exc),
-                "refreshed": refreshed,
-                "failed": failed,
+                "refreshed": progress.refreshed,
+                "failed": progress.failed,
                 "mode": parsed_mode.value,
                 "timestamp": datetime.now().isoformat(),
             }
         finally:
             db.close()
+
+    def _prepare_refresh(
+        self,
+        db,
+        price_cache,
+        *,
+        task: CeleryTaskLike,
+        mode: PriceRefreshMode,
+        market: str | None,
+        effective_market: str,
+        activity_lifecycle: str,
+        log_extra: Mapping[str, Any],
+    ) -> PriceRefreshPreparation:
+        gateway = self._deps.market_gateway
+        logger.info("[1/3] Warming market benchmarks...")
+        benchmark_result = self._deps.warm_benchmarks(market=market)
+        if benchmark_result.get("error"):
+            logger.error("Benchmark warmup failed: %s", benchmark_result.get("error"))
+
+        logger.info("[2/3] Determining symbols to refresh (mode=%s)...", mode.value)
+        all_symbols, symbol_markets = self._load_active_symbol_universe(
+            db,
+            market=market,
+            effective_market=effective_market,
+        )
+
+        def symbols_needing_auto_refresh(candidate_symbols: Sequence[str]) -> Sequence[str]:
+            logger.info(
+                "Auto refresh: %d active symbols (full universe, market cap order) %s",
+                len(candidate_symbols),
+                gateway.market_tag(market),
+                extra=log_extra,
+            )
+            refresh_symbols = price_cache.get_symbols_needing_refresh(
+                list(candidate_symbols),
+                max_age_hours=settings.refresh_skip_hours,
+            )
+            skipped = len(candidate_symbols) - len(refresh_symbols)
+            if skipped > 0:
+                logger.info(
+                    "Skipping %d recently-refreshed symbols (fresh within %sh)",
+                    skipped,
+                    settings.refresh_skip_hours,
+                )
+            return refresh_symbols
+
+        github_seed = None
+        if mode in LIVE_TOP_UP_MODES and all_symbols and market is not None:
+            github_seed = GitHubSeedOutcome.from_mapping(
+                self._deps.daily_price_bundle_service_factory().sync_from_github(
+                    db,
+                    market=effective_market,
+                    allow_stale=True,
+                )
+            )
+
+        refresh_plan = self._deps.plan_price_refresh(
+            db,
+            all_symbols=all_symbols,
+            mode=mode,
+            effective_market=effective_market,
+            market_calendar_service=self._deps.market_calendar_service_factory(),
+            github_seed=github_seed,
+            recently_refreshed_filter=(
+                symbols_needing_auto_refresh
+                if mode is PriceRefreshMode.AUTO
+                else None
+            ),
+        )
+        preparation = PriceRefreshPreparation(
+            all_symbols=all_symbols,
+            symbol_markets=symbol_markets,
+            github_seed=refresh_plan.github_seed,
+            refresh_plan=refresh_plan,
+            refresh_source=refresh_plan.source,
+            symbols=list(refresh_plan.symbols),
+            live_refresh_jobs=list(refresh_plan.jobs),
+        )
+        self._publish_github_seed_log(
+            github_seed=preparation.github_seed,
+            refresh_plan=refresh_plan,
+            effective_market=effective_market,
+            all_symbols=all_symbols,
+            activity_lifecycle=activity_lifecycle,
+            db=db,
+            task=task,
+            log_extra=log_extra,
+        )
+        self._log_live_symbol_plan(
+            refresh_plan=refresh_plan,
+            refresh_source=preparation.refresh_source,
+            symbols=preparation.symbols,
+            mode=mode,
+            market=market,
+            effective_market=effective_market,
+            log_extra=log_extra,
+        )
+        return preparation
+
+    def _complete_without_live_fetch(
+        self,
+        db,
+        price_cache,
+        *,
+        task: CeleryTaskLike,
+        mode: PriceRefreshMode,
+        market: str | None,
+        effective_market: str,
+        activity_lifecycle: str,
+        preparation: PriceRefreshPreparation,
+    ) -> dict[str, Any] | None:
+        if preparation.refresh_source is PriceRefreshSource.GITHUB and not preparation.symbols:
+            message = (
+                preparation.refresh_plan.completion_message
+                or "GitHub daily price bundle is current - no live fetch needed"
+            )
+            trading_day = self._completion_trading_day(
+                preparation.github_seed,
+                effective_market,
+            )
+            outcome = PriceRefreshOutcome(
+                status="completed",
+                source=PriceRefreshSource.GITHUB,
+                mode=mode,
+                message=message,
+                github_seed=preparation.github_seed,
+            )
+            finalization = PriceRefreshFinalization(
+                metadata_status="completed",
+                metadata_refreshed=len(preparation.all_symbols),
+                metadata_total=len(preparation.all_symbols),
+                activity_current=len(preparation.all_symbols) if preparation.all_symbols else 0,
+                activity_total=len(preparation.all_symbols) if preparation.all_symbols else 0,
+                message=message,
+                market_success_rates={effective_market: (trading_day, 1.0)},
+            )
+            self._deps.activity_reporter.finalize_success(
+                db,
+                price_cache,
+                task=task,
+                market=market,
+                effective_market=effective_market,
+                lifecycle=activity_lifecycle,
+                finalization=finalization,
+            )
+            return outcome.to_task_result()
+
+        if preparation.symbols:
+            return None
+
+        message = self._empty_refresh_message(preparation.refresh_plan, mode)
+        outcome = PriceRefreshOutcome(
+            status="completed",
+            source=preparation.refresh_source,
+            mode=mode,
+            message=message,
+            github_seed=preparation.github_seed,
+        )
+        finalization = PriceRefreshFinalization(
+            metadata_status="completed",
+            metadata_refreshed=0,
+            metadata_total=0,
+            activity_current=0,
+            activity_total=0,
+            message=message,
+            heartbeat_status=None,
+        )
+        self._deps.activity_reporter.finalize_success(
+            db,
+            price_cache,
+            task=task,
+            market=market,
+            effective_market=effective_market,
+            lifecycle=activity_lifecycle,
+            finalization=finalization,
+        )
+        return outcome.to_task_result()
+
+    def _execute_live_refresh(
+        self,
+        db,
+        price_cache,
+        *,
+        task: CeleryTaskLike,
+        mode: PriceRefreshMode,
+        market: str | None,
+        effective_market: str,
+        activity_lifecycle: str,
+        preparation: PriceRefreshPreparation,
+        progress: PriceRefreshProgressState,
+    ) -> PriceRefreshOutcome:
+        total = len(preparation.symbols)
+        progress.total = total
+        symbol_market_totals = Counter(
+            preparation.symbol_markets.get(str(symbol).upper(), effective_market)
+            for symbol in preparation.symbols
+        )
+        bulk_fetcher = self._deps.bulk_fetcher_factory()
+
+        self._deps.activity_reporter.publish_progress(
+            db,
+            price_cache,
+            task=task,
+            market=market,
+            effective_market=effective_market,
+            lifecycle=activity_lifecycle,
+            current=0,
+            total=total,
+            percent=0,
+            message="Refreshing market prices",
+            refreshed=0,
+            failed=0,
+        )
+
+        logger.info("[3/3] Fetching %d symbols...", total)
+        execution_result = self._deps.live_runner.run(
+            task=task,
+            bulk_fetcher=bulk_fetcher,
+            price_cache=price_cache,
+            db=db,
+            jobs=preparation.live_refresh_jobs,
+            total=total,
+            batch_size=100,
+            market=market,
+            effective_market=effective_market,
+            activity_lifecycle=activity_lifecycle,
+            symbol_markets=preparation.symbol_markets,
+            activity_reporter=self._deps.activity_reporter,
+        )
+        progress.processed = execution_result.processed
+        progress.refreshed = execution_result.refreshed
+        progress.failed = execution_result.failed
+
+        success_rate = progress.refreshed / total if total > 0 else 0
+        status = "completed" if success_rate >= 0.95 else "partial"
+        market_success_rates = self._market_success_rates(
+            symbol_market_totals=symbol_market_totals,
+            refreshed_by_market=execution_result.refreshed_by_market,
+        )
+
+        self._deps.retry_scheduler.schedule(
+            execution_result.failed_symbols,
+            effective_market=effective_market,
+            symbol_markets=preparation.symbol_markets,
+            activity_lifecycle=activity_lifecycle,
+        )
+
+        logger.info("=" * 80)
+        logger.info("Smart refresh completed (%s mode):", mode.value)
+        logger.info("  Refreshed: %s", progress.refreshed)
+        logger.info("  Failed: %s", progress.failed)
+        logger.info("  Total: %s", total)
+        if execution_result.failed_symbols:
+            logger.info("  Failed symbols: %s...", execution_result.failed_symbols[:10])
+        logger.info("=" * 80)
+
+        finalization = PriceRefreshFinalization(
+            metadata_status=status,
+            metadata_refreshed=progress.refreshed,
+            metadata_total=total,
+            activity_current=total,
+            activity_total=total,
+            message=f"Price refresh {status}",
+            market_success_rates=market_success_rates,
+        )
+        self._deps.activity_reporter.finalize_success(
+            db,
+            price_cache,
+            task=task,
+            market=market,
+            effective_market=effective_market,
+            lifecycle=activity_lifecycle,
+            finalization=finalization,
+        )
+
+        return PriceRefreshOutcome(
+            status=status,
+            source=(
+                PriceRefreshSource.GITHUB_AND_LIVE
+                if preparation.refresh_plan.used_github_seed
+                else PriceRefreshSource.LIVE
+            ),
+            mode=mode,
+            refreshed=progress.refreshed,
+            failed=progress.failed,
+            total=total,
+            failed_symbols=execution_result.failed_symbols,
+            github_seed=preparation.github_seed,
+        )
+
+    def _market_success_rates(
+        self,
+        *,
+        symbol_market_totals: Mapping[str, int],
+        refreshed_by_market: Mapping[str, int],
+    ) -> dict[str, tuple[Any, float]]:
+        market_success_rates = {}
+        for refresh_market, market_total in symbol_market_totals.items():
+            market_success_rate = (
+                refreshed_by_market[refresh_market] / market_total
+                if market_total > 0
+                else 0
+            )
+            if market_success_rate >= 0.95:
+                market_success_rates[refresh_market] = (
+                    self._deps.market_calendar_service_factory().last_completed_trading_day(
+                        refresh_market
+                    ),
+                    market_success_rate,
+                )
+        return market_success_rates
 
     def _should_reject_full_refresh(
         self,
@@ -612,7 +565,7 @@ class PriceRefreshWorkflow:
         )
         if is_manual:
             return False
-        now_et = self._deps.get_eastern_now()
+        now_et = self._deps.market_gateway.get_eastern_now()
         weekday = now_et.weekday()
         hour = now_et.hour
         in_weekday_window = weekday < 5 and 16 <= hour < 24
@@ -640,12 +593,14 @@ class PriceRefreshWorkflow:
             StockUniverse.is_active == True
         )
         if market is not None:
-            query = query.filter(StockUniverse.market == self._deps.normalize_market(market))
+            query = query.filter(
+                StockUniverse.market == self._deps.market_gateway.normalize_market(market)
+            )
         query = query.order_by(StockUniverse.market_cap.desc().nullslast())
         universe_rows = query.all()
         all_symbols = [row.symbol for row in universe_rows]
         symbol_markets = {
-            str(row.symbol).upper(): self._deps.normalize_market(
+            str(row.symbol).upper(): self._deps.market_gateway.normalize_market(
                 getattr(row, "market", None) or effective_market
             )
             for row in universe_rows
@@ -682,17 +637,13 @@ class PriceRefreshWorkflow:
                 github_seed.stale_reason,
                 extra=log_extra,
             )
-            self._deps.mark_market_activity_progress_safely(
+            self._deps.activity_reporter.publish_github_seed_fallback(
                 db,
+                task=task,
                 market=effective_market,
-                stage_key="prices",
                 lifecycle=activity_lifecycle,
-                task_name=getattr(task, "name", "smart_refresh_cache"),
-                task_id=getattr(getattr(task, "request", None), "id", None),
-                current=0,
                 total=len(all_symbols),
-                percent=0,
-                message=f"GitHub price bundle {github_seed.status_value}; using live price refresh",
+                status_value=github_seed.status_value,
             )
 
     def _log_live_symbol_plan(
@@ -719,14 +670,14 @@ class PriceRefreshWorkflow:
             logger.info(
                 "Full refresh: %d symbols (market cap order) %s",
                 len(symbols),
-                self._deps.market_tag(market),
+                self._deps.market_gateway.market_tag(market),
                 extra=log_extra,
             )
         elif mode in {PriceRefreshMode.BOOTSTRAP, PriceRefreshMode.DELTA}:
             logger.info(
                 "Delta refresh: %d symbols %s",
                 len(symbols),
-                self._deps.market_tag(market),
+                self._deps.market_gateway.market_tag(market),
                 extra=log_extra,
             )
 
@@ -753,117 +704,3 @@ class PriceRefreshWorkflow:
         if mode in {PriceRefreshMode.BOOTSTRAP, PriceRefreshMode.DELTA}:
             return "All symbols already fresh - no live fetch needed"
         return "No active symbols found in universe"
-
-    @staticmethod
-    def _github_seed_from_plan(refresh_plan: PriceRefreshPlan) -> GitHubSeedOutcome | None:
-        github_seed = getattr(refresh_plan, "github_seed", None)
-        if github_seed is not None:
-            return github_seed
-        return GitHubSeedOutcome.from_mapping(getattr(refresh_plan, "github_sync", None))
-
-    @staticmethod
-    def _source_from_plan(refresh_plan: PriceRefreshPlan) -> PriceRefreshSource:
-        source = getattr(refresh_plan, "source", PriceRefreshSource.LIVE)
-        if isinstance(source, PriceRefreshSource):
-            return source
-        return PriceRefreshSource(str(source))
-
-    def _finalize_success(
-        self,
-        db,
-        price_cache,
-        task: CeleryTaskLike,
-        *,
-        market: str | None,
-        effective_market: str,
-        activity_lifecycle: str,
-        finalization: PriceRefreshFinalization,
-    ) -> None:
-        price_cache.save_warmup_metadata(
-            finalization.metadata_status,
-            finalization.metadata_refreshed,
-            finalization.metadata_total,
-            market=market,
-        )
-        if finalization.heartbeat_status is not None:
-            price_cache.complete_warmup_heartbeat(
-                finalization.heartbeat_status,
-                market=market,
-            )
-        self._deps.mark_market_activity_completed(
-            db,
-            market=effective_market,
-            stage_key="prices",
-            lifecycle=activity_lifecycle,
-            task_name=getattr(task, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(task, "request", None), "id", None),
-            current=finalization.activity_current,
-            total=finalization.activity_total,
-            message=finalization.message,
-        )
-        for refresh_market, (trading_day, success_rate) in finalization.market_success_rates.items():
-            self._deps.record_market_refresh_success(
-                db,
-                market=refresh_market,
-                trading_day=trading_day,
-                success_rate=success_rate,
-            )
-
-    def _record_failure(
-        self,
-        db,
-        price_cache,
-        task: CeleryTaskLike,
-        *,
-        market: str | None,
-        effective_market: str,
-        activity_lifecycle: str,
-        refreshed: int,
-        total: int,
-        current: int,
-        message: str,
-    ) -> None:
-        price_cache.save_warmup_metadata(
-            "failed",
-            refreshed,
-            total,
-            message,
-            market=market,
-        )
-        price_cache.complete_warmup_heartbeat("failed", market=market)
-        self._deps.mark_market_activity_failed_safely(
-            db,
-            market=effective_market,
-            stage_key="prices",
-            lifecycle=activity_lifecycle,
-            task_name=getattr(task, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(task, "request", None), "id", None),
-            current=current,
-            total=total,
-            message=message,
-        )
-
-    def _schedule_failed_retries(
-        self,
-        failed_symbols: Sequence[str],
-        *,
-        execution_context: LivePriceRefreshExecutionContext,
-        activity_lifecycle: str,
-    ) -> None:
-        if not failed_symbols:
-            return
-        failed_symbols_by_market: dict[str, list[str]] = {}
-        for symbol in failed_symbols:
-            failed_symbols_by_market.setdefault(
-                execution_context.market_for_symbol(symbol),
-                [],
-            ).append(symbol)
-        for retry_market, retry_symbols in failed_symbols_by_market.items():
-            kwargs = {
-                "symbols": retry_symbols,
-                "market": retry_market,
-                "attempt": 1,
-            }
-            if activity_lifecycle == "bootstrap":
-                kwargs["countdown"] = 30
-            self._deps.schedule_failed_symbol_retry(**kwargs)

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -1,0 +1,869 @@
+"""Application workflow for smart market price refreshes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+import logging
+from typing import Any, Protocol
+
+from celery.exceptions import SoftTimeLimitExceeded
+
+from ..config import settings
+from ..services.price_refresh_execution import run_price_refresh_jobs
+from ..services.price_refresh_planning import (
+    GitHubSeedOutcome,
+    LIVE_TOP_UP_MODES,
+    PriceRefreshMode,
+    PriceRefreshPlan,
+    PriceRefreshSource,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CeleryTaskLike(Protocol):
+    name: str
+    request: Any
+
+    def update_state(self, *args, **kwargs) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class PriceRefreshOutcome:
+    status: str
+    mode: PriceRefreshMode
+    source: PriceRefreshSource
+    message: str | None = None
+    refreshed: int = 0
+    failed: int = 0
+    total: int = 0
+    failed_symbols: list[str] = field(default_factory=list)
+    completed_at: datetime = field(default_factory=datetime.now)
+    github_seed: GitHubSeedOutcome | None = None
+
+    def to_task_result(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "status": self.status,
+            "source": self.source.value,
+            "refreshed": self.refreshed,
+            "failed": self.failed,
+            "total": self.total,
+            "mode": self.mode.value,
+            "completed_at": self.completed_at.isoformat(),
+        }
+        if self.github_seed is not None:
+            result["github_sync_status"] = self.github_seed.status_value
+            result["source_revision"] = self.github_seed.source_revision
+        if self.message is not None:
+            result["message"] = self.message
+        if self.failed_symbols:
+            result["failed_symbols"] = self.failed_symbols[:20]
+        return result
+
+
+@dataclass(frozen=True)
+class PriceRefreshFinalization:
+    metadata_status: str
+    metadata_refreshed: int
+    metadata_total: int
+    activity_current: int
+    activity_total: int
+    message: str
+    heartbeat_status: str | None = "completed"
+    market_success_rates: Mapping[str, tuple[Any, float]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PriceRefreshWorkflowDependencies:
+    session_factory: Callable[[], Any]
+    price_cache_factory: Callable[[], Any]
+    bulk_fetcher_factory: Callable[[], Any]
+    warm_benchmarks: Callable[..., Mapping[str, Any]]
+    plan_price_refresh: Callable[..., PriceRefreshPlan]
+    fetch_with_backoff: Callable[..., Mapping[str, Mapping[str, Any]]]
+    track_symbol_failures: Callable[..., None]
+    schedule_failed_symbol_retry: Callable[..., None]
+    record_market_refresh_success: Callable[..., None]
+    mark_market_activity_started: Callable[..., None]
+    mark_market_activity_completed: Callable[..., None]
+    mark_market_activity_progress_safely: Callable[..., None]
+    mark_market_activity_failed_safely: Callable[..., None]
+    daily_price_bundle_service_factory: Callable[[], Any]
+    market_calendar_service_factory: Callable[[], Any]
+    rate_limiter_factory: Callable[[], Any]
+    normalize_market: Callable[[str], str]
+    market_tag: Callable[[str | None], str]
+    log_extra: Callable[[str | None], Mapping[str, Any]]
+    get_eastern_now: Callable[[], Any]
+    is_trading_day: Callable[[Any], bool]
+    format_market_status: Callable[[], str]
+    is_market_enabled_now: Callable[[str], bool]
+    raise_if_transient_database_error: Callable[[Exception], None]
+    safe_rollback: Callable[[Any], None]
+    time_window_bypass_enabled: Callable[[], bool] = lambda: False
+
+
+@dataclass
+class LivePriceRefreshExecutionContext:
+    task: CeleryTaskLike
+    bulk_fetcher: Any
+    price_cache: Any
+    db: Any
+    market: str | None
+    effective_market: str
+    activity_lifecycle: str
+    symbol_markets: dict[str, str]
+    dependencies: PriceRefreshWorkflowDependencies
+    processed: int = 0
+
+    def market_for_symbol(self, symbol: str) -> str:
+        return self.symbol_markets.get(str(symbol).upper(), self.effective_market)
+
+    def fetch_batch(self, symbols: Sequence[str], *, period: str, market: str | None):
+        return self.dependencies.fetch_with_backoff(
+            self.bulk_fetcher,
+            list(symbols),
+            period=period,
+            market=market,
+        )
+
+    def store_prices(self, price_data_by_symbol: Mapping[str, Any]) -> None:
+        self.price_cache.store_batch_in_cache(
+            dict(price_data_by_symbol),
+            also_store_db=True,
+        )
+
+    def track_symbol_failures(
+        self,
+        successes: Sequence[str],
+        failures: Sequence[str],
+        *,
+        failure_details: Mapping[str, str],
+    ) -> None:
+        self.dependencies.track_symbol_failures(
+            self.price_cache,
+            list(successes),
+            list(failures),
+            self.db,
+            failure_details=dict(failure_details),
+        )
+
+    def publish_progress(
+        self,
+        current: int,
+        total: int,
+        percent: float,
+        message: str,
+        *,
+        refreshed: int,
+        failed: int,
+    ) -> None:
+        self.processed = current
+        self.task.update_state(
+            state="PROGRESS",
+            meta={
+                "current": current,
+                "total": total,
+                "percent": percent,
+                "refreshed": refreshed,
+                "failed": failed,
+            },
+        )
+        self.price_cache.update_warmup_heartbeat(
+            current,
+            total,
+            percent,
+            market=self.market,
+        )
+        self.dependencies.mark_market_activity_progress_safely(
+            self.db,
+            market=self.effective_market,
+            stage_key="prices",
+            lifecycle=self.activity_lifecycle,
+            task_name=getattr(self.task, "name", "smart_refresh_cache"),
+            task_id=getattr(getattr(self.task, "request", None), "id", None),
+            current=current,
+            total=total,
+            percent=round(percent, 1),
+            message=message,
+        )
+
+    def extend_lock(self) -> None:
+        task_id = getattr(getattr(self.task, "request", None), "id", None) or "unknown"
+        from ..wiring.bootstrap import get_data_fetch_lock
+
+        get_data_fetch_lock().extend_lock(task_id, 300, market=self.market)
+
+    def wait_between_batches(self) -> None:
+        rate_limiter = self.dependencies.rate_limiter_factory()
+        if self.market is not None:
+            rate_limiter.wait_for_market("yfinance:batch", self.market)
+            return
+        rate_limiter.wait(
+            "yfinance:batch",
+            min_interval_s=settings.yfinance_batch_rate_limit_interval,
+        )
+
+    def raise_if_transient_database_error(self, exc: Exception) -> None:
+        self.dependencies.raise_if_transient_database_error(exc)
+
+
+class PriceRefreshWorkflow:
+    def __init__(self, dependencies: PriceRefreshWorkflowDependencies) -> None:
+        self._deps = dependencies
+
+    def run(
+        self,
+        *,
+        task: CeleryTaskLike,
+        mode: PriceRefreshMode | str = PriceRefreshMode.AUTO,
+        market: str | None = None,
+        activity_lifecycle: str | None = None,
+    ) -> dict[str, Any]:
+        parsed_mode = PriceRefreshMode.parse(mode)
+        effective_market = (
+            self._deps.normalize_market(market) if market is not None else "US"
+        )
+        activity_lifecycle = activity_lifecycle or "daily_refresh"
+        log_extra = self._deps.log_extra(market)
+
+        logger.info("=" * 80)
+        logger.info(
+            "TASK: Smart Cache Refresh %s (mode=%s)",
+            self._deps.market_tag(market),
+            parsed_mode.value,
+            extra=log_extra,
+        )
+        logger.info("Market status: %s", self._deps.format_market_status(), extra=log_extra)
+        logger.info("Timestamp: %s", datetime.now().strftime("%Y-%m-%d %H:%M:%S"), extra=log_extra)
+        logger.info("=" * 80)
+
+        if market is not None and not self._deps.is_market_enabled_now(
+            self._deps.normalize_market(market)
+        ):
+            logger.info("Skipping smart refresh for disabled market %s", market, extra=log_extra)
+            return {
+                "status": "skipped",
+                "reason": f"market {effective_market} is disabled in local runtime preferences",
+                "market": effective_market,
+                "mode": parsed_mode.value,
+                "timestamp": datetime.now().isoformat(),
+            }
+
+        if self._should_reject_full_refresh(parsed_mode, task, market):
+            now_et = self._deps.get_eastern_now()
+            return {
+                "skipped": True,
+                "reason": f"Outside refresh window (weekday={now_et.weekday()}, hour={now_et.hour})",
+                "mode": parsed_mode.value,
+                "timestamp": datetime.now().isoformat(),
+            }
+
+        if parsed_mode is PriceRefreshMode.AUTO:
+            today = self._deps.get_eastern_now().date()
+            if not self._deps.is_trading_day(today):
+                logger.info("Skipping smart refresh (auto) - %s is not a trading day", today)
+                return {
+                    "skipped": True,
+                    "reason": "Not a trading day",
+                    "date": today.isoformat(),
+                    "mode": parsed_mode.value,
+                }
+
+        price_cache = self._deps.price_cache_factory()
+        db = self._deps.session_factory()
+
+        refreshed = 0
+        processed = 0
+        failed = 0
+        github_seed: GitHubSeedOutcome | None = None
+        execution_context: LivePriceRefreshExecutionContext | None = None
+
+        try:
+            self._deps.mark_market_activity_started(
+                db,
+                market=effective_market,
+                stage_key="prices",
+                lifecycle=activity_lifecycle,
+                task_name=getattr(task, "name", "smart_refresh_cache"),
+                task_id=getattr(getattr(task, "request", None), "id", None),
+                message="Refreshing market prices",
+            )
+
+            logger.info("[1/3] Warming market benchmarks...")
+            benchmark_result = self._deps.warm_benchmarks(market=market)
+            if benchmark_result.get("error"):
+                logger.error("Benchmark warmup failed: %s", benchmark_result.get("error"))
+
+            logger.info("[2/3] Determining symbols to refresh (mode=%s)...", parsed_mode.value)
+            all_symbols, symbol_markets = self._load_active_symbol_universe(
+                db,
+                market=market,
+                effective_market=effective_market,
+            )
+
+            def symbols_needing_auto_refresh(candidate_symbols: Sequence[str]) -> Sequence[str]:
+                logger.info(
+                    "Auto refresh: %d active symbols (full universe, market cap order) %s",
+                    len(candidate_symbols),
+                    self._deps.market_tag(market),
+                    extra=log_extra,
+                )
+                refresh_symbols = price_cache.get_symbols_needing_refresh(
+                    list(candidate_symbols),
+                    max_age_hours=settings.refresh_skip_hours,
+                )
+                skipped = len(candidate_symbols) - len(refresh_symbols)
+                if skipped > 0:
+                    logger.info(
+                        "Skipping %d recently-refreshed symbols (fresh within %sh)",
+                        skipped,
+                        settings.refresh_skip_hours,
+                    )
+                return refresh_symbols
+
+            if (
+                parsed_mode in LIVE_TOP_UP_MODES
+                and all_symbols
+                and market is not None
+            ):
+                github_seed = GitHubSeedOutcome.from_mapping(
+                    self._deps.daily_price_bundle_service_factory().sync_from_github(
+                        db,
+                        market=effective_market,
+                        allow_stale=True,
+                    )
+                )
+
+            refresh_plan = self._deps.plan_price_refresh(
+                db,
+                all_symbols=all_symbols,
+                mode=parsed_mode,
+                effective_market=effective_market,
+                market_calendar_service=self._deps.market_calendar_service_factory(),
+                github_sync=github_seed,
+                recently_refreshed_filter=(
+                    symbols_needing_auto_refresh
+                    if parsed_mode is PriceRefreshMode.AUTO
+                    else None
+                ),
+            )
+            github_seed = self._github_seed_from_plan(refresh_plan)
+            refresh_source = self._source_from_plan(refresh_plan)
+            symbols = list(refresh_plan.symbols)
+            live_refresh_jobs = list(refresh_plan.jobs)
+
+            self._publish_github_seed_log(
+                github_seed=github_seed,
+                refresh_plan=refresh_plan,
+                effective_market=effective_market,
+                all_symbols=all_symbols,
+                activity_lifecycle=activity_lifecycle,
+                db=db,
+                task=task,
+                log_extra=log_extra,
+            )
+            self._log_live_symbol_plan(
+                refresh_plan=refresh_plan,
+                refresh_source=refresh_source,
+                symbols=symbols,
+                mode=parsed_mode,
+                market=market,
+                effective_market=effective_market,
+                log_extra=log_extra,
+            )
+
+            if refresh_source is PriceRefreshSource.GITHUB and not symbols:
+                message = (
+                    refresh_plan.completion_message
+                    or "GitHub daily price bundle is current - no live fetch needed"
+                )
+                trading_day = self._completion_trading_day(github_seed, effective_market)
+                outcome = PriceRefreshOutcome(
+                    status="completed",
+                    source=PriceRefreshSource.GITHUB,
+                    mode=parsed_mode,
+                    message=message,
+                    github_seed=github_seed,
+                )
+                finalization = PriceRefreshFinalization(
+                    metadata_status="completed",
+                    metadata_refreshed=len(all_symbols),
+                    metadata_total=len(all_symbols),
+                    activity_current=len(all_symbols) if all_symbols else 0,
+                    activity_total=len(all_symbols) if all_symbols else 0,
+                    message=message,
+                    market_success_rates={effective_market: (trading_day, 1.0)},
+                )
+                self._finalize_success(
+                    db,
+                    price_cache,
+                    task,
+                    market=market,
+                    effective_market=effective_market,
+                    activity_lifecycle=activity_lifecycle,
+                    finalization=finalization,
+                )
+                return outcome.to_task_result()
+
+            if not symbols:
+                message = self._empty_refresh_message(refresh_plan, parsed_mode)
+                outcome = PriceRefreshOutcome(
+                    status="completed",
+                    source=refresh_source,
+                    mode=parsed_mode,
+                    message=message,
+                    github_seed=github_seed,
+                )
+                finalization = PriceRefreshFinalization(
+                    metadata_status="completed",
+                    metadata_refreshed=0,
+                    metadata_total=0,
+                    activity_current=0,
+                    activity_total=0,
+                    message=message,
+                    heartbeat_status=None,
+                )
+                self._finalize_success(
+                    db,
+                    price_cache,
+                    task,
+                    market=market,
+                    effective_market=effective_market,
+                    activity_lifecycle=activity_lifecycle,
+                    finalization=finalization,
+                )
+                return outcome.to_task_result()
+
+            total = len(symbols)
+            symbol_market_totals = Counter(
+                symbol_markets.get(str(symbol).upper(), effective_market)
+                for symbol in symbols
+            )
+            bulk_fetcher = self._deps.bulk_fetcher_factory()
+            execution_context = LivePriceRefreshExecutionContext(
+                task=task,
+                bulk_fetcher=bulk_fetcher,
+                price_cache=price_cache,
+                db=db,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                symbol_markets=symbol_markets,
+                dependencies=self._deps,
+            )
+
+            price_cache.update_warmup_heartbeat(0, total, 0.0, market=market)
+            self._deps.mark_market_activity_progress_safely(
+                db,
+                market=effective_market,
+                stage_key="prices",
+                lifecycle=activity_lifecycle,
+                task_name=getattr(task, "name", "smart_refresh_cache"),
+                task_id=getattr(getattr(task, "request", None), "id", None),
+                current=0,
+                total=total,
+                percent=0,
+                message="Refreshing market prices",
+            )
+
+            logger.info("[3/3] Fetching %d symbols...", total)
+            execution_result = run_price_refresh_jobs(
+                jobs=live_refresh_jobs,
+                total=total,
+                batch_size=100,
+                market=market,
+                context=execution_context,
+            )
+            processed = execution_context.processed
+            refreshed = execution_result.refreshed
+            failed = execution_result.failed
+
+            success_rate = refreshed / total if total > 0 else 0
+            status = "completed" if success_rate >= 0.95 else "partial"
+            market_success_rates = {}
+            for refresh_market, market_total in symbol_market_totals.items():
+                market_success_rate = (
+                    execution_result.refreshed_by_market[refresh_market] / market_total
+                    if market_total > 0
+                    else 0
+                )
+                if market_success_rate >= 0.95:
+                    market_success_rates[refresh_market] = (
+                        self._deps.market_calendar_service_factory().last_completed_trading_day(
+                            refresh_market
+                        ),
+                        market_success_rate,
+                    )
+
+            self._schedule_failed_retries(
+                execution_result.failed_symbols,
+                execution_context=execution_context,
+                activity_lifecycle=activity_lifecycle,
+            )
+
+            logger.info("=" * 80)
+            logger.info("Smart refresh completed (%s mode):", parsed_mode.value)
+            logger.info("  Refreshed: %s", refreshed)
+            logger.info("  Failed: %s", failed)
+            logger.info("  Total: %s", total)
+            if execution_result.failed_symbols:
+                logger.info("  Failed symbols: %s...", execution_result.failed_symbols[:10])
+            logger.info("=" * 80)
+
+            finalization = PriceRefreshFinalization(
+                metadata_status=status,
+                metadata_refreshed=refreshed,
+                metadata_total=total,
+                activity_current=total,
+                activity_total=total,
+                message=f"Price refresh {status}",
+                market_success_rates=market_success_rates,
+            )
+            self._finalize_success(
+                db,
+                price_cache,
+                task,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                finalization=finalization,
+            )
+
+            outcome = PriceRefreshOutcome(
+                status=status,
+                source=(
+                    PriceRefreshSource.GITHUB_AND_LIVE
+                    if refresh_plan.used_github_seed
+                    else PriceRefreshSource.LIVE
+                ),
+                mode=parsed_mode,
+                refreshed=refreshed,
+                failed=failed,
+                total=total,
+                failed_symbols=execution_result.failed_symbols,
+                github_seed=github_seed,
+            )
+            return outcome.to_task_result()
+
+        except SoftTimeLimitExceeded:
+            logger.error("Soft time limit exceeded in smart_refresh_cache", exc_info=True)
+            self._deps.safe_rollback(db)
+            current_progress = getattr(execution_context, "processed", processed)
+            self._record_failure(
+                db,
+                price_cache,
+                task,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                refreshed=refreshed,
+                total=locals().get("total", 0),
+                current=current_progress,
+                message="Soft time limit exceeded",
+            )
+            raise
+        except Exception as exc:
+            self._deps.raise_if_transient_database_error(exc)
+            logger.error("Error in smart_refresh_cache task: %s", exc, exc_info=True)
+            self._deps.safe_rollback(db)
+            current_progress = getattr(execution_context, "processed", processed)
+            self._record_failure(
+                db,
+                price_cache,
+                task,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                refreshed=refreshed,
+                total=locals().get("total", 0),
+                current=current_progress,
+                message=str(exc),
+            )
+            return {
+                "status": "failed",
+                "error": str(exc),
+                "refreshed": refreshed,
+                "failed": failed,
+                "mode": parsed_mode.value,
+                "timestamp": datetime.now().isoformat(),
+            }
+        finally:
+            db.close()
+
+    def _should_reject_full_refresh(
+        self,
+        mode: PriceRefreshMode,
+        task: CeleryTaskLike,
+        market: str | None,
+    ) -> bool:
+        if mode is not PriceRefreshMode.FULL or market is not None:
+            return False
+        is_manual = (
+            self._deps.time_window_bypass_enabled()
+            or (
+                getattr(getattr(task, "request", None), "headers", None)
+                and task.request.headers.get("origin") == "manual"
+            )
+        )
+        if is_manual:
+            return False
+        now_et = self._deps.get_eastern_now()
+        weekday = now_et.weekday()
+        hour = now_et.hour
+        in_weekday_window = weekday < 5 and 16 <= hour < 24
+        in_sunday_window = weekday == 6 and 1 <= hour < 6
+        if in_weekday_window or in_sunday_window:
+            return False
+        logger.warning(
+            "Rejecting Beat-scheduled full refresh outside time window "
+            "(weekday=%s, hour=%s). Likely a catchup storm.",
+            weekday,
+            hour,
+        )
+        return True
+
+    def _load_active_symbol_universe(
+        self,
+        db,
+        *,
+        market: str | None,
+        effective_market: str,
+    ) -> tuple[list[str], dict[str, str]]:
+        from ..models.stock_universe import StockUniverse
+
+        query = db.query(StockUniverse.symbol, StockUniverse.market).filter(
+            StockUniverse.is_active == True
+        )
+        if market is not None:
+            query = query.filter(StockUniverse.market == self._deps.normalize_market(market))
+        query = query.order_by(StockUniverse.market_cap.desc().nullslast())
+        universe_rows = query.all()
+        all_symbols = [row.symbol for row in universe_rows]
+        symbol_markets = {
+            str(row.symbol).upper(): self._deps.normalize_market(
+                getattr(row, "market", None) or effective_market
+            )
+            for row in universe_rows
+        }
+        return all_symbols, symbol_markets
+
+    def _publish_github_seed_log(
+        self,
+        *,
+        github_seed: GitHubSeedOutcome | None,
+        refresh_plan: PriceRefreshPlan,
+        effective_market: str,
+        all_symbols: Sequence[str],
+        activity_lifecycle: str,
+        db,
+        task: CeleryTaskLike,
+        log_extra: Mapping[str, Any],
+    ) -> None:
+        if github_seed and github_seed.stale_reason:
+            logger.info(
+                "GitHub daily price bundle for %s imported with stale manifest: %s",
+                effective_market,
+                github_seed.stale_reason,
+                extra=log_extra,
+            )
+        if github_seed and not refresh_plan.used_github_seed:
+            reason = github_seed.reason or github_seed.error
+            logger.warning(
+                "GitHub daily price bundle not used for %s (status=%s, reason=%s, stale_reason=%s); "
+                "using live refresh policy",
+                effective_market,
+                github_seed.status_value,
+                reason,
+                github_seed.stale_reason,
+                extra=log_extra,
+            )
+            self._deps.mark_market_activity_progress_safely(
+                db,
+                market=effective_market,
+                stage_key="prices",
+                lifecycle=activity_lifecycle,
+                task_name=getattr(task, "name", "smart_refresh_cache"),
+                task_id=getattr(getattr(task, "request", None), "id", None),
+                current=0,
+                total=len(all_symbols),
+                percent=0,
+                message=f"GitHub price bundle {github_seed.status_value}; using live price refresh",
+            )
+
+    def _log_live_symbol_plan(
+        self,
+        *,
+        refresh_plan: PriceRefreshPlan,
+        refresh_source: PriceRefreshSource,
+        symbols: Sequence[str],
+        mode: PriceRefreshMode,
+        market: str | None,
+        effective_market: str,
+        log_extra: Mapping[str, Any],
+    ) -> None:
+        if not symbols:
+            return
+        if refresh_source is PriceRefreshSource.GITHUB_AND_LIVE:
+            logger.info(
+                "GitHub daily price bundle synced for %s; live refresh will top up %d symbols",
+                effective_market,
+                len(symbols),
+                extra=log_extra,
+            )
+        elif mode is PriceRefreshMode.FULL:
+            logger.info(
+                "Full refresh: %d symbols (market cap order) %s",
+                len(symbols),
+                self._deps.market_tag(market),
+                extra=log_extra,
+            )
+        elif mode in {PriceRefreshMode.BOOTSTRAP, PriceRefreshMode.DELTA}:
+            logger.info(
+                "Delta refresh: %d symbols %s",
+                len(symbols),
+                self._deps.market_tag(market),
+                extra=log_extra,
+            )
+
+    def _completion_trading_day(
+        self,
+        github_seed: GitHubSeedOutcome | None,
+        effective_market: str,
+    ):
+        if github_seed and github_seed.as_of_date is not None:
+            return github_seed.as_of_date
+        return self._deps.market_calendar_service_factory().last_completed_trading_day(
+            effective_market
+        )
+
+    @staticmethod
+    def _empty_refresh_message(
+        refresh_plan: PriceRefreshPlan,
+        mode: PriceRefreshMode,
+    ) -> str:
+        if refresh_plan.completion_message:
+            return refresh_plan.completion_message
+        if mode is PriceRefreshMode.AUTO:
+            return "All symbols recently refreshed - nothing to do"
+        if mode in {PriceRefreshMode.BOOTSTRAP, PriceRefreshMode.DELTA}:
+            return "All symbols already fresh - no live fetch needed"
+        return "No active symbols found in universe"
+
+    @staticmethod
+    def _github_seed_from_plan(refresh_plan: PriceRefreshPlan) -> GitHubSeedOutcome | None:
+        github_seed = getattr(refresh_plan, "github_seed", None)
+        if github_seed is not None:
+            return github_seed
+        return GitHubSeedOutcome.from_mapping(getattr(refresh_plan, "github_sync", None))
+
+    @staticmethod
+    def _source_from_plan(refresh_plan: PriceRefreshPlan) -> PriceRefreshSource:
+        source = getattr(refresh_plan, "source", PriceRefreshSource.LIVE)
+        if isinstance(source, PriceRefreshSource):
+            return source
+        return PriceRefreshSource(str(source))
+
+    def _finalize_success(
+        self,
+        db,
+        price_cache,
+        task: CeleryTaskLike,
+        *,
+        market: str | None,
+        effective_market: str,
+        activity_lifecycle: str,
+        finalization: PriceRefreshFinalization,
+    ) -> None:
+        price_cache.save_warmup_metadata(
+            finalization.metadata_status,
+            finalization.metadata_refreshed,
+            finalization.metadata_total,
+            market=market,
+        )
+        if finalization.heartbeat_status is not None:
+            price_cache.complete_warmup_heartbeat(
+                finalization.heartbeat_status,
+                market=market,
+            )
+        self._deps.mark_market_activity_completed(
+            db,
+            market=effective_market,
+            stage_key="prices",
+            lifecycle=activity_lifecycle,
+            task_name=getattr(task, "name", "smart_refresh_cache"),
+            task_id=getattr(getattr(task, "request", None), "id", None),
+            current=finalization.activity_current,
+            total=finalization.activity_total,
+            message=finalization.message,
+        )
+        for refresh_market, (trading_day, success_rate) in finalization.market_success_rates.items():
+            self._deps.record_market_refresh_success(
+                db,
+                market=refresh_market,
+                trading_day=trading_day,
+                success_rate=success_rate,
+            )
+
+    def _record_failure(
+        self,
+        db,
+        price_cache,
+        task: CeleryTaskLike,
+        *,
+        market: str | None,
+        effective_market: str,
+        activity_lifecycle: str,
+        refreshed: int,
+        total: int,
+        current: int,
+        message: str,
+    ) -> None:
+        price_cache.save_warmup_metadata(
+            "failed",
+            refreshed,
+            total,
+            message,
+            market=market,
+        )
+        price_cache.complete_warmup_heartbeat("failed", market=market)
+        self._deps.mark_market_activity_failed_safely(
+            db,
+            market=effective_market,
+            stage_key="prices",
+            lifecycle=activity_lifecycle,
+            task_name=getattr(task, "name", "smart_refresh_cache"),
+            task_id=getattr(getattr(task, "request", None), "id", None),
+            current=current,
+            total=total,
+            message=message,
+        )
+
+    def _schedule_failed_retries(
+        self,
+        failed_symbols: Sequence[str],
+        *,
+        execution_context: LivePriceRefreshExecutionContext,
+        activity_lifecycle: str,
+    ) -> None:
+        if not failed_symbols:
+            return
+        failed_symbols_by_market: dict[str, list[str]] = {}
+        for symbol in failed_symbols:
+            failed_symbols_by_market.setdefault(
+                execution_context.market_for_symbol(symbol),
+                [],
+            ).append(symbol)
+        for retry_market, retry_symbols in failed_symbols_by_market.items():
+            kwargs = {
+                "symbols": retry_symbols,
+                "market": retry_market,
+                "attempt": 1,
+            }
+            if activity_lifecycle == "bootstrap":
+                kwargs["countdown"] = 30
+            self._deps.schedule_failed_symbol_retry(**kwargs)

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -20,6 +20,7 @@ from ..services.price_refresh_activity import (
 )
 from ..services.price_refresh_live_runner import (
     LivePriceRefreshRunner,
+    PriceRefreshExecutionError,
     PriceRefreshRetryScheduler,
 )
 from ..services.price_refresh_execution import PriceRefreshExecutionSummary
@@ -75,17 +76,10 @@ class PriceRefreshPreparation:
     live_refresh_jobs: list[PriceRefreshJob]
 
 
-@dataclass
-class PriceRefreshProgressState:
-    refreshed: int = 0
-    processed: int = 0
-    failed: int = 0
-    total: int = 0
-
-    def update_from_summary(self, summary: PriceRefreshExecutionSummary) -> None:
-        self.refreshed = summary.refreshed
-        self.processed = summary.processed
-        self.failed = summary.failed
+@dataclass(frozen=True)
+class PriceRefreshTerminalCompletion:
+    outcome: PriceRefreshOutcome
+    finalization: PriceRefreshFinalization
 
 
 class PriceRefreshWorkflow:
@@ -153,7 +147,6 @@ class PriceRefreshWorkflow:
 
         price_cache = self._deps.price_cache_factory()
         db = self._deps.session_factory()
-        progress = PriceRefreshProgressState()
 
         try:
             self._deps.activity_reporter.start_prices(
@@ -196,23 +189,51 @@ class PriceRefreshWorkflow:
                 effective_market=effective_market,
                 activity_lifecycle=activity_lifecycle,
                 preparation=preparation,
-                progress=progress,
             )
             return outcome.to_task_result()
 
-        except SoftTimeLimitExceeded:
-            logger.error("Soft time limit exceeded in smart_refresh_cache", exc_info=True)
+        except PriceRefreshExecutionError as exc:
+            cause = exc.cause
             self._deps.safe_rollback(db)
-            self._deps.activity_reporter.record_failure(
+            if isinstance(cause, SoftTimeLimitExceeded):
+                logger.error("Soft time limit exceeded in smart_refresh_cache", exc_info=True)
+                self._record_refresh_failure(
+                    db,
+                    price_cache,
+                    task=task,
+                    market=market,
+                    effective_market=effective_market,
+                    activity_lifecycle=activity_lifecycle,
+                    summary=exc.summary,
+                    message="Soft time limit exceeded",
+                )
+                raise cause
+
+            self._deps.raise_if_transient_database_error(cause)
+            logger.error("Error in smart_refresh_cache task: %s", cause, exc_info=True)
+            self._record_refresh_failure(
                 db,
                 price_cache,
                 task=task,
                 market=market,
                 effective_market=effective_market,
-                lifecycle=activity_lifecycle,
-                refreshed=progress.refreshed,
-                total=progress.total,
-                current=progress.processed,
+                activity_lifecycle=activity_lifecycle,
+                summary=exc.summary,
+                message=str(cause),
+            )
+            return self._failure_task_result(parsed_mode, exc.summary, str(cause))
+
+        except SoftTimeLimitExceeded:
+            logger.error("Soft time limit exceeded in smart_refresh_cache", exc_info=True)
+            self._deps.safe_rollback(db)
+            self._record_refresh_failure(
+                db,
+                price_cache,
+                task=task,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                summary=PriceRefreshExecutionSummary.empty(),
                 message="Soft time limit exceeded",
             )
             raise
@@ -220,28 +241,60 @@ class PriceRefreshWorkflow:
             self._deps.raise_if_transient_database_error(exc)
             logger.error("Error in smart_refresh_cache task: %s", exc, exc_info=True)
             self._deps.safe_rollback(db)
-            self._deps.activity_reporter.record_failure(
+            summary = PriceRefreshExecutionSummary.empty()
+            self._record_refresh_failure(
                 db,
                 price_cache,
                 task=task,
                 market=market,
                 effective_market=effective_market,
-                lifecycle=activity_lifecycle,
-                refreshed=progress.refreshed,
-                total=progress.total,
-                current=progress.processed,
+                activity_lifecycle=activity_lifecycle,
+                summary=summary,
                 message=str(exc),
             )
-            return {
-                "status": "failed",
-                "error": str(exc),
-                "refreshed": progress.refreshed,
-                "failed": progress.failed,
-                "mode": parsed_mode.value,
-                "timestamp": datetime.now().isoformat(),
-            }
+            return self._failure_task_result(parsed_mode, summary, str(exc))
         finally:
             db.close()
+
+    def _record_refresh_failure(
+        self,
+        db,
+        price_cache,
+        *,
+        task: CeleryTaskLike,
+        market: str | None,
+        effective_market: str,
+        activity_lifecycle: str,
+        summary: PriceRefreshExecutionSummary,
+        message: str,
+    ) -> None:
+        self._deps.activity_reporter.record_failure(
+            db,
+            price_cache,
+            task=task,
+            market=market,
+            effective_market=effective_market,
+            lifecycle=activity_lifecycle,
+            refreshed=summary.refreshed,
+            total=summary.total,
+            current=summary.processed,
+            message=message,
+        )
+
+    def _failure_task_result(
+        self,
+        mode: PriceRefreshMode,
+        summary: PriceRefreshExecutionSummary,
+        error: str,
+    ) -> dict[str, Any]:
+        return {
+            "status": "failed",
+            "error": error,
+            "refreshed": summary.refreshed,
+            "failed": summary.failed,
+            "mode": mode.value,
+            "timestamp": datetime.now().isoformat(),
+        }
 
     def _prepare_refresh(
         self,
@@ -353,61 +406,13 @@ class PriceRefreshWorkflow:
         activity_lifecycle: str,
         preparation: PriceRefreshPreparation,
     ) -> dict[str, Any] | None:
-        if preparation.refresh_source is PriceRefreshSource.GITHUB and not preparation.symbols:
-            message = (
-                preparation.refresh_plan.completion_message
-                or "GitHub daily price bundle is current - no live fetch needed"
-            )
-            trading_day = self._completion_trading_day(
-                preparation.github_seed,
-                effective_market,
-            )
-            outcome = PriceRefreshOutcome(
-                status="completed",
-                source=PriceRefreshSource.GITHUB,
-                mode=mode,
-                message=message,
-                github_seed=preparation.github_seed,
-            )
-            finalization = PriceRefreshFinalization(
-                metadata_status="completed",
-                metadata_refreshed=len(preparation.all_symbols),
-                metadata_total=len(preparation.all_symbols),
-                activity_current=len(preparation.all_symbols) if preparation.all_symbols else 0,
-                activity_total=len(preparation.all_symbols) if preparation.all_symbols else 0,
-                message=message,
-                market_success_rates={effective_market: (trading_day, 1.0)},
-            )
-            self._deps.activity_reporter.finalize_success(
-                db,
-                price_cache,
-                task=task,
-                market=market,
-                effective_market=effective_market,
-                lifecycle=activity_lifecycle,
-                finalization=finalization,
-            )
-            return outcome.to_task_result()
-
         if preparation.symbols:
             return None
 
-        message = self._empty_refresh_message(preparation.refresh_plan, mode)
-        outcome = PriceRefreshOutcome(
-            status="completed",
-            source=preparation.refresh_source,
+        completion = self._terminal_completion(
             mode=mode,
-            message=message,
-            github_seed=preparation.github_seed,
-        )
-        finalization = PriceRefreshFinalization(
-            metadata_status="completed",
-            metadata_refreshed=0,
-            metadata_total=0,
-            activity_current=0,
-            activity_total=0,
-            message=message,
-            heartbeat_status=None,
+            effective_market=effective_market,
+            preparation=preparation,
         )
         self._deps.activity_reporter.finalize_success(
             db,
@@ -416,9 +421,58 @@ class PriceRefreshWorkflow:
             market=market,
             effective_market=effective_market,
             lifecycle=activity_lifecycle,
+            finalization=completion.finalization,
+        )
+        return completion.outcome.to_task_result()
+
+    def _terminal_completion(
+        self,
+        *,
+        mode: PriceRefreshMode,
+        effective_market: str,
+        preparation: PriceRefreshPreparation,
+    ) -> PriceRefreshTerminalCompletion:
+        if preparation.refresh_source is PriceRefreshSource.GITHUB:
+            message = (
+                preparation.refresh_plan.completion_message
+                or "GitHub daily price bundle is current - no live fetch needed"
+            )
+            symbol_count = len(preparation.all_symbols)
+            trading_day = self._completion_trading_day(
+                preparation.github_seed,
+                effective_market,
+            )
+            finalization = PriceRefreshFinalization(
+                metadata_status="completed",
+                metadata_refreshed=symbol_count,
+                metadata_total=symbol_count,
+                activity_current=symbol_count,
+                activity_total=symbol_count,
+                message=message,
+                market_success_rates={effective_market: (trading_day, 1.0)},
+            )
+        else:
+            message = self._empty_refresh_message(preparation.refresh_plan, mode)
+            finalization = PriceRefreshFinalization(
+                metadata_status="completed",
+                metadata_refreshed=0,
+                metadata_total=0,
+                activity_current=0,
+                activity_total=0,
+                message=message,
+                heartbeat_status=None,
+            )
+
+        return PriceRefreshTerminalCompletion(
+            outcome=PriceRefreshOutcome(
+                status="completed",
+                source=preparation.refresh_source,
+                mode=mode,
+                message=message,
+                github_seed=preparation.github_seed,
+            ),
             finalization=finalization,
         )
-        return outcome.to_task_result()
 
     def _execute_live_refresh(
         self,
@@ -431,10 +485,8 @@ class PriceRefreshWorkflow:
         effective_market: str,
         activity_lifecycle: str,
         preparation: PriceRefreshPreparation,
-        progress: PriceRefreshProgressState,
     ) -> PriceRefreshOutcome:
         total = len(preparation.symbols)
-        progress.total = total
         symbol_market_totals = Counter(
             preparation.symbol_markets.get(str(symbol).upper(), effective_market)
             for symbol in preparation.symbols
@@ -470,13 +522,9 @@ class PriceRefreshWorkflow:
             activity_lifecycle=activity_lifecycle,
             symbol_markets=preparation.symbol_markets,
             activity_reporter=self._deps.activity_reporter,
-            progress_recorder=progress.update_from_summary,
         )
-        progress.processed = execution_result.processed
-        progress.refreshed = execution_result.refreshed
-        progress.failed = execution_result.failed
 
-        success_rate = progress.refreshed / total if total > 0 else 0
+        success_rate = execution_result.refreshed / total if total > 0 else 0
         status = "completed" if success_rate >= 0.95 else "partial"
         market_success_rates = self._market_success_rates(
             symbol_market_totals=symbol_market_totals,
@@ -492,8 +540,8 @@ class PriceRefreshWorkflow:
 
         logger.info("=" * 80)
         logger.info("Smart refresh completed (%s mode):", mode.value)
-        logger.info("  Refreshed: %s", progress.refreshed)
-        logger.info("  Failed: %s", progress.failed)
+        logger.info("  Refreshed: %s", execution_result.refreshed)
+        logger.info("  Failed: %s", execution_result.failed)
         logger.info("  Total: %s", total)
         if execution_result.failed_symbols:
             logger.info("  Failed symbols: %s...", execution_result.failed_symbols[:10])
@@ -501,7 +549,7 @@ class PriceRefreshWorkflow:
 
         finalization = PriceRefreshFinalization(
             metadata_status=status,
-            metadata_refreshed=progress.refreshed,
+            metadata_refreshed=execution_result.refreshed,
             metadata_total=total,
             activity_current=total,
             activity_total=total,
@@ -526,8 +574,8 @@ class PriceRefreshWorkflow:
                 else PriceRefreshSource.LIVE
             ),
             mode=mode,
-            refreshed=progress.refreshed,
-            failed=progress.failed,
+            refreshed=execution_result.refreshed,
+            failed=execution_result.failed,
             total=total,
             failed_symbols=execution_result.failed_symbols,
             github_seed=preparation.github_seed,

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -433,7 +433,7 @@ class PriceRefreshWorkflow:
             db=db,
             jobs=refresh_plan.live_refresh_jobs,
             total=total,
-            batch_size=100,
+            batch_size=None,
             market=market,
             effective_market=effective_market,
             activity_lifecycle=activity_lifecycle,
@@ -450,6 +450,7 @@ class PriceRefreshWorkflow:
 
         self._deps.retry_scheduler.schedule(
             execution_result.failed_symbols,
+            failure_kinds=execution_result.failure_kinds,
             effective_market=effective_market,
             symbol_markets=refresh_plan.symbol_markets,
             activity_lifecycle=activity_lifecycle,

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -16,6 +16,7 @@ from ..services.price_refresh_actions import (
     PriceRefreshAction,
     PriceRefreshActionFactory,
     PriceRefreshPreparation,
+    TerminalPriceRefreshAction,
 )
 from ..services.price_refresh_activity import (
     CeleryTaskLike,
@@ -158,7 +159,7 @@ class PriceRefreshWorkflow:
                 effective_market=effective_market,
                 preparation=preparation,
             )
-            if not action.requires_live_fetch:
+            if isinstance(action, TerminalPriceRefreshAction):
                 return self._complete_terminal_action(
                     db,
                     price_cache,
@@ -356,11 +357,7 @@ class PriceRefreshWorkflow:
         preparation = PriceRefreshPreparation(
             all_symbols=all_symbols,
             symbol_markets=symbol_markets,
-            github_seed=refresh_plan.github_seed,
             refresh_plan=refresh_plan,
-            refresh_source=refresh_plan.source,
-            symbols=list(refresh_plan.symbols),
-            live_refresh_jobs=list(refresh_plan.jobs),
         )
         self._publish_github_seed_log(
             github_seed=preparation.github_seed,
@@ -413,10 +410,8 @@ class PriceRefreshWorkflow:
         market: str | None,
         effective_market: str,
         activity_lifecycle: str,
-        action: PriceRefreshAction,
+        action: TerminalPriceRefreshAction,
     ) -> dict[str, Any]:
-        if action.terminal_completion is None:
-            raise ValueError("price refresh action requires live fetch")
         self._deps.activity_reporter.finalize_success(
             db,
             price_cache,
@@ -424,9 +419,9 @@ class PriceRefreshWorkflow:
             market=market,
             effective_market=effective_market,
             lifecycle=activity_lifecycle,
-            finalization=action.terminal_completion.finalization,
+            finalization=action.completion.finalization,
         )
-        return action.terminal_completion.outcome.to_task_result()
+        return action.completion.outcome.to_task_result()
 
     def _execute_live_refresh(
         self,

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -12,6 +12,11 @@ from typing import Any
 from celery.exceptions import SoftTimeLimitExceeded
 
 from ..config import settings
+from ..services.price_refresh_actions import (
+    PriceRefreshAction,
+    PriceRefreshActionFactory,
+    PriceRefreshPreparation,
+)
 from ..services.price_refresh_activity import (
     CeleryTaskLike,
     PriceRefreshActivityReporter,
@@ -27,7 +32,6 @@ from ..services.price_refresh_execution import PriceRefreshExecutionSummary
 from ..services.price_refresh_planning import (
     GitHubSeedOutcome,
     LIVE_TOP_UP_MODES,
-    PriceRefreshJob,
     PriceRefreshMode,
     PriceRefreshPlan,
     PriceRefreshSource,
@@ -63,23 +67,6 @@ class PriceRefreshWorkflowDependencies:
     raise_if_transient_database_error: Callable[[Exception], None]
     safe_rollback: Callable[[Any], None]
     time_window_bypass_enabled: Callable[[], bool] = lambda: False
-
-
-@dataclass(frozen=True)
-class PriceRefreshPreparation:
-    all_symbols: list[str]
-    symbol_markets: dict[str, str]
-    github_seed: GitHubSeedOutcome | None
-    refresh_plan: PriceRefreshPlan
-    refresh_source: PriceRefreshSource
-    symbols: list[str]
-    live_refresh_jobs: list[PriceRefreshJob]
-
-
-@dataclass(frozen=True)
-class PriceRefreshTerminalCompletion:
-    outcome: PriceRefreshOutcome
-    finalization: PriceRefreshFinalization
 
 
 class PriceRefreshWorkflow:
@@ -166,19 +153,21 @@ class PriceRefreshWorkflow:
                 activity_lifecycle=activity_lifecycle,
                 log_extra=log_extra,
             )
-
-            no_live_result = self._complete_without_live_fetch(
-                db,
-                price_cache,
-                task=task,
+            action = self._build_executable_action(
                 mode=parsed_mode,
-                market=market,
                 effective_market=effective_market,
-                activity_lifecycle=activity_lifecycle,
                 preparation=preparation,
             )
-            if no_live_result is not None:
-                return no_live_result
+            if not action.requires_live_fetch:
+                return self._complete_terminal_action(
+                    db,
+                    price_cache,
+                    task=task,
+                    market=market,
+                    effective_market=effective_market,
+                    activity_lifecycle=activity_lifecycle,
+                    action=action,
+                )
 
             outcome = self._execute_live_refresh(
                 db,
@@ -188,7 +177,7 @@ class PriceRefreshWorkflow:
                 market=market,
                 effective_market=effective_market,
                 activity_lifecycle=activity_lifecycle,
-                preparation=preparation,
+                preparation=action.preparation,
             )
             return outcome.to_task_result()
 
@@ -394,26 +383,40 @@ class PriceRefreshWorkflow:
         )
         return preparation
 
-    def _complete_without_live_fetch(
+    def _build_executable_action(
+        self,
+        *,
+        mode: PriceRefreshMode,
+        effective_market: str,
+        preparation: PriceRefreshPreparation,
+    ) -> PriceRefreshAction:
+        def last_completed_trading_day(action_market: str) -> Any:
+            return (
+                self._deps.market_calendar_service_factory()
+                .last_completed_trading_day(action_market)
+            )
+
+        return PriceRefreshActionFactory(
+            last_completed_trading_day=last_completed_trading_day,
+        ).build(
+            mode=mode,
+            effective_market=effective_market,
+            preparation=preparation,
+        )
+
+    def _complete_terminal_action(
         self,
         db,
         price_cache,
         *,
         task: CeleryTaskLike,
-        mode: PriceRefreshMode,
         market: str | None,
         effective_market: str,
         activity_lifecycle: str,
-        preparation: PriceRefreshPreparation,
-    ) -> dict[str, Any] | None:
-        if preparation.symbols:
-            return None
-
-        completion = self._terminal_completion(
-            mode=mode,
-            effective_market=effective_market,
-            preparation=preparation,
-        )
+        action: PriceRefreshAction,
+    ) -> dict[str, Any]:
+        if action.terminal_completion is None:
+            raise ValueError("price refresh action requires live fetch")
         self._deps.activity_reporter.finalize_success(
             db,
             price_cache,
@@ -421,58 +424,9 @@ class PriceRefreshWorkflow:
             market=market,
             effective_market=effective_market,
             lifecycle=activity_lifecycle,
-            finalization=completion.finalization,
+            finalization=action.terminal_completion.finalization,
         )
-        return completion.outcome.to_task_result()
-
-    def _terminal_completion(
-        self,
-        *,
-        mode: PriceRefreshMode,
-        effective_market: str,
-        preparation: PriceRefreshPreparation,
-    ) -> PriceRefreshTerminalCompletion:
-        if preparation.refresh_source is PriceRefreshSource.GITHUB:
-            message = (
-                preparation.refresh_plan.completion_message
-                or "GitHub daily price bundle is current - no live fetch needed"
-            )
-            symbol_count = len(preparation.all_symbols)
-            trading_day = self._completion_trading_day(
-                preparation.github_seed,
-                effective_market,
-            )
-            finalization = PriceRefreshFinalization(
-                metadata_status="completed",
-                metadata_refreshed=symbol_count,
-                metadata_total=symbol_count,
-                activity_current=symbol_count,
-                activity_total=symbol_count,
-                message=message,
-                market_success_rates={effective_market: (trading_day, 1.0)},
-            )
-        else:
-            message = self._empty_refresh_message(preparation.refresh_plan, mode)
-            finalization = PriceRefreshFinalization(
-                metadata_status="completed",
-                metadata_refreshed=0,
-                metadata_total=0,
-                activity_current=0,
-                activity_total=0,
-                message=message,
-                heartbeat_status=None,
-            )
-
-        return PriceRefreshTerminalCompletion(
-            outcome=PriceRefreshOutcome(
-                status="completed",
-                source=preparation.refresh_source,
-                mode=mode,
-                message=message,
-                github_seed=preparation.github_seed,
-            ),
-            finalization=finalization,
-        )
+        return action.terminal_completion.outcome.to_task_result()
 
     def _execute_live_refresh(
         self,
@@ -735,27 +689,3 @@ class PriceRefreshWorkflow:
                 self._deps.market_gateway.market_tag(market),
                 extra=log_extra,
             )
-
-    def _completion_trading_day(
-        self,
-        github_seed: GitHubSeedOutcome | None,
-        effective_market: str,
-    ):
-        if github_seed and github_seed.as_of_date is not None:
-            return github_seed.as_of_date
-        return self._deps.market_calendar_service_factory().last_completed_trading_day(
-            effective_market
-        )
-
-    @staticmethod
-    def _empty_refresh_message(
-        refresh_plan: PriceRefreshPlan,
-        mode: PriceRefreshMode,
-    ) -> str:
-        if refresh_plan.completion_message:
-            return refresh_plan.completion_message
-        if mode is PriceRefreshMode.AUTO:
-            return "All symbols recently refreshed - nothing to do"
-        if mode in {PriceRefreshMode.BOOTSTRAP, PriceRefreshMode.DELTA}:
-            return "All symbols already fresh - no live fetch needed"
-        return "No active symbols found in universe"

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -166,6 +166,7 @@ class PriceRefreshWorkflow:
                     completion=terminal_completion,
                 )
 
+            self._warm_benchmarks(market=market)
             outcome = self._execute_live_refresh(
                 db,
                 price_cache,
@@ -295,11 +296,6 @@ class PriceRefreshWorkflow:
         log_extra: Mapping[str, Any],
     ) -> PriceRefreshPlan:
         gateway = self._deps.market_gateway
-        logger.info("[1/3] Warming market benchmarks...")
-        benchmark_result = self._deps.warm_benchmarks(market=market)
-        if benchmark_result.get("error"):
-            logger.error("Benchmark warmup failed: %s", benchmark_result.get("error"))
-
         def symbols_needing_auto_refresh(candidate_symbols: Sequence[str]) -> Sequence[str]:
             logger.info(
                 "Auto refresh: %d active symbols (full universe, market cap order) %s",
@@ -320,7 +316,7 @@ class PriceRefreshWorkflow:
             )
             return refresh_symbols
 
-        logger.info("[2/3] Determining symbols to refresh (mode=%s)...", mode.value)
+        logger.info("[1/2] Determining symbols to refresh (mode=%s)...", mode.value)
         refresh_plan = self._deps.build_refresh_plan(
             db,
             mode=mode,
@@ -352,6 +348,12 @@ class PriceRefreshWorkflow:
             log_extra=log_extra,
         )
         return refresh_plan
+
+    def _warm_benchmarks(self, *, market: str | None) -> None:
+        logger.info("Warming market benchmarks before live price fetch...")
+        benchmark_result = self._deps.warm_benchmarks(market=market)
+        if benchmark_result.get("error"):
+            logger.error("Benchmark warmup failed: %s", benchmark_result.get("error"))
 
     def _build_terminal_completion(
         self,
@@ -423,7 +425,7 @@ class PriceRefreshWorkflow:
             failed=0,
         )
 
-        logger.info("[3/3] Fetching %d symbols...", total)
+        logger.info("[2/2] Fetching %d symbols...", total)
         execution_result = self._deps.live_runner.run(
             task=task,
             bulk_fetcher=bulk_fetcher,

--- a/backend/app/services/price_refresh_workflow.py
+++ b/backend/app/services/price_refresh_workflow.py
@@ -13,9 +13,8 @@ from celery.exceptions import SoftTimeLimitExceeded
 
 from ..config import settings
 from ..services.price_refresh_actions import (
-    PriceRefreshActionFactory,
-    PriceRefreshPreparation,
     PriceRefreshTerminalCompletion,
+    build_terminal_completion,
 )
 from ..services.price_refresh_activity import (
     CeleryTaskLike,
@@ -31,7 +30,6 @@ from ..services.price_refresh_live_runner import (
 from ..services.price_refresh_execution import PriceRefreshExecutionSummary
 from ..services.price_refresh_planning import (
     GitHubSeedOutcome,
-    LIVE_TOP_UP_MODES,
     PriceRefreshMode,
     PriceRefreshPlan,
     PriceRefreshSource,
@@ -57,9 +55,8 @@ class PriceRefreshWorkflowDependencies:
     price_cache_factory: Callable[[], Any]
     bulk_fetcher_factory: Callable[[], Any]
     warm_benchmarks: Callable[..., Mapping[str, Any]]
-    plan_price_refresh: Callable[..., PriceRefreshPlan]
-    daily_price_bundle_service_factory: Callable[[], Any]
-    market_calendar_service_factory: Callable[[], Any]
+    build_refresh_plan: Callable[..., PriceRefreshPlan]
+    last_completed_trading_day: Callable[[str], Any]
     activity_reporter: PriceRefreshActivityReporter
     live_runner: LivePriceRefreshRunner
     retry_scheduler: PriceRefreshRetryScheduler
@@ -143,7 +140,7 @@ class PriceRefreshWorkflow:
                 lifecycle=activity_lifecycle,
                 message="Refreshing market prices",
             )
-            preparation = self._prepare_refresh(
+            refresh_plan = self._prepare_refresh(
                 db,
                 price_cache,
                 task=task,
@@ -156,7 +153,7 @@ class PriceRefreshWorkflow:
             terminal_completion = self._build_terminal_completion(
                 mode=parsed_mode,
                 effective_market=effective_market,
-                preparation=preparation,
+                refresh_plan=refresh_plan,
             )
             if terminal_completion is not None:
                 return self._complete_terminal_refresh(
@@ -177,7 +174,7 @@ class PriceRefreshWorkflow:
                 market=market,
                 effective_market=effective_market,
                 activity_lifecycle=activity_lifecycle,
-                preparation=preparation,
+                refresh_plan=refresh_plan,
             )
             return outcome.to_task_result()
 
@@ -296,19 +293,12 @@ class PriceRefreshWorkflow:
         effective_market: str,
         activity_lifecycle: str,
         log_extra: Mapping[str, Any],
-    ) -> PriceRefreshPreparation:
+    ) -> PriceRefreshPlan:
         gateway = self._deps.market_gateway
         logger.info("[1/3] Warming market benchmarks...")
         benchmark_result = self._deps.warm_benchmarks(market=market)
         if benchmark_result.get("error"):
             logger.error("Benchmark warmup failed: %s", benchmark_result.get("error"))
-
-        logger.info("[2/3] Determining symbols to refresh (mode=%s)...", mode.value)
-        all_symbols, symbol_markets = self._load_active_symbol_universe(
-            db,
-            market=market,
-            effective_market=effective_market,
-        )
 
         def symbols_needing_auto_refresh(candidate_symbols: Sequence[str]) -> Sequence[str]:
             logger.info(
@@ -327,42 +317,26 @@ class PriceRefreshWorkflow:
                     "Skipping %d recently-refreshed symbols (fresh within %sh)",
                     skipped,
                     settings.refresh_skip_hours,
-                )
+            )
             return refresh_symbols
 
-        github_seed = None
-        if mode in LIVE_TOP_UP_MODES and all_symbols and market is not None:
-            github_seed = GitHubSeedOutcome.from_mapping(
-                self._deps.daily_price_bundle_service_factory().sync_from_github(
-                    db,
-                    market=effective_market,
-                    allow_stale=True,
-                )
-            )
-
-        refresh_plan = self._deps.plan_price_refresh(
+        logger.info("[2/3] Determining symbols to refresh (mode=%s)...", mode.value)
+        refresh_plan = self._deps.build_refresh_plan(
             db,
-            all_symbols=all_symbols,
             mode=mode,
+            market=market,
             effective_market=effective_market,
-            market_calendar_service=self._deps.market_calendar_service_factory(),
-            github_seed=github_seed,
             recently_refreshed_filter=(
                 symbols_needing_auto_refresh
                 if mode is PriceRefreshMode.AUTO
                 else None
             ),
         )
-        preparation = PriceRefreshPreparation(
-            all_symbols=all_symbols,
-            symbol_markets=symbol_markets,
-            refresh_plan=refresh_plan,
-        )
         self._publish_github_seed_log(
-            github_seed=preparation.github_seed,
+            github_seed=refresh_plan.github_seed,
             refresh_plan=refresh_plan,
             effective_market=effective_market,
-            all_symbols=all_symbols,
+            all_symbols=refresh_plan.all_symbols,
             activity_lifecycle=activity_lifecycle,
             db=db,
             task=task,
@@ -370,34 +344,27 @@ class PriceRefreshWorkflow:
         )
         self._log_live_symbol_plan(
             refresh_plan=refresh_plan,
-            refresh_source=preparation.refresh_source,
-            symbols=preparation.symbols,
+            refresh_source=refresh_plan.source,
+            symbols=refresh_plan.symbols,
             mode=mode,
             market=market,
             effective_market=effective_market,
             log_extra=log_extra,
         )
-        return preparation
+        return refresh_plan
 
     def _build_terminal_completion(
         self,
         *,
         mode: PriceRefreshMode,
         effective_market: str,
-        preparation: PriceRefreshPreparation,
+        refresh_plan: PriceRefreshPlan,
     ) -> PriceRefreshTerminalCompletion | None:
-        def last_completed_trading_day(action_market: str) -> Any:
-            return (
-                self._deps.market_calendar_service_factory()
-                .last_completed_trading_day(action_market)
-            )
-
-        return PriceRefreshActionFactory(
-            last_completed_trading_day=last_completed_trading_day,
-        ).build_terminal_completion(
+        return build_terminal_completion(
             mode=mode,
             effective_market=effective_market,
-            preparation=preparation,
+            plan=refresh_plan,
+            last_completed_trading_day=self._deps.last_completed_trading_day,
         )
 
     def _complete_terminal_refresh(
@@ -432,12 +399,12 @@ class PriceRefreshWorkflow:
         market: str | None,
         effective_market: str,
         activity_lifecycle: str,
-        preparation: PriceRefreshPreparation,
+        refresh_plan: PriceRefreshPlan,
     ) -> PriceRefreshOutcome:
-        total = len(preparation.symbols)
+        total = len(refresh_plan.symbols)
         symbol_market_totals = Counter(
-            preparation.symbol_markets.get(str(symbol).upper(), effective_market)
-            for symbol in preparation.symbols
+            refresh_plan.symbol_markets.get(str(symbol).upper(), effective_market)
+            for symbol in refresh_plan.symbols
         )
         bulk_fetcher = self._deps.bulk_fetcher_factory()
 
@@ -462,13 +429,13 @@ class PriceRefreshWorkflow:
             bulk_fetcher=bulk_fetcher,
             price_cache=price_cache,
             db=db,
-            jobs=preparation.live_refresh_jobs,
+            jobs=refresh_plan.live_refresh_jobs,
             total=total,
             batch_size=100,
             market=market,
             effective_market=effective_market,
             activity_lifecycle=activity_lifecycle,
-            symbol_markets=preparation.symbol_markets,
+            symbol_markets=refresh_plan.symbol_markets,
             activity_reporter=self._deps.activity_reporter,
         )
 
@@ -482,7 +449,7 @@ class PriceRefreshWorkflow:
         self._deps.retry_scheduler.schedule(
             execution_result.failed_symbols,
             effective_market=effective_market,
-            symbol_markets=preparation.symbol_markets,
+            symbol_markets=refresh_plan.symbol_markets,
             activity_lifecycle=activity_lifecycle,
         )
 
@@ -518,7 +485,7 @@ class PriceRefreshWorkflow:
             status=status,
             source=(
                 PriceRefreshSource.GITHUB_AND_LIVE
-                if preparation.refresh_plan.used_github_seed
+                if refresh_plan.used_github_seed
                 else PriceRefreshSource.LIVE
             ),
             mode=mode,
@@ -526,7 +493,7 @@ class PriceRefreshWorkflow:
             failed=execution_result.failed,
             total=total,
             failed_symbols=execution_result.failed_symbols,
-            github_seed=preparation.github_seed,
+            github_seed=refresh_plan.github_seed,
         )
 
     def _market_success_rates(
@@ -544,9 +511,7 @@ class PriceRefreshWorkflow:
             )
             if market_success_rate >= 0.95:
                 market_success_rates[refresh_market] = (
-                    self._deps.market_calendar_service_factory().last_completed_trading_day(
-                        refresh_market
-                    ),
+                    self._deps.last_completed_trading_day(refresh_market),
                     market_success_rate,
                 )
         return market_success_rates
@@ -582,33 +547,6 @@ class PriceRefreshWorkflow:
             hour,
         )
         return True
-
-    def _load_active_symbol_universe(
-        self,
-        db,
-        *,
-        market: str | None,
-        effective_market: str,
-    ) -> tuple[list[str], dict[str, str]]:
-        from ..models.stock_universe import StockUniverse
-
-        query = db.query(StockUniverse.symbol, StockUniverse.market).filter(
-            StockUniverse.is_active == True
-        )
-        if market is not None:
-            query = query.filter(
-                StockUniverse.market == self._deps.market_gateway.normalize_market(market)
-            )
-        query = query.order_by(StockUniverse.market_cap.desc().nullslast())
-        universe_rows = query.all()
-        all_symbols = [row.symbol for row in universe_rows]
-        symbol_markets = {
-            str(row.symbol).upper(): self._deps.market_gateway.normalize_market(
-                getattr(row, "market", None) or effective_market
-            )
-            for row in universe_rows
-        }
-        return all_symbols, symbol_markets
 
     def _publish_github_seed_log(
         self,

--- a/backend/app/services/runtime_activity_contract.py
+++ b/backend/app/services/runtime_activity_contract.py
@@ -6,14 +6,11 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 ACTIVE_ACTIVITY_STATUSES = frozenset({"queued", "running"})
-RUNTIME_PROGRESS_MODES = frozenset({"determinate", "indeterminate"})
-RUNTIME_ACTIVITY_PAYLOAD_FIELDS = frozenset({
+PERSISTED_RUNTIME_ACTIVITY_FIELDS = frozenset({
     "market",
     "lifecycle",
     "stage_key",
-    "stage_label",
     "status",
-    "progress_mode",
     "percent",
     "current",
     "total",
@@ -149,7 +146,7 @@ class RuntimeActivityRecord:
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "RuntimeActivityRecord":
-        missing_fields = RUNTIME_ACTIVITY_PAYLOAD_FIELDS.difference(payload)
+        missing_fields = PERSISTED_RUNTIME_ACTIVITY_FIELDS.difference(payload)
         if missing_fields:
             missing = ", ".join(sorted(missing_fields))
             raise ValueError(f"missing required runtime activity fields: {missing}")
@@ -159,9 +156,6 @@ class RuntimeActivityRecord:
         lifecycle = str(payload.get("lifecycle") or "")
         if not lifecycle:
             raise ValueError("missing lifecycle")
-        raw_progress_mode = str(payload.get("progress_mode") or "")
-        if raw_progress_mode not in RUNTIME_PROGRESS_MODES:
-            raise ValueError(f"invalid progress_mode: {raw_progress_mode}")
         current = payload.get("current")
         total = payload.get("total")
 
@@ -176,14 +170,10 @@ class RuntimeActivityRecord:
             market=str(payload.get("market") or "").upper(),
             lifecycle=lifecycle,
             stage_key=stage_key,
-            stage_label=(
-                str(payload["stage_label"])
-                if payload.get("stage_label") is not None
-                else None
-            ),
+            stage_label=stage_label(stage_key),
             status=status,
-            progress_mode=raw_progress_mode,
-            percent=percent,
+            progress_mode=progress_mode(status, percent, current, total),
+            percent=resolve_progress_percent(percent, current, total),
             current=current,
             total=total,
             message=(
@@ -212,6 +202,21 @@ class RuntimeActivityRecord:
             "stage_label": self.stage_label,
             "status": self.status,
             "progress_mode": self.progress_mode,
+            "percent": self.percent,
+            "current": self.current,
+            "total": self.total,
+            "message": self.message,
+            "task_name": self.task_name,
+            "task_id": self.task_id,
+            "updated_at": self.updated_at,
+        }
+
+    def to_persisted_payload(self) -> dict[str, Any]:
+        return {
+            "market": self.market,
+            "lifecycle": self.lifecycle,
+            "stage_key": self.stage_key,
+            "status": self.status,
             "percent": self.percent,
             "current": self.current,
             "total": self.total,

--- a/backend/app/services/runtime_activity_contract.py
+++ b/backend/app/services/runtime_activity_contract.py
@@ -1,0 +1,185 @@
+"""Shared runtime activity response contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+ACTIVE_ACTIVITY_STATUSES = frozenset({"queued", "running"})
+
+RUNTIME_STAGE_SEQUENCE = (
+    "universe",
+    "prices",
+    "fundamentals",
+    "breadth",
+    "groups",
+    "scan",
+)
+
+STAGE_LABELS = {
+    "universe": "Universe Refresh",
+    "prices": "Price Refresh",
+    "fundamentals": "Fundamentals Refresh",
+    "breadth": "Breadth Calculation",
+    "groups": "Group Rankings",
+    "snapshot": "Feature Snapshot",
+    "scan": "Scan",
+}
+
+DEFAULT_LIFECYCLE_BY_STAGE = {
+    "universe": "weekly_refresh",
+    "prices": "daily_refresh",
+    "fundamentals": "weekly_refresh",
+    "breadth": "daily_refresh",
+    "groups": "daily_refresh",
+    "snapshot": "daily_refresh",
+    "scan": "daily_refresh",
+}
+
+
+def stage_label(stage_key: str | None) -> str | None:
+    if stage_key is None:
+        return None
+    return STAGE_LABELS.get(stage_key, str(stage_key).replace("_", " ").title())
+
+
+def default_lifecycle(stage_key: str | None) -> str:
+    if stage_key is None:
+        return "daily_refresh"
+    return DEFAULT_LIFECYCLE_BY_STAGE.get(stage_key, "daily_refresh")
+
+
+def stage_index(stage_key: str | None) -> int:
+    if stage_key in RUNTIME_STAGE_SEQUENCE:
+        return RUNTIME_STAGE_SEQUENCE.index(stage_key)
+    return len(RUNTIME_STAGE_SEQUENCE)
+
+
+def resolve_progress_percent(
+    percent: float | None,
+    current: int | None,
+    total: int | None,
+) -> float | None:
+    if percent is not None:
+        return float(percent)
+    if current is None or total in (None, 0):
+        return None
+    return round((float(current) / float(total)) * 100.0, 1)
+
+
+def progress_mode(
+    status: str | None,
+    percent: float | None,
+    current: int | None = None,
+    total: int | None = None,
+) -> str:
+    resolved_percent = resolve_progress_percent(percent, current, total)
+    if resolved_percent is not None or status in {"completed", "idle"}:
+        return "determinate"
+    return "indeterminate"
+
+
+@dataclass(frozen=True)
+class RuntimeActivityRecord:
+    market: str
+    lifecycle: str
+    stage_key: str | None
+    stage_label: str | None
+    status: str
+    progress_mode: str
+    percent: float | None
+    current: int | None
+    total: int | None
+    message: str | None
+    task_name: str | None
+    task_id: str | None
+    updated_at: str | None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        market: str,
+        stage_key: str | None,
+        lifecycle: str | None,
+        status: str,
+        task_name: str | None = None,
+        task_id: str | None = None,
+        percent: float | None = None,
+        current: int | None = None,
+        total: int | None = None,
+        message: str | None = None,
+        updated_at: str | None = None,
+    ) -> "RuntimeActivityRecord":
+        resolved_stage_label = stage_label(stage_key)
+        resolved_lifecycle = lifecycle or default_lifecycle(stage_key)
+        resolved_percent = resolve_progress_percent(percent, current, total)
+        resolved_message = message or _default_message(status, resolved_stage_label)
+        return cls(
+            market=str(market).upper(),
+            lifecycle=resolved_lifecycle,
+            stage_key=stage_key,
+            stage_label=resolved_stage_label,
+            status=status,
+            progress_mode=progress_mode(status, resolved_percent, current, total),
+            percent=resolved_percent,
+            current=current,
+            total=total,
+            message=resolved_message,
+            task_name=task_name,
+            task_id=task_id,
+            updated_at=updated_at,
+        )
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "RuntimeActivityRecord":
+        return cls.create(
+            market=str(payload.get("market") or ""),
+            stage_key=payload.get("stage_key"),
+            lifecycle=payload.get("lifecycle"),
+            status=str(payload.get("status") or "idle"),
+            task_name=payload.get("task_name"),
+            task_id=payload.get("task_id"),
+            percent=payload.get("percent"),
+            current=payload.get("current"),
+            total=payload.get("total"),
+            message=payload.get("message"),
+            updated_at=payload.get("updated_at"),
+        )
+
+    @property
+    def active(self) -> bool:
+        return self.status in ACTIVE_ACTIVITY_STATUSES
+
+    @property
+    def active_bootstrap(self) -> bool:
+        return self.lifecycle == "bootstrap" and self.active
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "market": self.market,
+            "lifecycle": self.lifecycle,
+            "stage_key": self.stage_key,
+            "stage_label": self.stage_label,
+            "status": self.status,
+            "progress_mode": self.progress_mode,
+            "percent": self.percent,
+            "current": self.current,
+            "total": self.total,
+            "message": self.message,
+            "task_name": self.task_name,
+            "task_id": self.task_id,
+            "updated_at": self.updated_at,
+        }
+
+
+def _default_message(status: str, resolved_stage_label: str | None) -> str | None:
+    if resolved_stage_label is None:
+        return None
+    action = {
+        "queued": "Queued",
+        "running": "Running",
+        "completed": "Completed",
+        "failed": "Failed",
+    }.get(status, "Updated")
+    return f"{action} {resolved_stage_label.lower()}"

--- a/backend/app/services/runtime_activity_contract.py
+++ b/backend/app/services/runtime_activity_contract.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Mapping
 
 ACTIVE_ACTIVITY_STATUSES = frozenset({"queued", "running"})
@@ -54,6 +54,13 @@ def stage_label(stage_key: str | None) -> str | None:
     if stage_key is None:
         return None
     return STAGE_LABELS.get(stage_key, str(stage_key).replace("_", " ").title())
+
+
+def bootstrap_stage_metadata() -> list[dict[str, str]]:
+    return [
+        {"key": stage_key, "label": stage_label(stage_key) or stage_key}
+        for stage_key in RUNTIME_STAGE_SEQUENCE
+    ]
 
 
 def default_lifecycle(stage_key: str | None) -> str:
@@ -277,24 +284,6 @@ class RuntimeActivityUpdate:
     total: int | None = None
     message: str | None = None
     updated_at: str | None = None
-
-    def inherit_context(self, existing: RuntimeActivityRecord | None) -> "RuntimeActivityUpdate":
-        if existing is None:
-            return self
-        if self.status != "running" or existing.status not in ACTIVE_ACTIVITY_STATUSES:
-            return self
-        if existing.task_id and self.task_id and existing.task_id != self.task_id:
-            return self
-        if existing.stage_key and existing.stage_key != self.stage_key:
-            return self
-        return replace(
-            self,
-            stage_key=existing.stage_key or self.stage_key,
-            lifecycle=self.lifecycle or existing.lifecycle,
-            task_name=self.task_name or existing.task_name,
-            task_id=self.task_id or existing.task_id,
-            message=self.message or existing.message,
-        )
 
     def to_record(self) -> RuntimeActivityRecord:
         return RuntimeActivityRecord.create(

--- a/backend/app/services/runtime_activity_contract.py
+++ b/backend/app/services/runtime_activity_contract.py
@@ -94,6 +94,12 @@ def progress_mode(
     total: int | None = None,
 ) -> str:
     resolved_percent = resolve_progress_percent(percent, current, total)
+    if (
+        status in ACTIVE_ACTIVITY_STATUSES
+        and resolved_percent is not None
+        and resolved_percent >= 100.0
+    ):
+        return "indeterminate"
     if resolved_percent is not None or status in {"completed", "idle"}:
         return "determinate"
     return "indeterminate"

--- a/backend/app/services/runtime_activity_contract.py
+++ b/backend/app/services/runtime_activity_contract.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 ACTIVE_ACTIVITY_STATUSES = frozenset({"queued", "running"})
+_MISSING = object()
 
 RUNTIME_STAGE_SEQUENCE = (
     "universe",
@@ -133,17 +134,52 @@ class RuntimeActivityRecord:
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "RuntimeActivityRecord":
-        return cls.create(
-            market=str(payload.get("market") or ""),
-            stage_key=payload.get("stage_key"),
-            lifecycle=payload.get("lifecycle"),
-            status=str(payload.get("status") or "idle"),
+        stage_key = payload.get("stage_key")
+        status = str(payload.get("status") or "idle")
+        lifecycle = payload.get("lifecycle") or default_lifecycle(stage_key)
+        current = payload.get("current")
+        total = payload.get("total")
+
+        raw_percent = payload.get("percent", _MISSING)
+        percent = (
+            resolve_progress_percent(None, current, total)
+            if raw_percent is _MISSING
+            else (float(raw_percent) if raw_percent is not None else None)
+        )
+
+        raw_stage_label = payload.get("stage_label", _MISSING)
+        raw_progress_mode = payload.get("progress_mode", _MISSING)
+        raw_message = payload.get("message", _MISSING)
+
+        return cls(
+            market=str(payload.get("market") or "").upper(),
+            lifecycle=str(lifecycle),
+            stage_key=stage_key,
+            stage_label=(
+                stage_label(stage_key)
+                if raw_stage_label is _MISSING
+                else (
+                    str(raw_stage_label)
+                    if raw_stage_label is not None
+                    else None
+                )
+            ),
+            status=status,
+            progress_mode=(
+                progress_mode(status, percent, current, total)
+                if raw_progress_mode is _MISSING
+                else str(raw_progress_mode)
+            ),
+            percent=percent,
+            current=current,
+            total=total,
+            message=(
+                _default_message(status, stage_label(stage_key))
+                if raw_message is _MISSING
+                else (str(raw_message) if raw_message is not None else None)
+            ),
             task_name=payload.get("task_name"),
             task_id=payload.get("task_id"),
-            percent=payload.get("percent"),
-            current=payload.get("current"),
-            total=payload.get("total"),
-            message=payload.get("message"),
             updated_at=payload.get("updated_at"),
         )
 

--- a/backend/app/services/runtime_activity_contract.py
+++ b/backend/app/services/runtime_activity_contract.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Mapping
 
 ACTIVE_ACTIVITY_STATUSES = frozenset({"queued", "running"})
@@ -146,45 +146,7 @@ class RuntimeActivityRecord:
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "RuntimeActivityRecord":
-        missing_fields = PERSISTED_RUNTIME_ACTIVITY_FIELDS.difference(payload)
-        if missing_fields:
-            missing = ", ".join(sorted(missing_fields))
-            raise ValueError(f"missing required runtime activity fields: {missing}")
-
-        stage_key = payload.get("stage_key")
-        status = str(payload.get("status") or "idle")
-        lifecycle = str(payload.get("lifecycle") or "")
-        if not lifecycle:
-            raise ValueError("missing lifecycle")
-        current = payload.get("current")
-        total = payload.get("total")
-
-        raw_percent = payload.get("percent")
-        percent = (
-            float(raw_percent)
-            if raw_percent is not None
-            else None
-        )
-
-        return cls(
-            market=str(payload.get("market") or "").upper(),
-            lifecycle=lifecycle,
-            stage_key=stage_key,
-            stage_label=stage_label(stage_key),
-            status=status,
-            progress_mode=progress_mode(status, percent, current, total),
-            percent=resolve_progress_percent(percent, current, total),
-            current=current,
-            total=total,
-            message=(
-                str(payload["message"])
-                if payload.get("message") is not None
-                else None
-            ),
-            task_name=payload.get("task_name"),
-            task_id=payload.get("task_id"),
-            updated_at=payload.get("updated_at"),
-        )
+        return PersistedRuntimeActivity.from_payload(payload).to_record()
 
     @property
     def active(self) -> bool:
@@ -211,7 +173,82 @@ class RuntimeActivityRecord:
             "updated_at": self.updated_at,
         }
 
-    def to_persisted_payload(self) -> dict[str, Any]:
+
+@dataclass(frozen=True)
+class PersistedRuntimeActivity:
+    market: str
+    lifecycle: str
+    stage_key: str | None
+    status: str
+    percent: float | None
+    current: int | None
+    total: int | None
+    message: str | None
+    task_name: str | None
+    task_id: str | None
+    updated_at: str | None
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "PersistedRuntimeActivity":
+        missing_fields = PERSISTED_RUNTIME_ACTIVITY_FIELDS.difference(payload)
+        if missing_fields:
+            missing = ", ".join(sorted(missing_fields))
+            raise ValueError(f"missing required runtime activity fields: {missing}")
+
+        lifecycle = str(payload.get("lifecycle") or "")
+        if not lifecycle:
+            raise ValueError("missing lifecycle")
+        raw_percent = payload.get("percent")
+        return cls(
+            market=str(payload.get("market") or "").upper(),
+            lifecycle=lifecycle,
+            stage_key=payload.get("stage_key"),
+            status=str(payload.get("status") or "idle"),
+            percent=float(raw_percent) if raw_percent is not None else None,
+            current=payload.get("current"),
+            total=payload.get("total"),
+            message=(
+                str(payload["message"])
+                if payload.get("message") is not None
+                else None
+            ),
+            task_name=payload.get("task_name"),
+            task_id=payload.get("task_id"),
+            updated_at=payload.get("updated_at"),
+        )
+
+    @classmethod
+    def from_record(cls, record: RuntimeActivityRecord) -> "PersistedRuntimeActivity":
+        return cls(
+            market=record.market,
+            lifecycle=record.lifecycle,
+            stage_key=record.stage_key,
+            status=record.status,
+            percent=record.percent,
+            current=record.current,
+            total=record.total,
+            message=record.message,
+            task_name=record.task_name,
+            task_id=record.task_id,
+            updated_at=record.updated_at,
+        )
+
+    def to_record(self) -> RuntimeActivityRecord:
+        return RuntimeActivityRecord.create(
+            market=self.market,
+            stage_key=self.stage_key,
+            lifecycle=self.lifecycle,
+            status=self.status,
+            task_name=self.task_name,
+            task_id=self.task_id,
+            percent=self.percent,
+            current=self.current,
+            total=self.total,
+            message=self.message,
+            updated_at=self.updated_at,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
         return {
             "market": self.market,
             "lifecycle": self.lifecycle,
@@ -225,6 +262,54 @@ class RuntimeActivityRecord:
             "task_id": self.task_id,
             "updated_at": self.updated_at,
         }
+
+
+@dataclass(frozen=True)
+class RuntimeActivityUpdate:
+    market: str
+    stage_key: str | None
+    lifecycle: str | None
+    status: str
+    task_name: str | None = None
+    task_id: str | None = None
+    percent: float | None = None
+    current: int | None = None
+    total: int | None = None
+    message: str | None = None
+    updated_at: str | None = None
+
+    def inherit_context(self, existing: RuntimeActivityRecord | None) -> "RuntimeActivityUpdate":
+        if existing is None:
+            return self
+        if self.status != "running" or existing.status not in ACTIVE_ACTIVITY_STATUSES:
+            return self
+        if existing.task_id and self.task_id and existing.task_id != self.task_id:
+            return self
+        if existing.stage_key and existing.stage_key != self.stage_key:
+            return self
+        return replace(
+            self,
+            stage_key=existing.stage_key or self.stage_key,
+            lifecycle=self.lifecycle or existing.lifecycle,
+            task_name=self.task_name or existing.task_name,
+            task_id=self.task_id or existing.task_id,
+            message=self.message or existing.message,
+        )
+
+    def to_record(self) -> RuntimeActivityRecord:
+        return RuntimeActivityRecord.create(
+            market=self.market,
+            stage_key=self.stage_key,
+            lifecycle=self.lifecycle,
+            status=self.status,
+            task_name=self.task_name,
+            task_id=self.task_id,
+            percent=self.percent,
+            current=self.current,
+            total=self.total,
+            message=self.message,
+            updated_at=self.updated_at,
+        )
 
 
 def _default_message(status: str, resolved_stage_label: str | None) -> str | None:

--- a/backend/app/services/runtime_activity_contract.py
+++ b/backend/app/services/runtime_activity_contract.py
@@ -6,7 +6,22 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 ACTIVE_ACTIVITY_STATUSES = frozenset({"queued", "running"})
-_MISSING = object()
+RUNTIME_PROGRESS_MODES = frozenset({"determinate", "indeterminate"})
+RUNTIME_ACTIVITY_PAYLOAD_FIELDS = frozenset({
+    "market",
+    "lifecycle",
+    "stage_key",
+    "stage_label",
+    "status",
+    "progress_mode",
+    "percent",
+    "current",
+    "total",
+    "message",
+    "task_name",
+    "task_id",
+    "updated_at",
+})
 
 RUNTIME_STAGE_SEQUENCE = (
     "universe",
@@ -134,49 +149,47 @@ class RuntimeActivityRecord:
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "RuntimeActivityRecord":
+        missing_fields = RUNTIME_ACTIVITY_PAYLOAD_FIELDS.difference(payload)
+        if missing_fields:
+            missing = ", ".join(sorted(missing_fields))
+            raise ValueError(f"missing required runtime activity fields: {missing}")
+
         stage_key = payload.get("stage_key")
         status = str(payload.get("status") or "idle")
-        lifecycle = payload.get("lifecycle") or default_lifecycle(stage_key)
+        lifecycle = str(payload.get("lifecycle") or "")
+        if not lifecycle:
+            raise ValueError("missing lifecycle")
+        raw_progress_mode = str(payload.get("progress_mode") or "")
+        if raw_progress_mode not in RUNTIME_PROGRESS_MODES:
+            raise ValueError(f"invalid progress_mode: {raw_progress_mode}")
         current = payload.get("current")
         total = payload.get("total")
 
-        raw_percent = payload.get("percent", _MISSING)
+        raw_percent = payload.get("percent")
         percent = (
-            resolve_progress_percent(None, current, total)
-            if raw_percent is _MISSING
-            else (float(raw_percent) if raw_percent is not None else None)
+            float(raw_percent)
+            if raw_percent is not None
+            else None
         )
-
-        raw_stage_label = payload.get("stage_label", _MISSING)
-        raw_progress_mode = payload.get("progress_mode", _MISSING)
-        raw_message = payload.get("message", _MISSING)
 
         return cls(
             market=str(payload.get("market") or "").upper(),
-            lifecycle=str(lifecycle),
+            lifecycle=lifecycle,
             stage_key=stage_key,
             stage_label=(
-                stage_label(stage_key)
-                if raw_stage_label is _MISSING
-                else (
-                    str(raw_stage_label)
-                    if raw_stage_label is not None
-                    else None
-                )
+                str(payload["stage_label"])
+                if payload.get("stage_label") is not None
+                else None
             ),
             status=status,
-            progress_mode=(
-                progress_mode(status, percent, current, total)
-                if raw_progress_mode is _MISSING
-                else str(raw_progress_mode)
-            ),
+            progress_mode=raw_progress_mode,
             percent=percent,
             current=current,
             total=total,
             message=(
-                _default_message(status, stage_label(stage_key))
-                if raw_message is _MISSING
-                else (str(raw_message) if raw_message is not None else None)
+                str(payload["message"])
+                if payload.get("message") is not None
+                else None
             ),
             task_name=payload.get("task_name"),
             task_id=payload.get("task_id"),

--- a/backend/app/services/runtime_activity_contract.py
+++ b/backend/app/services/runtime_activity_contract.py
@@ -6,6 +6,14 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 ACTIVE_ACTIVITY_STATUSES = frozenset({"queued", "running"})
+ACTIVE_PROGRESS_STATUSES = frozenset({
+    "queued",
+    "running",
+    "reserved",
+    "waiting",
+    "stale",
+    "stuck",
+})
 PERSISTED_RUNTIME_ACTIVITY_FIELDS = frozenset({
     "market",
     "lifecycle",
@@ -95,7 +103,7 @@ def progress_mode(
 ) -> str:
     resolved_percent = resolve_progress_percent(percent, current, total)
     if (
-        status in ACTIVE_ACTIVITY_STATUSES
+        status in ACTIVE_PROGRESS_STATUSES
         and resolved_percent is not None
         and resolved_percent >= 100.0
     ):

--- a/backend/app/services/runtime_activity_presenter.py
+++ b/backend/app/services/runtime_activity_presenter.py
@@ -4,40 +4,28 @@ from __future__ import annotations
 
 from typing import Any
 
-ACTIVE_STATUSES = {"queued", "running"}
-
-STAGE_SEQUENCE = (
-    "universe",
-    "prices",
-    "fundamentals",
-    "breadth",
-    "groups",
-    "scan",
+from .runtime_activity_contract import (
+    ACTIVE_ACTIVITY_STATUSES,
+    RUNTIME_STAGE_SEQUENCE,
+    RuntimeActivityRecord,
+    stage_index,
 )
 
 
-def _bootstrap_progress_percent(record: dict[str, Any] | None) -> float:
+def _bootstrap_progress_percent(record: RuntimeActivityRecord | None) -> float:
     if record is None:
         return 0.0
-    stage_key = record.get("stage_key")
-    if stage_key not in STAGE_SEQUENCE:
+    if record.stage_key not in RUNTIME_STAGE_SEQUENCE:
         return 0.0
-    stage_index = STAGE_SEQUENCE.index(stage_key)
-    raw_percent = record.get("percent")
+    current_stage_index = stage_index(record.stage_key)
+    raw_percent = record.percent
     if raw_percent is not None:
         stage_fraction = max(0.0, min(float(raw_percent), 100.0)) / 100.0
-    elif record.get("status") == "completed":
+    elif record.status == "completed":
         stage_fraction = 1.0
     else:
         stage_fraction = 0.0
-    return round(((stage_index + stage_fraction) / len(STAGE_SEQUENCE)) * 100.0, 2)
-
-
-def _is_active_bootstrap_payload(payload: dict[str, Any]) -> bool:
-    return (
-        payload.get("lifecycle") == "bootstrap"
-        and payload.get("status") in ACTIVE_STATUSES
-    )
+    return round(((current_stage_index + stage_fraction) / len(RUNTIME_STAGE_SEQUENCE)) * 100.0, 2)
 
 
 def build_runtime_activity_status(
@@ -48,73 +36,74 @@ def build_runtime_activity_status(
 ) -> dict[str, Any]:
     enabled_markets = list(bootstrap_status.enabled_markets)
     primary_market = bootstrap_status.primary_market
-    active_markets = [
-        payload["market"]
+    activity_records = [
+        RuntimeActivityRecord.from_payload(payload)
         for payload in market_payloads
-        if payload.get("status") in ACTIVE_STATUSES
     ]
-    has_failed = any(payload.get("status") == "failed" for payload in market_payloads)
+    active_markets = [
+        record.market
+        for record in activity_records
+        if record.status in ACTIVE_ACTIVITY_STATUSES
+    ]
+    has_failed = any(record.status == "failed" for record in activity_records)
     summary_status = "warning" if has_failed else ("active" if active_markets else "idle")
 
-    primary_payload = next(
-        (payload for payload in market_payloads if payload["market"] == primary_market),
+    primary_record = next(
+        (record for record in activity_records if record.market == primary_market),
         None,
     )
     secondary_active = [
-        payload["market"]
-        for payload in market_payloads
-        if payload["market"] != primary_market and _is_active_bootstrap_payload(payload)
+        record.market
+        for record in activity_records
+        if record.market != primary_market and record.active_bootstrap
     ]
-    secondary_active_payload = next(
+    secondary_active_record = next(
         (
-            payload
-            for payload in market_payloads
-            if payload["market"] != primary_market and _is_active_bootstrap_payload(payload)
+            record
+            for record in activity_records
+            if record.market != primary_market and record.active_bootstrap
         ),
         None,
     )
     bootstrap_current = None
     bootstrap_total = None
 
-    if bootstrap_status.bootstrap_state == "ready" and secondary_active_payload:
-        bootstrap_progress_mode = secondary_active_payload.get("progress_mode") or "indeterminate"
-        bootstrap_percent = secondary_active_payload.get("percent")
-        bootstrap_stage = secondary_active_payload.get("stage_label")
-        bootstrap_message = (
-            secondary_active_payload.get("message")
-            or "Additional market loading continues."
-        )
-        bootstrap_current = secondary_active_payload.get("current")
-        bootstrap_total = secondary_active_payload.get("total")
+    if bootstrap_status.bootstrap_state == "ready" and secondary_active_record:
+        bootstrap_progress_mode = secondary_active_record.progress_mode or "indeterminate"
+        bootstrap_percent = secondary_active_record.percent
+        bootstrap_stage = secondary_active_record.stage_label
+        bootstrap_message = secondary_active_record.message or "Additional market loading continues."
+        bootstrap_current = secondary_active_record.current
+        bootstrap_total = secondary_active_record.total
     elif bootstrap_status.bootstrap_state == "ready":
         bootstrap_progress_mode = "determinate"
         bootstrap_percent = 100.0
-        bootstrap_stage = primary_payload.get("stage_label") if primary_payload else None
+        bootstrap_stage = primary_record.stage_label if primary_record else None
         bootstrap_message = (
             "Primary market is ready."
             if not secondary_active
             else "Primary market is ready while additional market loading continues."
         )
-    elif any(payload.get("progress_mode") == "determinate" for payload in market_payloads):
-        focus_payload = next(
-            (payload for payload in market_payloads if payload.get("status") in ACTIVE_STATUSES),
-            primary_payload,
+    elif any(record.progress_mode == "determinate" for record in activity_records):
+        focus_record = next(
+            (record for record in activity_records if record.status in ACTIVE_ACTIVITY_STATUSES),
+            primary_record,
         )
         bootstrap_progress_mode = "determinate"
         bootstrap_percent = round(
-            sum(_bootstrap_progress_percent(payload) for payload in market_payloads)
-            / max(len(market_payloads), 1),
+            sum(_bootstrap_progress_percent(record) for record in activity_records)
+            / max(len(activity_records), 1),
             2,
         )
-        bootstrap_stage = focus_payload.get("stage_label") if focus_payload else None
-        bootstrap_message = focus_payload.get("message") if focus_payload else "Bootstrap queued."
+        bootstrap_stage = focus_record.stage_label if focus_record else None
+        bootstrap_message = focus_record.message if focus_record else "Bootstrap queued."
     else:
         bootstrap_progress_mode = "indeterminate"
         bootstrap_percent = None
-        bootstrap_stage = primary_payload.get("stage_label") if primary_payload else None
+        bootstrap_stage = primary_record.stage_label if primary_record else None
         bootstrap_message = (
-            primary_payload.get("message")
-            if primary_payload is not None
+            primary_record.message
+            if primary_record is not None
             else "Bootstrap queued."
         )
 

--- a/backend/app/services/runtime_activity_presenter.py
+++ b/backend/app/services/runtime_activity_presenter.py
@@ -70,7 +70,11 @@ def build_runtime_activity_status(
 
     if bootstrap_status.bootstrap_state == "ready" and secondary_active_record:
         bootstrap_progress_mode = secondary_active_record.progress_mode or "indeterminate"
-        bootstrap_percent = secondary_active_record.percent
+        bootstrap_percent = (
+            _bootstrap_progress_percent(secondary_active_record)
+            if bootstrap_progress_mode == "determinate"
+            else None
+        )
         bootstrap_stage = secondary_active_record.stage_label
         bootstrap_message = secondary_active_record.message or "Additional market loading continues."
         bootstrap_current = secondary_active_record.current

--- a/backend/app/services/runtime_activity_presenter.py
+++ b/backend/app/services/runtime_activity_presenter.py
@@ -1,0 +1,151 @@
+"""Presentation helpers for runtime activity status responses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+ACTIVE_STATUSES = {"queued", "running"}
+
+STAGE_SEQUENCE = (
+    "universe",
+    "prices",
+    "fundamentals",
+    "breadth",
+    "groups",
+    "scan",
+)
+
+
+def _bootstrap_progress_percent(record: dict[str, Any] | None) -> float:
+    if record is None:
+        return 0.0
+    stage_key = record.get("stage_key")
+    if stage_key not in STAGE_SEQUENCE:
+        return 0.0
+    stage_index = STAGE_SEQUENCE.index(stage_key)
+    raw_percent = record.get("percent")
+    if raw_percent is not None:
+        stage_fraction = max(0.0, min(float(raw_percent), 100.0)) / 100.0
+    elif record.get("status") == "completed":
+        stage_fraction = 1.0
+    else:
+        stage_fraction = 0.0
+    return round(((stage_index + stage_fraction) / len(STAGE_SEQUENCE)) * 100.0, 2)
+
+
+def _is_active_bootstrap_payload(payload: dict[str, Any]) -> bool:
+    return (
+        payload.get("lifecycle") == "bootstrap"
+        and payload.get("status") in ACTIVE_STATUSES
+    )
+
+
+def build_runtime_activity_status(
+    *,
+    bootstrap_status,
+    bootstrap_run: dict[str, Any],
+    market_payloads: list[dict[str, Any]],
+) -> dict[str, Any]:
+    enabled_markets = list(bootstrap_status.enabled_markets)
+    primary_market = bootstrap_status.primary_market
+    active_markets = [
+        payload["market"]
+        for payload in market_payloads
+        if payload.get("status") in ACTIVE_STATUSES
+    ]
+    has_failed = any(payload.get("status") == "failed" for payload in market_payloads)
+    summary_status = "warning" if has_failed else ("active" if active_markets else "idle")
+
+    primary_payload = next(
+        (payload for payload in market_payloads if payload["market"] == primary_market),
+        None,
+    )
+    secondary_active = [
+        payload["market"]
+        for payload in market_payloads
+        if payload["market"] != primary_market and _is_active_bootstrap_payload(payload)
+    ]
+    secondary_active_payload = next(
+        (
+            payload
+            for payload in market_payloads
+            if payload["market"] != primary_market and _is_active_bootstrap_payload(payload)
+        ),
+        None,
+    )
+    bootstrap_current = None
+    bootstrap_total = None
+
+    if bootstrap_status.bootstrap_state == "ready" and secondary_active_payload:
+        bootstrap_progress_mode = secondary_active_payload.get("progress_mode") or "indeterminate"
+        bootstrap_percent = secondary_active_payload.get("percent")
+        bootstrap_stage = secondary_active_payload.get("stage_label")
+        bootstrap_message = (
+            secondary_active_payload.get("message")
+            or "Additional market loading continues."
+        )
+        bootstrap_current = secondary_active_payload.get("current")
+        bootstrap_total = secondary_active_payload.get("total")
+    elif bootstrap_status.bootstrap_state == "ready":
+        bootstrap_progress_mode = "determinate"
+        bootstrap_percent = 100.0
+        bootstrap_stage = primary_payload.get("stage_label") if primary_payload else None
+        bootstrap_message = (
+            "Primary market is ready."
+            if not secondary_active
+            else "Primary market is ready while additional market loading continues."
+        )
+    elif any(payload.get("progress_mode") == "determinate" for payload in market_payloads):
+        focus_payload = next(
+            (payload for payload in market_payloads if payload.get("status") in ACTIVE_STATUSES),
+            primary_payload,
+        )
+        bootstrap_progress_mode = "determinate"
+        bootstrap_percent = round(
+            sum(_bootstrap_progress_percent(payload) for payload in market_payloads)
+            / max(len(market_payloads), 1),
+            2,
+        )
+        bootstrap_stage = focus_payload.get("stage_label") if focus_payload else None
+        bootstrap_message = focus_payload.get("message") if focus_payload else "Bootstrap queued."
+    else:
+        bootstrap_progress_mode = "indeterminate"
+        bootstrap_percent = None
+        bootstrap_stage = primary_payload.get("stage_label") if primary_payload else None
+        bootstrap_message = (
+            primary_payload.get("message")
+            if primary_payload is not None
+            else "Bootstrap queued."
+        )
+
+    background_warning = None
+    if len(enabled_markets) > 1 and (
+        bootstrap_status.bootstrap_state == "running" or bool(secondary_active)
+    ):
+        background_warning = (
+            "Additional enabled markets are still loading in the background."
+        )
+
+    return {
+        "bootstrap": {
+            "state": bootstrap_status.bootstrap_state,
+            "app_ready": not bootstrap_status.bootstrap_required,
+            "primary_market": primary_market,
+            "enabled_markets": enabled_markets,
+            "task_id": bootstrap_run.get("primary_task_id"),
+            "market_task_ids": bootstrap_run.get("market_task_ids") or {},
+            "current_stage": bootstrap_stage,
+            "progress_mode": bootstrap_progress_mode,
+            "percent": bootstrap_percent,
+            "current": bootstrap_current,
+            "total": bootstrap_total,
+            "message": bootstrap_message,
+            "background_warning": background_warning,
+        },
+        "summary": {
+            "active_market_count": len(active_markets),
+            "active_markets": active_markets,
+            "status": summary_status,
+        },
+        "markets": market_payloads,
+    }

--- a/backend/app/services/runtime_activity_presenter.py
+++ b/backend/app/services/runtime_activity_presenter.py
@@ -121,6 +121,7 @@ def build_runtime_activity_status(
             "app_ready": not bootstrap_status.bootstrap_required,
             "primary_market": primary_market,
             "enabled_markets": enabled_markets,
+            "queue_state": bootstrap_run.get("queue_state") or "queued",
             "task_id": bootstrap_run.get("primary_task_id"),
             "market_task_ids": bootstrap_run.get("market_task_ids") or {},
             "current_stage": bootstrap_stage,

--- a/backend/app/services/runtime_activity_presenter.py
+++ b/backend/app/services/runtime_activity_presenter.py
@@ -8,6 +8,7 @@ from .runtime_activity_contract import (
     ACTIVE_ACTIVITY_STATUSES,
     RUNTIME_STAGE_SEQUENCE,
     RuntimeActivityRecord,
+    bootstrap_stage_metadata,
     stage_index,
 )
 
@@ -135,6 +136,7 @@ def build_runtime_activity_status(
             "total": bootstrap_total,
             "message": bootstrap_message,
             "background_warning": background_warning,
+            "stages": bootstrap_stage_metadata(),
         },
         "summary": {
             "active_market_count": len(active_markets),

--- a/backend/app/services/runtime_activity_reducer.py
+++ b/backend/app/services/runtime_activity_reducer.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Set
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
 from .runtime_activity_contract import RuntimeActivityRecord, stage_index
 
 _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
+_PRESERVED_EXISTING_STATUSES = frozenset({"running", "completed", "failed"})
 
 
 @dataclass(frozen=True)
@@ -37,8 +38,6 @@ def _coerce_activity_record(
 def reduce_market_activity(
     existing_payload: RuntimeActivityRecord | Mapping[str, Any] | None,
     incoming_payload: RuntimeActivityRecord | Mapping[str, Any],
-    *,
-    preserve_existing_statuses: Set[str] | None = None,
 ) -> RuntimeActivityTransition:
     """Return the activity payload that should win this state transition."""
     incoming = _coerce_activity_record(incoming_payload)
@@ -46,17 +45,18 @@ def reduce_market_activity(
         raise ValueError("incoming runtime activity payload is invalid")
 
     existing = _coerce_activity_record(existing_payload)
-    if not preserve_existing_statuses or existing is None:
+    if existing is None:
         return RuntimeActivityTransition(should_persist=True, record=incoming)
 
     existing_status = existing.status
-    if existing_status not in preserve_existing_statuses:
+    if existing_status not in _PRESERVED_EXISTING_STATUSES:
         return RuntimeActivityTransition(should_persist=True, record=incoming)
 
     payload_status = incoming.status
     same_task = existing.task_id == incoming.task_id
     same_stage = existing.stage_key == incoming.stage_key
     same_owner = same_task and same_stage
+    incoming_has_owner = incoming.task_id is not None
 
     if existing_status == "running":
         if payload_status == "queued" or (
@@ -68,13 +68,19 @@ def reduce_market_activity(
     elif existing_status == "completed":
         if payload_status != "failed":
             incoming_new_cycle = (
-                payload_status in {"queued", "running"} and not same_owner
+                payload_status in {"queued", "running"}
+                and incoming_has_owner
+                and not same_owner
             )
             if not incoming_new_cycle:
                 return RuntimeActivityTransition(should_persist=False, record=existing)
     elif existing_status == "failed":
         supersedes_failed_activity = _should_supersede_failed_activity(existing, incoming)
-        incoming_new_cycle = payload_status in {"queued", "running"} and not same_owner
+        incoming_new_cycle = (
+            payload_status in {"queued", "running"}
+            and incoming_has_owner
+            and not same_owner
+        )
         if incoming_new_cycle:
             existing_stage_index = stage_index(existing.stage_key)
             payload_stage_index = stage_index(incoming.stage_key)

--- a/backend/app/services/runtime_activity_reducer.py
+++ b/backend/app/services/runtime_activity_reducer.py
@@ -6,7 +6,11 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from .runtime_activity_contract import RuntimeActivityRecord, stage_index
+from .runtime_activity_contract import (
+    RuntimeActivityRecord,
+    RuntimeActivityUpdate,
+    stage_index,
+)
 
 _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
 _PRESERVED_EXISTING_STATUSES = frozenset({"running", "completed", "failed"})
@@ -23,12 +27,16 @@ class RuntimeActivityTransition:
 
 
 def _coerce_activity_record(
-    payload: RuntimeActivityRecord | Mapping[str, Any] | None,
+    payload: RuntimeActivityRecord | RuntimeActivityUpdate | Mapping[str, Any] | None,
+    *,
+    existing: RuntimeActivityRecord | None = None,
 ) -> RuntimeActivityRecord | None:
     if payload is None:
         return None
     if isinstance(payload, RuntimeActivityRecord):
         return payload
+    if isinstance(payload, RuntimeActivityUpdate):
+        return payload.inherit_context(existing).to_record()
     try:
         return RuntimeActivityRecord.from_payload(payload)
     except ValueError:
@@ -37,14 +45,14 @@ def _coerce_activity_record(
 
 def reduce_market_activity(
     existing_payload: RuntimeActivityRecord | Mapping[str, Any] | None,
-    incoming_payload: RuntimeActivityRecord | Mapping[str, Any],
+    incoming_payload: RuntimeActivityRecord | RuntimeActivityUpdate | Mapping[str, Any],
 ) -> RuntimeActivityTransition:
     """Return the activity payload that should win this state transition."""
-    incoming = _coerce_activity_record(incoming_payload)
+    existing = _coerce_activity_record(existing_payload)
+    incoming = _coerce_activity_record(incoming_payload, existing=existing)
     if incoming is None:
         raise ValueError("incoming runtime activity payload is invalid")
 
-    existing = _coerce_activity_record(existing_payload)
     if existing is None:
         return RuntimeActivityTransition(should_persist=True, record=incoming)
 

--- a/backend/app/services/runtime_activity_reducer.py
+++ b/backend/app/services/runtime_activity_reducer.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from .runtime_activity_contract import (
+    ACTIVE_ACTIVITY_STATUSES,
     RuntimeActivityRecord,
     RuntimeActivityUpdate,
     stage_index,
@@ -36,7 +37,7 @@ def _coerce_activity_record(
     if isinstance(payload, RuntimeActivityRecord):
         return payload
     if isinstance(payload, RuntimeActivityUpdate):
-        return payload.inherit_context(existing).to_record()
+        return _inherit_existing_context(existing, payload).to_record()
     try:
         return RuntimeActivityRecord.from_payload(payload)
     except ValueError:
@@ -67,11 +68,7 @@ def reduce_market_activity(
     incoming_has_owner = incoming.task_id is not None
 
     if existing_status == "running":
-        if payload_status == "queued" or (
-            payload_status != "failed" and not same_owner
-        ):
-            return RuntimeActivityTransition(should_persist=False, record=existing)
-        if payload_status == "failed" and not same_owner:
+        if payload_status == "queued" or not same_owner:
             return RuntimeActivityTransition(should_persist=False, record=existing)
     elif existing_status == "completed":
         if payload_status != "failed":
@@ -83,28 +80,62 @@ def reduce_market_activity(
             if not incoming_new_cycle:
                 return RuntimeActivityTransition(should_persist=False, record=existing)
     elif existing_status == "failed":
-        supersedes_failed_activity = _should_supersede_failed_activity(existing, incoming)
-        incoming_new_cycle = (
-            payload_status in {"queued", "running"}
-            and incoming_has_owner
-            and not same_owner
-        )
-        if incoming_new_cycle:
-            existing_stage_index = stage_index(existing.stage_key)
-            payload_stage_index = stage_index(incoming.stage_key)
-            lifecycle_changed = existing.lifecycle != incoming.lifecycle
-            incoming_new_cycle = (
-                lifecycle_changed or payload_stage_index <= existing_stage_index
-            )
-        if supersedes_failed_activity:
-            pass
-        elif payload_status == "failed" and same_owner:
+        if _should_supersede_failed_activity(existing, incoming):
+            return RuntimeActivityTransition(should_persist=True, record=incoming)
+        if payload_status == "failed" and same_owner:
             if _should_preserve_existing_failed_message(existing, incoming):
                 return RuntimeActivityTransition(should_persist=False, record=existing)
-        elif not incoming_new_cycle:
+        elif not _is_new_cycle_after_failed(
+            existing,
+            incoming,
+            same_owner=same_owner,
+            incoming_has_owner=incoming_has_owner,
+        ):
             return RuntimeActivityTransition(should_persist=False, record=existing)
 
     return RuntimeActivityTransition(should_persist=True, record=incoming)
+
+
+def _inherit_existing_context(
+    existing: RuntimeActivityRecord | None,
+    update: RuntimeActivityUpdate,
+) -> RuntimeActivityUpdate:
+    if existing is None or existing.status not in ACTIVE_ACTIVITY_STATUSES:
+        if update.status == "failed" and update.stage_key is None:
+            return replace(update, stage_key="scan")
+        return update
+    if update.status not in {"running", "failed"}:
+        return update
+    if existing.task_id and update.task_id and existing.task_id != update.task_id:
+        return update
+    if update.stage_key is not None and existing.stage_key != update.stage_key:
+        return update
+    if update.lifecycle is not None and existing.lifecycle != update.lifecycle:
+        return update
+    return replace(
+        update,
+        stage_key=update.stage_key or existing.stage_key,
+        lifecycle=update.lifecycle or existing.lifecycle,
+        task_name=update.task_name or existing.task_name,
+        task_id=update.task_id or existing.task_id,
+        message=update.message or existing.message,
+    )
+
+
+def _is_new_cycle_after_failed(
+    existing: RuntimeActivityRecord,
+    incoming: RuntimeActivityRecord,
+    *,
+    same_owner: bool,
+    incoming_has_owner: bool,
+) -> bool:
+    if incoming.status not in {"queued", "running"} or not incoming_has_owner or same_owner:
+        return False
+    lifecycle_changed = existing.lifecycle != incoming.lifecycle
+    payload_restarts_at_or_before_failed_stage = (
+        stage_index(incoming.stage_key) <= stage_index(existing.stage_key)
+    )
+    return lifecycle_changed or payload_restarts_at_or_before_failed_stage
 
 
 def _should_preserve_existing_failed_message(

--- a/backend/app/services/runtime_activity_reducer.py
+++ b/backend/app/services/runtime_activity_reducer.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Set
 from dataclasses import dataclass
 from typing import Any
 
-from .runtime_activity_contract import stage_index
+from .runtime_activity_contract import RuntimeActivityRecord, stage_index
 
 _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
 
@@ -14,71 +14,91 @@ _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
 @dataclass(frozen=True)
 class RuntimeActivityTransition:
     should_persist: bool
-    payload: dict[str, Any]
+    record: RuntimeActivityRecord
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        return self.record.to_payload()
+
+
+def _coerce_activity_record(
+    payload: RuntimeActivityRecord | Mapping[str, Any] | None,
+) -> RuntimeActivityRecord | None:
+    if payload is None:
+        return None
+    if isinstance(payload, RuntimeActivityRecord):
+        return payload
+    try:
+        return RuntimeActivityRecord.from_payload(payload)
+    except ValueError:
+        return None
 
 
 def reduce_market_activity(
-    existing_payload: Mapping[str, Any] | None,
-    incoming_payload: Mapping[str, Any],
+    existing_payload: RuntimeActivityRecord | Mapping[str, Any] | None,
+    incoming_payload: RuntimeActivityRecord | Mapping[str, Any],
     *,
     preserve_existing_statuses: Set[str] | None = None,
 ) -> RuntimeActivityTransition:
     """Return the activity payload that should win this state transition."""
-    payload = dict(incoming_payload)
-    if not preserve_existing_statuses or not isinstance(existing_payload, Mapping):
-        return RuntimeActivityTransition(should_persist=True, payload=payload)
+    incoming = _coerce_activity_record(incoming_payload)
+    if incoming is None:
+        raise ValueError("incoming runtime activity payload is invalid")
 
-    existing = dict(existing_payload)
-    existing_status = existing.get("status")
+    existing = _coerce_activity_record(existing_payload)
+    if not preserve_existing_statuses or existing is None:
+        return RuntimeActivityTransition(should_persist=True, record=incoming)
+
+    existing_status = existing.status
     if existing_status not in preserve_existing_statuses:
-        return RuntimeActivityTransition(should_persist=True, payload=payload)
+        return RuntimeActivityTransition(should_persist=True, record=incoming)
 
-    payload_status = payload.get("status")
-    same_task = existing.get("task_id") == payload.get("task_id")
-    same_stage = existing.get("stage_key") == payload.get("stage_key")
+    payload_status = incoming.status
+    same_task = existing.task_id == incoming.task_id
+    same_stage = existing.stage_key == incoming.stage_key
     same_owner = same_task and same_stage
 
     if existing_status == "running":
         if payload_status == "queued" or (
             payload_status != "failed" and not same_owner
         ):
-            return RuntimeActivityTransition(should_persist=False, payload=existing)
+            return RuntimeActivityTransition(should_persist=False, record=existing)
         if payload_status == "failed" and not same_owner:
-            return RuntimeActivityTransition(should_persist=False, payload=existing)
+            return RuntimeActivityTransition(should_persist=False, record=existing)
     elif existing_status == "completed":
         if payload_status != "failed":
             incoming_new_cycle = (
                 payload_status in {"queued", "running"} and not same_owner
             )
             if not incoming_new_cycle:
-                return RuntimeActivityTransition(should_persist=False, payload=existing)
+                return RuntimeActivityTransition(should_persist=False, record=existing)
     elif existing_status == "failed":
-        supersedes_failed_activity = _should_supersede_failed_activity(existing, payload)
+        supersedes_failed_activity = _should_supersede_failed_activity(existing, incoming)
         incoming_new_cycle = payload_status in {"queued", "running"} and not same_owner
         if incoming_new_cycle:
-            existing_stage_index = stage_index(existing.get("stage_key"))
-            payload_stage_index = stage_index(payload.get("stage_key"))
-            lifecycle_changed = existing.get("lifecycle") != payload.get("lifecycle")
+            existing_stage_index = stage_index(existing.stage_key)
+            payload_stage_index = stage_index(incoming.stage_key)
+            lifecycle_changed = existing.lifecycle != incoming.lifecycle
             incoming_new_cycle = (
                 lifecycle_changed or payload_stage_index <= existing_stage_index
             )
         if supersedes_failed_activity:
             pass
         elif payload_status == "failed" and same_owner:
-            if _should_preserve_existing_failed_message(existing, payload):
-                return RuntimeActivityTransition(should_persist=False, payload=existing)
+            if _should_preserve_existing_failed_message(existing, incoming):
+                return RuntimeActivityTransition(should_persist=False, record=existing)
         elif not incoming_new_cycle:
-            return RuntimeActivityTransition(should_persist=False, payload=existing)
+            return RuntimeActivityTransition(should_persist=False, record=existing)
 
-    return RuntimeActivityTransition(should_persist=True, payload=payload)
+    return RuntimeActivityTransition(should_persist=True, record=incoming)
 
 
 def _should_preserve_existing_failed_message(
-    existing_payload: Mapping[str, Any],
-    payload: Mapping[str, Any],
+    existing_payload: RuntimeActivityRecord,
+    payload: RuntimeActivityRecord,
 ) -> bool:
-    existing_message = str(existing_payload.get("message") or "").strip()
-    incoming_message = str(payload.get("message") or "").strip()
+    existing_message = str(existing_payload.message or "").strip()
+    incoming_message = str(payload.message or "").strip()
     return bool(
         existing_message
         and incoming_message
@@ -88,20 +108,18 @@ def _should_preserve_existing_failed_message(
 
 
 def _should_supersede_failed_activity(
-    existing_payload: Mapping[str, Any],
-    payload: Mapping[str, Any],
+    existing_payload: RuntimeActivityRecord,
+    payload: RuntimeActivityRecord,
 ) -> bool:
     """Allow a real scan stage to replace stale optional-stage failures."""
-    if existing_payload.get("stage_key") not in _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES:
+    if existing_payload.stage_key not in _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES:
         return False
-    if payload.get("status") not in {"running", "completed"}:
+    if payload.status not in {"running", "completed"}:
         return False
-    if payload.get("stage_key") != "scan":
+    if payload.stage_key != "scan":
         return False
-    if existing_payload.get("lifecycle") != payload.get("lifecycle"):
+    if existing_payload.lifecycle != payload.lifecycle:
         return False
-    if payload.get("lifecycle") != "bootstrap":
+    if payload.lifecycle != "bootstrap":
         return False
-    return stage_index(payload.get("stage_key")) > stage_index(
-        existing_payload.get("stage_key")
-    )
+    return stage_index(payload.stage_key) > stage_index(existing_payload.stage_key)

--- a/backend/app/services/runtime_activity_reducer.py
+++ b/backend/app/services/runtime_activity_reducer.py
@@ -1,0 +1,107 @@
+"""Pure transition rules for persisted runtime market activity."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Set
+from dataclasses import dataclass
+from typing import Any
+
+from .runtime_activity_contract import stage_index
+
+_OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES = frozenset({"groups"})
+
+
+@dataclass(frozen=True)
+class RuntimeActivityTransition:
+    should_persist: bool
+    payload: dict[str, Any]
+
+
+def reduce_market_activity(
+    existing_payload: Mapping[str, Any] | None,
+    incoming_payload: Mapping[str, Any],
+    *,
+    preserve_existing_statuses: Set[str] | None = None,
+) -> RuntimeActivityTransition:
+    """Return the activity payload that should win this state transition."""
+    payload = dict(incoming_payload)
+    if not preserve_existing_statuses or not isinstance(existing_payload, Mapping):
+        return RuntimeActivityTransition(should_persist=True, payload=payload)
+
+    existing = dict(existing_payload)
+    existing_status = existing.get("status")
+    if existing_status not in preserve_existing_statuses:
+        return RuntimeActivityTransition(should_persist=True, payload=payload)
+
+    payload_status = payload.get("status")
+    same_task = existing.get("task_id") == payload.get("task_id")
+    same_stage = existing.get("stage_key") == payload.get("stage_key")
+    same_owner = same_task and same_stage
+
+    if existing_status == "running":
+        if payload_status == "queued" or (
+            payload_status != "failed" and not same_owner
+        ):
+            return RuntimeActivityTransition(should_persist=False, payload=existing)
+        if payload_status == "failed" and not same_owner:
+            return RuntimeActivityTransition(should_persist=False, payload=existing)
+    elif existing_status == "completed":
+        if payload_status != "failed":
+            incoming_new_cycle = (
+                payload_status in {"queued", "running"} and not same_owner
+            )
+            if not incoming_new_cycle:
+                return RuntimeActivityTransition(should_persist=False, payload=existing)
+    elif existing_status == "failed":
+        supersedes_failed_activity = _should_supersede_failed_activity(existing, payload)
+        incoming_new_cycle = payload_status in {"queued", "running"} and not same_owner
+        if incoming_new_cycle:
+            existing_stage_index = stage_index(existing.get("stage_key"))
+            payload_stage_index = stage_index(payload.get("stage_key"))
+            lifecycle_changed = existing.get("lifecycle") != payload.get("lifecycle")
+            incoming_new_cycle = (
+                lifecycle_changed or payload_stage_index <= existing_stage_index
+            )
+        if supersedes_failed_activity:
+            pass
+        elif payload_status == "failed" and same_owner:
+            if _should_preserve_existing_failed_message(existing, payload):
+                return RuntimeActivityTransition(should_persist=False, payload=existing)
+        elif not incoming_new_cycle:
+            return RuntimeActivityTransition(should_persist=False, payload=existing)
+
+    return RuntimeActivityTransition(should_persist=True, payload=payload)
+
+
+def _should_preserve_existing_failed_message(
+    existing_payload: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> bool:
+    existing_message = str(existing_payload.get("message") or "").strip()
+    incoming_message = str(payload.get("message") or "").strip()
+    return bool(
+        existing_message
+        and incoming_message
+        and existing_message != incoming_message
+        and len(existing_message) >= len(incoming_message)
+    )
+
+
+def _should_supersede_failed_activity(
+    existing_payload: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> bool:
+    """Allow a real scan stage to replace stale optional-stage failures."""
+    if existing_payload.get("stage_key") not in _OPTIONAL_FAILURE_SCAN_SUPERSEDE_STAGES:
+        return False
+    if payload.get("status") not in {"running", "completed"}:
+        return False
+    if payload.get("stage_key") != "scan":
+        return False
+    if existing_payload.get("lifecycle") != payload.get("lifecycle"):
+        return False
+    if payload.get("lifecycle") != "bootstrap":
+        return False
+    return stage_index(payload.get("stage_key")) > stage_index(
+        existing_payload.get("stage_key")
+    )

--- a/backend/app/services/runtime_preferences_service.py
+++ b/backend/app/services/runtime_preferences_service.py
@@ -247,20 +247,22 @@ def get_runtime_bootstrap_status(db: Session) -> RuntimeBootstrapStatus:
     empty_system = readiness.empty_system
 
     bootstrap_state = prefs.bootstrap_state
-    all_markets_ready = (
-        readiness.ready
-        if bootstrap_state in {"running", "ready", "failed"}
+    readiness_active = bootstrap_state in {"running", "ready", "failed"}
+    primary_result = readiness.market_results.get(prefs.primary_market)
+    primary_market_ready = (
+        bool(primary_result and primary_result.ready)
+        if readiness_active
         else False
     )
-    if all_markets_ready:
+    if primary_market_ready:
         bootstrap_state = "ready"
     elif empty_system and bootstrap_state == "ready":
         bootstrap_state = "not_started"
-    elif bootstrap_state == "ready" and not all_markets_ready:
+    elif bootstrap_state == "ready" and not primary_market_ready:
         bootstrap_state = "running"
 
     bootstrap_required = empty_system or (
-        bootstrap_state in {"running", "failed"} and not all_markets_ready
+        bootstrap_state in {"running", "failed"} and not primary_market_ready
     )
 
     return RuntimeBootstrapStatus(

--- a/backend/app/services/static_daily_price_refresh_service.py
+++ b/backend/app/services/static_daily_price_refresh_service.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, Callable
 
-from sqlalchemy import func
-
-from app.models.stock import StockPrice
 from app.models.stock_universe import StockUniverse
 from app.services.bulk_data_fetcher import BulkDataFetcher
+from app.services.price_refresh_planning import (
+    NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+    STALE_PRICE_TOP_UP_PERIOD,
+    classify_price_history,
+)
 from app.utils.symbol_support import split_supported_price_symbols
 
 
-STATIC_DAILY_PRICE_REFRESH_PERIOD = "7d"
-STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD = "2y"
+STATIC_DAILY_PRICE_REFRESH_PERIOD = STALE_PRICE_TOP_UP_PERIOD
+STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD = NO_HISTORY_PRICE_BOOTSTRAP_PERIOD
 STATIC_DAILY_PRICE_REFRESH_BATCH_SIZE = 250
 
 # Markets where Yahoo's 429 backoff windows are long enough that a single
@@ -82,29 +84,15 @@ class StaticDailyPriceRefreshService:
                 query = query.filter(StockUniverse.market == market)
             active_symbols = [symbol for symbol, in query.all()]
             supported_symbols, skipped_symbols = split_supported_price_symbols(active_symbols)
-            latest_rows = (
-                db.query(StockPrice.symbol, func.max(StockPrice.date))
-                .filter(StockPrice.symbol.in_(supported_symbols))
-                .group_by(StockPrice.symbol)
-                .all()
+            coverage = classify_price_history(
+                db,
+                symbols=supported_symbols,
+                as_of_date=as_of_date,
             )
 
-        latest_by_symbol = {symbol: latest_date for symbol, latest_date in latest_rows}
-        db_fresh_symbols = [
-            symbol
-            for symbol in supported_symbols
-            if latest_by_symbol.get(symbol) is not None
-            and latest_by_symbol[symbol] >= as_of_date
-        ]
-        stale_symbols = [
-            symbol
-            for symbol in supported_symbols
-            if latest_by_symbol.get(symbol) is not None
-            and latest_by_symbol[symbol] < as_of_date
-        ]
-        no_history_symbols = [
-            symbol for symbol in supported_symbols if symbol not in latest_by_symbol
-        ]
+        db_fresh_symbols = list(coverage.fresh)
+        stale_symbols = list(coverage.stale)
+        no_history_symbols = list(coverage.no_history)
 
         if not stale_symbols and not no_history_symbols:
             print(

--- a/backend/app/services/static_daily_price_refresh_service.py
+++ b/backend/app/services/static_daily_price_refresh_service.py
@@ -7,10 +7,10 @@ from typing import Any, Callable
 
 from app.models.stock_universe import StockUniverse
 from app.services.bulk_data_fetcher import BulkDataFetcher
+from app.services.price_history_coverage import classify_price_history
 from app.services.price_refresh_planning import (
     NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
     STALE_PRICE_TOP_UP_PERIOD,
-    classify_price_history,
 )
 from app.utils.symbol_support import split_supported_price_symbols
 

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -28,7 +28,7 @@ from ..services.market_activity_service import (
     mark_market_activity_progress,
     mark_market_activity_started,
 )
-from ..services.price_refresh_planning import plan_price_refresh
+from ..services.price_refresh_planning import LIVE_TOP_UP_MODES, plan_price_refresh
 from ..config import settings
 from ..utils.market_hours import is_market_open, is_trading_day, get_eastern_now, format_market_status
 from ..wiring.bootstrap import (
@@ -1788,15 +1788,20 @@ def smart_refresh_cache(
                 )
             return refresh_symbols
 
+        if mode in LIVE_TOP_UP_MODES and all_symbols and market is not None:
+            github_sync = get_daily_price_bundle_service().sync_from_github(
+                db,
+                market=effective_market,
+                allow_stale=True,
+            )
+
         refresh_plan = plan_price_refresh(
             db,
             all_symbols=all_symbols,
             mode=mode,
-            activity_lifecycle=activity_lifecycle,
             effective_market=effective_market,
-            price_bundle_service=get_daily_price_bundle_service(),
             market_calendar_service=get_market_calendar_service(),
-            github_seed_allowed=bool(all_symbols and market is not None),
+            github_sync=github_sync,
             recently_refreshed_filter=(
                 _symbols_needing_auto_refresh if mode == "auto" else None
             ),

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -42,6 +42,9 @@ from .transient_database import raise_if_transient_database_error
 
 logger = logging.getLogger(__name__)
 _GITHUB_SYNC_SUCCESS_STATUSES = frozenset({"success", "up_to_date"})
+_LIVE_TOP_UP_MODES = frozenset({"bootstrap", "delta"})
+_STALE_PRICE_TOP_UP_PERIOD = "7d"
+_NO_HISTORY_PRICE_BOOTSTRAP_PERIOD = "2y"
 
 _SMART_REFRESH_TIME_WINDOW_BYPASS: ContextVar[bool] = ContextVar(
     "smart_refresh_time_window_bypass",
@@ -1098,6 +1101,56 @@ def _fetch_with_backoff(
     raise RateLimitExhaustedError(symbols, market)
 
 
+def _classify_symbols_by_price_history(db, *, symbols: list[str], as_of_date) -> dict[str, list[str]]:
+    """Split symbols by whether DB prices already cover ``as_of_date``."""
+    from sqlalchemy import func
+
+    from ..models.stock import StockPrice
+
+    normalized_symbols = [str(symbol).upper() for symbol in symbols]
+    latest_by_symbol = {}
+    for chunk_start in range(0, len(normalized_symbols), 500):
+        chunk_symbols = normalized_symbols[chunk_start:chunk_start + 500]
+        rows = (
+            db.query(StockPrice.symbol, func.max(StockPrice.date))
+            .filter(StockPrice.symbol.in_(chunk_symbols))
+            .group_by(StockPrice.symbol)
+            .all()
+        )
+        latest_by_symbol.update({str(symbol).upper(): latest_date for symbol, latest_date in rows})
+
+    fresh_symbols = []
+    stale_symbols = []
+    no_history_symbols = []
+    for symbol in normalized_symbols:
+        latest_date = latest_by_symbol.get(symbol)
+        if latest_date is None:
+            no_history_symbols.append(symbol)
+        elif latest_date < as_of_date:
+            stale_symbols.append(symbol)
+        else:
+            fresh_symbols.append(symbol)
+
+    return {
+        "fresh": fresh_symbols,
+        "stale": stale_symbols,
+        "no_history": no_history_symbols,
+    }
+
+
+def _build_live_price_refresh_jobs(
+    coverage: dict[str, list[str]],
+) -> list[tuple[str, list[str], str]]:
+    jobs: list[tuple[str, list[str], str]] = []
+    stale_symbols = coverage.get("stale") or []
+    no_history_symbols = coverage.get("no_history") or []
+    if stale_symbols:
+        jobs.append(("stale", stale_symbols, _STALE_PRICE_TOP_UP_PERIOD))
+    if no_history_symbols:
+        jobs.append(("no_history", no_history_symbols, _NO_HISTORY_PRICE_BOOTSTRAP_PERIOD))
+    return jobs
+
+
 def _classify_no_data_failure(error_message: str) -> bool:
     """Heuristic classifier for delisted/no-data provider failures."""
     lower = (error_message or "").lower()
@@ -1641,6 +1694,9 @@ def smart_refresh_cache(
         mode: Refresh mode
             - "auto": Full universe, skip symbols refreshed within 4h (smart refresh)
             - "full": Full universe, force re-fetch everything regardless of freshness
+            - "bootstrap": GitHub-first first-run seed; accepts recent stale bundles
+              and live-fetches only stale/no-history gaps
+            - "delta": GitHub-first scheduled refresh; live-fetches only stale/no-history gaps
 
     Returns:
         Dict with refresh statistics
@@ -1765,29 +1821,84 @@ def smart_refresh_cache(
             for r in universe_rows
         }
 
+        live_top_up_mode = mode in _LIVE_TOP_UP_MODES or activity_lifecycle == "bootstrap"
+        price_bundle_service = get_daily_price_bundle_service()
         github_seed_allowed = (
             all_symbols
             and market is not None
             and activity_lifecycle in {"daily_refresh", "bootstrap"}
         )
-        github_sync = (
-            get_daily_price_bundle_service().sync_from_github(
-                db,
-                market=effective_market,
-            )
-            if github_seed_allowed
-            else {"status": "skipped", "reason": "empty_universe"}
-        )
+        if github_seed_allowed:
+            github_sync_kwargs = {"market": effective_market}
+            if live_top_up_mode:
+                github_sync_kwargs["allow_stale"] = True
+            github_sync = price_bundle_service.sync_from_github(db, **github_sync_kwargs)
+        else:
+            github_sync = {"status": "skipped", "reason": "empty_universe"}
+
+        live_refresh_jobs: list[tuple[str, list[str], str]] = []
         if github_sync.get("status") in _GITHUB_SYNC_SUCCESS_STATUSES:
             used_github_seed = True
-            symbols = get_daily_price_bundle_service().symbols_missing_as_of(
-                db,
-                symbols=all_symbols,
-                as_of_date=str(github_sync.get("as_of_date") or ""),
-            )
+            if github_sync.get("stale_reason"):
+                logger.info(
+                    "GitHub daily price bundle for %s imported with stale manifest: %s",
+                    effective_market,
+                    github_sync.get("stale_reason"),
+                    extra=_log_extra,
+                )
+            if live_top_up_mode:
+                target_as_of = get_market_calendar_service().last_completed_trading_day(effective_market)
+                try:
+                    github_as_of = datetime.fromisoformat(
+                        str(github_sync.get("as_of_date"))
+                    ).date()
+                except (TypeError, ValueError):
+                    github_as_of = None
+                if github_as_of == target_as_of:
+                    symbols = price_bundle_service.symbols_missing_as_of(
+                        db,
+                        symbols=all_symbols,
+                        as_of_date=target_as_of.isoformat(),
+                    )
+                    if symbols:
+                        coverage = _classify_symbols_by_price_history(
+                            db,
+                            symbols=symbols,
+                            as_of_date=target_as_of,
+                        )
+                        live_refresh_jobs = _build_live_price_refresh_jobs(coverage)
+                        symbols = [
+                            symbol
+                            for _kind, job_symbols, _period in live_refresh_jobs
+                            for symbol in job_symbols
+                        ]
+                else:
+                    coverage = _classify_symbols_by_price_history(
+                        db,
+                        symbols=all_symbols,
+                        as_of_date=target_as_of,
+                    )
+                    live_refresh_jobs = _build_live_price_refresh_jobs(coverage)
+                    symbols = [
+                        symbol
+                        for _kind, job_symbols, _period in live_refresh_jobs
+                        for symbol in job_symbols
+                    ]
+            else:
+                symbols = price_bundle_service.symbols_missing_as_of(
+                    db,
+                    symbols=all_symbols,
+                    as_of_date=str(github_sync.get("as_of_date") or ""),
+                )
+                if symbols:
+                    live_refresh_jobs = [(
+                        "missing_or_stale",
+                        symbols,
+                        _NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+                    )]
             if symbols:
                 logger.info(
-                    "GitHub daily price bundle synced for %s; falling back to live refresh for %d missing/stale symbols",
+                    "GitHub daily price bundle synced for %s; live refresh will top up %d symbols",
                     effective_market,
                     len(symbols),
                     extra=_log_extra,
@@ -1836,32 +1947,91 @@ def smart_refresh_cache(
                     "mode": mode,
                     "completed_at": datetime.now().isoformat(),
                 }
-        elif mode == "full":
-            # Full refresh: ALL active symbols for the market, ordered by market cap DESC
-            symbols = all_symbols
-            logger.info(
-                "Full refresh: %d symbols (market cap order) %s",
-                len(symbols), market_tag(market), extra=_log_extra,
-            )
         else:
-            # Auto mode: Full universe for market, skip recently-refreshed symbols
-            symbols = all_symbols
-            logger.info(
-                "Auto refresh: %d active symbols (full universe, market cap order) %s",
-                len(symbols), market_tag(market), extra=_log_extra,
-            )
+            status = github_sync.get("status")
+            reason = github_sync.get("reason") or github_sync.get("error")
+            stale_reason = github_sync.get("stale_reason")
+            if github_seed_allowed:
+                logger.warning(
+                    "GitHub daily price bundle not used for %s (status=%s, reason=%s, stale_reason=%s); using live refresh policy",
+                    effective_market,
+                    status,
+                    reason,
+                    stale_reason,
+                    extra=_log_extra,
+                )
+                _mark_market_activity_progress_safely(
+                    db,
+                    market=effective_market,
+                    stage_key="prices",
+                    lifecycle=activity_lifecycle,
+                    task_name=getattr(self, "name", "smart_refresh_cache"),
+                    task_id=getattr(getattr(self, "request", None), "id", None),
+                    current=0,
+                    total=len(all_symbols),
+                    percent=0,
+                    message=f"GitHub price bundle {status}; using live price refresh",
+                )
 
-            # Filter out symbols refreshed within skip window
-            original_count = len(symbols)
-            symbols = price_cache.get_symbols_needing_refresh(symbols, max_age_hours=settings.refresh_skip_hours)
-            skipped = original_count - len(symbols)
-            if skipped > 0:
-                logger.info(f"Skipping {skipped} recently-refreshed symbols (fresh within {settings.refresh_skip_hours}h)")
+            if live_top_up_mode:
+                target_as_of = get_market_calendar_service().last_completed_trading_day(effective_market)
+                coverage = _classify_symbols_by_price_history(
+                    db,
+                    symbols=all_symbols,
+                    as_of_date=target_as_of,
+                )
+                live_refresh_jobs = _build_live_price_refresh_jobs(coverage)
+                symbols = [
+                    symbol
+                    for _kind, job_symbols, _period in live_refresh_jobs
+                    for symbol in job_symbols
+                ]
+                logger.info(
+                    "Delta refresh: %d stale symbols and %d no-history symbols %s",
+                    len(coverage.get("stale") or []),
+                    len(coverage.get("no_history") or []),
+                    market_tag(market),
+                    extra=_log_extra,
+                )
+            elif mode == "full":
+                # Full refresh: ALL active symbols for the market, ordered by market cap DESC
+                symbols = all_symbols
+                live_refresh_jobs = [(
+                    "full",
+                    symbols,
+                    _NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+                )]
+                logger.info(
+                    "Full refresh: %d symbols (market cap order) %s",
+                    len(symbols), market_tag(market), extra=_log_extra,
+                )
+            else:
+                # Auto mode: Full universe for market, skip recently-refreshed symbols
+                symbols = all_symbols
+                logger.info(
+                    "Auto refresh: %d active symbols (full universe, market cap order) %s",
+                    len(symbols), market_tag(market), extra=_log_extra,
+                )
+
+                # Filter out symbols refreshed within skip window
+                original_count = len(symbols)
+                symbols = price_cache.get_symbols_needing_refresh(symbols, max_age_hours=settings.refresh_skip_hours)
+                skipped = original_count - len(symbols)
+                if skipped > 0:
+                    logger.info(f"Skipping {skipped} recently-refreshed symbols (fresh within {settings.refresh_skip_hours}h)")
+                if symbols:
+                    live_refresh_jobs = [(
+                        "auto",
+                        symbols,
+                        _NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+                    )]
 
         if not symbols:
             message = (
                 "All symbols recently refreshed - nothing to do"
                 if mode == "auto" else
+                "All symbols already fresh - no live fetch needed"
+                if live_top_up_mode else
                 "No active symbols found in universe"
             )
             price_cache.save_warmup_metadata("completed", 0, 0, market=market)
@@ -1893,7 +2063,10 @@ def smart_refresh_cache(
         refreshed_by_market: Counter[str] = Counter()
         failed_by_market: Counter[str] = Counter()
         batch_size = 100
-        total_batches = (total + batch_size - 1) // batch_size if total > 0 else 0
+        total_batches = sum(
+            (len(job_symbols) + batch_size - 1) // batch_size
+            for _kind, job_symbols, _period in live_refresh_jobs
+        )
         bulk_fetcher = BulkDataFetcher()
 
         def _market_for_symbol(symbol: str) -> str:
@@ -1918,114 +2091,130 @@ def smart_refresh_cache(
         # Step 3: Batch fetch with progress tracking
         logger.info(f"[3/3] Fetching {total} symbols...")
 
-        for batch_start in range(0, total, batch_size):
-            batch_symbols = symbols[batch_start:batch_start + batch_size]
-            batch_num = (batch_start // batch_size) + 1
+        processed_count = 0
+        batch_num = 0
+        for job_kind, job_symbols, fetch_period in live_refresh_jobs:
+            for batch_start in range(0, len(job_symbols), batch_size):
+                batch_symbols = job_symbols[batch_start:batch_start + batch_size]
+                batch_num += 1
 
-            logger.info(f"Batch {batch_num}/{total_batches}: Fetching {len(batch_symbols)} symbols")
+                logger.info(
+                    "Batch %d/%d: Fetching %d symbols (%s, period=%s)",
+                    batch_num,
+                    total_batches,
+                    len(batch_symbols),
+                    job_kind,
+                    fetch_period,
+                )
 
-            batch_successes = []
-            batch_failures = []
-            failure_details = {}
+                batch_successes = []
+                batch_failures = []
+                failure_details = {}
 
-            try:
-                # Batch fetch using yf.download() (single HTTP request per batch)
-                batch_results = _fetch_with_backoff(bulk_fetcher, batch_symbols, period="2y", market=market)
+                try:
+                    # Batch fetch using yf.download() (single HTTP request per batch)
+                    batch_results = _fetch_with_backoff(
+                        bulk_fetcher,
+                        batch_symbols,
+                        period=fetch_period,
+                        market=market,
+                    )
 
-                # Separate successes from failures, then batch-store all successes
-                batch_to_store = {}
-                for symbol, data in batch_results.items():
-                    if not data.get('has_error') and data.get('price_data') is not None:
-                        price_df = data['price_data']
-                        if not price_df.empty:
-                            batch_to_store[symbol] = price_df
-                            refreshed += 1
-                            refreshed_by_market[_market_for_symbol(symbol)] += 1
-                            batch_successes.append(symbol)
+                    # Separate successes from failures, then batch-store all successes
+                    batch_to_store = {}
+                    for symbol, data in batch_results.items():
+                        if not data.get('has_error') and data.get('price_data') is not None:
+                            price_df = data['price_data']
+                            if not price_df.empty:
+                                batch_to_store[symbol] = price_df
+                                refreshed += 1
+                                refreshed_by_market[_market_for_symbol(symbol)] += 1
+                                batch_successes.append(symbol)
+                            else:
+                                failed += 1
+                                failed_symbols.append(symbol)
+                                failed_by_market[_market_for_symbol(symbol)] += 1
+                                batch_failures.append(symbol)
+                                failure_details[symbol] = "Empty data returned"
                         else:
                             failed += 1
                             failed_symbols.append(symbol)
                             failed_by_market[_market_for_symbol(symbol)] += 1
                             batch_failures.append(symbol)
-                            failure_details[symbol] = "Empty data returned"
+                            failure_details[symbol] = data.get('error', 'Unknown error')
+
+                    # Batch store in Redis (pipeline) + DB (single transaction)
+                    if batch_to_store:
+                        price_cache.store_batch_in_cache(batch_to_store, also_store_db=True)
+
+                except SoftTimeLimitExceeded:
+                    raise
+                except Exception as e:
+                    raise_if_transient_database_error(e)
+                    logger.error(f"Batch {batch_num} error: {e}")
+                    failed += len(batch_symbols)
+                    failed_symbols.extend(batch_symbols)
+                    failed_by_market.update(_market_for_symbol(symbol) for symbol in batch_symbols)
+                    batch_failures.extend(batch_symbols)
+                    failure_details.update({symbol: str(e) for symbol in batch_symbols})
+
+                # Track symbol failures for auto-deactivation of delisted symbols
+                _track_symbol_failures(
+                    price_cache,
+                    batch_successes,
+                    batch_failures,
+                    db,
+                    failure_details=failure_details,
+                )
+
+                # Update progress for UI and stuck detection
+                processed_count += len(batch_symbols)
+                progress = min(processed_count, total)
+                percent = (progress / total) * 100
+                processed = progress
+
+                # Update Celery task state
+                self.update_state(
+                    state='PROGRESS',
+                    meta={
+                        'current': progress,
+                        'total': total,
+                        'percent': percent,
+                        'refreshed': refreshed,
+                        'failed': failed
+                    }
+                )
+
+                # Update heartbeat for stuck detection
+                price_cache.update_warmup_heartbeat(progress, total, percent, market=market)
+                _mark_market_activity_progress_safely(
+                    db,
+                    market=effective_market,
+                    stage_key="prices",
+                    lifecycle=activity_lifecycle,
+                    task_name=getattr(self, "name", "smart_refresh_cache"),
+                    task_id=getattr(getattr(self, "request", None), "id", None),
+                    current=progress,
+                    total=total,
+                    percent=round(percent, 1),
+                    message=f"Batch {batch_num}/{total_batches} · refreshing prices",
+                )
+
+                # Extend lock TTL to prevent expiry during long-running tasks
+                task_id = self.request.id or 'unknown'
+                from ..wiring.bootstrap import get_data_fetch_lock
+                lock = get_data_fetch_lock()
+                lock.extend_lock(task_id, 300, market=market)
+
+                # Rate limit between batches (per-market key when scoped)
+                if processed_count < total:
+                    if market is not None:
+                        get_rate_limiter().wait_for_market("yfinance:batch", market)
                     else:
-                        failed += 1
-                        failed_symbols.append(symbol)
-                        failed_by_market[_market_for_symbol(symbol)] += 1
-                        batch_failures.append(symbol)
-                        failure_details[symbol] = data.get('error', 'Unknown error')
-
-                # Batch store in Redis (pipeline) + DB (single transaction)
-                if batch_to_store:
-                    price_cache.store_batch_in_cache(batch_to_store, also_store_db=True)
-
-            except SoftTimeLimitExceeded:
-                raise
-            except Exception as e:
-                raise_if_transient_database_error(e)
-                logger.error(f"Batch {batch_num} error: {e}")
-                failed += len(batch_symbols)
-                failed_symbols.extend(batch_symbols)
-                failed_by_market.update(_market_for_symbol(symbol) for symbol in batch_symbols)
-                batch_failures.extend(batch_symbols)
-                failure_details.update({symbol: str(e) for symbol in batch_symbols})
-
-            # Track symbol failures for auto-deactivation of delisted symbols
-            _track_symbol_failures(
-                price_cache,
-                batch_successes,
-                batch_failures,
-                db,
-                failure_details=failure_details,
-            )
-
-            # Update progress for UI and stuck detection
-            progress = min((batch_start + batch_size), total)
-            percent = (progress / total) * 100
-            processed = progress
-
-            # Update Celery task state
-            self.update_state(
-                state='PROGRESS',
-                meta={
-                    'current': progress,
-                    'total': total,
-                    'percent': percent,
-                    'refreshed': refreshed,
-                    'failed': failed
-                }
-            )
-
-            # Update heartbeat for stuck detection
-            price_cache.update_warmup_heartbeat(progress, total, percent, market=market)
-            _mark_market_activity_progress_safely(
-                db,
-                market=effective_market,
-                stage_key="prices",
-                lifecycle=activity_lifecycle,
-                task_name=getattr(self, "name", "smart_refresh_cache"),
-                task_id=getattr(getattr(self, "request", None), "id", None),
-                current=progress,
-                total=total,
-                percent=round(percent, 1),
-                message=f"Batch {batch_num}/{total_batches} · refreshing prices",
-            )
-
-            # Extend lock TTL to prevent expiry during long-running tasks
-            task_id = self.request.id or 'unknown'
-            from ..wiring.bootstrap import get_data_fetch_lock
-            lock = get_data_fetch_lock()
-            lock.extend_lock(task_id, 300, market=market)
-
-            # Rate limit between batches (per-market key when scoped)
-            if batch_start + batch_size < total:
-                if market is not None:
-                    get_rate_limiter().wait_for_market("yfinance:batch", market)
-                else:
-                    get_rate_limiter().wait(
-                        "yfinance:batch",
-                        min_interval_s=settings.yfinance_batch_rate_limit_interval,
-                    )
+                        get_rate_limiter().wait(
+                            "yfinance:batch",
+                            min_interval_s=settings.yfinance_batch_rate_limit_interval,
+                        )
 
         # Save final warmup metadata (treat >95% success as "completed")
         success_rate = refreshed / total if total > 0 else 0

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -28,7 +28,17 @@ from ..services.market_activity_service import (
     mark_market_activity_started,
 )
 from ..services.price_refresh_planning import plan_price_refresh
+from ..services.price_refresh_activity import (
+    PriceRefreshActivityDependencies,
+    PriceRefreshActivityReporter,
+)
+from ..services.price_refresh_live_runner import (
+    LivePriceRefreshRunner,
+    LivePriceRefreshRunnerDependencies,
+    PriceRefreshRetryScheduler,
+)
 from ..services.price_refresh_workflow import (
+    PriceRefreshMarketGateway,
     PriceRefreshWorkflow,
     PriceRefreshWorkflowDependencies,
 )
@@ -1625,33 +1635,47 @@ def run_smart_price_refresh(
 ) -> dict:
     from ..services.bulk_data_fetcher import BulkDataFetcher
     from ..services.runtime_preferences_service import is_market_enabled_now
-    from ..wiring.bootstrap import get_price_cache
+    from ..wiring.bootstrap import get_data_fetch_lock, get_price_cache
     from .market_queues import market_tag, log_extra, normalize_market
 
+    activity_reporter = PriceRefreshActivityReporter(
+        PriceRefreshActivityDependencies(
+            record_market_refresh_success=_record_market_refresh_success_safely,
+            mark_market_activity_started=mark_market_activity_started,
+            mark_market_activity_completed=mark_market_activity_completed,
+            mark_market_activity_progress_safely=_mark_market_activity_progress_safely,
+            mark_market_activity_failed_safely=_mark_market_activity_failed_safely,
+        )
+    )
+    live_runner = LivePriceRefreshRunner(
+        LivePriceRefreshRunnerDependencies(
+            fetch_with_backoff=_fetch_with_backoff,
+            track_symbol_failures=_track_symbol_failures,
+            rate_limiter_factory=get_rate_limiter,
+            data_fetch_lock_factory=get_data_fetch_lock,
+            raise_if_transient_database_error=raise_if_transient_database_error,
+        )
+    )
     dependencies = PriceRefreshWorkflowDependencies(
         session_factory=SessionLocal,
         price_cache_factory=get_price_cache,
         bulk_fetcher_factory=BulkDataFetcher,
         warm_benchmarks=warm_spy_cache,
         plan_price_refresh=plan_price_refresh,
-        fetch_with_backoff=_fetch_with_backoff,
-        track_symbol_failures=_track_symbol_failures,
-        schedule_failed_symbol_retry=_schedule_failed_symbol_retry,
-        record_market_refresh_success=_record_market_refresh_success_safely,
-        mark_market_activity_started=mark_market_activity_started,
-        mark_market_activity_completed=mark_market_activity_completed,
-        mark_market_activity_progress_safely=_mark_market_activity_progress_safely,
-        mark_market_activity_failed_safely=_mark_market_activity_failed_safely,
         daily_price_bundle_service_factory=get_daily_price_bundle_service,
         market_calendar_service_factory=get_market_calendar_service,
-        rate_limiter_factory=get_rate_limiter,
-        normalize_market=normalize_market,
-        market_tag=market_tag,
-        log_extra=log_extra,
-        get_eastern_now=get_eastern_now,
-        is_trading_day=is_trading_day,
-        format_market_status=format_market_status,
-        is_market_enabled_now=is_market_enabled_now,
+        activity_reporter=activity_reporter,
+        live_runner=live_runner,
+        retry_scheduler=PriceRefreshRetryScheduler(_schedule_failed_symbol_retry),
+        market_gateway=PriceRefreshMarketGateway(
+            normalize_market=normalize_market,
+            market_tag=market_tag,
+            log_extra=log_extra,
+            get_eastern_now=get_eastern_now,
+            is_trading_day=is_trading_day,
+            format_market_status=format_market_status,
+            is_market_enabled_now=is_market_enabled_now,
+        ),
         raise_if_transient_database_error=raise_if_transient_database_error,
         safe_rollback=safe_rollback,
         time_window_bypass_enabled=lambda: _SMART_REFRESH_TIME_WINDOW_BYPASS.get(),

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -27,6 +27,13 @@ from ..services.market_activity_service import (
     mark_market_activity_progress,
     mark_market_activity_started,
 )
+from ..services.price_fetch_failures import (
+    classify_price_fetch_error,
+    is_no_data_price_failure,
+    is_rate_limit_error as is_price_rate_limit_error,
+    is_retryable_price_failure,
+    normalize_price_fetch_failure_kind,
+)
 from ..services.price_refresh_plan_builder import build_market_price_refresh_plan
 from ..services.price_refresh_activity import (
     PriceRefreshActivityDependencies,
@@ -1020,8 +1027,7 @@ def prewarm_all_active_symbols(self):
 
 def _is_rate_limit_error(error_str: str) -> bool:
     """Check if an error string indicates a rate limit."""
-    lower = error_str.lower()
-    return any(indicator in lower for indicator in ("rate", "429", "too many", "limit", "throttl"))
+    return is_price_rate_limit_error(error_str)
 
 
 class RateLimitExhaustedError(RuntimeError):
@@ -1113,17 +1119,7 @@ def _fetch_with_backoff(
 
 def _classify_no_data_failure(error_message: str) -> bool:
     """Heuristic classifier for delisted/no-data provider failures."""
-    lower = (error_message or "").lower()
-    indicators = (
-        "no data",
-        "possibly delisted",
-        "delisted",
-        "missing from results",
-        "symbol not in download results",
-        "returned empty",
-        "empty data",
-    )
-    return any(indicator in lower for indicator in indicators)
+    return is_no_data_price_failure(error_message)
 
 
 def _track_symbol_failures(
@@ -1352,6 +1348,7 @@ def retry_failed_price_symbols(
     refreshed = 0
     failed_symbols: list[str] = []
     failure_details: dict[str, str] = {}
+    failure_kinds: dict[str, str] = {}
     try:
         batch_results = _fetch_with_backoff(
             bulk_fetcher,
@@ -1369,6 +1366,9 @@ def retry_failed_price_symbols(
                     continue
             failed_symbols.append(symbol)
             failure_details[symbol] = data.get("error", "Unknown error")
+            kind = normalize_price_fetch_failure_kind(data.get("error_kind"))
+            if kind is not None:
+                failure_kinds[symbol] = kind.value
         missing = sorted(set(deduped_symbols) - set(batch_results))
         failed_symbols.extend(missing)
         failure_details.update({symbol: "Missing from retry result" for symbol in missing})
@@ -1386,6 +1386,9 @@ def retry_failed_price_symbols(
         )
         failed_symbols = deduped_symbols
         failure_details = {symbol: str(exc) for symbol in deduped_symbols}
+        kind = classify_price_fetch_error(str(exc))
+        if kind is not None:
+            failure_kinds = {symbol: kind.value for symbol in deduped_symbols}
 
     successes = [symbol for symbol in deduped_symbols if symbol not in set(failed_symbols)]
     _track_symbol_failures(
@@ -1394,9 +1397,17 @@ def retry_failed_price_symbols(
         failed_symbols,
         failure_details=failure_details,
     )
-    if failed_symbols and attempt < 3:
+    retryable_failed_symbols = [
+        symbol
+        for symbol in failed_symbols
+        if is_retryable_price_failure(
+            kind=failure_kinds.get(symbol),
+            error=failure_details.get(symbol, ""),
+        )
+    ]
+    if retryable_failed_symbols and attempt < 3:
         _schedule_failed_symbol_retry(
-            failed_symbols,
+            retryable_failed_symbols,
             market=market,
             attempt=attempt + 1,
             countdown=retry_countdown,
@@ -1669,7 +1680,6 @@ def run_smart_price_refresh(
         LivePriceRefreshRunnerDependencies(
             fetch_with_backoff=_fetch_with_backoff,
             track_symbol_failures=_track_symbol_failures,
-            rate_limiter_factory=get_rate_limiter,
             data_fetch_lock_factory=get_data_fetch_lock,
             raise_if_transient_database_error=raise_if_transient_database_error,
         )

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -9,10 +9,8 @@ Provides background tasks for:
 All data-fetching tasks use the @serialized_data_fetch decorator
 to ensure only one task fetches external data at a time.
 """
-from collections import Counter
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
 import logging
 from typing import List, Optional
 from datetime import datetime, timezone
@@ -29,8 +27,11 @@ from ..services.market_activity_service import (
     mark_market_activity_progress,
     mark_market_activity_started,
 )
-from ..services.price_refresh_execution import run_price_refresh_jobs
-from ..services.price_refresh_planning import LIVE_TOP_UP_MODES, plan_price_refresh
+from ..services.price_refresh_planning import plan_price_refresh
+from ..services.price_refresh_workflow import (
+    PriceRefreshWorkflow,
+    PriceRefreshWorkflowDependencies,
+)
 from ..config import settings
 from ..utils.market_hours import is_market_open, is_trading_day, get_eastern_now, format_market_status
 from ..wiring.bootstrap import (
@@ -1250,169 +1251,6 @@ def _record_market_refresh_success_safely(
         )
 
 
-@dataclass
-class LivePriceRefreshExecutionContext:
-    task: object
-    bulk_fetcher: object
-    price_cache: object
-    db: object
-    market: str | None
-    effective_market: str
-    activity_lifecycle: str
-    symbol_markets: dict[str, str]
-    processed: int = 0
-
-    def market_for_symbol(self, symbol: str) -> str:
-        return self.symbol_markets.get(str(symbol).upper(), self.effective_market)
-
-    def fetch_batch(self, symbols, *, period: str, market: str | None):
-        return _fetch_with_backoff(
-            self.bulk_fetcher,
-            list(symbols),
-            period=period,
-            market=market,
-        )
-
-    def store_prices(self, price_data_by_symbol) -> None:
-        self.price_cache.store_batch_in_cache(
-            dict(price_data_by_symbol),
-            also_store_db=True,
-        )
-
-    def track_symbol_failures(self, successes, failures, *, failure_details) -> None:
-        _track_symbol_failures(
-            self.price_cache,
-            list(successes),
-            list(failures),
-            self.db,
-            failure_details=dict(failure_details),
-        )
-
-    def publish_progress(
-        self,
-        current: int,
-        total: int,
-        percent: float,
-        message: str,
-        *,
-        refreshed: int,
-        failed: int,
-    ) -> None:
-        self.processed = current
-        self.task.update_state(
-            state="PROGRESS",
-            meta={
-                "current": current,
-                "total": total,
-                "percent": percent,
-                "refreshed": refreshed,
-                "failed": failed,
-            },
-        )
-        self.price_cache.update_warmup_heartbeat(
-            current,
-            total,
-            percent,
-            market=self.market,
-        )
-        _mark_market_activity_progress_safely(
-            self.db,
-            market=self.effective_market,
-            stage_key="prices",
-            lifecycle=self.activity_lifecycle,
-            task_name=getattr(self.task, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(self.task, "request", None), "id", None),
-            current=current,
-            total=total,
-            percent=round(percent, 1),
-            message=message,
-        )
-
-    def extend_lock(self) -> None:
-        task_id = getattr(getattr(self.task, "request", None), "id", None) or "unknown"
-        from ..wiring.bootstrap import get_data_fetch_lock
-
-        get_data_fetch_lock().extend_lock(task_id, 300, market=self.market)
-
-    def wait_between_batches(self) -> None:
-        if self.market is not None:
-            get_rate_limiter().wait_for_market("yfinance:batch", self.market)
-            return
-        get_rate_limiter().wait(
-            "yfinance:batch",
-            min_interval_s=settings.yfinance_batch_rate_limit_interval,
-        )
-
-    def raise_if_transient_database_error(self, exc: Exception) -> None:
-        raise_if_transient_database_error(exc)
-
-
-def _complete_price_refresh_without_live_fetch(
-    *,
-    db,
-    price_cache,
-    task,
-    market: str | None,
-    effective_market: str,
-    activity_lifecycle: str,
-    mode: str,
-    message: str,
-    metadata_refreshed: int,
-    metadata_total: int,
-    activity_current: int,
-    activity_total: int,
-    heartbeat_status: str | None = None,
-    source: str | None = None,
-    github_sync: dict | None = None,
-    trading_day=None,
-) -> dict:
-    price_cache.save_warmup_metadata(
-        "completed",
-        metadata_refreshed,
-        metadata_total,
-        market=market,
-    )
-    if heartbeat_status is not None:
-        price_cache.complete_warmup_heartbeat(heartbeat_status, market=market)
-    mark_market_activity_completed(
-        db,
-        market=effective_market,
-        stage_key="prices",
-        lifecycle=activity_lifecycle,
-        task_name=getattr(task, "name", "smart_refresh_cache"),
-        task_id=getattr(getattr(task, "request", None), "id", None),
-        current=activity_current,
-        total=activity_total,
-        message=message,
-    )
-    if trading_day is not None:
-        _record_market_refresh_success_safely(
-            db,
-            market=effective_market,
-            trading_day=trading_day,
-            success_rate=1.0,
-        )
-
-    result = {
-        "status": "completed",
-        "refreshed": 0,
-        "failed": 0,
-        "total": 0,
-        "message": message,
-        "mode": mode,
-        "completed_at": datetime.now().isoformat(),
-    }
-    if source is not None:
-        result.update(
-            {
-                "source": source,
-                "github_sync_status": github_sync.get("status") if github_sync else None,
-                "source_revision": github_sync.get("source_revision") if github_sync else None,
-            }
-        )
-    return result
-
-
 def _schedule_failed_symbol_retry(
     symbols: list[str],
     *,
@@ -1778,6 +1616,54 @@ def auto_refresh_after_close(self, market: str | None = None):
     return result
 
 
+def run_smart_price_refresh(
+    *,
+    task,
+    mode: str,
+    market: str | None,
+    activity_lifecycle: str | None,
+) -> dict:
+    from ..services.bulk_data_fetcher import BulkDataFetcher
+    from ..services.runtime_preferences_service import is_market_enabled_now
+    from ..wiring.bootstrap import get_price_cache
+    from .market_queues import market_tag, log_extra, normalize_market
+
+    dependencies = PriceRefreshWorkflowDependencies(
+        session_factory=SessionLocal,
+        price_cache_factory=get_price_cache,
+        bulk_fetcher_factory=BulkDataFetcher,
+        warm_benchmarks=warm_spy_cache,
+        plan_price_refresh=plan_price_refresh,
+        fetch_with_backoff=_fetch_with_backoff,
+        track_symbol_failures=_track_symbol_failures,
+        schedule_failed_symbol_retry=_schedule_failed_symbol_retry,
+        record_market_refresh_success=_record_market_refresh_success_safely,
+        mark_market_activity_started=mark_market_activity_started,
+        mark_market_activity_completed=mark_market_activity_completed,
+        mark_market_activity_progress_safely=_mark_market_activity_progress_safely,
+        mark_market_activity_failed_safely=_mark_market_activity_failed_safely,
+        daily_price_bundle_service_factory=get_daily_price_bundle_service,
+        market_calendar_service_factory=get_market_calendar_service,
+        rate_limiter_factory=get_rate_limiter,
+        normalize_market=normalize_market,
+        market_tag=market_tag,
+        log_extra=log_extra,
+        get_eastern_now=get_eastern_now,
+        is_trading_day=is_trading_day,
+        format_market_status=format_market_status,
+        is_market_enabled_now=is_market_enabled_now,
+        raise_if_transient_database_error=raise_if_transient_database_error,
+        safe_rollback=safe_rollback,
+        time_window_bypass_enabled=lambda: _SMART_REFRESH_TIME_WINDOW_BYPASS.get(),
+    )
+    return PriceRefreshWorkflow(dependencies).run(
+        task=task,
+        mode=mode,
+        market=market,
+        activity_lifecycle=activity_lifecycle,
+    )
+
+
 @celery_app.task(
     bind=True,
     name='app.tasks.cache_tasks.smart_refresh_cache',
@@ -1790,475 +1676,13 @@ def smart_refresh_cache(
     market: str | None = None,
     activity_lifecycle: str | None = None,
 ):
-    """
-    Smart cache refresh with market cap prioritization.
-
-    This is the unified refresh task that replaces the confusing split
-    between daily_cache_warmup and force_refresh_stale_intraday.
-
-    Key features:
-    1. Always warms benchmarks first (required for RS calculations)
-    2. Fetches symbols in market cap order (high cap first)
-    3. Updates heartbeat for stuck detection
-    4. Saves warmup metadata for partial completion tracking
-
-    Args:
-        mode: Refresh mode
-            - "auto": Full universe, skip symbols refreshed within 4h (smart refresh)
-            - "full": Full universe, force re-fetch everything regardless of freshness
-            - "bootstrap": GitHub-first first-run seed; accepts recent stale bundles
-              and live-fetches only stale/no-history gaps
-            - "delta": GitHub-first scheduled refresh; live-fetches only stale/no-history gaps
-
-    Returns:
-        Dict with refresh statistics
-    """
-    import time
-    from ..wiring.bootstrap import get_price_cache
-    from ..services.bulk_data_fetcher import BulkDataFetcher
-    from ..models.stock_universe import StockUniverse
-    from .market_queues import market_tag, log_extra, normalize_market
-    from ..services.runtime_preferences_service import is_market_enabled_now
-
-    effective_market = normalize_market(market) if market is not None else "US"
-    _market_label = effective_market.lower()
-    activity_lifecycle = activity_lifecycle or "daily_refresh"
-    _log_extra = log_extra(market)
-    logger.info("=" * 80)
-    logger.info(
-        "TASK: Smart Cache Refresh %s (mode=%s)", market_tag(market), mode,
-        extra=_log_extra,
+    """Run the smart price refresh workflow behind the Celery data-fetch lock."""
+    return run_smart_price_refresh(
+        task=self,
+        mode=mode,
+        market=market,
+        activity_lifecycle=activity_lifecycle,
     )
-    logger.info("Market status: %s", format_market_status(), extra=_log_extra)
-    logger.info("Timestamp: %s", datetime.now().strftime('%Y-%m-%d %H:%M:%S'), extra=_log_extra)
-    logger.info("=" * 80)
-
-    if market is not None and not is_market_enabled_now(normalize_market(market)):
-        logger.info("Skipping smart refresh for disabled market %s", market, extra=_log_extra)
-        return {
-            'status': 'skipped',
-            'reason': f'market {effective_market} is disabled in local runtime preferences',
-            'market': effective_market,
-            'mode': mode,
-            'timestamp': datetime.now().isoformat(),
-        }
-
-    # Time-window guard: reject Beat-scheduled full mode outside expected windows.
-    # This prevents catchup storms (Beat replaying missed schedules on restart).
-    # Manual API calls set headers={'origin': 'manual'} to bypass this guard.
-    is_manual = (
-        _SMART_REFRESH_TIME_WINDOW_BYPASS.get()
-        or (
-            getattr(self.request, 'headers', None)
-            and self.request.headers.get('origin') == 'manual'
-        )
-    )
-    # Time-window guard only applies to the legacy US-only scheduling path
-    # (market is None). Per-market beat entries fire at local-market
-    # hours in ET (e.g. HK at 4:30 AM ET, TW at 1:00 AM ET) which fall outside
-    # the legacy US window, so skip the guard when market is explicit.
-    if mode == "full" and not is_manual and market is None:
-        now_et = get_eastern_now()
-        weekday = now_et.weekday()  # 0=Mon, 6=Sun
-        hour = now_et.hour
-
-        # Allow: weekdays 4PM-midnight (daily refresh window)
-        # Allow: Sunday 1AM-6AM (weekly refresh window)
-        in_weekday_window = weekday < 5 and 16 <= hour < 24
-        in_sunday_window = weekday == 6 and 1 <= hour < 6
-
-        if not in_weekday_window and not in_sunday_window:
-            logger.warning(
-                f"Rejecting Beat-scheduled full refresh outside time window "
-                f"(weekday={weekday}, hour={hour}). Likely a catchup storm."
-            )
-            return {
-                'skipped': True,
-                'reason': f'Outside refresh window (weekday={weekday}, hour={hour})',
-                'mode': mode,
-                'timestamp': datetime.now().isoformat()
-            }
-
-    # Skip on non-trading days in auto mode (full mode can be on-demand)
-    if mode == "auto":
-        today = get_eastern_now().date()
-        if not is_trading_day(today):
-            logger.info(f"Skipping smart refresh (auto) - {today} is not a trading day")
-            return {'skipped': True, 'reason': 'Not a trading day', 'date': today.isoformat(), 'mode': mode}
-
-    price_cache = get_price_cache()
-    db = SessionLocal()
-
-    refreshed = 0
-    processed = 0
-    failed = 0
-    failed_symbols = []
-    github_sync: dict | None = None
-    used_github_seed = False
-
-    try:
-        mark_market_activity_started(
-            db,
-            market=effective_market,
-            stage_key="prices",
-            lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
-            message="Refreshing market prices",
-        )
-        # Step 1: Always warm market benchmarks first (required for RS
-        # calculations). Scoped to caller's market to avoid redundant work
-        # across parallel per-market refreshes.
-        logger.info("[1/3] Warming market benchmarks...")
-        benchmark_result = warm_spy_cache(market=market)
-        if benchmark_result.get('error'):
-            logger.error(f"Benchmark warmup failed: {benchmark_result.get('error')}")
-
-        # Step 2: Get symbols to refresh, ordered by market cap
-        logger.info(f"[2/3] Determining symbols to refresh (mode={mode})...")
-
-        # Build universe query, optionally filtered by market.
-        _uni_q = db.query(StockUniverse.symbol, StockUniverse.market).filter(
-            StockUniverse.is_active == True
-        )
-        if market is not None:
-            _uni_q = _uni_q.filter(StockUniverse.market == normalize_market(market))
-        _uni_q = _uni_q.order_by(StockUniverse.market_cap.desc().nullslast())
-        universe_rows = _uni_q.all()
-        all_symbols = [r.symbol for r in universe_rows]
-        symbol_markets = {
-            str(r.symbol).upper(): normalize_market(
-                getattr(r, "market", None) or effective_market
-            )
-            for r in universe_rows
-        }
-
-        def _symbols_needing_auto_refresh(candidate_symbols):
-            logger.info(
-                "Auto refresh: %d active symbols (full universe, market cap order) %s",
-                len(candidate_symbols),
-                market_tag(market),
-                extra=_log_extra,
-            )
-            refresh_symbols = price_cache.get_symbols_needing_refresh(
-                list(candidate_symbols),
-                max_age_hours=settings.refresh_skip_hours,
-            )
-            skipped = len(candidate_symbols) - len(refresh_symbols)
-            if skipped > 0:
-                logger.info(
-                    "Skipping %d recently-refreshed symbols (fresh within %sh)",
-                    skipped,
-                    settings.refresh_skip_hours,
-                )
-            return refresh_symbols
-
-        if mode in LIVE_TOP_UP_MODES and all_symbols and market is not None:
-            github_sync = get_daily_price_bundle_service().sync_from_github(
-                db,
-                market=effective_market,
-                allow_stale=True,
-            )
-
-        refresh_plan = plan_price_refresh(
-            db,
-            all_symbols=all_symbols,
-            mode=mode,
-            effective_market=effective_market,
-            market_calendar_service=get_market_calendar_service(),
-            github_sync=github_sync,
-            recently_refreshed_filter=(
-                _symbols_needing_auto_refresh if mode == "auto" else None
-            ),
-        )
-        github_sync = dict(refresh_plan.github_sync) if refresh_plan.github_sync else None
-        used_github_seed = refresh_plan.used_github_seed
-        symbols = list(refresh_plan.symbols)
-        live_refresh_jobs = list(refresh_plan.jobs)
-
-        if github_sync and github_sync.get("stale_reason"):
-            logger.info(
-                "GitHub daily price bundle for %s imported with stale manifest: %s",
-                effective_market,
-                github_sync.get("stale_reason"),
-                extra=_log_extra,
-            )
-        if github_sync and not used_github_seed:
-            status = github_sync.get("status")
-            reason = github_sync.get("reason") or github_sync.get("error")
-            stale_reason = github_sync.get("stale_reason")
-            logger.warning(
-                "GitHub daily price bundle not used for %s (status=%s, reason=%s, stale_reason=%s); using live refresh policy",
-                effective_market,
-                status,
-                reason,
-                stale_reason,
-                extra=_log_extra,
-            )
-            _mark_market_activity_progress_safely(
-                db,
-                market=effective_market,
-                stage_key="prices",
-                lifecycle=activity_lifecycle,
-                task_name=getattr(self, "name", "smart_refresh_cache"),
-                task_id=getattr(getattr(self, "request", None), "id", None),
-                current=0,
-                total=len(all_symbols),
-                percent=0,
-                message=f"GitHub price bundle {status}; using live price refresh",
-            )
-
-        if symbols:
-            if refresh_plan.source == "github+live":
-                logger.info(
-                    "GitHub daily price bundle synced for %s; live refresh will top up %d symbols",
-                    effective_market,
-                    len(symbols),
-                    extra=_log_extra,
-                )
-            elif mode == "full":
-                logger.info(
-                    "Full refresh: %d symbols (market cap order) %s",
-                    len(symbols), market_tag(market), extra=_log_extra,
-                )
-            elif mode in {"bootstrap", "delta"}:
-                logger.info(
-                    "Delta refresh: %d symbols %s",
-                    len(symbols),
-                    market_tag(market),
-                    extra=_log_extra,
-                )
-
-        if refresh_plan.source == "github" and not symbols:
-            message = (
-                refresh_plan.completion_message
-                or "GitHub daily price bundle is current - no live fetch needed"
-            )
-            try:
-                trading_day = datetime.fromisoformat(
-                    str(github_sync.get("as_of_date") if github_sync else None)
-                ).date()
-            except (TypeError, ValueError):
-                trading_day = get_market_calendar_service().last_completed_trading_day(effective_market)
-            return _complete_price_refresh_without_live_fetch(
-                db=db,
-                price_cache=price_cache,
-                task=self,
-                market=market,
-                effective_market=effective_market,
-                activity_lifecycle=activity_lifecycle,
-                mode=mode,
-                message=message,
-                metadata_refreshed=len(all_symbols),
-                metadata_total=len(all_symbols),
-                activity_current=len(all_symbols) if all_symbols else 0,
-                activity_total=len(all_symbols) if all_symbols else 0,
-                heartbeat_status="completed",
-                source="github",
-                github_sync=github_sync,
-                trading_day=trading_day,
-            )
-
-        if not symbols:
-            if refresh_plan.completion_message:
-                message = refresh_plan.completion_message
-            elif mode == "auto":
-                message = "All symbols recently refreshed - nothing to do"
-            elif mode in {"bootstrap", "delta"}:
-                message = "All symbols already fresh - no live fetch needed"
-            else:
-                message = "No active symbols found in universe"
-            return _complete_price_refresh_without_live_fetch(
-                db=db,
-                price_cache=price_cache,
-                task=self,
-                market=market,
-                effective_market=effective_market,
-                activity_lifecycle=activity_lifecycle,
-                mode=mode,
-                message=message,
-                metadata_refreshed=0,
-                metadata_total=0,
-                activity_current=0,
-                activity_total=0,
-            )
-
-        total = len(symbols)
-        symbol_market_totals = Counter(
-            symbol_markets.get(str(symbol).upper(), effective_market) for symbol in symbols
-        )
-        refreshed_by_market: Counter[str] = Counter()
-        batch_size = 100
-        bulk_fetcher = BulkDataFetcher()
-        execution_context = LivePriceRefreshExecutionContext(
-            task=self,
-            bulk_fetcher=bulk_fetcher,
-            price_cache=price_cache,
-            db=db,
-            market=market,
-            effective_market=effective_market,
-            activity_lifecycle=activity_lifecycle,
-            symbol_markets=symbol_markets,
-        )
-
-        # Write initial heartbeat before batch loop to prevent false "stuck" detection.
-        # Without this, the health endpoint sees lock held + no heartbeat = stuck.
-        price_cache.update_warmup_heartbeat(0, total, 0.0, market=market)
-        _mark_market_activity_progress_safely(
-            db,
-            market=effective_market,
-            stage_key="prices",
-            lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
-            current=0,
-            total=total,
-            percent=0,
-            message="Refreshing market prices",
-        )
-
-        # Step 3: Batch fetch with progress tracking
-        logger.info(f"[3/3] Fetching {total} symbols...")
-
-        execution_result = run_price_refresh_jobs(
-            jobs=live_refresh_jobs,
-            total=total,
-            batch_size=batch_size,
-            market=market,
-            context=execution_context,
-        )
-        processed = execution_context.processed
-        refreshed = execution_result.refreshed
-        failed = execution_result.failed
-        failed_symbols = execution_result.failed_symbols
-        refreshed_by_market = execution_result.refreshed_by_market
-
-        # Save final warmup metadata (treat >95% success as "completed")
-        success_rate = refreshed / total if total > 0 else 0
-        status = "completed" if success_rate >= 0.95 else "partial"
-        price_cache.save_warmup_metadata(status, refreshed, total, market=market)
-        price_cache.complete_warmup_heartbeat("completed", market=market)
-        for refresh_market, market_total in symbol_market_totals.items():
-            market_success_rate = (
-                refreshed_by_market[refresh_market] / market_total if market_total > 0 else 0
-            )
-            if market_success_rate < 0.95:
-                continue
-            _record_market_refresh_success_safely(
-                db,
-                market=refresh_market,
-                trading_day=get_market_calendar_service().last_completed_trading_day(refresh_market),
-                success_rate=market_success_rate,
-            )
-        if failed_symbols:
-            failed_symbols_by_market: dict[str, list[str]] = {}
-            for symbol in failed_symbols:
-                failed_symbols_by_market.setdefault(
-                    execution_context.market_for_symbol(symbol),
-                    [],
-                ).append(symbol)
-            for retry_market, retry_symbols in failed_symbols_by_market.items():
-                if activity_lifecycle == "bootstrap":
-                    _schedule_failed_symbol_retry(
-                        retry_symbols,
-                        market=retry_market,
-                        attempt=1,
-                        countdown=30,
-                    )
-                else:
-                    _schedule_failed_symbol_retry(
-                        retry_symbols,
-                        market=retry_market,
-                        attempt=1,
-                    )
-
-        logger.info("=" * 80)
-        logger.info(f"✓ Smart refresh completed ({mode} mode):")
-        logger.info(f"  Refreshed: {refreshed}")
-        logger.info(f"  Failed: {failed}")
-        logger.info(f"  Total: {total}")
-        if failed_symbols:
-            logger.info(f"  Failed symbols: {failed_symbols[:10]}...")
-        logger.info("=" * 80)
-        mark_market_activity_completed(
-            db,
-            market=effective_market,
-            stage_key="prices",
-            lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
-            current=total,
-            total=total,
-            message=f"Price refresh {status}",
-        )
-
-        return {
-            "status": status,
-            "source": "github+live" if used_github_seed else "live",
-            "github_sync_status": github_sync.get("status") if github_sync else None,
-            "source_revision": github_sync.get("source_revision") if github_sync else None,
-            "refreshed": refreshed,
-            "failed": failed,
-            "total": total,
-            "failed_symbols": failed_symbols[:20],
-            "mode": mode,
-            "completed_at": datetime.now().isoformat()
-        }
-
-    except SoftTimeLimitExceeded:
-        logger.error("Soft time limit exceeded in smart_refresh_cache", exc_info=True)
-        safe_rollback(db)
-        current_progress = getattr(locals().get("execution_context"), "processed", processed)
-        price_cache.save_warmup_metadata(
-            "failed",
-            refreshed,
-            locals().get("total", 0),
-            "Soft time limit exceeded",
-            market=market,
-        )
-        price_cache.complete_warmup_heartbeat("failed", market=market)
-        _mark_market_activity_failed_safely(
-            db,
-            market=effective_market,
-            stage_key="prices",
-            lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
-            current=current_progress,
-            total=locals().get("total", 0),
-            message="Soft time limit exceeded",
-        )
-        raise
-    except Exception as e:
-        raise_if_transient_database_error(e)
-        logger.error(f"Error in smart_refresh_cache task: {e}", exc_info=True)
-        safe_rollback(db)
-        current_progress = getattr(locals().get("execution_context"), "processed", processed)
-        # Save partial progress
-        price_cache.save_warmup_metadata("failed", refreshed, locals().get('total', 0), str(e), market=market)
-        price_cache.complete_warmup_heartbeat("failed", market=market)
-        _mark_market_activity_failed_safely(
-            db,
-            market=effective_market,
-            stage_key="prices",
-            lifecycle=activity_lifecycle,
-            task_name=getattr(self, "name", "smart_refresh_cache"),
-            task_id=getattr(getattr(self, "request", None), "id", None),
-            current=current_progress,
-            total=locals().get("total", 0),
-            message=str(e),
-        )
-        return {
-            "status": "failed",
-            "error": str(e),
-            "refreshed": refreshed,
-            "failed": failed,
-            "mode": mode,
-            "timestamp": datetime.now().isoformat()
-        }
-
-    finally:
-        db.close()
 
 
 @celery_app.task(bind=True, name='app.tasks.cache_tasks.cleanup_old_price_data')

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -28,6 +28,7 @@ from ..services.market_activity_service import (
     mark_market_activity_progress,
     mark_market_activity_started,
 )
+from ..services.price_refresh_planning import plan_price_refresh
 from ..config import settings
 from ..utils.market_hours import is_market_open, is_trading_day, get_eastern_now, format_market_status
 from ..wiring.bootstrap import (
@@ -41,10 +42,6 @@ from .data_fetch_lock import serialized_data_fetch
 from .transient_database import raise_if_transient_database_error
 
 logger = logging.getLogger(__name__)
-_GITHUB_SYNC_SUCCESS_STATUSES = frozenset({"success", "up_to_date"})
-_LIVE_TOP_UP_MODES = frozenset({"bootstrap", "delta"})
-_STALE_PRICE_TOP_UP_PERIOD = "7d"
-_NO_HISTORY_PRICE_BOOTSTRAP_PERIOD = "2y"
 
 _SMART_REFRESH_TIME_WINDOW_BYPASS: ContextVar[bool] = ContextVar(
     "smart_refresh_time_window_bypass",
@@ -1101,56 +1098,6 @@ def _fetch_with_backoff(
     raise RateLimitExhaustedError(symbols, market)
 
 
-def _classify_symbols_by_price_history(db, *, symbols: list[str], as_of_date) -> dict[str, list[str]]:
-    """Split symbols by whether DB prices already cover ``as_of_date``."""
-    from sqlalchemy import func
-
-    from ..models.stock import StockPrice
-
-    normalized_symbols = [str(symbol).upper() for symbol in symbols]
-    latest_by_symbol = {}
-    for chunk_start in range(0, len(normalized_symbols), 500):
-        chunk_symbols = normalized_symbols[chunk_start:chunk_start + 500]
-        rows = (
-            db.query(StockPrice.symbol, func.max(StockPrice.date))
-            .filter(StockPrice.symbol.in_(chunk_symbols))
-            .group_by(StockPrice.symbol)
-            .all()
-        )
-        latest_by_symbol.update({str(symbol).upper(): latest_date for symbol, latest_date in rows})
-
-    fresh_symbols = []
-    stale_symbols = []
-    no_history_symbols = []
-    for symbol in normalized_symbols:
-        latest_date = latest_by_symbol.get(symbol)
-        if latest_date is None:
-            no_history_symbols.append(symbol)
-        elif latest_date < as_of_date:
-            stale_symbols.append(symbol)
-        else:
-            fresh_symbols.append(symbol)
-
-    return {
-        "fresh": fresh_symbols,
-        "stale": stale_symbols,
-        "no_history": no_history_symbols,
-    }
-
-
-def _build_live_price_refresh_jobs(
-    coverage: dict[str, list[str]],
-) -> list[tuple[str, list[str], str]]:
-    jobs: list[tuple[str, list[str], str]] = []
-    stale_symbols = coverage.get("stale") or []
-    no_history_symbols = coverage.get("no_history") or []
-    if stale_symbols:
-        jobs.append(("stale", stale_symbols, _STALE_PRICE_TOP_UP_PERIOD))
-    if no_history_symbols:
-        jobs.append(("no_history", no_history_symbols, _NO_HISTORY_PRICE_BOOTSTRAP_PERIOD))
-    return jobs
-
-
 def _classify_no_data_failure(error_message: str) -> bool:
     """Heuristic classifier for delisted/no-data provider failures."""
     lower = (error_message or "").lower()
@@ -1821,219 +1768,154 @@ def smart_refresh_cache(
             for r in universe_rows
         }
 
-        live_top_up_mode = mode in _LIVE_TOP_UP_MODES or activity_lifecycle == "bootstrap"
-        price_bundle_service = get_daily_price_bundle_service()
-        github_seed_allowed = (
-            all_symbols
-            and market is not None
-            and activity_lifecycle in {"daily_refresh", "bootstrap"}
-        )
-        if github_seed_allowed:
-            github_sync_kwargs = {"market": effective_market}
-            if live_top_up_mode:
-                github_sync_kwargs["allow_stale"] = True
-            github_sync = price_bundle_service.sync_from_github(db, **github_sync_kwargs)
-        else:
-            github_sync = {"status": "skipped", "reason": "empty_universe"}
-
-        live_refresh_jobs: list[tuple[str, list[str], str]] = []
-        if github_sync.get("status") in _GITHUB_SYNC_SUCCESS_STATUSES:
-            used_github_seed = True
-            if github_sync.get("stale_reason"):
+        def _symbols_needing_auto_refresh(candidate_symbols):
+            logger.info(
+                "Auto refresh: %d active symbols (full universe, market cap order) %s",
+                len(candidate_symbols),
+                market_tag(market),
+                extra=_log_extra,
+            )
+            refresh_symbols = price_cache.get_symbols_needing_refresh(
+                list(candidate_symbols),
+                max_age_hours=settings.refresh_skip_hours,
+            )
+            skipped = len(candidate_symbols) - len(refresh_symbols)
+            if skipped > 0:
                 logger.info(
-                    "GitHub daily price bundle for %s imported with stale manifest: %s",
-                    effective_market,
-                    github_sync.get("stale_reason"),
-                    extra=_log_extra,
+                    "Skipping %d recently-refreshed symbols (fresh within %sh)",
+                    skipped,
+                    settings.refresh_skip_hours,
                 )
-            if live_top_up_mode:
-                target_as_of = get_market_calendar_service().last_completed_trading_day(effective_market)
-                try:
-                    github_as_of = datetime.fromisoformat(
-                        str(github_sync.get("as_of_date"))
-                    ).date()
-                except (TypeError, ValueError):
-                    github_as_of = None
-                if github_as_of == target_as_of:
-                    symbols = price_bundle_service.symbols_missing_as_of(
-                        db,
-                        symbols=all_symbols,
-                        as_of_date=target_as_of.isoformat(),
-                    )
-                    if symbols:
-                        coverage = _classify_symbols_by_price_history(
-                            db,
-                            symbols=symbols,
-                            as_of_date=target_as_of,
-                        )
-                        live_refresh_jobs = _build_live_price_refresh_jobs(coverage)
-                        symbols = [
-                            symbol
-                            for _kind, job_symbols, _period in live_refresh_jobs
-                            for symbol in job_symbols
-                        ]
-                else:
-                    coverage = _classify_symbols_by_price_history(
-                        db,
-                        symbols=all_symbols,
-                        as_of_date=target_as_of,
-                    )
-                    live_refresh_jobs = _build_live_price_refresh_jobs(coverage)
-                    symbols = [
-                        symbol
-                        for _kind, job_symbols, _period in live_refresh_jobs
-                        for symbol in job_symbols
-                    ]
-            else:
-                symbols = price_bundle_service.symbols_missing_as_of(
-                    db,
-                    symbols=all_symbols,
-                    as_of_date=str(github_sync.get("as_of_date") or ""),
-                )
-                if symbols:
-                    live_refresh_jobs = [(
-                        "missing_or_stale",
-                        symbols,
-                        _NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
-                    )]
-            if symbols:
+            return refresh_symbols
+
+        refresh_plan = plan_price_refresh(
+            db,
+            all_symbols=all_symbols,
+            mode=mode,
+            activity_lifecycle=activity_lifecycle,
+            effective_market=effective_market,
+            price_bundle_service=get_daily_price_bundle_service(),
+            market_calendar_service=get_market_calendar_service(),
+            github_seed_allowed=bool(all_symbols and market is not None),
+            recently_refreshed_filter=(
+                _symbols_needing_auto_refresh if mode == "auto" else None
+            ),
+        )
+        github_sync = dict(refresh_plan.github_sync) if refresh_plan.github_sync else None
+        used_github_seed = refresh_plan.used_github_seed
+        symbols = list(refresh_plan.symbols)
+        live_refresh_jobs = list(refresh_plan.jobs)
+
+        if github_sync and github_sync.get("stale_reason"):
+            logger.info(
+                "GitHub daily price bundle for %s imported with stale manifest: %s",
+                effective_market,
+                github_sync.get("stale_reason"),
+                extra=_log_extra,
+            )
+        if github_sync and not used_github_seed:
+            status = github_sync.get("status")
+            reason = github_sync.get("reason") or github_sync.get("error")
+            stale_reason = github_sync.get("stale_reason")
+            logger.warning(
+                "GitHub daily price bundle not used for %s (status=%s, reason=%s, stale_reason=%s); using live refresh policy",
+                effective_market,
+                status,
+                reason,
+                stale_reason,
+                extra=_log_extra,
+            )
+            _mark_market_activity_progress_safely(
+                db,
+                market=effective_market,
+                stage_key="prices",
+                lifecycle=activity_lifecycle,
+                task_name=getattr(self, "name", "smart_refresh_cache"),
+                task_id=getattr(getattr(self, "request", None), "id", None),
+                current=0,
+                total=len(all_symbols),
+                percent=0,
+                message=f"GitHub price bundle {status}; using live price refresh",
+            )
+
+        if symbols:
+            if refresh_plan.source == "github+live":
                 logger.info(
                     "GitHub daily price bundle synced for %s; live refresh will top up %d symbols",
                     effective_market,
                     len(symbols),
                     extra=_log_extra,
                 )
-            else:
-                message = "GitHub daily price bundle is current - no live fetch needed"
-                price_cache.save_warmup_metadata(
-                    "completed",
-                    len(all_symbols),
-                    len(all_symbols),
-                    market=market,
-                )
-                price_cache.complete_warmup_heartbeat("completed", market=market)
-                mark_market_activity_completed(
-                    db,
-                    market=effective_market,
-                    stage_key="prices",
-                    lifecycle=activity_lifecycle,
-                    task_name=getattr(self, "name", "smart_refresh_cache"),
-                    task_id=getattr(getattr(self, "request", None), "id", None),
-                    current=len(all_symbols) if all_symbols else 0,
-                    total=len(all_symbols) if all_symbols else 0,
-                    message=message,
-                )
-                try:
-                    trading_day = datetime.fromisoformat(
-                        str(github_sync.get("as_of_date"))
-                    ).date()
-                except (TypeError, ValueError):
-                    trading_day = get_market_calendar_service().last_completed_trading_day(effective_market)
-                _record_market_refresh_success_safely(
-                    db,
-                    market=effective_market,
-                    trading_day=trading_day,
-                    success_rate=1.0,
-                )
-                return {
-                    "status": "completed",
-                    "source": "github",
-                    "github_sync_status": github_sync.get("status"),
-                    "source_revision": github_sync.get("source_revision"),
-                    "refreshed": 0,
-                    "failed": 0,
-                    "total": 0,
-                    "message": message,
-                    "mode": mode,
-                    "completed_at": datetime.now().isoformat(),
-                }
-        else:
-            status = github_sync.get("status")
-            reason = github_sync.get("reason") or github_sync.get("error")
-            stale_reason = github_sync.get("stale_reason")
-            if github_seed_allowed:
-                logger.warning(
-                    "GitHub daily price bundle not used for %s (status=%s, reason=%s, stale_reason=%s); using live refresh policy",
-                    effective_market,
-                    status,
-                    reason,
-                    stale_reason,
-                    extra=_log_extra,
-                )
-                _mark_market_activity_progress_safely(
-                    db,
-                    market=effective_market,
-                    stage_key="prices",
-                    lifecycle=activity_lifecycle,
-                    task_name=getattr(self, "name", "smart_refresh_cache"),
-                    task_id=getattr(getattr(self, "request", None), "id", None),
-                    current=0,
-                    total=len(all_symbols),
-                    percent=0,
-                    message=f"GitHub price bundle {status}; using live price refresh",
-                )
-
-            if live_top_up_mode:
-                target_as_of = get_market_calendar_service().last_completed_trading_day(effective_market)
-                coverage = _classify_symbols_by_price_history(
-                    db,
-                    symbols=all_symbols,
-                    as_of_date=target_as_of,
-                )
-                live_refresh_jobs = _build_live_price_refresh_jobs(coverage)
-                symbols = [
-                    symbol
-                    for _kind, job_symbols, _period in live_refresh_jobs
-                    for symbol in job_symbols
-                ]
-                logger.info(
-                    "Delta refresh: %d stale symbols and %d no-history symbols %s",
-                    len(coverage.get("stale") or []),
-                    len(coverage.get("no_history") or []),
-                    market_tag(market),
-                    extra=_log_extra,
-                )
             elif mode == "full":
-                # Full refresh: ALL active symbols for the market, ordered by market cap DESC
-                symbols = all_symbols
-                live_refresh_jobs = [(
-                    "full",
-                    symbols,
-                    _NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
-                )]
                 logger.info(
                     "Full refresh: %d symbols (market cap order) %s",
                     len(symbols), market_tag(market), extra=_log_extra,
                 )
-            else:
-                # Auto mode: Full universe for market, skip recently-refreshed symbols
-                symbols = all_symbols
+            elif mode in {"bootstrap", "delta"}:
                 logger.info(
-                    "Auto refresh: %d active symbols (full universe, market cap order) %s",
-                    len(symbols), market_tag(market), extra=_log_extra,
+                    "Delta refresh: %d symbols %s",
+                    len(symbols),
+                    market_tag(market),
+                    extra=_log_extra,
                 )
 
-                # Filter out symbols refreshed within skip window
-                original_count = len(symbols)
-                symbols = price_cache.get_symbols_needing_refresh(symbols, max_age_hours=settings.refresh_skip_hours)
-                skipped = original_count - len(symbols)
-                if skipped > 0:
-                    logger.info(f"Skipping {skipped} recently-refreshed symbols (fresh within {settings.refresh_skip_hours}h)")
-                if symbols:
-                    live_refresh_jobs = [(
-                        "auto",
-                        symbols,
-                        _NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
-                    )]
+        if refresh_plan.source == "github" and not symbols:
+            message = (
+                refresh_plan.completion_message
+                or "GitHub daily price bundle is current - no live fetch needed"
+            )
+            price_cache.save_warmup_metadata(
+                "completed",
+                len(all_symbols),
+                len(all_symbols),
+                market=market,
+            )
+            price_cache.complete_warmup_heartbeat("completed", market=market)
+            mark_market_activity_completed(
+                db,
+                market=effective_market,
+                stage_key="prices",
+                lifecycle=activity_lifecycle,
+                task_name=getattr(self, "name", "smart_refresh_cache"),
+                task_id=getattr(getattr(self, "request", None), "id", None),
+                current=len(all_symbols) if all_symbols else 0,
+                total=len(all_symbols) if all_symbols else 0,
+                message=message,
+            )
+            try:
+                trading_day = datetime.fromisoformat(
+                    str(github_sync.get("as_of_date") if github_sync else None)
+                ).date()
+            except (TypeError, ValueError):
+                trading_day = get_market_calendar_service().last_completed_trading_day(effective_market)
+            _record_market_refresh_success_safely(
+                db,
+                market=effective_market,
+                trading_day=trading_day,
+                success_rate=1.0,
+            )
+            return {
+                "status": "completed",
+                "source": "github",
+                "github_sync_status": github_sync.get("status") if github_sync else None,
+                "source_revision": github_sync.get("source_revision") if github_sync else None,
+                "refreshed": 0,
+                "failed": 0,
+                "total": 0,
+                "message": message,
+                "mode": mode,
+                "completed_at": datetime.now().isoformat(),
+            }
 
         if not symbols:
-            message = (
-                "All symbols recently refreshed - nothing to do"
-                if mode == "auto" else
-                "All symbols already fresh - no live fetch needed"
-                if live_top_up_mode else
-                "No active symbols found in universe"
-            )
+            if refresh_plan.completion_message:
+                message = refresh_plan.completion_message
+            elif mode == "auto":
+                message = "All symbols recently refreshed - nothing to do"
+            elif mode in {"bootstrap", "delta"}:
+                message = "All symbols already fresh - no live fetch needed"
+            else:
+                message = "No active symbols found in universe"
             price_cache.save_warmup_metadata("completed", 0, 0, market=market)
             mark_market_activity_completed(
                 db,
@@ -2064,8 +1946,8 @@ def smart_refresh_cache(
         failed_by_market: Counter[str] = Counter()
         batch_size = 100
         total_batches = sum(
-            (len(job_symbols) + batch_size - 1) // batch_size
-            for _kind, job_symbols, _period in live_refresh_jobs
+            (len(job.symbols) + batch_size - 1) // batch_size
+            for job in live_refresh_jobs
         )
         bulk_fetcher = BulkDataFetcher()
 
@@ -2093,7 +1975,8 @@ def smart_refresh_cache(
 
         processed_count = 0
         batch_num = 0
-        for job_kind, job_symbols, fetch_period in live_refresh_jobs:
+        for job in live_refresh_jobs:
+            job_symbols = list(job.symbols)
             for batch_start in range(0, len(job_symbols), batch_size):
                 batch_symbols = job_symbols[batch_start:batch_start + batch_size]
                 batch_num += 1
@@ -2103,8 +1986,8 @@ def smart_refresh_cache(
                     batch_num,
                     total_batches,
                     len(batch_symbols),
-                    job_kind,
-                    fetch_period,
+                    job.kind,
+                    job.period,
                 )
 
                 batch_successes = []
@@ -2116,7 +1999,7 @@ def smart_refresh_cache(
                     batch_results = _fetch_with_backoff(
                         bulk_fetcher,
                         batch_symbols,
-                        period=fetch_period,
+                        period=job.period,
                         market=market,
                     )
 

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -27,7 +27,7 @@ from ..services.market_activity_service import (
     mark_market_activity_progress,
     mark_market_activity_started,
 )
-from ..services.price_refresh_planning import plan_price_refresh
+from ..services.price_refresh_planning import build_market_price_refresh_plan
 from ..services.price_refresh_activity import (
     PriceRefreshActivityDependencies,
     PriceRefreshActivityReporter,
@@ -1638,6 +1638,24 @@ def run_smart_price_refresh(
     from ..wiring.bootstrap import get_data_fetch_lock, get_price_cache
     from .market_queues import market_tag, log_extra, normalize_market
 
+    def build_refresh_plan(db, *, mode, market, effective_market, recently_refreshed_filter):
+        return build_market_price_refresh_plan(
+            db,
+            mode=mode,
+            market=market,
+            effective_market=effective_market,
+            normalize_market=normalize_market,
+            market_calendar_service=get_market_calendar_service(),
+            sync_github_seed=lambda sync_db, *, market, allow_stale: (
+                get_daily_price_bundle_service().sync_from_github(
+                    sync_db,
+                    market=market,
+                    allow_stale=allow_stale,
+                )
+            ),
+            recently_refreshed_filter=recently_refreshed_filter,
+        )
+
     activity_reporter = PriceRefreshActivityReporter(
         PriceRefreshActivityDependencies(
             record_market_refresh_success=_record_market_refresh_success_safely,
@@ -1661,9 +1679,10 @@ def run_smart_price_refresh(
         price_cache_factory=get_price_cache,
         bulk_fetcher_factory=BulkDataFetcher,
         warm_benchmarks=warm_spy_cache,
-        plan_price_refresh=plan_price_refresh,
-        daily_price_bundle_service_factory=get_daily_price_bundle_service,
-        market_calendar_service_factory=get_market_calendar_service,
+        build_refresh_plan=build_refresh_plan,
+        last_completed_trading_day=lambda market_code: (
+            get_market_calendar_service().last_completed_trading_day(market_code)
+        ),
         activity_reporter=activity_reporter,
         live_runner=live_runner,
         retry_scheduler=PriceRefreshRetryScheduler(_schedule_failed_symbol_retry),

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -27,7 +27,7 @@ from ..services.market_activity_service import (
     mark_market_activity_progress,
     mark_market_activity_started,
 )
-from ..services.price_refresh_planning import build_market_price_refresh_plan
+from ..services.price_refresh_plan_builder import build_market_price_refresh_plan
 from ..services.price_refresh_activity import (
     PriceRefreshActivityDependencies,
     PriceRefreshActivityReporter,

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -32,8 +32,9 @@ from ..services.price_fetch_failures import (
     is_no_data_price_failure,
     is_rate_limit_error as is_price_rate_limit_error,
     is_retryable_price_failure,
-    normalize_price_fetch_failure_kind,
 )
+from ..services.price_refresh_execution import classify_price_refresh_batch
+from ..services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
 from ..services.price_refresh_plan_builder import build_market_price_refresh_plan
 from ..services.price_refresh_activity import (
     PriceRefreshActivityDependencies,
@@ -1346,6 +1347,7 @@ def retry_failed_price_symbols(
     price_cache = get_price_cache()
     bulk_fetcher = BulkDataFetcher()
     refreshed = 0
+    successes: list[str] = []
     failed_symbols: list[str] = []
     failure_details: dict[str, str] = {}
     failure_kinds: dict[str, str] = {}
@@ -1356,24 +1358,26 @@ def retry_failed_price_symbols(
             period="2y",
             market=market,
         )
-        batch_to_store = {}
-        for symbol, data in batch_results.items():
-            if not data.get("has_error") and data.get("price_data") is not None:
-                price_df = data["price_data"]
-                if not price_df.empty:
-                    batch_to_store[symbol] = price_df
-                    refreshed += 1
-                    continue
-            failed_symbols.append(symbol)
-            failure_details[symbol] = data.get("error", "Unknown error")
-            kind = normalize_price_fetch_failure_kind(data.get("error_kind"))
-            if kind is not None:
-                failure_kinds[symbol] = kind.value
-        missing = sorted(set(deduped_symbols) - set(batch_results))
-        failed_symbols.extend(missing)
-        failure_details.update({symbol: "Missing from retry result" for symbol in missing})
-        if batch_to_store:
-            price_cache.store_batch_in_cache(batch_to_store, also_store_db=True)
+        retry_job = PriceRefreshJob(
+            kind=PriceRefreshJobKind.NO_HISTORY,
+            symbols=tuple(deduped_symbols),
+            period="2y",
+        )
+        outcome = classify_price_refresh_batch(
+            batch_number=1,
+            total_batches=1,
+            job=retry_job,
+            symbols=tuple(deduped_symbols),
+            batch_results=batch_results,
+            market_for_symbol=lambda _symbol: market,
+        )
+        refreshed = outcome.refreshed
+        successes = list(outcome.successes)
+        failed_symbols = list(outcome.failures)
+        failure_details = dict(outcome.failure_details)
+        failure_kinds = dict(outcome.failure_kinds)
+        if outcome.price_data_by_symbol:
+            price_cache.store_batch_in_cache(dict(outcome.price_data_by_symbol), also_store_db=True)
     except SoftTimeLimitExceeded:
         raise
     except Exception as exc:
@@ -1390,7 +1394,6 @@ def retry_failed_price_symbols(
         if kind is not None:
             failure_kinds = {symbol: kind.value for symbol in deduped_symbols}
 
-    successes = [symbol for symbol in deduped_symbols if symbol not in set(failed_symbols)]
     _track_symbol_failures(
         price_cache,
         successes,

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -28,6 +28,7 @@ from ..services.market_activity_service import (
     mark_market_activity_progress,
     mark_market_activity_started,
 )
+from ..services.price_refresh_execution import run_price_refresh_jobs
 from ..services.price_refresh_planning import LIVE_TOP_UP_MODES, plan_price_refresh
 from ..config import settings
 from ..utils.market_hours import is_market_open, is_trading_day, get_eastern_now, format_market_status
@@ -1948,16 +1949,66 @@ def smart_refresh_cache(
             symbol_markets.get(str(symbol).upper(), effective_market) for symbol in symbols
         )
         refreshed_by_market: Counter[str] = Counter()
-        failed_by_market: Counter[str] = Counter()
         batch_size = 100
-        total_batches = sum(
-            (len(job.symbols) + batch_size - 1) // batch_size
-            for job in live_refresh_jobs
-        )
         bulk_fetcher = BulkDataFetcher()
 
         def _market_for_symbol(symbol: str) -> str:
             return symbol_markets.get(str(symbol).upper(), effective_market)
+
+        def _update_live_task_state(
+            current: int,
+            total_symbols: int,
+            percent: float,
+            refreshed_count: int,
+            failed_count: int,
+        ) -> None:
+            self.update_state(
+                state="PROGRESS",
+                meta={
+                    "current": current,
+                    "total": total_symbols,
+                    "percent": percent,
+                    "refreshed": refreshed_count,
+                    "failed": failed_count,
+                },
+            )
+
+        def _mark_live_refresh_progress(
+            current: int,
+            total_symbols: int,
+            percent: float,
+            message: str,
+        ) -> None:
+            nonlocal processed
+            processed = current
+            price_cache.update_warmup_heartbeat(current, total_symbols, percent, market=market)
+            _mark_market_activity_progress_safely(
+                db,
+                market=effective_market,
+                stage_key="prices",
+                lifecycle=activity_lifecycle,
+                task_name=getattr(self, "name", "smart_refresh_cache"),
+                task_id=getattr(getattr(self, "request", None), "id", None),
+                current=current,
+                total=total_symbols,
+                percent=round(percent, 1),
+                message=message,
+            )
+
+        def _extend_live_refresh_lock() -> None:
+            task_id = self.request.id or "unknown"
+            from ..wiring.bootstrap import get_data_fetch_lock
+            lock = get_data_fetch_lock()
+            lock.extend_lock(task_id, 300, market=market)
+
+        def _wait_between_live_batches() -> None:
+            if market is not None:
+                get_rate_limiter().wait_for_market("yfinance:batch", market)
+            else:
+                get_rate_limiter().wait(
+                    "yfinance:batch",
+                    min_interval_s=settings.yfinance_batch_rate_limit_interval,
+                )
 
         # Write initial heartbeat before batch loop to prevent false "stuck" detection.
         # Without this, the health endpoint sees lock held + no heartbeat = stuck.
@@ -1978,131 +2029,27 @@ def smart_refresh_cache(
         # Step 3: Batch fetch with progress tracking
         logger.info(f"[3/3] Fetching {total} symbols...")
 
-        processed_count = 0
-        batch_num = 0
-        for job in live_refresh_jobs:
-            job_symbols = list(job.symbols)
-            for batch_start in range(0, len(job_symbols), batch_size):
-                batch_symbols = job_symbols[batch_start:batch_start + batch_size]
-                batch_num += 1
-
-                logger.info(
-                    "Batch %d/%d: Fetching %d symbols (%s, period=%s)",
-                    batch_num,
-                    total_batches,
-                    len(batch_symbols),
-                    job.kind,
-                    job.period,
-                )
-
-                batch_successes = []
-                batch_failures = []
-                failure_details = {}
-
-                try:
-                    # Batch fetch using yf.download() (single HTTP request per batch)
-                    batch_results = _fetch_with_backoff(
-                        bulk_fetcher,
-                        batch_symbols,
-                        period=job.period,
-                        market=market,
-                    )
-
-                    # Separate successes from failures, then batch-store all successes
-                    batch_to_store = {}
-                    for symbol, data in batch_results.items():
-                        if not data.get('has_error') and data.get('price_data') is not None:
-                            price_df = data['price_data']
-                            if not price_df.empty:
-                                batch_to_store[symbol] = price_df
-                                refreshed += 1
-                                refreshed_by_market[_market_for_symbol(symbol)] += 1
-                                batch_successes.append(symbol)
-                            else:
-                                failed += 1
-                                failed_symbols.append(symbol)
-                                failed_by_market[_market_for_symbol(symbol)] += 1
-                                batch_failures.append(symbol)
-                                failure_details[symbol] = "Empty data returned"
-                        else:
-                            failed += 1
-                            failed_symbols.append(symbol)
-                            failed_by_market[_market_for_symbol(symbol)] += 1
-                            batch_failures.append(symbol)
-                            failure_details[symbol] = data.get('error', 'Unknown error')
-
-                    # Batch store in Redis (pipeline) + DB (single transaction)
-                    if batch_to_store:
-                        price_cache.store_batch_in_cache(batch_to_store, also_store_db=True)
-
-                except SoftTimeLimitExceeded:
-                    raise
-                except Exception as e:
-                    raise_if_transient_database_error(e)
-                    logger.error(f"Batch {batch_num} error: {e}")
-                    failed += len(batch_symbols)
-                    failed_symbols.extend(batch_symbols)
-                    failed_by_market.update(_market_for_symbol(symbol) for symbol in batch_symbols)
-                    batch_failures.extend(batch_symbols)
-                    failure_details.update({symbol: str(e) for symbol in batch_symbols})
-
-                # Track symbol failures for auto-deactivation of delisted symbols
-                _track_symbol_failures(
-                    price_cache,
-                    batch_successes,
-                    batch_failures,
-                    db,
-                    failure_details=failure_details,
-                )
-
-                # Update progress for UI and stuck detection
-                processed_count += len(batch_symbols)
-                progress = min(processed_count, total)
-                percent = (progress / total) * 100
-                processed = progress
-
-                # Update Celery task state
-                self.update_state(
-                    state='PROGRESS',
-                    meta={
-                        'current': progress,
-                        'total': total,
-                        'percent': percent,
-                        'refreshed': refreshed,
-                        'failed': failed
-                    }
-                )
-
-                # Update heartbeat for stuck detection
-                price_cache.update_warmup_heartbeat(progress, total, percent, market=market)
-                _mark_market_activity_progress_safely(
-                    db,
-                    market=effective_market,
-                    stage_key="prices",
-                    lifecycle=activity_lifecycle,
-                    task_name=getattr(self, "name", "smart_refresh_cache"),
-                    task_id=getattr(getattr(self, "request", None), "id", None),
-                    current=progress,
-                    total=total,
-                    percent=round(percent, 1),
-                    message=f"Batch {batch_num}/{total_batches} · refreshing prices",
-                )
-
-                # Extend lock TTL to prevent expiry during long-running tasks
-                task_id = self.request.id or 'unknown'
-                from ..wiring.bootstrap import get_data_fetch_lock
-                lock = get_data_fetch_lock()
-                lock.extend_lock(task_id, 300, market=market)
-
-                # Rate limit between batches (per-market key when scoped)
-                if processed_count < total:
-                    if market is not None:
-                        get_rate_limiter().wait_for_market("yfinance:batch", market)
-                    else:
-                        get_rate_limiter().wait(
-                            "yfinance:batch",
-                            min_interval_s=settings.yfinance_batch_rate_limit_interval,
-                        )
+        execution_result = run_price_refresh_jobs(
+            jobs=live_refresh_jobs,
+            total=total,
+            batch_size=batch_size,
+            bulk_fetcher=bulk_fetcher,
+            price_cache=price_cache,
+            db=db,
+            market=market,
+            fetch_with_backoff=_fetch_with_backoff,
+            track_symbol_failures=_track_symbol_failures,
+            market_for_symbol=_market_for_symbol,
+            mark_progress=_mark_live_refresh_progress,
+            update_task_state=_update_live_task_state,
+            extend_lock=_extend_live_refresh_lock,
+            wait_between_batches=_wait_between_live_batches,
+            raise_if_transient_database_error=raise_if_transient_database_error,
+        )
+        refreshed = execution_result.refreshed
+        failed = execution_result.failed
+        failed_symbols = execution_result.failed_symbols
+        refreshed_by_market = execution_result.refreshed_by_market
 
         # Save final warmup metadata (treat >95% success as "completed")
         success_rate = refreshed / total if total > 0 else 0

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -12,6 +12,7 @@ to ensure only one task fetches external data at a time.
 from collections import Counter
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 import logging
 from typing import List, Optional
 from datetime import datetime, timezone
@@ -1249,6 +1250,169 @@ def _record_market_refresh_success_safely(
         )
 
 
+@dataclass
+class LivePriceRefreshExecutionContext:
+    task: object
+    bulk_fetcher: object
+    price_cache: object
+    db: object
+    market: str | None
+    effective_market: str
+    activity_lifecycle: str
+    symbol_markets: dict[str, str]
+    processed: int = 0
+
+    def market_for_symbol(self, symbol: str) -> str:
+        return self.symbol_markets.get(str(symbol).upper(), self.effective_market)
+
+    def fetch_batch(self, symbols, *, period: str, market: str | None):
+        return _fetch_with_backoff(
+            self.bulk_fetcher,
+            list(symbols),
+            period=period,
+            market=market,
+        )
+
+    def store_prices(self, price_data_by_symbol) -> None:
+        self.price_cache.store_batch_in_cache(
+            dict(price_data_by_symbol),
+            also_store_db=True,
+        )
+
+    def track_symbol_failures(self, successes, failures, *, failure_details) -> None:
+        _track_symbol_failures(
+            self.price_cache,
+            list(successes),
+            list(failures),
+            self.db,
+            failure_details=dict(failure_details),
+        )
+
+    def publish_progress(
+        self,
+        current: int,
+        total: int,
+        percent: float,
+        message: str,
+        *,
+        refreshed: int,
+        failed: int,
+    ) -> None:
+        self.processed = current
+        self.task.update_state(
+            state="PROGRESS",
+            meta={
+                "current": current,
+                "total": total,
+                "percent": percent,
+                "refreshed": refreshed,
+                "failed": failed,
+            },
+        )
+        self.price_cache.update_warmup_heartbeat(
+            current,
+            total,
+            percent,
+            market=self.market,
+        )
+        _mark_market_activity_progress_safely(
+            self.db,
+            market=self.effective_market,
+            stage_key="prices",
+            lifecycle=self.activity_lifecycle,
+            task_name=getattr(self.task, "name", "smart_refresh_cache"),
+            task_id=getattr(getattr(self.task, "request", None), "id", None),
+            current=current,
+            total=total,
+            percent=round(percent, 1),
+            message=message,
+        )
+
+    def extend_lock(self) -> None:
+        task_id = getattr(getattr(self.task, "request", None), "id", None) or "unknown"
+        from ..wiring.bootstrap import get_data_fetch_lock
+
+        get_data_fetch_lock().extend_lock(task_id, 300, market=self.market)
+
+    def wait_between_batches(self) -> None:
+        if self.market is not None:
+            get_rate_limiter().wait_for_market("yfinance:batch", self.market)
+            return
+        get_rate_limiter().wait(
+            "yfinance:batch",
+            min_interval_s=settings.yfinance_batch_rate_limit_interval,
+        )
+
+    def raise_if_transient_database_error(self, exc: Exception) -> None:
+        raise_if_transient_database_error(exc)
+
+
+def _complete_price_refresh_without_live_fetch(
+    *,
+    db,
+    price_cache,
+    task,
+    market: str | None,
+    effective_market: str,
+    activity_lifecycle: str,
+    mode: str,
+    message: str,
+    metadata_refreshed: int,
+    metadata_total: int,
+    activity_current: int,
+    activity_total: int,
+    heartbeat_status: str | None = None,
+    source: str | None = None,
+    github_sync: dict | None = None,
+    trading_day=None,
+) -> dict:
+    price_cache.save_warmup_metadata(
+        "completed",
+        metadata_refreshed,
+        metadata_total,
+        market=market,
+    )
+    if heartbeat_status is not None:
+        price_cache.complete_warmup_heartbeat(heartbeat_status, market=market)
+    mark_market_activity_completed(
+        db,
+        market=effective_market,
+        stage_key="prices",
+        lifecycle=activity_lifecycle,
+        task_name=getattr(task, "name", "smart_refresh_cache"),
+        task_id=getattr(getattr(task, "request", None), "id", None),
+        current=activity_current,
+        total=activity_total,
+        message=message,
+    )
+    if trading_day is not None:
+        _record_market_refresh_success_safely(
+            db,
+            market=effective_market,
+            trading_day=trading_day,
+            success_rate=1.0,
+        )
+
+    result = {
+        "status": "completed",
+        "refreshed": 0,
+        "failed": 0,
+        "total": 0,
+        "message": message,
+        "mode": mode,
+        "completed_at": datetime.now().isoformat(),
+    }
+    if source is not None:
+        result.update(
+            {
+                "source": source,
+                "github_sync_status": github_sync.get("status") if github_sync else None,
+                "source_revision": github_sync.get("source_revision") if github_sync else None,
+            }
+        )
+    return result
+
+
 def _schedule_failed_symbol_retry(
     symbols: list[str],
     *,
@@ -1870,48 +2034,30 @@ def smart_refresh_cache(
                 refresh_plan.completion_message
                 or "GitHub daily price bundle is current - no live fetch needed"
             )
-            price_cache.save_warmup_metadata(
-                "completed",
-                len(all_symbols),
-                len(all_symbols),
-                market=market,
-            )
-            price_cache.complete_warmup_heartbeat("completed", market=market)
-            mark_market_activity_completed(
-                db,
-                market=effective_market,
-                stage_key="prices",
-                lifecycle=activity_lifecycle,
-                task_name=getattr(self, "name", "smart_refresh_cache"),
-                task_id=getattr(getattr(self, "request", None), "id", None),
-                current=len(all_symbols) if all_symbols else 0,
-                total=len(all_symbols) if all_symbols else 0,
-                message=message,
-            )
             try:
                 trading_day = datetime.fromisoformat(
                     str(github_sync.get("as_of_date") if github_sync else None)
                 ).date()
             except (TypeError, ValueError):
                 trading_day = get_market_calendar_service().last_completed_trading_day(effective_market)
-            _record_market_refresh_success_safely(
-                db,
-                market=effective_market,
+            return _complete_price_refresh_without_live_fetch(
+                db=db,
+                price_cache=price_cache,
+                task=self,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                mode=mode,
+                message=message,
+                metadata_refreshed=len(all_symbols),
+                metadata_total=len(all_symbols),
+                activity_current=len(all_symbols) if all_symbols else 0,
+                activity_total=len(all_symbols) if all_symbols else 0,
+                heartbeat_status="completed",
+                source="github",
+                github_sync=github_sync,
                 trading_day=trading_day,
-                success_rate=1.0,
             )
-            return {
-                "status": "completed",
-                "source": "github",
-                "github_sync_status": github_sync.get("status") if github_sync else None,
-                "source_revision": github_sync.get("source_revision") if github_sync else None,
-                "refreshed": 0,
-                "failed": 0,
-                "total": 0,
-                "message": message,
-                "mode": mode,
-                "completed_at": datetime.now().isoformat(),
-            }
 
         if not symbols:
             if refresh_plan.completion_message:
@@ -1922,27 +2068,20 @@ def smart_refresh_cache(
                 message = "All symbols already fresh - no live fetch needed"
             else:
                 message = "No active symbols found in universe"
-            price_cache.save_warmup_metadata("completed", 0, 0, market=market)
-            mark_market_activity_completed(
-                db,
-                market=effective_market,
-                stage_key="prices",
-                lifecycle=activity_lifecycle,
-                task_name=getattr(self, "name", "smart_refresh_cache"),
-                task_id=getattr(getattr(self, "request", None), "id", None),
-                current=0,
-                total=0,
+            return _complete_price_refresh_without_live_fetch(
+                db=db,
+                price_cache=price_cache,
+                task=self,
+                market=market,
+                effective_market=effective_market,
+                activity_lifecycle=activity_lifecycle,
+                mode=mode,
                 message=message,
+                metadata_refreshed=0,
+                metadata_total=0,
+                activity_current=0,
+                activity_total=0,
             )
-            return {
-                "status": "completed",
-                "refreshed": 0,
-                "failed": 0,
-                "total": 0,
-                "message": message,
-                "mode": mode,
-                "completed_at": datetime.now().isoformat()
-            }
 
         total = len(symbols)
         symbol_market_totals = Counter(
@@ -1951,64 +2090,16 @@ def smart_refresh_cache(
         refreshed_by_market: Counter[str] = Counter()
         batch_size = 100
         bulk_fetcher = BulkDataFetcher()
-
-        def _market_for_symbol(symbol: str) -> str:
-            return symbol_markets.get(str(symbol).upper(), effective_market)
-
-        def _update_live_task_state(
-            current: int,
-            total_symbols: int,
-            percent: float,
-            refreshed_count: int,
-            failed_count: int,
-        ) -> None:
-            self.update_state(
-                state="PROGRESS",
-                meta={
-                    "current": current,
-                    "total": total_symbols,
-                    "percent": percent,
-                    "refreshed": refreshed_count,
-                    "failed": failed_count,
-                },
-            )
-
-        def _mark_live_refresh_progress(
-            current: int,
-            total_symbols: int,
-            percent: float,
-            message: str,
-        ) -> None:
-            nonlocal processed
-            processed = current
-            price_cache.update_warmup_heartbeat(current, total_symbols, percent, market=market)
-            _mark_market_activity_progress_safely(
-                db,
-                market=effective_market,
-                stage_key="prices",
-                lifecycle=activity_lifecycle,
-                task_name=getattr(self, "name", "smart_refresh_cache"),
-                task_id=getattr(getattr(self, "request", None), "id", None),
-                current=current,
-                total=total_symbols,
-                percent=round(percent, 1),
-                message=message,
-            )
-
-        def _extend_live_refresh_lock() -> None:
-            task_id = self.request.id or "unknown"
-            from ..wiring.bootstrap import get_data_fetch_lock
-            lock = get_data_fetch_lock()
-            lock.extend_lock(task_id, 300, market=market)
-
-        def _wait_between_live_batches() -> None:
-            if market is not None:
-                get_rate_limiter().wait_for_market("yfinance:batch", market)
-            else:
-                get_rate_limiter().wait(
-                    "yfinance:batch",
-                    min_interval_s=settings.yfinance_batch_rate_limit_interval,
-                )
+        execution_context = LivePriceRefreshExecutionContext(
+            task=self,
+            bulk_fetcher=bulk_fetcher,
+            price_cache=price_cache,
+            db=db,
+            market=market,
+            effective_market=effective_market,
+            activity_lifecycle=activity_lifecycle,
+            symbol_markets=symbol_markets,
+        )
 
         # Write initial heartbeat before batch loop to prevent false "stuck" detection.
         # Without this, the health endpoint sees lock held + no heartbeat = stuck.
@@ -2033,19 +2124,10 @@ def smart_refresh_cache(
             jobs=live_refresh_jobs,
             total=total,
             batch_size=batch_size,
-            bulk_fetcher=bulk_fetcher,
-            price_cache=price_cache,
-            db=db,
             market=market,
-            fetch_with_backoff=_fetch_with_backoff,
-            track_symbol_failures=_track_symbol_failures,
-            market_for_symbol=_market_for_symbol,
-            mark_progress=_mark_live_refresh_progress,
-            update_task_state=_update_live_task_state,
-            extend_lock=_extend_live_refresh_lock,
-            wait_between_batches=_wait_between_live_batches,
-            raise_if_transient_database_error=raise_if_transient_database_error,
+            context=execution_context,
         )
+        processed = execution_context.processed
         refreshed = execution_result.refreshed
         failed = execution_result.failed
         failed_symbols = execution_result.failed_symbols
@@ -2071,7 +2153,10 @@ def smart_refresh_cache(
         if failed_symbols:
             failed_symbols_by_market: dict[str, list[str]] = {}
             for symbol in failed_symbols:
-                failed_symbols_by_market.setdefault(_market_for_symbol(symbol), []).append(symbol)
+                failed_symbols_by_market.setdefault(
+                    execution_context.market_for_symbol(symbol),
+                    [],
+                ).append(symbol)
             for retry_market, retry_symbols in failed_symbols_by_market.items():
                 if activity_lifecycle == "bootstrap":
                     _schedule_failed_symbol_retry(
@@ -2123,6 +2208,7 @@ def smart_refresh_cache(
     except SoftTimeLimitExceeded:
         logger.error("Soft time limit exceeded in smart_refresh_cache", exc_info=True)
         safe_rollback(db)
+        current_progress = getattr(locals().get("execution_context"), "processed", processed)
         price_cache.save_warmup_metadata(
             "failed",
             refreshed,
@@ -2138,7 +2224,7 @@ def smart_refresh_cache(
             lifecycle=activity_lifecycle,
             task_name=getattr(self, "name", "smart_refresh_cache"),
             task_id=getattr(getattr(self, "request", None), "id", None),
-            current=processed,
+            current=current_progress,
             total=locals().get("total", 0),
             message="Soft time limit exceeded",
         )
@@ -2147,6 +2233,7 @@ def smart_refresh_cache(
         raise_if_transient_database_error(e)
         logger.error(f"Error in smart_refresh_cache task: {e}", exc_info=True)
         safe_rollback(db)
+        current_progress = getattr(locals().get("execution_context"), "processed", processed)
         # Save partial progress
         price_cache.save_warmup_metadata("failed", refreshed, locals().get('total', 0), str(e), market=market)
         price_cache.complete_warmup_heartbeat("failed", market=market)
@@ -2157,7 +2244,7 @@ def smart_refresh_cache(
             lifecycle=activity_lifecycle,
             task_name=getattr(self, "name", "smart_refresh_cache"),
             task_id=getattr(getattr(self, "request", None), "id", None),
-            current=processed,
+            current=current_progress,
             total=locals().get("total", 0),
             message=str(e),
         )

--- a/backend/app/tasks/daily_market_pipeline_tasks.py
+++ b/backend/app/tasks/daily_market_pipeline_tasks.py
@@ -134,7 +134,7 @@ def _build_daily_market_pipeline_signatures(market: str, trading_date: date) -> 
     market_code = _normalize_pipeline_market(market)
     as_of_date = trading_date.isoformat()
     return [
-        smart_refresh_cache.si(mode="full", market=market_code).set(
+        smart_refresh_cache.si(mode="delta", market=market_code).set(
             queue=data_fetch_queue_for_market(market_code)
         ),
         guard_price_refresh.s(market=market_code).set(

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -244,7 +244,7 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
             market_task_ids=market_task_ids,
         )
     except Exception:
-        logger.warning(
+        logger.error(
             "Queued bootstrap tasks but failed to record task manifest",
             extra={
                 "primary_market": primary,
@@ -253,6 +253,7 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
             },
             exc_info=True,
         )
+        raise
 
     logger.info(
         "Queued local runtime bootstrap",

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Iterable
 
-from celery import chain, chord, group
+from celery import chain
 
 from ..database import SessionLocal
 from ..domain.bootstrap.plan import (
@@ -24,6 +25,12 @@ from ..tasks.market_queues import (
 from ..celery_app import celery_app
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReadinessFailure:
+    stage_key: str
+    activity_message: str
 
 
 def _bootstrap_universe_name(market: str) -> str:
@@ -68,6 +75,61 @@ def _build_market_bootstrap_signatures(market_plan: MarketBootstrapPlan) -> list
     ]
 
 
+def _apply_bootstrap_workflow(workflow, errback):
+    try:
+        return workflow.apply_async(link_error=errback)
+    except TypeError:
+        return workflow.apply_async()
+
+
+def _readiness_failure(market_result) -> ReadinessFailure:
+    if market_result is None or not market_result.core_ready:
+        return ReadinessFailure(
+            stage_key="core",
+            activity_message="Bootstrap core data incomplete",
+        )
+    return ReadinessFailure(
+        stage_key="scan",
+        activity_message="Bootstrap scan did not publish",
+    )
+
+
+def _mark_missing_readiness_failures(db, readiness, markets: list[str]) -> tuple[list[str], list[str]]:
+    core_missing_markets = []
+    scan_missing_markets = []
+    for market in markets:
+        market_code = str(market).upper()
+        market_result = readiness.market_results.get(market_code) or readiness.market_results.get(market)
+        failure = _readiness_failure(market_result)
+        if failure.stage_key == "core":
+            core_missing_markets.append(market_code)
+        else:
+            scan_missing_markets.append(market_code)
+        mark_market_activity_failed(
+            db,
+            market=market_code,
+            stage_key=failure.stage_key,
+            lifecycle="bootstrap",
+            task_name="runtime_bootstrap",
+            task_id=None,
+            message=failure.activity_message,
+        )
+    return core_missing_markets, scan_missing_markets
+
+
+def _format_missing_reason(core_missing_markets: list[str], scan_missing_markets: list[str]) -> str:
+    failure_reasons = []
+    if core_missing_markets:
+        failure_reasons.append(
+            "missing core market data for: " + ", ".join(core_missing_markets)
+        )
+    if scan_missing_markets:
+        failure_reasons.append(
+            "missing published auto scans for: " + ", ".join(scan_missing_markets)
+        )
+    return "; ".join(failure_reasons)
+
+
 def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Iterable[str]) -> str:
     plan = build_bootstrap_plan(
         primary_market=primary_market,
@@ -76,33 +138,44 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
     primary = plan.primary_market
     enabled = list(plan.enabled_markets)
 
-    market_workflows = []
+    market_plans_by_code = {market_plan.market: market_plan for market_plan in plan.market_plans}
+    primary_plan = market_plans_by_code[primary]
+    primary_completion = complete_local_runtime_bootstrap.si(
+        primary_market=primary,
+        enabled_markets=[primary],
+    ).set(queue="celery")
+    primary_errback = fail_local_runtime_bootstrap.s(
+        primary_market=primary,
+        enabled_markets=[primary],
+    ).set(queue="celery")
+    primary_task = _apply_bootstrap_workflow(
+        chain(*_build_market_bootstrap_signatures(primary_plan), primary_completion),
+        primary_errback,
+    )
+
     for market_plan in plan.market_plans:
-        market_workflows.append(
-            chain(*_build_market_bootstrap_signatures(market_plan))
+        if market_plan.market == primary:
+            continue
+        background_completion = complete_background_market_bootstrap.si(
+            market=market_plan.market,
+        ).set(queue="celery")
+        background_errback = fail_background_market_bootstrap.s(
+            market=market_plan.market,
+        ).set(queue="celery")
+        _apply_bootstrap_workflow(
+            chain(*_build_market_bootstrap_signatures(market_plan), background_completion),
+            background_errback,
         )
-    completion = complete_local_runtime_bootstrap.si(
-        primary_market=primary,
-        enabled_markets=enabled,
-    ).set(queue="celery")
-    workflow = chord(group(market_workflows), completion)
-    errback = fail_local_runtime_bootstrap.s(
-        primary_market=primary,
-        enabled_markets=enabled,
-    ).set(queue="celery")
-    try:
-        task = workflow.apply_async(link_error=errback)
-    except TypeError:
-        task = workflow.apply_async()
+
     logger.info(
         "Queued local runtime bootstrap",
         extra={
             "primary_market": primary,
             "enabled_markets": enabled,
-            "task_id": task.id,
+            "task_id": primary_task.id,
         },
     )
-    return task.id
+    return primary_task.id
 
 
 @celery_app.task(
@@ -125,43 +198,32 @@ def complete_local_runtime_bootstrap(primary_market: str, enabled_markets: list[
             bootstrap_started_at=prefs.bootstrap_started_at,
         )
         missing_markets = readiness.missing_markets
+        core_missing_markets, scan_missing_markets = _mark_missing_readiness_failures(
+            db,
+            readiness,
+            missing_markets,
+        )
+        primary_result = readiness.market_results.get(primary_market)
+        primary_ready = bool(primary_result and primary_result.ready)
         if missing_markets:
-            set_bootstrap_state(db, "failed")
-            core_missing_markets = []
-            scan_missing_markets = []
-            for market in missing_markets:
-                market_result = readiness.market_results[market]
-                if not market_result.core_ready:
-                    core_missing_markets.append(market)
-                    stage_key = "core"
-                    message = "Bootstrap core data incomplete"
-                else:
-                    scan_missing_markets.append(market)
-                    stage_key = "scan"
-                    message = "Bootstrap scan did not publish"
-                mark_market_activity_failed(
-                    db,
-                    market=market,
-                    stage_key=stage_key,
-                    lifecycle="bootstrap",
-                    task_name="runtime_bootstrap",
-                    task_id=None,
-                    message=message,
-                )
-            failure_reasons = []
-            if core_missing_markets:
-                failure_reasons.append(
-                    "missing core market data for: " + ", ".join(core_missing_markets)
-                )
-            if scan_missing_markets:
-                failure_reasons.append(
-                    "missing published auto scans for: " + ", ".join(scan_missing_markets)
-                )
+            reason = _format_missing_reason(core_missing_markets, scan_missing_markets)
+            if not primary_ready:
+                set_bootstrap_state(db, "failed")
+                return {
+                    "status": "failed",
+                    "primary_market": primary_market,
+                    "enabled_markets": enabled_markets,
+                    "reason": reason,
+                }
+            set_bootstrap_state(db, "ready")
             return {
-                "status": "failed",
+                "status": "ready_with_background_failures",
                 "primary_market": primary_market,
                 "enabled_markets": enabled_markets,
-                "reason": "; ".join(failure_reasons),
+                "background_failed_markets": [
+                    market for market in missing_markets if market != primary_market
+                ],
+                "reason": reason,
             }
         set_bootstrap_state(db, "ready")
     finally:
@@ -175,9 +237,52 @@ def complete_local_runtime_bootstrap(primary_market: str, enabled_markets: list[
         },
     )
     return {
+        "status": "ready",
         "primary_market": primary_market,
         "enabled_markets": enabled_markets,
     }
+
+
+@celery_app.task(
+    name="app.tasks.runtime_bootstrap_tasks.complete_background_market_bootstrap",
+    queue="celery",
+)
+def complete_background_market_bootstrap(market: str) -> dict:
+    from ..services.bootstrap_readiness_service import BootstrapReadinessService
+    from ..services.runtime_preferences_service import get_runtime_preferences
+
+    db = SessionLocal()
+    try:
+        prefs = get_runtime_preferences(db)
+        readiness = BootstrapReadinessService().evaluate(
+            db,
+            enabled_markets=[market],
+            bootstrap_started_at=prefs.bootstrap_started_at,
+        )
+        market_result = readiness.market_results.get(str(market).upper())
+        if market_result and market_result.ready:
+            return {
+                "status": "ready",
+                "market": str(market).upper(),
+            }
+        missing_markets = readiness.missing_markets or [str(market).upper()]
+        core_missing_markets, scan_missing_markets = _mark_missing_readiness_failures(
+            db,
+            readiness,
+            missing_markets,
+        )
+        reason = _format_missing_reason(core_missing_markets, scan_missing_markets)
+        if scan_missing_markets == [str(market).upper()] and not core_missing_markets:
+            reason = "missing published auto scan"
+        elif core_missing_markets == [str(market).upper()] and not scan_missing_markets:
+            reason = "missing core market data"
+        return {
+            "status": "failed",
+            "market": str(market).upper(),
+            "reason": reason,
+        }
+    finally:
+        db.close()
 
 
 @celery_app.task(
@@ -213,4 +318,34 @@ def fail_local_runtime_bootstrap(*args, primary_market: str, enabled_markets: li
         "status": "failed",
         "primary_market": primary_market,
         "enabled_markets": enabled_markets,
+    }
+
+
+@celery_app.task(
+    name="app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap",
+    queue="celery",
+)
+def fail_background_market_bootstrap(*args, market: str, **kwargs) -> dict:
+    db = SessionLocal()
+    try:
+        mark_current_market_activity_failed(
+            db,
+            market=str(market).upper(),
+            lifecycle="bootstrap",
+            message="Bootstrap failed",
+        )
+    finally:
+        db.close()
+
+    logger.warning(
+        "Marked background market bootstrap failed",
+        extra={
+            "market": market,
+            "callback_args": args,
+            "callback_kwargs": kwargs,
+        },
+    )
+    return {
+        "status": "failed",
+        "market": str(market).upper(),
     }

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -91,6 +91,16 @@ class BootstrapQueueManifestRecorder:
     def record_queued(self) -> None:
         self._record(BootstrapQueueState.QUEUED)
 
+    def record_dispatch_failed_safely(self) -> None:
+        try:
+            self._record(BootstrapQueueState.DISPATCH_FAILED)
+        except Exception:
+            logger.warning(
+                "Failed to record bootstrap dispatch failure",
+                extra=self.log_extra(),
+                exc_info=True,
+            )
+
     def _record(self, queue_state: BootstrapQueueState) -> None:
         record_runtime_bootstrap_run(
             primary_market=self.primary_market,
@@ -288,6 +298,7 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
             )
 
     except Exception:
+        manifest_recorder.record_dispatch_failed_safely()
         raise
 
     try:

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -21,6 +21,7 @@ from ..services.market_activity_service import (
 )
 from ..services.bootstrap_run_manifest import (
     BootstrapRunManifest,
+    BootstrapQueueState,
     BootstrapRunManifestRepository,
 )
 from ..tasks.market_queues import (
@@ -45,6 +46,66 @@ class MarketReadinessCompletion:
     market: str
     ready: bool
     failure: ReadinessFailure | None = None
+
+
+@dataclass
+class BootstrapQueueManifestRecorder:
+    primary_market: str
+    enabled_markets: list[str]
+    market_task_ids: dict[str, str]
+    primary_task_id: str | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        primary_market: str,
+        enabled_markets: Iterable[str],
+    ) -> "BootstrapQueueManifestRecorder":
+        return cls(
+            primary_market=primary_market,
+            enabled_markets=list(enabled_markets),
+            market_task_ids={},
+        )
+
+    def record_queueing(self) -> None:
+        self._record(BootstrapQueueState.QUEUEING)
+
+    def record_dispatched_market(self, *, market: str, task_id: str) -> None:
+        market_code = normalize_market(market)
+        if market_code == self.primary_market:
+            self.primary_task_id = task_id
+        self.market_task_ids[market_code] = task_id
+        self.record_partial_safely()
+
+    def record_partial_safely(self) -> None:
+        try:
+            self._record(BootstrapQueueState.PARTIAL)
+        except Exception:
+            logger.warning(
+                "Failed to record partial bootstrap task manifest",
+                extra=self.log_extra(),
+                exc_info=True,
+            )
+
+    def record_queued(self) -> None:
+        self._record(BootstrapQueueState.QUEUED)
+
+    def _record(self, queue_state: BootstrapQueueState) -> None:
+        record_runtime_bootstrap_run(
+            primary_market=self.primary_market,
+            enabled_markets=self.enabled_markets,
+            primary_task_id=self.primary_task_id,
+            market_task_ids=self.market_task_ids,
+            queue_state=queue_state.value,
+        )
+
+    def log_extra(self) -> dict:
+        return {
+            "primary_market": self.primary_market,
+            "enabled_markets": self.enabled_markets,
+            "market_task_ids": self.market_task_ids,
+        }
 
 
 def _bootstrap_universe_name(market: str) -> str:
@@ -115,7 +176,7 @@ def record_runtime_bootstrap_run(
     enabled_markets: Iterable[str],
     primary_task_id: str | None = None,
     market_task_ids: dict[str, str | None] | None = None,
-    queue_state: str = "queued",
+    queue_state: BootstrapQueueState | str = BootstrapQueueState.QUEUED,
 ) -> dict:
     db = SessionLocal()
     try:
@@ -192,36 +253,11 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
 
     market_plans_by_code = {market_plan.market: market_plan for market_plan in plan.market_plans}
     primary_plan = market_plans_by_code[primary]
-    market_task_ids: dict[str, str] = {}
-    primary_task_id: str | None = None
-
-    def record_partial_manifest() -> None:
-        try:
-            record_runtime_bootstrap_run(
-                primary_market=primary,
-                enabled_markets=enabled,
-                primary_task_id=primary_task_id,
-                market_task_ids=market_task_ids,
-                queue_state="partial",
-            )
-        except Exception:
-            logger.warning(
-                "Failed to record partial bootstrap task manifest",
-                extra={
-                    "primary_market": primary,
-                    "enabled_markets": enabled,
-                    "market_task_ids": market_task_ids,
-                },
-                exc_info=True,
-            )
-
-    record_runtime_bootstrap_run(
+    manifest_recorder = BootstrapQueueManifestRecorder.create(
         primary_market=primary,
         enabled_markets=enabled,
-        primary_task_id=None,
-        market_task_ids={},
-        queue_state="queueing",
     )
+    manifest_recorder.record_queueing()
 
     try:
         primary_task = _queue_market_bootstrap_workflow(
@@ -231,9 +267,10 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
             errback_task=fail_local_runtime_bootstrap,
             errback_kwargs={"primary_market": primary},
         )
-        primary_task_id = primary_task.id
-        market_task_ids[primary] = primary_task.id
-        record_partial_manifest()
+        manifest_recorder.record_dispatched_market(
+            market=primary,
+            task_id=primary_task.id,
+        )
 
         for market_plan in plan.market_plans:
             if market_plan.market == primary:
@@ -245,28 +282,20 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
                 errback_task=fail_background_market_bootstrap,
                 errback_kwargs={"market": market_plan.market},
             )
-            market_task_ids[market_plan.market] = background_task.id
-            record_partial_manifest()
+            manifest_recorder.record_dispatched_market(
+                market=market_plan.market,
+                task_id=background_task.id,
+            )
 
     except Exception:
         raise
 
     try:
-        record_runtime_bootstrap_run(
-            primary_market=primary,
-            enabled_markets=enabled,
-            primary_task_id=primary_task_id,
-            market_task_ids=market_task_ids,
-            queue_state="queued",
-        )
+        manifest_recorder.record_queued()
     except Exception:
         logger.warning(
             "Queued bootstrap tasks but failed to record task manifest",
-            extra={
-                "primary_market": primary,
-                "enabled_markets": enabled,
-                "market_task_ids": market_task_ids,
-            },
+            extra=manifest_recorder.log_extra(),
             exc_info=True,
         )
 
@@ -275,10 +304,10 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
         extra={
             "primary_market": primary,
             "enabled_markets": enabled,
-            "task_id": primary_task_id,
+            "task_id": manifest_recorder.primary_task_id,
         },
     )
-    return primary_task_id
+    return manifest_recorder.primary_task_id
 
 
 @celery_app.task(

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -113,8 +113,9 @@ def record_runtime_bootstrap_run(
     *,
     primary_market: str,
     enabled_markets: Iterable[str],
-    primary_task_id: str,
-    market_task_ids: dict[str, str],
+    primary_task_id: str | None = None,
+    market_task_ids: dict[str, str | None] | None = None,
+    queue_state: str = "queued",
 ) -> dict:
     db = SessionLocal()
     try:
@@ -124,7 +125,8 @@ def record_runtime_bootstrap_run(
                 primary_market=primary_market,
                 enabled_markets=enabled_markets,
                 primary_task_id=primary_task_id,
-                market_task_ids=market_task_ids,
+                market_task_ids=market_task_ids or {},
+                queue_state=queue_state,
                 queued_at=datetime.now(timezone.utc).isoformat(),
             ),
         )
@@ -192,6 +194,15 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
     primary_plan = market_plans_by_code[primary]
     market_task_ids: dict[str, str] = {}
     primary_task_id: str | None = None
+
+    record_runtime_bootstrap_run(
+        primary_market=primary,
+        enabled_markets=enabled,
+        primary_task_id=None,
+        market_task_ids={},
+        queue_state="queueing",
+    )
+
     try:
         primary_task = _queue_market_bootstrap_workflow(
             primary_plan,
@@ -223,6 +234,7 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
                     enabled_markets=enabled,
                     primary_task_id=primary_task_id,
                     market_task_ids=market_task_ids,
+                    queue_state="partial",
                 )
             except Exception:
                 logger.warning(
@@ -242,9 +254,10 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
             enabled_markets=enabled,
             primary_task_id=primary_task_id,
             market_task_ids=market_task_ids,
+            queue_state="queued",
         )
     except Exception:
-        logger.error(
+        logger.warning(
             "Queued bootstrap tasks but failed to record task manifest",
             extra={
                 "primary_market": primary,
@@ -253,7 +266,6 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
             },
             exc_info=True,
         )
-        raise
 
     logger.info(
         "Queued local runtime bootstrap",

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Iterable
 
 from celery import chain
@@ -17,7 +18,10 @@ from ..domain.bootstrap.plan import (
 from ..services.market_activity_service import (
     mark_current_market_activity_failed,
     mark_market_activity_failed,
-    save_runtime_bootstrap_run,
+)
+from ..services.bootstrap_run_manifest import (
+    BootstrapRunManifest,
+    BootstrapRunManifestRepository,
 )
 from ..tasks.market_queues import (
     data_fetch_queue_for_market,
@@ -114,12 +118,15 @@ def record_runtime_bootstrap_run(
 ) -> dict:
     db = SessionLocal()
     try:
-        return save_runtime_bootstrap_run(
+        return BootstrapRunManifestRepository().save(
             db,
-            primary_market=primary_market,
-            enabled_markets=list(enabled_markets),
-            primary_task_id=primary_task_id,
-            market_task_ids=market_task_ids,
+            BootstrapRunManifest.create(
+                primary_market=primary_market,
+                enabled_markets=enabled_markets,
+                primary_task_id=primary_task_id,
+                market_task_ids=market_task_ids,
+                queued_at=datetime.now(timezone.utc).isoformat(),
+            ),
         )
     finally:
         db.close()
@@ -208,12 +215,6 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
             )
             market_task_ids[market_plan.market] = background_task.id
 
-        record_runtime_bootstrap_run(
-            primary_market=primary,
-            enabled_markets=enabled,
-            primary_task_id=primary_task.id,
-            market_task_ids=market_task_ids,
-        )
     except Exception:
         if primary_task_id is not None and market_task_ids:
             try:
@@ -234,6 +235,24 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
                     exc_info=True,
                 )
         raise
+
+    try:
+        record_runtime_bootstrap_run(
+            primary_market=primary,
+            enabled_markets=enabled,
+            primary_task_id=primary_task_id,
+            market_task_ids=market_task_ids,
+        )
+    except Exception:
+        logger.warning(
+            "Queued bootstrap tasks but failed to record task manifest",
+            extra={
+                "primary_market": primary,
+                "enabled_markets": enabled,
+                "market_task_ids": market_task_ids,
+            },
+            exc_info=True,
+        )
 
     logger.info(
         "Queued local runtime bootstrap",

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -195,6 +195,26 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
     market_task_ids: dict[str, str] = {}
     primary_task_id: str | None = None
 
+    def record_partial_manifest() -> None:
+        try:
+            record_runtime_bootstrap_run(
+                primary_market=primary,
+                enabled_markets=enabled,
+                primary_task_id=primary_task_id,
+                market_task_ids=market_task_ids,
+                queue_state="partial",
+            )
+        except Exception:
+            logger.warning(
+                "Failed to record partial bootstrap task manifest",
+                extra={
+                    "primary_market": primary,
+                    "enabled_markets": enabled,
+                    "market_task_ids": market_task_ids,
+                },
+                exc_info=True,
+            )
+
     record_runtime_bootstrap_run(
         primary_market=primary,
         enabled_markets=enabled,
@@ -213,6 +233,7 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
         )
         primary_task_id = primary_task.id
         market_task_ids[primary] = primary_task.id
+        record_partial_manifest()
 
         for market_plan in plan.market_plans:
             if market_plan.market == primary:
@@ -225,27 +246,9 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
                 errback_kwargs={"market": market_plan.market},
             )
             market_task_ids[market_plan.market] = background_task.id
+            record_partial_manifest()
 
     except Exception:
-        if primary_task_id is not None and market_task_ids:
-            try:
-                record_runtime_bootstrap_run(
-                    primary_market=primary,
-                    enabled_markets=enabled,
-                    primary_task_id=primary_task_id,
-                    market_task_ids=market_task_ids,
-                    queue_state="partial",
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to record partial bootstrap task manifest",
-                    extra={
-                        "primary_market": primary,
-                        "enabled_markets": enabled,
-                        "market_task_ids": market_task_ids,
-                    },
-                    exc_info=True,
-                )
         raise
 
     try:

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -17,6 +17,7 @@ from ..domain.bootstrap.plan import (
 from ..services.market_activity_service import (
     mark_current_market_activity_failed,
     mark_market_activity_failed,
+    save_runtime_bootstrap_run,
 )
 from ..tasks.market_queues import (
     data_fetch_queue_for_market,
@@ -104,6 +105,26 @@ def _queue_market_bootstrap_workflow(
     )
 
 
+def record_runtime_bootstrap_run(
+    *,
+    primary_market: str,
+    enabled_markets: Iterable[str],
+    primary_task_id: str,
+    market_task_ids: dict[str, str],
+) -> dict:
+    db = SessionLocal()
+    try:
+        return save_runtime_bootstrap_run(
+            db,
+            primary_market=primary_market,
+            enabled_markets=list(enabled_markets),
+            primary_task_id=primary_task_id,
+            market_task_ids=market_task_ids,
+        )
+    finally:
+        db.close()
+
+
 def _readiness_failure(market_result) -> ReadinessFailure:
     if market_result is None or not market_result.core_ready:
         return ReadinessFailure(
@@ -162,34 +183,67 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
 
     market_plans_by_code = {market_plan.market: market_plan for market_plan in plan.market_plans}
     primary_plan = market_plans_by_code[primary]
-    primary_task = _queue_market_bootstrap_workflow(
-        primary_plan,
-        completion_task=complete_local_runtime_bootstrap,
-        completion_kwargs={"primary_market": primary},
-        errback_task=fail_local_runtime_bootstrap,
-        errback_kwargs={"primary_market": primary},
-    )
-
-    for market_plan in plan.market_plans:
-        if market_plan.market == primary:
-            continue
-        _queue_market_bootstrap_workflow(
-            market_plan,
-            completion_task=complete_background_market_bootstrap,
-            completion_kwargs={"market": market_plan.market},
-            errback_task=fail_background_market_bootstrap,
-            errback_kwargs={"market": market_plan.market},
+    market_task_ids: dict[str, str] = {}
+    primary_task_id: str | None = None
+    try:
+        primary_task = _queue_market_bootstrap_workflow(
+            primary_plan,
+            completion_task=complete_local_runtime_bootstrap,
+            completion_kwargs={"primary_market": primary},
+            errback_task=fail_local_runtime_bootstrap,
+            errback_kwargs={"primary_market": primary},
         )
+        primary_task_id = primary_task.id
+        market_task_ids[primary] = primary_task.id
+
+        for market_plan in plan.market_plans:
+            if market_plan.market == primary:
+                continue
+            background_task = _queue_market_bootstrap_workflow(
+                market_plan,
+                completion_task=complete_background_market_bootstrap,
+                completion_kwargs={"market": market_plan.market},
+                errback_task=fail_background_market_bootstrap,
+                errback_kwargs={"market": market_plan.market},
+            )
+            market_task_ids[market_plan.market] = background_task.id
+
+        record_runtime_bootstrap_run(
+            primary_market=primary,
+            enabled_markets=enabled,
+            primary_task_id=primary_task.id,
+            market_task_ids=market_task_ids,
+        )
+    except Exception:
+        if primary_task_id is not None and market_task_ids:
+            try:
+                record_runtime_bootstrap_run(
+                    primary_market=primary,
+                    enabled_markets=enabled,
+                    primary_task_id=primary_task_id,
+                    market_task_ids=market_task_ids,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to record partial bootstrap task manifest",
+                    extra={
+                        "primary_market": primary,
+                        "enabled_markets": enabled,
+                        "market_task_ids": market_task_ids,
+                    },
+                    exc_info=True,
+                )
+        raise
 
     logger.info(
         "Queued local runtime bootstrap",
         extra={
             "primary_market": primary,
             "enabled_markets": enabled,
-            "task_id": primary_task.id,
+            "task_id": primary_task_id,
         },
     )
-    return primary_task.id
+    return primary_task_id
 
 
 @celery_app.task(

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -21,6 +21,7 @@ from ..services.market_activity_service import (
 from ..tasks.market_queues import (
     data_fetch_queue_for_market,
     market_jobs_queue_for_market,
+    normalize_market,
 )
 from ..celery_app import celery_app
 
@@ -87,6 +88,22 @@ def _apply_bootstrap_workflow(workflow, errback):
     return workflow.apply_async(link_error=errback)
 
 
+def _queue_market_bootstrap_workflow(
+    market_plan: MarketBootstrapPlan,
+    *,
+    completion_task,
+    completion_kwargs: dict,
+    errback_task,
+    errback_kwargs: dict,
+):
+    completion = completion_task.si(**completion_kwargs).set(queue="celery")
+    errback = errback_task.s(**errback_kwargs).set(queue="celery")
+    return _apply_bootstrap_workflow(
+        chain(*_build_market_bootstrap_signatures(market_plan), completion),
+        errback,
+    )
+
+
 def _readiness_failure(market_result) -> ReadinessFailure:
     if market_result is None or not market_result.core_ready:
         return ReadinessFailure(
@@ -104,17 +121,18 @@ def _readiness_failure(market_result) -> ReadinessFailure:
 def _evaluate_market_readiness(db, *, market: str, bootstrap_started_at=None) -> MarketReadinessCompletion:
     from ..services.bootstrap_readiness_service import BootstrapReadinessService
 
+    market_code = normalize_market(market)
     readiness = BootstrapReadinessService().evaluate(
         db,
-        enabled_markets=[market],
+        enabled_markets=[market_code],
         bootstrap_started_at=bootstrap_started_at,
     )
-    market_result = next(iter(readiness.market_results.values()), None)
-    market_code = market_result.market if market_result else str(market).upper()
+    market_result = readiness.market_results.get(market_code)
+    result_market = market_result.market if market_result else market_code
     if market_result and market_result.ready:
-        return MarketReadinessCompletion(market=market_code, ready=True)
+        return MarketReadinessCompletion(market=result_market, ready=True)
     return MarketReadinessCompletion(
-        market=market_code,
+        market=result_market,
         ready=False,
         failure=_readiness_failure(market_result),
     )
@@ -144,29 +162,23 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
 
     market_plans_by_code = {market_plan.market: market_plan for market_plan in plan.market_plans}
     primary_plan = market_plans_by_code[primary]
-    primary_completion = complete_local_runtime_bootstrap.si(
-        primary_market=primary,
-    ).set(queue="celery")
-    primary_errback = fail_local_runtime_bootstrap.s(
-        primary_market=primary,
-    ).set(queue="celery")
-    primary_task = _apply_bootstrap_workflow(
-        chain(*_build_market_bootstrap_signatures(primary_plan), primary_completion),
-        primary_errback,
+    primary_task = _queue_market_bootstrap_workflow(
+        primary_plan,
+        completion_task=complete_local_runtime_bootstrap,
+        completion_kwargs={"primary_market": primary},
+        errback_task=fail_local_runtime_bootstrap,
+        errback_kwargs={"primary_market": primary},
     )
 
     for market_plan in plan.market_plans:
         if market_plan.market == primary:
             continue
-        background_completion = complete_background_market_bootstrap.si(
-            market=market_plan.market,
-        ).set(queue="celery")
-        background_errback = fail_background_market_bootstrap.s(
-            market=market_plan.market,
-        ).set(queue="celery")
-        _apply_bootstrap_workflow(
-            chain(*_build_market_bootstrap_signatures(market_plan), background_completion),
-            background_errback,
+        _queue_market_bootstrap_workflow(
+            market_plan,
+            completion_task=complete_background_market_bootstrap,
+            completion_kwargs={"market": market_plan.market},
+            errback_task=fail_background_market_bootstrap,
+            errback_kwargs={"market": market_plan.market},
         )
 
     logger.info(
@@ -184,12 +196,17 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
     name="app.tasks.runtime_bootstrap_tasks.complete_local_runtime_bootstrap",
     queue="celery",
 )
-def complete_local_runtime_bootstrap(primary_market: str, **_kwargs) -> dict:
+def complete_local_runtime_bootstrap(
+    primary_market: str,
+    enabled_markets: Iterable[str] | None = None,
+) -> dict:
     from ..services.runtime_preferences_service import (
         get_runtime_preferences,
         set_bootstrap_state,
     )
 
+    del enabled_markets  # Legacy Celery payload compatibility; readiness is primary-only.
+    primary_market = normalize_market(primary_market)
     db = SessionLocal()
     try:
         prefs = get_runtime_preferences(db)
@@ -258,9 +275,10 @@ def complete_background_market_bootstrap(market: str) -> dict:
     name="app.tasks.runtime_bootstrap_tasks.fail_local_runtime_bootstrap",
     queue="celery",
 )
-def fail_local_runtime_bootstrap(*args, primary_market: str, **kwargs) -> dict:
+def fail_local_runtime_bootstrap(*_celery_errback_args, primary_market: str) -> dict:
     from ..services.runtime_preferences_service import set_bootstrap_state
 
+    primary_market = normalize_market(primary_market)
     db = SessionLocal()
     try:
         set_bootstrap_state(db, "failed")
@@ -277,8 +295,7 @@ def fail_local_runtime_bootstrap(*args, primary_market: str, **kwargs) -> dict:
         "Marked local runtime bootstrap failed",
         extra={
             "primary_market": primary_market,
-            "callback_args": args,
-            "callback_kwargs": kwargs,
+            "callback_args": _celery_errback_args,
         },
     )
     return {
@@ -292,7 +309,8 @@ def fail_local_runtime_bootstrap(*args, primary_market: str, **kwargs) -> dict:
     name="app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap",
     queue="celery",
 )
-def fail_background_market_bootstrap(*args, market: str, **kwargs) -> dict:
+def fail_background_market_bootstrap(*_celery_errback_args, market: str) -> dict:
+    market = normalize_market(market)
     db = SessionLocal()
     try:
         mark_current_market_activity_failed(
@@ -308,8 +326,7 @@ def fail_background_market_bootstrap(*args, market: str, **kwargs) -> dict:
         "Marked background market bootstrap failed",
         extra={
             "market": market,
-            "callback_args": args,
-            "callback_kwargs": kwargs,
+            "callback_args": _celery_errback_args,
         },
     )
     return {

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -11,6 +11,7 @@ from celery import chain
 
 from ..database import SessionLocal
 from ..domain.bootstrap.plan import (
+    BootstrapOperation,
     BootstrapQueueKind,
     MarketBootstrapPlan,
     build_bootstrap_plan,
@@ -46,6 +47,27 @@ class MarketReadinessCompletion:
     market: str
     ready: bool
     failure: ReadinessFailure | None = None
+
+
+class BootstrapDispatchError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        primary_market: str,
+        enabled_markets: Iterable[str],
+        primary_task_id: str | None = None,
+        market_task_ids: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.primary_market = primary_market
+        self.enabled_markets = list(enabled_markets)
+        self.primary_task_id = primary_task_id
+        self.market_task_ids = dict(market_task_ids or {})
+
+    @property
+    def dispatched_any(self) -> bool:
+        return self.primary_task_id is not None or bool(self.market_task_ids)
 
 
 @dataclass
@@ -117,6 +139,15 @@ class BootstrapQueueManifestRecorder:
             "market_task_ids": self.market_task_ids,
         }
 
+    def dispatch_error(self, exc: Exception) -> BootstrapDispatchError:
+        return BootstrapDispatchError(
+            str(exc),
+            primary_market=self.primary_market,
+            enabled_markets=self.enabled_markets,
+            primary_task_id=self.primary_task_id,
+            market_task_ids=self.market_task_ids,
+        )
+
 
 def _bootstrap_universe_name(market: str) -> str:
     return f"market:{market.upper()}"
@@ -142,18 +173,22 @@ def _build_market_bootstrap_signatures(market_plan: MarketBootstrapPlan) -> list
         refresh_stock_universe,
     )
 
-    task_by_name = {
-        "refresh_stock_universe": refresh_stock_universe,
-        "refresh_official_market_universe": refresh_official_market_universe,
-        "load_tracked_ibd_industry_groups": load_tracked_ibd_industry_groups,
-        "smart_refresh_cache": smart_refresh_cache,
-        "refresh_all_fundamentals": refresh_all_fundamentals,
-        "calculate_daily_breadth_with_gapfill": calculate_daily_breadth_with_gapfill,
-        "calculate_daily_group_rankings_with_gapfill": calculate_daily_group_rankings_with_gapfill,
-        "build_daily_snapshot": build_daily_snapshot,
+    task_by_operation = {
+        BootstrapOperation.REFRESH_STOCK_UNIVERSE: refresh_stock_universe,
+        BootstrapOperation.REFRESH_OFFICIAL_MARKET_UNIVERSE: refresh_official_market_universe,
+        BootstrapOperation.LOAD_TRACKED_IBD_INDUSTRY_GROUPS: load_tracked_ibd_industry_groups,
+        BootstrapOperation.SMART_REFRESH_CACHE: smart_refresh_cache,
+        BootstrapOperation.REFRESH_ALL_FUNDAMENTALS: refresh_all_fundamentals,
+        BootstrapOperation.CALCULATE_DAILY_BREADTH_WITH_GAPFILL: (
+            calculate_daily_breadth_with_gapfill
+        ),
+        BootstrapOperation.CALCULATE_DAILY_GROUP_RANKINGS_WITH_GAPFILL: (
+            calculate_daily_group_rankings_with_gapfill
+        ),
+        BootstrapOperation.BUILD_DAILY_SNAPSHOT: build_daily_snapshot,
     }
     return [
-        task_by_name[stage.task_name]
+        task_by_operation[stage.operation]
         .si(**stage.kwargs)
         .set(queue=_queue_for_stage(stage))
         for stage in market_plan.stages
@@ -297,9 +332,9 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
                 task_id=background_task.id,
             )
 
-    except Exception:
+    except Exception as exc:
         manifest_recorder.record_dispatch_failed_safely()
-        raise
+        raise manifest_recorder.dispatch_error(exc) from exc
 
     try:
         manifest_recorder.record_queued()

--- a/backend/app/tasks/runtime_bootstrap_tasks.py
+++ b/backend/app/tasks/runtime_bootstrap_tasks.py
@@ -31,6 +31,14 @@ logger = logging.getLogger(__name__)
 class ReadinessFailure:
     stage_key: str
     activity_message: str
+    result_reason: str
+
+
+@dataclass(frozen=True)
+class MarketReadinessCompletion:
+    market: str
+    ready: bool
+    failure: ReadinessFailure | None = None
 
 
 def _bootstrap_universe_name(market: str) -> str:
@@ -76,10 +84,7 @@ def _build_market_bootstrap_signatures(market_plan: MarketBootstrapPlan) -> list
 
 
 def _apply_bootstrap_workflow(workflow, errback):
-    try:
-        return workflow.apply_async(link_error=errback)
-    except TypeError:
-        return workflow.apply_async()
+    return workflow.apply_async(link_error=errback)
 
 
 def _readiness_failure(market_result) -> ReadinessFailure:
@@ -87,47 +92,46 @@ def _readiness_failure(market_result) -> ReadinessFailure:
         return ReadinessFailure(
             stage_key="core",
             activity_message="Bootstrap core data incomplete",
+            result_reason="missing core market data",
         )
     return ReadinessFailure(
         stage_key="scan",
         activity_message="Bootstrap scan did not publish",
+        result_reason="missing published auto scan",
     )
 
 
-def _mark_missing_readiness_failures(db, readiness, markets: list[str]) -> tuple[list[str], list[str]]:
-    core_missing_markets = []
-    scan_missing_markets = []
-    for market in markets:
-        market_code = str(market).upper()
-        market_result = readiness.market_results.get(market_code) or readiness.market_results.get(market)
-        failure = _readiness_failure(market_result)
-        if failure.stage_key == "core":
-            core_missing_markets.append(market_code)
-        else:
-            scan_missing_markets.append(market_code)
-        mark_market_activity_failed(
-            db,
-            market=market_code,
-            stage_key=failure.stage_key,
-            lifecycle="bootstrap",
-            task_name="runtime_bootstrap",
-            task_id=None,
-            message=failure.activity_message,
-        )
-    return core_missing_markets, scan_missing_markets
+def _evaluate_market_readiness(db, *, market: str, bootstrap_started_at=None) -> MarketReadinessCompletion:
+    from ..services.bootstrap_readiness_service import BootstrapReadinessService
+
+    readiness = BootstrapReadinessService().evaluate(
+        db,
+        enabled_markets=[market],
+        bootstrap_started_at=bootstrap_started_at,
+    )
+    market_result = next(iter(readiness.market_results.values()), None)
+    market_code = market_result.market if market_result else str(market).upper()
+    if market_result and market_result.ready:
+        return MarketReadinessCompletion(market=market_code, ready=True)
+    return MarketReadinessCompletion(
+        market=market_code,
+        ready=False,
+        failure=_readiness_failure(market_result),
+    )
 
 
-def _format_missing_reason(core_missing_markets: list[str], scan_missing_markets: list[str]) -> str:
-    failure_reasons = []
-    if core_missing_markets:
-        failure_reasons.append(
-            "missing core market data for: " + ", ".join(core_missing_markets)
-        )
-    if scan_missing_markets:
-        failure_reasons.append(
-            "missing published auto scans for: " + ", ".join(scan_missing_markets)
-        )
-    return "; ".join(failure_reasons)
+def _mark_readiness_failure(db, completion: MarketReadinessCompletion) -> str:
+    failure = completion.failure or _readiness_failure(None)
+    mark_market_activity_failed(
+        db,
+        market=completion.market,
+        stage_key=failure.stage_key,
+        lifecycle="bootstrap",
+        task_name="runtime_bootstrap",
+        task_id=None,
+        message=failure.activity_message,
+    )
+    return failure.result_reason
 
 
 def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Iterable[str]) -> str:
@@ -142,11 +146,9 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
     primary_plan = market_plans_by_code[primary]
     primary_completion = complete_local_runtime_bootstrap.si(
         primary_market=primary,
-        enabled_markets=[primary],
     ).set(queue="celery")
     primary_errback = fail_local_runtime_bootstrap.s(
         primary_market=primary,
-        enabled_markets=[primary],
     ).set(queue="celery")
     primary_task = _apply_bootstrap_workflow(
         chain(*_build_market_bootstrap_signatures(primary_plan), primary_completion),
@@ -182,8 +184,7 @@ def queue_local_runtime_bootstrap(*, primary_market: str, enabled_markets: Itera
     name="app.tasks.runtime_bootstrap_tasks.complete_local_runtime_bootstrap",
     queue="celery",
 )
-def complete_local_runtime_bootstrap(primary_market: str, enabled_markets: list[str]) -> dict:
-    from ..services.bootstrap_readiness_service import BootstrapReadinessService
+def complete_local_runtime_bootstrap(primary_market: str, **_kwargs) -> dict:
     from ..services.runtime_preferences_service import (
         get_runtime_preferences,
         set_bootstrap_state,
@@ -192,37 +193,18 @@ def complete_local_runtime_bootstrap(primary_market: str, enabled_markets: list[
     db = SessionLocal()
     try:
         prefs = get_runtime_preferences(db)
-        readiness = BootstrapReadinessService().evaluate(
+        completion = _evaluate_market_readiness(
             db,
-            enabled_markets=enabled_markets,
+            market=primary_market,
             bootstrap_started_at=prefs.bootstrap_started_at,
         )
-        missing_markets = readiness.missing_markets
-        core_missing_markets, scan_missing_markets = _mark_missing_readiness_failures(
-            db,
-            readiness,
-            missing_markets,
-        )
-        primary_result = readiness.market_results.get(primary_market)
-        primary_ready = bool(primary_result and primary_result.ready)
-        if missing_markets:
-            reason = _format_missing_reason(core_missing_markets, scan_missing_markets)
-            if not primary_ready:
-                set_bootstrap_state(db, "failed")
-                return {
-                    "status": "failed",
-                    "primary_market": primary_market,
-                    "enabled_markets": enabled_markets,
-                    "reason": reason,
-                }
-            set_bootstrap_state(db, "ready")
+        if not completion.ready:
+            reason = _mark_readiness_failure(db, completion)
+            set_bootstrap_state(db, "failed")
             return {
-                "status": "ready_with_background_failures",
+                "status": "failed",
                 "primary_market": primary_market,
-                "enabled_markets": enabled_markets,
-                "background_failed_markets": [
-                    market for market in missing_markets if market != primary_market
-                ],
+                "market": completion.market,
                 "reason": reason,
             }
         set_bootstrap_state(db, "ready")
@@ -233,13 +215,12 @@ def complete_local_runtime_bootstrap(primary_market: str, enabled_markets: list[
         "Completed local runtime bootstrap",
         extra={
             "primary_market": primary_market,
-            "enabled_markets": enabled_markets,
         },
     )
     return {
         "status": "ready",
         "primary_market": primary_market,
-        "enabled_markets": enabled_markets,
+        "market": completion.market,
     }
 
 
@@ -248,37 +229,25 @@ def complete_local_runtime_bootstrap(primary_market: str, enabled_markets: list[
     queue="celery",
 )
 def complete_background_market_bootstrap(market: str) -> dict:
-    from ..services.bootstrap_readiness_service import BootstrapReadinessService
     from ..services.runtime_preferences_service import get_runtime_preferences
 
     db = SessionLocal()
     try:
         prefs = get_runtime_preferences(db)
-        readiness = BootstrapReadinessService().evaluate(
+        completion = _evaluate_market_readiness(
             db,
-            enabled_markets=[market],
+            market=market,
             bootstrap_started_at=prefs.bootstrap_started_at,
         )
-        market_result = readiness.market_results.get(str(market).upper())
-        if market_result and market_result.ready:
+        if completion.ready:
             return {
                 "status": "ready",
-                "market": str(market).upper(),
+                "market": completion.market,
             }
-        missing_markets = readiness.missing_markets or [str(market).upper()]
-        core_missing_markets, scan_missing_markets = _mark_missing_readiness_failures(
-            db,
-            readiness,
-            missing_markets,
-        )
-        reason = _format_missing_reason(core_missing_markets, scan_missing_markets)
-        if scan_missing_markets == [str(market).upper()] and not core_missing_markets:
-            reason = "missing published auto scan"
-        elif core_missing_markets == [str(market).upper()] and not scan_missing_markets:
-            reason = "missing core market data"
+        reason = _mark_readiness_failure(db, completion)
         return {
             "status": "failed",
-            "market": str(market).upper(),
+            "market": completion.market,
             "reason": reason,
         }
     finally:
@@ -289,19 +258,18 @@ def complete_background_market_bootstrap(market: str) -> dict:
     name="app.tasks.runtime_bootstrap_tasks.fail_local_runtime_bootstrap",
     queue="celery",
 )
-def fail_local_runtime_bootstrap(*args, primary_market: str, enabled_markets: list[str], **kwargs) -> dict:
+def fail_local_runtime_bootstrap(*args, primary_market: str, **kwargs) -> dict:
     from ..services.runtime_preferences_service import set_bootstrap_state
 
     db = SessionLocal()
     try:
         set_bootstrap_state(db, "failed")
-        for market in enabled_markets:
-            mark_current_market_activity_failed(
-                db,
-                market=str(market).upper(),
-                lifecycle="bootstrap",
-                message="Bootstrap failed",
-            )
+        mark_current_market_activity_failed(
+            db,
+            market=str(primary_market).upper(),
+            lifecycle="bootstrap",
+            message="Bootstrap failed",
+        )
     finally:
         db.close()
 
@@ -309,7 +277,6 @@ def fail_local_runtime_bootstrap(*args, primary_market: str, enabled_markets: li
         "Marked local runtime bootstrap failed",
         extra={
             "primary_market": primary_market,
-            "enabled_markets": enabled_markets,
             "callback_args": args,
             "callback_kwargs": kwargs,
         },
@@ -317,7 +284,7 @@ def fail_local_runtime_bootstrap(*args, primary_market: str, enabled_markets: li
     return {
         "status": "failed",
         "primary_market": primary_market,
-        "enabled_markets": enabled_markets,
+        "market": str(primary_market).upper(),
     }
 
 

--- a/backend/tests/unit/domain/test_bootstrap_plan.py
+++ b/backend/tests/unit/domain/test_bootstrap_plan.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from app.domain.bootstrap.plan import BootstrapQueueKind, build_bootstrap_plan
+from app.domain.bootstrap.plan import (
+    BootstrapOperation,
+    BootstrapQueueKind,
+    build_bootstrap_plan,
+)
 
 
 def test_us_bootstrap_plan_includes_us_only_industry_group_seed() -> None:
@@ -23,13 +27,13 @@ def test_non_us_bootstrap_plan_uses_official_universe_without_industry_seed() ->
     hk_plan = plan.market_plans[0]
 
     assert hk_plan.market == "HK"
-    assert [stage.task_name for stage in hk_plan.stages] == [
-        "refresh_official_market_universe",
-        "smart_refresh_cache",
-        "refresh_all_fundamentals",
-        "calculate_daily_breadth_with_gapfill",
-        "calculate_daily_group_rankings_with_gapfill",
-        "build_daily_snapshot",
+    assert [stage.operation for stage in hk_plan.stages] == [
+        BootstrapOperation.REFRESH_OFFICIAL_MARKET_UNIVERSE,
+        BootstrapOperation.SMART_REFRESH_CACHE,
+        BootstrapOperation.REFRESH_ALL_FUNDAMENTALS,
+        BootstrapOperation.CALCULATE_DAILY_BREADTH_WITH_GAPFILL,
+        BootstrapOperation.CALCULATE_DAILY_GROUP_RANKINGS_WITH_GAPFILL,
+        BootstrapOperation.BUILD_DAILY_SNAPSHOT,
     ]
     assert hk_plan.stages[-1].kwargs == {
         "market": "HK",
@@ -50,7 +54,7 @@ def test_au_bootstrap_plan_refreshes_universe_before_prices_and_fundamentals() -
         "prices",
         "fundamentals",
     ]
-    assert au_plan.stages[0].task_name == "refresh_official_market_universe"
+    assert au_plan.stages[0].operation == BootstrapOperation.REFRESH_OFFICIAL_MARKET_UNIVERSE
     assert au_plan.stages[0].kwargs["market"] == "AU"
 
 

--- a/backend/tests/unit/test_app_runtime_endpoints.py
+++ b/backend/tests/unit/test_app_runtime_endpoints.py
@@ -239,6 +239,7 @@ async def test_runtime_activity_endpoint_returns_runtime_activity_payload(client
                 "app_ready": False,
                 "primary_market": "US",
                 "enabled_markets": ["US", "HK"],
+                "queue_state": "partial",
                 "current_stage": "Price Refresh",
                 "progress_mode": "indeterminate",
                 "percent": None,
@@ -279,6 +280,7 @@ async def test_runtime_activity_endpoint_returns_runtime_activity_payload(client
     assert response.status_code == 200
     payload = response.json()
     assert payload["bootstrap"]["current_stage"] == "Price Refresh"
+    assert payload["bootstrap"]["queue_state"] == "partial"
     assert payload["bootstrap"]["progress_mode"] == "indeterminate"
     assert payload["bootstrap"]["percent"] is None
     assert payload["summary"]["active_markets"] == ["US"]

--- a/backend/tests/unit/test_app_runtime_endpoints.py
+++ b/backend/tests/unit/test_app_runtime_endpoints.py
@@ -455,6 +455,87 @@ async def test_runtime_bootstrap_start_does_not_persist_running_state_when_queue
 
 
 @pytest.mark.asyncio
+async def test_runtime_bootstrap_start_keeps_running_state_after_partial_dispatch_failure(
+    client,
+    monkeypatch,
+):
+    from app.api.v1 import app_runtime as module
+    from app.services import server_auth
+    from app.tasks.runtime_bootstrap_tasks import BootstrapDispatchError
+
+    saved_states = []
+
+    monkeypatch.setattr(server_auth.settings, "server_auth_enabled", False)
+
+    statuses = iter([
+        type(
+            "BootstrapStatus",
+            (),
+            {
+                "bootstrap_required": True,
+                "empty_system": True,
+                "primary_market": "US",
+                "enabled_markets": ["US"],
+                "bootstrap_state": "not_started",
+                "supported_markets": ["US", "HK", "JP", "TW"],
+            },
+        )(),
+        type(
+            "BootstrapStatus",
+            (),
+            {
+                "bootstrap_required": True,
+                "empty_system": True,
+                "primary_market": "US",
+                "enabled_markets": ["US", "HK"],
+                "bootstrap_state": "running",
+                "supported_markets": ["US", "HK", "JP", "TW"],
+            },
+        )(),
+    ])
+
+    def _save(_db, *, primary_market, enabled_markets, bootstrap_state):
+        saved_states.append(bootstrap_state)
+        return type(
+            "SavedPrefs",
+            (),
+            {
+                "primary_market": primary_market,
+                "enabled_markets": enabled_markets,
+                "bootstrap_state": bootstrap_state,
+            },
+        )()
+
+    def _queue(**_kwargs):
+        raise BootstrapDispatchError(
+            "queue failed after primary dispatch",
+            primary_market="US",
+            enabled_markets=["US", "HK"],
+            primary_task_id="primary-task-123",
+            market_task_ids={"US": "primary-task-123"},
+        )
+
+    monkeypatch.setattr(module, "get_runtime_bootstrap_status", lambda _db: next(statuses))
+    monkeypatch.setattr(module, "save_runtime_preferences", _save)
+    monkeypatch.setattr(module, "queue_local_runtime_bootstrap", _queue)
+    app.dependency_overrides[get_db] = lambda: _FakeDb()
+
+    try:
+        response = await client.post(
+            "/api/v1/runtime/bootstrap",
+            json={"primary_market": "US", "enabled_markets": ["US", "HK"]},
+        )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    assert saved_states == ["running"]
+    payload = response.json()
+    assert payload["task_id"] == "primary-task-123"
+    assert payload["bootstrap_state"] == "running"
+
+
+@pytest.mark.asyncio
 async def test_runtime_bootstrap_start_rejects_duplicate_running_bootstrap(client, monkeypatch):
     from app.api.v1 import app_runtime as module
     from app.services import server_auth

--- a/backend/tests/unit/test_bootstrap_run_manifest.py
+++ b/backend/tests/unit/test_bootstrap_run_manifest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+
+import app.models.app_settings  # noqa: F401
+
+
+def test_bootstrap_run_manifest_repository_round_trips_market_task_ids():
+    from app.services.bootstrap_run_manifest import (
+        BootstrapRunManifest,
+        BootstrapRunManifestRepository,
+    )
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    try:
+        repository = BootstrapRunManifestRepository()
+        manifest = BootstrapRunManifest(
+            primary_market="US",
+            enabled_markets=("US", "HK", "TW"),
+            primary_task_id="primary-task-123",
+            market_task_ids={
+                "US": "primary-task-123",
+                "HK": "background-task-2",
+                "TW": "background-task-3",
+            },
+        )
+
+        repository.save(db, manifest)
+        loaded = repository.load(db)
+
+        assert loaded == manifest
+    finally:
+        db.close()
+        engine.dispose()

--- a/backend/tests/unit/test_bootstrap_run_manifest.py
+++ b/backend/tests/unit/test_bootstrap_run_manifest.py
@@ -37,3 +37,37 @@ def test_bootstrap_run_manifest_repository_round_trips_market_task_ids():
     finally:
         db.close()
         engine.dispose()
+
+
+def test_bootstrap_run_manifest_repository_round_trips_queueing_manifest_without_task_ids():
+    from app.services.bootstrap_run_manifest import (
+        BootstrapRunManifest,
+        BootstrapRunManifestRepository,
+    )
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    try:
+        repository = BootstrapRunManifestRepository()
+        manifest = BootstrapRunManifest(
+            primary_market="us",
+            enabled_markets=("us", "hk"),
+            primary_task_id=None,
+            market_task_ids={},
+            queue_state="queueing",
+        )
+
+        repository.save(db, manifest)
+        loaded = repository.load(db)
+
+        assert loaded == BootstrapRunManifest(
+            primary_market="US",
+            enabled_markets=("US", "HK"),
+            primary_task_id=None,
+            market_task_ids={},
+            queue_state="queueing",
+        )
+    finally:
+        db.close()
+        engine.dispose()

--- a/backend/tests/unit/test_bootstrap_run_manifest.py
+++ b/backend/tests/unit/test_bootstrap_run_manifest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -71,3 +72,14 @@ def test_bootstrap_run_manifest_repository_round_trips_queueing_manifest_without
     finally:
         db.close()
         engine.dispose()
+
+
+def test_bootstrap_run_manifest_rejects_unknown_queue_state():
+    from app.services.bootstrap_run_manifest import BootstrapRunManifest
+
+    with pytest.raises(ValueError, match="invalid bootstrap queue_state"):
+        BootstrapRunManifest(
+            primary_market="US",
+            enabled_markets=("US",),
+            queue_state="almost_queued",
+        )

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -408,9 +408,23 @@ def test_smart_refresh_cache_delta_prefers_github_daily_bundle_and_skips_live_fe
                 "as_of_date": "2026-04-21",
                 "source_revision": "daily_prices_us:20260421120000",
             },
-            symbols_missing_as_of=lambda db, symbols, as_of_date: [],
         ),
     )
+
+    def _plan_price_refresh(db, **kwargs):
+        github_sync = kwargs["github_sync"]
+        assert github_sync["status"] == "success"
+        assert kwargs["mode"] == "delta"
+        return SimpleNamespace(
+            github_sync=github_sync,
+            used_github_seed=True,
+            source="github",
+            symbols=(),
+            jobs=(),
+            completion_message="GitHub daily price bundle is current - no live fetch needed",
+        )
+
+    monkeypatch.setattr(module, "plan_price_refresh", _plan_price_refresh)
     monkeypatch.setattr(
         module,
         "get_market_calendar_service",
@@ -584,7 +598,6 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
         "as_of_date": "2026-03-24",
         "source_revision": "sha-123",
     }
-    github_service.symbols_missing_as_of.return_value = []
     retry_calls = []
 
     monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
@@ -595,6 +608,21 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
     )
     monkeypatch.setattr("app.wiring.bootstrap.get_price_cache", lambda: fake_price_cache)
     monkeypatch.setattr(module, "get_daily_price_bundle_service", lambda: github_service)
+
+    def _plan_price_refresh(db, **kwargs):
+        github_sync = kwargs["github_sync"]
+        assert github_sync["status"] == "success"
+        assert kwargs["mode"] == "bootstrap"
+        return SimpleNamespace(
+            github_sync=github_sync,
+            used_github_seed=True,
+            source="github",
+            symbols=(),
+            jobs=(),
+            completion_message="GitHub daily price bundle is current - no live fetch needed",
+        )
+
+    monkeypatch.setattr(module, "plan_price_refresh", _plan_price_refresh)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -630,11 +658,6 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
         fake_db,
         market="HK",
         allow_stale=True,
-    )
-    github_service.symbols_missing_as_of.assert_called_once_with(
-        fake_db,
-        symbols=["0700.HK", "0005.HK"],
-        as_of_date="2026-03-24",
     )
     assert retry_calls == []
 

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -321,7 +321,7 @@ def test_smart_refresh_cache_retries_transient_database_errors_from_task_body(mo
     fake_lock.release.assert_called_once_with("task-123", market=None)
     fake_coordination.release_external_fetch.assert_called_once_with("task-123")
     fake_coordination.release_market_workload.assert_called_once_with("task-123", market=None)
-    module.safe_rollback.assert_not_called()
+    module.safe_rollback.assert_called_once_with(fake_db)
 
 
 def test_smart_refresh_cache_publishes_running_progress_per_batch(monkeypatch):

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -407,6 +407,93 @@ def test_smart_refresh_cache_publishes_running_progress_per_batch(monkeypatch):
     assert progress_updates[-1]["percent"] == pytest.approx(100.0)
 
 
+def test_smart_refresh_cache_failure_records_latest_batch_progress(monkeypatch):
+    import app.tasks.cache_tasks as module
+
+    fake_db = MagicMock()
+    symbols = [SimpleNamespace(symbol=f"SYM{i}") for i in range(101)]
+    fake_query = MagicMock()
+    fake_query.filter.return_value.filter.return_value.order_by.return_value.all.return_value = symbols
+    fake_query.filter.return_value.order_by.return_value.all.return_value = symbols
+    fake_db.query.return_value = fake_query
+
+    fake_price_cache = MagicMock()
+    fake_lock = MagicMock()
+    bulk_fetcher = MagicMock()
+    progress_updates: list[dict] = []
+    failures: list[dict] = []
+    fetch_calls = 0
+
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(module, "warm_spy_cache", MagicMock(return_value={"status": "ok"}))
+    monkeypatch.setattr(
+        module,
+        "get_eastern_now",
+        lambda: SimpleNamespace(weekday=lambda: 1, hour=17, date=lambda: date(2026, 3, 24)),
+    )
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_price_cache",
+        lambda: fake_price_cache,
+    )
+    monkeypatch.setattr(
+        module,
+        "get_daily_price_bundle_service",
+        lambda: SimpleNamespace(sync_from_github=lambda *_args, **_kwargs: {"status": "missing"}),
+    )
+    monkeypatch.setattr(
+        "app.services.bulk_data_fetcher.BulkDataFetcher",
+        lambda: bulk_fetcher,
+    )
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_data_fetch_lock",
+        lambda: fake_lock,
+    )
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_rate_limiter",
+        lambda: SimpleNamespace(wait_for_market=lambda *args, **kwargs: None, wait=lambda *args, **kwargs: None),
+    )
+    monkeypatch.setattr(module, "_track_symbol_failures", lambda *args, **kwargs: None)
+
+    def _fetch_with_backoff(_fetcher, batch_symbols, **kwargs):
+        nonlocal fetch_calls
+        fetch_calls += 1
+        if fetch_calls == 2:
+            raise SoftTimeLimitExceeded()
+        return {symbol: _success_result(symbol) for symbol in batch_symbols}
+
+    monkeypatch.setattr(module, "_fetch_with_backoff", _fetch_with_backoff)
+    monkeypatch.setattr(
+        module,
+        "mark_market_activity_progress",
+        lambda *args, **kwargs: progress_updates.append(kwargs),
+    )
+    monkeypatch.setattr(
+        module,
+        "mark_market_activity_failed",
+        lambda *args, **kwargs: failures.append(kwargs),
+    )
+    monkeypatch.setattr(module.smart_refresh_cache, "update_state", lambda *args, **kwargs: None)
+
+    with pytest.raises(SoftTimeLimitExceeded):
+        module.smart_refresh_cache.run.__wrapped__(
+            module.smart_refresh_cache,
+            "full",
+            market="US",
+            activity_lifecycle="bootstrap",
+        )
+
+    assert any(update["current"] == 100 for update in progress_updates)
+    fake_price_cache.save_warmup_metadata.assert_called_once_with(
+        "failed",
+        100,
+        101,
+        "Soft time limit exceeded",
+        market="US",
+    )
+    assert failures[-1]["current"] == 100
+    assert failures[-1]["total"] == 101
+
+
 def test_smart_refresh_cache_delta_prefers_github_daily_bundle_and_skips_live_fetch(monkeypatch):
     import app.tasks.cache_tasks as module
 

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import date
-import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -372,7 +371,7 @@ def test_smart_refresh_cache_publishes_running_progress_per_batch(monkeypatch):
     assert progress_updates[-1]["percent"] == pytest.approx(100.0)
 
 
-def test_smart_refresh_cache_prefers_github_daily_bundle_and_skips_live_fetch(monkeypatch):
+def test_smart_refresh_cache_delta_prefers_github_daily_bundle_and_skips_live_fetch(monkeypatch):
     import app.tasks.cache_tasks as module
 
     fake_db = MagicMock()
@@ -402,7 +401,7 @@ def test_smart_refresh_cache_prefers_github_daily_bundle_and_skips_live_fetch(mo
         module,
         "get_daily_price_bundle_service",
         lambda: SimpleNamespace(
-            sync_from_github=lambda db, market, warm_redis_symbols=None: {
+            sync_from_github=lambda db, market, warm_redis_symbols=None, allow_stale=False: {
                 "status": "success",
                 "source": "github",
                 "market": market,
@@ -412,6 +411,13 @@ def test_smart_refresh_cache_prefers_github_daily_bundle_and_skips_live_fetch(mo
             symbols_missing_as_of=lambda db, symbols, as_of_date: [],
         ),
     )
+    monkeypatch.setattr(
+        module,
+        "get_market_calendar_service",
+        lambda: SimpleNamespace(
+            last_completed_trading_day=lambda market: date(2026, 4, 21)
+        ),
+    )
 
     started = []
     completed = []
@@ -419,7 +425,7 @@ def test_smart_refresh_cache_prefers_github_daily_bundle_and_skips_live_fetch(mo
     monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: completed.append(kwargs))
 
     result = module.smart_refresh_cache.run.__wrapped__(
-        module.smart_refresh_cache, "full", market="US"
+        module.smart_refresh_cache, "delta", market="US"
     )
 
     assert result["status"] == "completed"
@@ -613,7 +619,7 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
 
     result = module.smart_refresh_cache.run.__wrapped__(
         module.smart_refresh_cache,
-        mode="full",
+        mode="bootstrap",
         market="HK",
         activity_lifecycle="bootstrap",
     )
@@ -631,207 +637,6 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
         as_of_date="2026-03-24",
     )
     assert retry_calls == []
-
-
-def test_bootstrap_stale_github_bundle_uses_short_live_top_up(monkeypatch, caplog):
-    import app.tasks.cache_tasks as module
-    from app.models.stock import StockPrice
-    from app.models.stock_universe import StockUniverse
-
-    fake_db = MagicMock()
-    universe_rows = [
-        SimpleNamespace(symbol="0700.HK", market="HK"),
-        SimpleNamespace(symbol="0005.HK", market="HK"),
-        SimpleNamespace(symbol="9999.HK", market="HK"),
-    ]
-    price_rows = [
-        ("0700.HK", date(2026, 6, 5)),
-        ("0005.HK", date(2026, 6, 5)),
-    ]
-
-    def _query_for(rows):
-        query = MagicMock()
-        query.filter.return_value = query
-        query.order_by.return_value = query
-        query.group_by.return_value = query
-        query.all.return_value = rows
-        return query
-
-    universe_query = _query_for(universe_rows)
-    price_query = _query_for(price_rows)
-
-    def _query(*entities):
-        model = getattr(entities[0], "class_", None)
-        if model is StockUniverse:
-            return universe_query
-        if model is StockPrice:
-            return price_query
-        return MagicMock()
-
-    fake_db.query.side_effect = _query
-    fake_price_cache = MagicMock()
-    github_service = MagicMock()
-    github_service.sync_from_github.return_value = {
-        "status": "success",
-        "as_of_date": "2026-06-05",
-        "source_revision": "daily_prices_hk:20260605090000",
-        "stale_reason": "Daily price bundle as_of_date 2026-06-05 is behind expected session 2026-06-08",
-    }
-    github_service.symbols_missing_as_of.return_value = []
-    fetch_calls = []
-
-    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
-    monkeypatch.setattr(module, "warm_spy_cache", MagicMock(return_value={"status": "ok"}))
-    monkeypatch.setattr(
-        "app.services.runtime_preferences_service.is_market_enabled_now",
-        lambda _market: True,
-    )
-    monkeypatch.setattr("app.wiring.bootstrap.get_price_cache", lambda: fake_price_cache)
-    monkeypatch.setattr(module, "get_daily_price_bundle_service", lambda: github_service)
-    monkeypatch.setattr("app.services.bulk_data_fetcher.BulkDataFetcher", lambda: MagicMock())
-    monkeypatch.setattr(
-        "app.wiring.bootstrap.get_data_fetch_lock",
-        lambda: SimpleNamespace(extend_lock=lambda *args, **kwargs: None),
-    )
-    monkeypatch.setattr(
-        "app.wiring.bootstrap.get_rate_limiter",
-        lambda: SimpleNamespace(wait_for_market=lambda *args, **kwargs: None),
-    )
-    monkeypatch.setattr(module, "_track_symbol_failures", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module.smart_refresh_cache, "update_state", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "mark_market_activity_progress", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        module,
-        "get_market_calendar_service",
-        lambda: SimpleNamespace(
-            last_completed_trading_day=lambda market: date(2026, 6, 8)
-        ),
-    )
-
-    def _fetch(_fetcher, batch_symbols, *, period, market=None, **_kwargs):
-        fetch_calls.append({"symbols": list(batch_symbols), "period": period, "market": market})
-        return {symbol: _success_result(symbol) for symbol in batch_symbols}
-
-    monkeypatch.setattr(module, "_fetch_with_backoff", _fetch)
-    caplog.set_level(logging.INFO, logger=module.logger.name)
-
-    result = module.smart_refresh_cache.run.__wrapped__(
-        module.smart_refresh_cache,
-        mode="bootstrap",
-        market="HK",
-        activity_lifecycle="bootstrap",
-    )
-
-    assert result["status"] == "completed"
-    assert result["source"] == "github+live"
-    assert result["refreshed"] == 3
-    assert result["total"] == 3
-    github_service.sync_from_github.assert_called_once_with(
-        fake_db,
-        market="HK",
-        allow_stale=True,
-    )
-    assert fetch_calls == [
-        {"symbols": ["0700.HK", "0005.HK"], "period": "7d", "market": "HK"},
-        {"symbols": ["9999.HK"], "period": "2y", "market": "HK"},
-    ]
-    assert "Daily price bundle as_of_date 2026-06-05 is behind expected session 2026-06-08" in caplog.text
-
-
-def test_bootstrap_current_github_bundle_splits_missing_symbols_by_history(monkeypatch):
-    import app.tasks.cache_tasks as module
-    from app.models.stock import StockPrice
-    from app.models.stock_universe import StockUniverse
-
-    fake_db = MagicMock()
-    universe_rows = [
-        SimpleNamespace(symbol="0700.HK", market="HK"),
-        SimpleNamespace(symbol="0005.HK", market="HK"),
-        SimpleNamespace(symbol="9999.HK", market="HK"),
-    ]
-    price_rows = [("0700.HK", date(2026, 6, 5))]
-
-    def _query_for(rows):
-        query = MagicMock()
-        query.filter.return_value = query
-        query.order_by.return_value = query
-        query.group_by.return_value = query
-        query.all.return_value = rows
-        return query
-
-    universe_query = _query_for(universe_rows)
-    price_query = _query_for(price_rows)
-
-    def _query(*entities):
-        model = getattr(entities[0], "class_", None)
-        if model is StockUniverse:
-            return universe_query
-        if model is StockPrice:
-            return price_query
-        return MagicMock()
-
-    fake_db.query.side_effect = _query
-    fake_price_cache = MagicMock()
-    github_service = MagicMock()
-    github_service.sync_from_github.return_value = {
-        "status": "success",
-        "as_of_date": "2026-06-08",
-        "source_revision": "daily_prices_hk:20260608090000",
-    }
-    github_service.symbols_missing_as_of.return_value = ["0700.HK", "9999.HK"]
-    fetch_calls = []
-
-    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
-    monkeypatch.setattr(module, "warm_spy_cache", MagicMock(return_value={"status": "ok"}))
-    monkeypatch.setattr(
-        "app.services.runtime_preferences_service.is_market_enabled_now",
-        lambda _market: True,
-    )
-    monkeypatch.setattr("app.wiring.bootstrap.get_price_cache", lambda: fake_price_cache)
-    monkeypatch.setattr(module, "get_daily_price_bundle_service", lambda: github_service)
-    monkeypatch.setattr("app.services.bulk_data_fetcher.BulkDataFetcher", lambda: MagicMock())
-    monkeypatch.setattr(
-        "app.wiring.bootstrap.get_data_fetch_lock",
-        lambda: SimpleNamespace(extend_lock=lambda *args, **kwargs: None),
-    )
-    monkeypatch.setattr(
-        "app.wiring.bootstrap.get_rate_limiter",
-        lambda: SimpleNamespace(wait_for_market=lambda *args, **kwargs: None),
-    )
-    monkeypatch.setattr(module, "_track_symbol_failures", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module.smart_refresh_cache, "update_state", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "mark_market_activity_progress", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        module,
-        "get_market_calendar_service",
-        lambda: SimpleNamespace(
-            last_completed_trading_day=lambda market: date(2026, 6, 8)
-        ),
-    )
-
-    def _fetch(_fetcher, batch_symbols, *, period, market=None, **_kwargs):
-        fetch_calls.append({"symbols": list(batch_symbols), "period": period, "market": market})
-        return {symbol: _success_result(symbol) for symbol in batch_symbols}
-
-    monkeypatch.setattr(module, "_fetch_with_backoff", _fetch)
-
-    result = module.smart_refresh_cache.run.__wrapped__(
-        module.smart_refresh_cache,
-        mode="bootstrap",
-        market="HK",
-        activity_lifecycle="bootstrap",
-    )
-
-    assert result["status"] == "completed"
-    assert result["source"] == "github+live"
-    assert fetch_calls == [
-        {"symbols": ["0700.HK"], "period": "7d", "market": "HK"},
-        {"symbols": ["9999.HK"], "period": "2y", "market": "HK"},
-    ]
 
 
 def test_bootstrap_smart_refresh_uses_short_failed_symbol_retry_delay(monkeypatch):

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -50,6 +50,28 @@ def _postgres_recovery_error() -> OperationalError:
     )
 
 
+def _live_price_refresh_plan(symbol: str = "AAPL"):
+    from app.services.price_refresh_planning import (
+        NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+        PriceRefreshJob,
+        PriceRefreshJobKind,
+        PriceRefreshPlan,
+    )
+
+    return PriceRefreshPlan(
+        symbols=(symbol,),
+        jobs=(
+            PriceRefreshJob(
+                kind=PriceRefreshJobKind.FULL,
+                symbols=(symbol,),
+                period=NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+            ),
+        ),
+        all_symbols=(symbol,),
+        symbol_markets={symbol: "US"},
+    )
+
+
 @pytest_asyncio.fixture
 async def client():
     transport = httpx.ASGITransport(app=app)
@@ -118,6 +140,7 @@ def test_smart_refresh_cache_reraises_soft_time_limit(monkeypatch):
     monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
     monkeypatch.setattr(module, "get_eastern_now", lambda: SimpleNamespace(weekday=lambda: 6, hour=2, date=lambda: date(2026, 3, 22)))
     monkeypatch.setattr(module, "warm_spy_cache", MagicMock(side_effect=SoftTimeLimitExceeded()))
+    monkeypatch.setattr(module, "build_market_price_refresh_plan", lambda *args, **kwargs: _live_price_refresh_plan())
     monkeypatch.setattr(module, "safe_rollback", MagicMock())
     monkeypatch.setattr(
         "app.wiring.bootstrap.get_price_cache",
@@ -253,6 +276,7 @@ def test_smart_refresh_cache_publishes_failed_market_activity(monkeypatch):
         lambda: SimpleNamespace(weekday=lambda: 1, hour=17, date=lambda: date(2026, 3, 24)),
     )
     monkeypatch.setattr(module, "warm_spy_cache", MagicMock(side_effect=RuntimeError("benchmark unavailable")))
+    monkeypatch.setattr(module, "build_market_price_refresh_plan", lambda *args, **kwargs: _live_price_refresh_plan())
     monkeypatch.setattr(
         "app.wiring.bootstrap.get_price_cache",
         lambda: fake_price_cache,
@@ -290,6 +314,7 @@ def test_smart_refresh_cache_retries_transient_database_errors_from_task_body(mo
         lambda: SimpleNamespace(weekday=lambda: 1, hour=17, date=lambda: date(2026, 3, 24)),
     )
     monkeypatch.setattr(module, "warm_spy_cache", MagicMock(side_effect=_postgres_recovery_error()))
+    monkeypatch.setattr(module, "build_market_price_refresh_plan", lambda *args, **kwargs: _live_price_refresh_plan())
     monkeypatch.setattr(module, "safe_rollback", MagicMock())
     monkeypatch.setattr(
         "app.wiring.bootstrap.get_price_cache",
@@ -940,6 +965,7 @@ def test_smart_refresh_cache_rolls_back_before_failure_reporting(monkeypatch):
         lambda: SimpleNamespace(weekday=lambda: 1, hour=17, date=lambda: date(2026, 3, 24)),
     )
     monkeypatch.setattr(module, "warm_spy_cache", MagicMock(side_effect=RuntimeError("benchmark unavailable")))
+    monkeypatch.setattr(module, "build_market_price_refresh_plan", lambda *args, **kwargs: _live_price_refresh_plan())
     monkeypatch.setattr(module, "safe_rollback", MagicMock())
     monkeypatch.setattr(
         "app.wiring.bootstrap.get_price_cache",

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -448,17 +448,20 @@ def test_smart_refresh_cache_delta_prefers_github_daily_bundle_and_skips_live_fe
     )
 
     def _plan_price_refresh(db, **kwargs):
-        github_sync = kwargs["github_sync"]
-        assert github_sync["status"] == "success"
+        from app.services.price_refresh_planning import PriceRefreshPlan, PriceRefreshSource
+
+        github_seed = kwargs["github_seed"]
+        assert github_seed.status.value == "success"
         assert kwargs["mode"] == "delta"
-        return SimpleNamespace(
-            github_sync=github_sync,
-            used_github_seed=True,
-            source="github",
+        plan = PriceRefreshPlan(
             symbols=(),
             jobs=(),
+            github_seed=github_seed,
+            github_seed_used=True,
             completion_message="GitHub daily price bundle is current - no live fetch needed",
         )
+        assert plan.source is PriceRefreshSource.GITHUB
+        return plan
 
     monkeypatch.setattr(module, "plan_price_refresh", _plan_price_refresh)
     monkeypatch.setattr(
@@ -646,17 +649,20 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
     monkeypatch.setattr(module, "get_daily_price_bundle_service", lambda: github_service)
 
     def _plan_price_refresh(db, **kwargs):
-        github_sync = kwargs["github_sync"]
-        assert github_sync["status"] == "success"
+        from app.services.price_refresh_planning import PriceRefreshPlan, PriceRefreshSource
+
+        github_seed = kwargs["github_seed"]
+        assert github_seed.status.value == "success"
         assert kwargs["mode"] == "bootstrap"
-        return SimpleNamespace(
-            github_sync=github_sync,
-            used_github_seed=True,
-            source="github",
+        plan = PriceRefreshPlan(
             symbols=(),
             jobs=(),
+            github_seed=github_seed,
+            github_seed_used=True,
             completion_message="GitHub daily price bundle is current - no live fetch needed",
         )
+        assert plan.source is PriceRefreshSource.GITHUB
+        return plan
 
     monkeypatch.setattr(module, "plan_price_refresh", _plan_price_refresh)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -363,6 +363,7 @@ def test_smart_refresh_cache_publishes_running_progress_per_batch(monkeypatch):
     fake_lock = MagicMock()
     bulk_fetcher = MagicMock()
     progress_updates: list[dict] = []
+    fetch_batches: list[tuple[str, ...]] = []
 
     monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
     monkeypatch.setattr(module, "warm_spy_cache", MagicMock(return_value={"status": "ok"}))
@@ -402,14 +403,11 @@ def test_smart_refresh_cache_publishes_running_progress_per_batch(monkeypatch):
         lambda: SimpleNamespace(wait_for_market=lambda *args, **kwargs: None, wait=lambda *args, **kwargs: None),
     )
     monkeypatch.setattr(module, "_track_symbol_failures", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        module,
-        "_fetch_with_backoff",
-        lambda _fetcher, batch_symbols, **kwargs: {
-            symbol: _success_result(symbol)
-            for symbol in batch_symbols
-        },
-    )
+    def _fetch_with_backoff(_fetcher, batch_symbols, **kwargs):
+        fetch_batches.append(tuple(batch_symbols))
+        return {symbol: _success_result(symbol) for symbol in batch_symbols}
+
+    monkeypatch.setattr(module, "_fetch_with_backoff", _fetch_with_backoff)
     monkeypatch.setattr(
         module,
         "mark_market_activity_progress",
@@ -425,14 +423,15 @@ def test_smart_refresh_cache_publishes_running_progress_per_batch(monkeypatch):
     assert progress_updates[0]["current"] == 0
     assert progress_updates[0]["total"] == 101
     assert progress_updates[0]["percent"] == 0
-    assert any(update["message"] == "Batch 1/2 · refreshing prices" for update in progress_updates)
-    assert any(update["message"] == "Batch 2/2 · refreshing prices" for update in progress_updates)
+    assert len(fetch_batches) == 1
+    assert len(fetch_batches[0]) == 101
+    assert any(update["message"] == "Batch 1/1 · refreshing prices" for update in progress_updates)
     assert progress_updates[-1]["current"] == 101
     assert progress_updates[-1]["total"] == 101
     assert progress_updates[-1]["percent"] == pytest.approx(100.0)
 
 
-def test_smart_refresh_cache_failure_records_latest_batch_progress(monkeypatch):
+def test_smart_refresh_cache_failure_records_delegated_batch_progress(monkeypatch):
     import app.tasks.cache_tasks as module
 
     fake_db = MagicMock()
@@ -482,9 +481,7 @@ def test_smart_refresh_cache_failure_records_latest_batch_progress(monkeypatch):
     def _fetch_with_backoff(_fetcher, batch_symbols, **kwargs):
         nonlocal fetch_calls
         fetch_calls += 1
-        if fetch_calls == 2:
-            raise SoftTimeLimitExceeded()
-        return {symbol: _success_result(symbol) for symbol in batch_symbols}
+        raise SoftTimeLimitExceeded()
 
     monkeypatch.setattr(module, "_fetch_with_backoff", _fetch_with_backoff)
     monkeypatch.setattr(
@@ -507,15 +504,16 @@ def test_smart_refresh_cache_failure_records_latest_batch_progress(monkeypatch):
             activity_lifecycle="bootstrap",
         )
 
-    assert any(update["current"] == 100 for update in progress_updates)
+    assert fetch_calls == 1
+    assert progress_updates[-1]["current"] == 0
     fake_price_cache.save_warmup_metadata.assert_called_once_with(
         "failed",
-        100,
+        0,
         101,
         "Soft time limit exceeded",
         market="US",
     )
-    assert failures[-1]["current"] == 100
+    assert failures[-1]["current"] == 0
     assert failures[-1]["total"] == 101
 
 
@@ -951,6 +949,49 @@ def test_failed_price_retry_preserves_bootstrap_retry_delay(monkeypatch):
     assert retry_calls == [
         {"symbols": ["AAPL"], "market": "US", "attempt": 3, "countdown": 30}
     ]
+
+
+def test_failed_price_retry_does_not_reschedule_permanent_no_data(monkeypatch):
+    import app.tasks.cache_tasks as module
+
+    fake_price_cache = MagicMock()
+    retry_calls = []
+
+    monkeypatch.setattr("app.wiring.bootstrap.get_price_cache", lambda: fake_price_cache)
+    monkeypatch.setattr("app.services.bulk_data_fetcher.BulkDataFetcher", lambda: MagicMock())
+    monkeypatch.setattr(module, "_track_symbol_failures", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "_fetch_with_backoff",
+        lambda _fetcher, batch_symbols, **kwargs: {
+            symbol: {
+                "has_error": True,
+                "error": "Provider returned no usable rows",
+                "error_kind": "no_price_data",
+                "price_data": None,
+            }
+            for symbol in batch_symbols
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "_schedule_failed_symbol_retry",
+        lambda symbols, *, market, attempt, countdown=600: retry_calls.append(
+            {"symbols": symbols, "market": market, "attempt": attempt, "countdown": countdown}
+        ),
+    )
+
+    result = module.retry_failed_price_symbols.run.__wrapped__(
+        module.retry_failed_price_symbols,
+        symbols=["0143.T"],
+        market="JP",
+        attempt=1,
+        retry_countdown=30,
+    )
+
+    assert result["status"] == "partial"
+    assert result["failed_symbols"] == ["0143.T"]
+    assert retry_calls == []
 
 
 def test_smart_refresh_cache_rolls_back_before_failure_reporting(monkeypatch):

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -619,13 +620,218 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
 
     assert result["status"] == "completed"
     assert result["source"] == "github"
-    github_service.sync_from_github.assert_called_once_with(fake_db, market="HK")
+    github_service.sync_from_github.assert_called_once_with(
+        fake_db,
+        market="HK",
+        allow_stale=True,
+    )
     github_service.symbols_missing_as_of.assert_called_once_with(
         fake_db,
         symbols=["0700.HK", "0005.HK"],
         as_of_date="2026-03-24",
     )
     assert retry_calls == []
+
+
+def test_bootstrap_stale_github_bundle_uses_short_live_top_up(monkeypatch, caplog):
+    import app.tasks.cache_tasks as module
+    from app.models.stock import StockPrice
+    from app.models.stock_universe import StockUniverse
+
+    fake_db = MagicMock()
+    universe_rows = [
+        SimpleNamespace(symbol="0700.HK", market="HK"),
+        SimpleNamespace(symbol="0005.HK", market="HK"),
+        SimpleNamespace(symbol="9999.HK", market="HK"),
+    ]
+    price_rows = [
+        ("0700.HK", date(2026, 6, 5)),
+        ("0005.HK", date(2026, 6, 5)),
+    ]
+
+    def _query_for(rows):
+        query = MagicMock()
+        query.filter.return_value = query
+        query.order_by.return_value = query
+        query.group_by.return_value = query
+        query.all.return_value = rows
+        return query
+
+    universe_query = _query_for(universe_rows)
+    price_query = _query_for(price_rows)
+
+    def _query(*entities):
+        model = getattr(entities[0], "class_", None)
+        if model is StockUniverse:
+            return universe_query
+        if model is StockPrice:
+            return price_query
+        return MagicMock()
+
+    fake_db.query.side_effect = _query
+    fake_price_cache = MagicMock()
+    github_service = MagicMock()
+    github_service.sync_from_github.return_value = {
+        "status": "success",
+        "as_of_date": "2026-06-05",
+        "source_revision": "daily_prices_hk:20260605090000",
+        "stale_reason": "Daily price bundle as_of_date 2026-06-05 is behind expected session 2026-06-08",
+    }
+    github_service.symbols_missing_as_of.return_value = []
+    fetch_calls = []
+
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(module, "warm_spy_cache", MagicMock(return_value={"status": "ok"}))
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.is_market_enabled_now",
+        lambda _market: True,
+    )
+    monkeypatch.setattr("app.wiring.bootstrap.get_price_cache", lambda: fake_price_cache)
+    monkeypatch.setattr(module, "get_daily_price_bundle_service", lambda: github_service)
+    monkeypatch.setattr("app.services.bulk_data_fetcher.BulkDataFetcher", lambda: MagicMock())
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_data_fetch_lock",
+        lambda: SimpleNamespace(extend_lock=lambda *args, **kwargs: None),
+    )
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_rate_limiter",
+        lambda: SimpleNamespace(wait_for_market=lambda *args, **kwargs: None),
+    )
+    monkeypatch.setattr(module, "_track_symbol_failures", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.smart_refresh_cache, "update_state", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_progress", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "get_market_calendar_service",
+        lambda: SimpleNamespace(
+            last_completed_trading_day=lambda market: date(2026, 6, 8)
+        ),
+    )
+
+    def _fetch(_fetcher, batch_symbols, *, period, market=None, **_kwargs):
+        fetch_calls.append({"symbols": list(batch_symbols), "period": period, "market": market})
+        return {symbol: _success_result(symbol) for symbol in batch_symbols}
+
+    monkeypatch.setattr(module, "_fetch_with_backoff", _fetch)
+    caplog.set_level(logging.INFO, logger=module.logger.name)
+
+    result = module.smart_refresh_cache.run.__wrapped__(
+        module.smart_refresh_cache,
+        mode="bootstrap",
+        market="HK",
+        activity_lifecycle="bootstrap",
+    )
+
+    assert result["status"] == "completed"
+    assert result["source"] == "github+live"
+    assert result["refreshed"] == 3
+    assert result["total"] == 3
+    github_service.sync_from_github.assert_called_once_with(
+        fake_db,
+        market="HK",
+        allow_stale=True,
+    )
+    assert fetch_calls == [
+        {"symbols": ["0700.HK", "0005.HK"], "period": "7d", "market": "HK"},
+        {"symbols": ["9999.HK"], "period": "2y", "market": "HK"},
+    ]
+    assert "Daily price bundle as_of_date 2026-06-05 is behind expected session 2026-06-08" in caplog.text
+
+
+def test_bootstrap_current_github_bundle_splits_missing_symbols_by_history(monkeypatch):
+    import app.tasks.cache_tasks as module
+    from app.models.stock import StockPrice
+    from app.models.stock_universe import StockUniverse
+
+    fake_db = MagicMock()
+    universe_rows = [
+        SimpleNamespace(symbol="0700.HK", market="HK"),
+        SimpleNamespace(symbol="0005.HK", market="HK"),
+        SimpleNamespace(symbol="9999.HK", market="HK"),
+    ]
+    price_rows = [("0700.HK", date(2026, 6, 5))]
+
+    def _query_for(rows):
+        query = MagicMock()
+        query.filter.return_value = query
+        query.order_by.return_value = query
+        query.group_by.return_value = query
+        query.all.return_value = rows
+        return query
+
+    universe_query = _query_for(universe_rows)
+    price_query = _query_for(price_rows)
+
+    def _query(*entities):
+        model = getattr(entities[0], "class_", None)
+        if model is StockUniverse:
+            return universe_query
+        if model is StockPrice:
+            return price_query
+        return MagicMock()
+
+    fake_db.query.side_effect = _query
+    fake_price_cache = MagicMock()
+    github_service = MagicMock()
+    github_service.sync_from_github.return_value = {
+        "status": "success",
+        "as_of_date": "2026-06-08",
+        "source_revision": "daily_prices_hk:20260608090000",
+    }
+    github_service.symbols_missing_as_of.return_value = ["0700.HK", "9999.HK"]
+    fetch_calls = []
+
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(module, "warm_spy_cache", MagicMock(return_value={"status": "ok"}))
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.is_market_enabled_now",
+        lambda _market: True,
+    )
+    monkeypatch.setattr("app.wiring.bootstrap.get_price_cache", lambda: fake_price_cache)
+    monkeypatch.setattr(module, "get_daily_price_bundle_service", lambda: github_service)
+    monkeypatch.setattr("app.services.bulk_data_fetcher.BulkDataFetcher", lambda: MagicMock())
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_data_fetch_lock",
+        lambda: SimpleNamespace(extend_lock=lambda *args, **kwargs: None),
+    )
+    monkeypatch.setattr(
+        "app.wiring.bootstrap.get_rate_limiter",
+        lambda: SimpleNamespace(wait_for_market=lambda *args, **kwargs: None),
+    )
+    monkeypatch.setattr(module, "_track_symbol_failures", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.smart_refresh_cache, "update_state", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_progress", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "get_market_calendar_service",
+        lambda: SimpleNamespace(
+            last_completed_trading_day=lambda market: date(2026, 6, 8)
+        ),
+    )
+
+    def _fetch(_fetcher, batch_symbols, *, period, market=None, **_kwargs):
+        fetch_calls.append({"symbols": list(batch_symbols), "period": period, "market": market})
+        return {symbol: _success_result(symbol) for symbol in batch_symbols}
+
+    monkeypatch.setattr(module, "_fetch_with_backoff", _fetch)
+
+    result = module.smart_refresh_cache.run.__wrapped__(
+        module.smart_refresh_cache,
+        mode="bootstrap",
+        market="HK",
+        activity_lifecycle="bootstrap",
+    )
+
+    assert result["status"] == "completed"
+    assert result["source"] == "github+live"
+    assert fetch_calls == [
+        {"symbols": ["0700.HK"], "period": "7d", "market": "HK"},
+        {"symbols": ["9999.HK"], "period": "2y", "market": "HK"},
+    ]
 
 
 def test_bootstrap_smart_refresh_uses_short_failed_symbol_retry_delay(monkeypatch):

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -534,15 +534,26 @@ def test_smart_refresh_cache_delta_prefers_github_daily_bundle_and_skips_live_fe
         ),
     )
 
-    def _plan_price_refresh(db, **kwargs):
-        from app.services.price_refresh_planning import PriceRefreshPlan, PriceRefreshSource
+    def _build_market_price_refresh_plan(db, **kwargs):
+        from app.services.price_refresh_planning import (
+            GitHubSeedOutcome,
+            PriceRefreshPlan,
+            PriceRefreshSource,
+        )
 
-        github_seed = kwargs["github_seed"]
+        github_seed = GitHubSeedOutcome.from_mapping(
+            kwargs["sync_github_seed"](
+                db,
+                market=kwargs["effective_market"],
+                allow_stale=True,
+            )
+        )
         assert github_seed.status.value == "success"
         assert kwargs["mode"] == "delta"
         plan = PriceRefreshPlan(
             symbols=(),
             jobs=(),
+            all_symbols=("AAPL", "MSFT"),
             github_seed=github_seed,
             github_seed_used=True,
             completion_message="GitHub daily price bundle is current - no live fetch needed",
@@ -550,7 +561,7 @@ def test_smart_refresh_cache_delta_prefers_github_daily_bundle_and_skips_live_fe
         assert plan.source is PriceRefreshSource.GITHUB
         return plan
 
-    monkeypatch.setattr(module, "plan_price_refresh", _plan_price_refresh)
+    monkeypatch.setattr(module, "build_market_price_refresh_plan", _build_market_price_refresh_plan)
     monkeypatch.setattr(
         module,
         "get_market_calendar_service",
@@ -735,15 +746,26 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
     monkeypatch.setattr("app.wiring.bootstrap.get_price_cache", lambda: fake_price_cache)
     monkeypatch.setattr(module, "get_daily_price_bundle_service", lambda: github_service)
 
-    def _plan_price_refresh(db, **kwargs):
-        from app.services.price_refresh_planning import PriceRefreshPlan, PriceRefreshSource
+    def _build_market_price_refresh_plan(db, **kwargs):
+        from app.services.price_refresh_planning import (
+            GitHubSeedOutcome,
+            PriceRefreshPlan,
+            PriceRefreshSource,
+        )
 
-        github_seed = kwargs["github_seed"]
+        github_seed = GitHubSeedOutcome.from_mapping(
+            kwargs["sync_github_seed"](
+                db,
+                market=kwargs["effective_market"],
+                allow_stale=True,
+            )
+        )
         assert github_seed.status.value == "success"
         assert kwargs["mode"] == "bootstrap"
         plan = PriceRefreshPlan(
             symbols=(),
             jobs=(),
+            all_symbols=("0700.HK", "0005.HK"),
             github_seed=github_seed,
             github_seed_used=True,
             completion_message="GitHub daily price bundle is current - no live fetch needed",
@@ -751,7 +773,7 @@ def test_bootstrap_explicit_market_smart_refresh_uses_github_seed(monkeypatch):
         assert plan.source is PriceRefreshSource.GITHUB
         return plan
 
-    monkeypatch.setattr(module, "plan_price_refresh", _plan_price_refresh)
+    monkeypatch.setattr(module, "build_market_price_refresh_plan", _build_market_price_refresh_plan)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
     monkeypatch.setattr(

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -133,6 +133,42 @@ def test_smart_refresh_cache_reraises_soft_time_limit(monkeypatch):
     fake_db.close.assert_called_once()
 
 
+def test_smart_refresh_cache_delegates_to_price_refresh_workflow(monkeypatch):
+    import app.tasks.cache_tasks as module
+
+    delegated_calls = []
+
+    def _run_workflow(*, task, mode, market, activity_lifecycle):
+        delegated_calls.append(
+            {
+                "task": task,
+                "mode": mode,
+                "market": market,
+                "activity_lifecycle": activity_lifecycle,
+            }
+        )
+        return {"status": "completed", "mode": mode, "market": market}
+
+    monkeypatch.setattr(module, "run_smart_price_refresh", _run_workflow)
+
+    result = module.smart_refresh_cache.run.__wrapped__(
+        module.smart_refresh_cache,
+        mode="bootstrap",
+        market="HK",
+        activity_lifecycle="bootstrap",
+    )
+
+    assert result == {"status": "completed", "mode": "bootstrap", "market": "HK"}
+    assert delegated_calls == [
+        {
+            "task": module.smart_refresh_cache,
+            "mode": "bootstrap",
+            "market": "HK",
+            "activity_lifecycle": "bootstrap",
+        }
+    ]
+
+
 def test_smart_refresh_cache_allows_in_process_bypass_outside_time_window(monkeypatch):
     import app.tasks.cache_tasks as module
 

--- a/backend/tests/unit/test_cache_refresh_unification.py
+++ b/backend/tests/unit/test_cache_refresh_unification.py
@@ -994,6 +994,69 @@ def test_failed_price_retry_does_not_reschedule_permanent_no_data(monkeypatch):
     assert retry_calls == []
 
 
+def test_failed_price_retry_uses_shared_batch_classifier(monkeypatch):
+    from collections import Counter
+
+    import app.tasks.cache_tasks as module
+    from app.services.price_refresh_execution import PriceRefreshBatchOutcome
+
+    fake_price_cache = MagicMock()
+    classifier_calls = []
+    price_frame = _price_df(date(2026, 3, 20), 150.0)
+
+    monkeypatch.setattr("app.wiring.bootstrap.get_price_cache", lambda: fake_price_cache)
+    monkeypatch.setattr("app.services.bulk_data_fetcher.BulkDataFetcher", lambda: MagicMock())
+    monkeypatch.setattr(module, "_track_symbol_failures", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "_fetch_with_backoff",
+        lambda _fetcher, batch_symbols, **kwargs: {
+            symbol: {
+                "has_error": False,
+                "error": None,
+                "price_data": price_frame,
+            }
+            for symbol in batch_symbols
+        },
+    )
+
+    def _classify_price_refresh_batch(**kwargs):
+        classifier_calls.append(kwargs)
+        return PriceRefreshBatchOutcome(
+            batch_number=kwargs["batch_number"],
+            total_batches=kwargs["total_batches"],
+            job=kwargs["job"],
+            symbols=tuple(kwargs["symbols"]),
+            price_data_by_symbol={"AAPL": price_frame},
+            successes=("AAPL",),
+            failures=(),
+            failure_details={},
+            failure_kinds={},
+            refreshed_by_market=Counter({"US": 1}),
+            failed_by_market=Counter(),
+        )
+
+    monkeypatch.setattr(module, "classify_price_refresh_batch", _classify_price_refresh_batch)
+
+    result = module.retry_failed_price_symbols.run.__wrapped__(
+        module.retry_failed_price_symbols,
+        symbols=["aapl"],
+        market="US",
+        attempt=1,
+        retry_countdown=30,
+    )
+
+    assert result["status"] == "completed"
+    assert result["refreshed"] == 1
+    assert len(classifier_calls) == 1
+    assert classifier_calls[0]["symbols"] == ("AAPL",)
+    assert classifier_calls[0]["batch_results"]["AAPL"]["price_data"] is price_frame
+    fake_price_cache.store_batch_in_cache.assert_called_once_with(
+        {"AAPL": price_frame},
+        also_store_db=True,
+    )
+
+
 def test_smart_refresh_cache_rolls_back_before_failure_reporting(monkeypatch):
     import app.tasks.cache_tasks as module
 

--- a/backend/tests/unit/test_daily_market_pipeline_tasks.py
+++ b/backend/tests/unit/test_daily_market_pipeline_tasks.py
@@ -59,7 +59,7 @@ def test_daily_market_pipeline_orders_refresh_compute_and_scan(monkeypatch):
         "app.interfaces.tasks.feature_store_tasks.build_daily_snapshot",
         "app.tasks.daily_market_pipeline_tasks.guard_snapshot_result",
     ]
-    assert signatures[0].kwargs == {"mode": "full", "market": "HK"}
+    assert signatures[0].kwargs == {"mode": "delta", "market": "HK"}
     assert signatures[-2].kwargs == {
         "market": "HK",
         "as_of_date_str": "2026-03-16",

--- a/backend/tests/unit/test_daily_price_bundle_scripts.py
+++ b/backend/tests/unit/test_daily_price_bundle_scripts.py
@@ -287,11 +287,6 @@ def test_cn_daily_price_shard_bootstrap_fetches_missing_symbols_and_exports_shar
     class FakeService:
         DAILY_PRICE_BAR_PERIOD = "2y"
 
-        def symbols_missing_as_of(self, db, *, symbols, as_of_date):
-            assert symbols == ["000001.SZ", "600000.SS"]
-            assert as_of_date == date(2026, 5, 8)
-            return ["600000.SS"]
-
         def export_daily_price_bundle(self, db, **kwargs):
             captured["export"] = kwargs
             kwargs["output_path"].write_bytes(b"bundle")
@@ -308,6 +303,16 @@ def test_cn_daily_price_shard_bootstrap_fetches_missing_symbols_and_exports_shar
             )
             or len(batch)
         )
+
+    def fake_classify_price_history(db, *, symbols, as_of_date):
+        assert symbols == ["000001.SZ", "600000.SS"]
+        assert as_of_date == date(2026, 5, 8)
+        return SimpleNamespace(refresh_symbols=("600000.SS",))
+
+    monkeypatch.setattr(
+        "app.scripts.bootstrap_cn_daily_price_shard.classify_price_history",
+        fake_classify_price_history,
+    )
 
     class FakeFetcher:
         def fetch_prices_in_batches(self, symbols, *, period, market):

--- a/backend/tests/unit/test_fx_service.py
+++ b/backend/tests/unit/test_fx_service.py
@@ -223,6 +223,61 @@ class TestLookupChain:
         assert quote.rate == 0.12
         assert quote.source == "yfinance"
 
+    def test_stale_database_fallback_suppresses_repeated_live_fetches(self):
+        stale_row = MagicMock()
+        stale_row.from_currency = "JPY"
+        stale_row.to_currency = "USD"
+        stale_row.rate = 0.0064
+        stale_row.as_of_date = date.today() - timedelta(days=1)
+        stale_row.source = "yfinance"
+        calls = []
+
+        def fetcher(currency):
+            calls.append(currency)
+            return None
+
+        svc = _make_service(rate_fetcher=fetcher, db_rows=stale_row)
+
+        first = svc.get_usd_rate("JPY")
+        second = svc.get_usd_rate("JPY")
+        third = svc.get_usd_rate("JPY")
+
+        assert first is not None and first.rate == 0.0064
+        assert second is not None and second.rate == 0.0064
+        assert third is not None and third.rate == 0.0064
+        assert calls == ["JPY"]
+
+    def test_quote_one_day_ahead_of_system_date_is_fresh(self, monkeypatch):
+        import app.services.fx_service as fx_module
+
+        class _UtcMonday(date):
+            @classmethod
+            def today(cls):
+                return cls(2026, 6, 8)  # Monday in UTC
+
+        monkeypatch.setattr(fx_module, "date", _UtcMonday)
+
+        calls = []
+
+        def fetcher(currency):
+            calls.append(currency)
+            return 0.0065
+
+        svc = _make_service(rate_fetcher=fetcher)
+        svc._memo["JPY"] = FXQuote(
+            from_currency="JPY",
+            to_currency="USD",
+            rate=0.0064,
+            as_of_date=_UtcMonday(2026, 6, 9),  # Tuesday in JP/TW/HK local time
+            source="yfinance",
+        )
+
+        quote = svc.get_usd_rate("JPY")
+
+        assert quote is not None
+        assert quote.rate == 0.0064
+        assert calls == []
+
     def test_database_source_is_preserved_on_rehydrate(self):
         db_row = MagicMock()
         db_row.from_currency = "HKD"

--- a/backend/tests/unit/test_fx_service.py
+++ b/backend/tests/unit/test_fx_service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 from pathlib import Path
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -277,6 +278,42 @@ class TestLookupChain:
         assert quote is not None
         assert quote.rate == 0.0064
         assert calls == []
+
+    def test_stale_fetch_suppression_still_accepts_fresh_redis_quote(self, monkeypatch):
+        stale_quote = FXQuote(
+            from_currency="JPY",
+            to_currency="USD",
+            rate=0.0064,
+            as_of_date=date.today() - timedelta(days=1),
+            source="yfinance",
+        )
+        fresh_quote = FXQuote(
+            from_currency="JPY",
+            to_currency="USD",
+            rate=0.0065,
+            as_of_date=date.today(),
+            source="yfinance",
+        )
+        calls = []
+
+        def fetcher(currency):
+            calls.append(currency)
+            return None
+
+        svc = _make_service(rate_fetcher=fetcher)
+        svc._memo["JPY"] = stale_quote
+        svc._stale_fallback_retry_after["JPY"] = (
+            stale_quote,
+            time.monotonic() + 60,
+            svc._latest_trading_close(date.today()),
+        )
+        monkeypatch.setattr(svc, "_read_redis", lambda _currency: fresh_quote)
+
+        quote = svc.get_usd_rate("JPY")
+
+        assert quote is fresh_quote
+        assert calls == []
+        assert "JPY" not in svc._stale_fallback_retry_after
 
     def test_database_source_is_preserved_on_rehydrate(self):
         db_row = MagicMock()

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -160,7 +161,7 @@ def test_runtime_activity_status_marks_running_stage_without_real_percent_as_ind
     assert us_market["percent"] is None
 
 
-def test_runtime_activity_record_from_payload_preserves_explicit_contract_fields():
+def test_runtime_activity_record_from_payload_derives_response_fields():
     from app.services.runtime_activity_contract import RuntimeActivityRecord
 
     record = RuntimeActivityRecord.from_payload(
@@ -168,9 +169,7 @@ def test_runtime_activity_record_from_payload_preserves_explicit_contract_fields
             "market": "jp",
             "lifecycle": "bootstrap",
             "stage_key": "prices",
-            "stage_label": "Live Price Backfill",
             "status": "running",
-            "progress_mode": "indeterminate",
             "percent": None,
             "current": 25,
             "total": 100,
@@ -182,15 +181,15 @@ def test_runtime_activity_record_from_payload_preserves_explicit_contract_fields
     )
 
     assert record.market == "JP"
-    assert record.stage_label == "Live Price Backfill"
-    assert record.progress_mode == "indeterminate"
-    assert record.percent is None
+    assert record.stage_label == "Price Refresh"
+    assert record.progress_mode == "determinate"
+    assert record.percent == 25.0
     assert record.current == 25
     assert record.total == 100
     assert record.message == "Waiting on provider"
 
 
-def test_runtime_activity_record_from_payload_rejects_invalid_contract_fields():
+def test_runtime_activity_record_from_payload_rejects_missing_persisted_fields():
     from app.services.runtime_activity_contract import RuntimeActivityRecord
 
     with pytest.raises(ValueError, match="missing required runtime activity fields"):
@@ -204,24 +203,55 @@ def test_runtime_activity_record_from_payload_rejects_invalid_contract_fields():
             }
         )
 
-    with pytest.raises(ValueError, match="invalid progress_mode"):
-        RuntimeActivityRecord.from_payload(
-            {
-                "market": "US",
-                "lifecycle": "bootstrap",
-                "stage_key": "prices",
-                "stage_label": "Price Refresh",
-                "status": "running",
-                "progress_mode": "mostly",
-                "percent": 50,
-                "current": 50,
-                "total": 100,
-                "message": "Refreshing prices",
-                "task_name": "smart_refresh_cache",
-                "task_id": "task-us",
-                "updated_at": "2026-06-09T01:02:03+00:00",
-            }
-        )
+    record = RuntimeActivityRecord.from_payload(
+        {
+            "market": "US",
+            "lifecycle": "bootstrap",
+            "stage_key": "prices",
+            "stage_label": "Stale Label",
+            "status": "running",
+            "progress_mode": "mostly",
+            "percent": 50,
+            "current": 50,
+            "total": 100,
+            "message": "Refreshing prices",
+            "task_name": "smart_refresh_cache",
+            "task_id": "task-us",
+            "updated_at": "2026-06-09T01:02:03+00:00",
+        }
+    )
+    assert record.stage_label == "Price Refresh"
+    assert record.progress_mode == "determinate"
+
+
+def test_market_activity_persists_only_canonical_state_fields(db_session):
+    from app.models.app_settings import AppSetting
+    from app.services import market_activity_service as module
+    from app.services.market_activity_service import _activity_key
+
+    returned = module.mark_market_activity_started(
+        db_session,
+        market="JP",
+        stage_key="prices",
+        lifecycle="bootstrap",
+        task_name="smart_refresh_cache",
+        task_id="task-jp",
+        current=25,
+        total=100,
+        message="Refreshing prices",
+    )
+
+    setting = (
+        db_session.query(AppSetting)
+        .filter(AppSetting.key == _activity_key("JP"))
+        .one()
+    )
+    persisted = json.loads(setting.value)
+
+    assert returned["stage_label"] == "Price Refresh"
+    assert returned["progress_mode"] == "determinate"
+    assert "stage_label" not in persisted
+    assert "progress_mode" not in persisted
 
 
 def test_mark_market_activity_progress_updates_running_record_with_determinate_progress(
@@ -830,7 +860,7 @@ def test_runtime_activity_status_reports_active_background_bootstrap_progress_af
     assert payload["bootstrap"]["state"] == "ready"
     assert payload["bootstrap"]["app_ready"] is True
     assert payload["bootstrap"]["progress_mode"] == "determinate"
-    assert payload["bootstrap"]["percent"] == 32.0
+    assert payload["bootstrap"]["percent"] == pytest.approx(38.67)
     assert payload["bootstrap"]["current"] == 1200
     assert payload["bootstrap"]["total"] == 3750
     assert payload["bootstrap"]["current_stage"] == "Fundamentals Refresh"
@@ -842,6 +872,49 @@ def test_runtime_activity_status_reports_active_background_bootstrap_progress_af
     assert hk_market["lifecycle"] == "bootstrap"
     assert hk_market["status"] == "running"
     assert hk_market["progress_mode"] == "determinate"
+
+
+def test_runtime_activity_status_stage_weights_completed_background_price_refresh(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_completed(
+        db_session,
+        market="US",
+        stage_key="snapshot",
+        lifecycle="bootstrap",
+        task_name="build_daily_snapshot",
+        task_id="task-us",
+        message="Primary bootstrap complete",
+    )
+    module.mark_market_activity_started(
+        db_session,
+        market="JP",
+        stage_key="prices",
+        lifecycle="bootstrap",
+        task_name="smart_refresh_cache",
+        task_id="task-jp",
+        current=3750,
+        total=3750,
+        message="Refreshing market prices",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=False, enabled=["US", "JP"], state="ready"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    assert payload["bootstrap"]["state"] == "ready"
+    assert payload["bootstrap"]["app_ready"] is True
+    assert payload["bootstrap"]["current_stage"] == "Price Refresh"
+    assert payload["bootstrap"]["percent"] == pytest.approx(33.33)
+    assert payload["bootstrap"]["current"] == 3750
+    assert payload["bootstrap"]["total"] == 3750
 
 
 def test_runtime_activity_status_ignores_non_bootstrap_secondary_progress_after_primary_ready(

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -694,7 +694,7 @@ def test_failed_activity_can_replace_completed_record(db_session, monkeypatch):
     assert hk_market["message"] == "Bootstrap scan did not publish"
 
 
-def test_runtime_activity_status_marks_primary_ready_with_secondary_bootstrap_running(
+def test_runtime_activity_status_reports_active_background_bootstrap_progress_after_primary_ready(
     db_session,
     monkeypatch,
 ):
@@ -716,6 +716,8 @@ def test_runtime_activity_status_marks_primary_ready_with_secondary_bootstrap_ru
         lifecycle="bootstrap",
         task_name="refresh_all_fundamentals",
         task_id="task-hk",
+        current=1200,
+        total=3750,
         message="Refreshing fundamentals",
     )
     monkeypatch.setattr(
@@ -730,14 +732,18 @@ def test_runtime_activity_status_marks_primary_ready_with_secondary_bootstrap_ru
     assert payload["bootstrap"]["state"] == "ready"
     assert payload["bootstrap"]["app_ready"] is True
     assert payload["bootstrap"]["progress_mode"] == "determinate"
-    assert payload["bootstrap"]["percent"] == 100.0
+    assert payload["bootstrap"]["percent"] == 32.0
+    assert payload["bootstrap"]["current"] == 1200
+    assert payload["bootstrap"]["total"] == 3750
+    assert payload["bootstrap"]["current_stage"] == "Fundamentals Refresh"
+    assert payload["bootstrap"]["message"] == "Refreshing fundamentals"
     assert "background" in payload["bootstrap"]["background_warning"].lower()
     assert payload["summary"]["active_market_count"] == 1
     assert payload["summary"]["active_markets"] == ["HK"]
     hk_market = next(item for item in payload["markets"] if item["market"] == "HK")
     assert hk_market["lifecycle"] == "bootstrap"
     assert hk_market["status"] == "running"
-    assert hk_market["progress_mode"] == "indeterminate"
+    assert hk_market["progress_mode"] == "determinate"
 
 
 def test_mark_market_activity_queued_does_not_overwrite_newer_state_for_same_task(

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -159,6 +159,36 @@ def test_runtime_activity_status_marks_running_stage_without_real_percent_as_ind
     assert us_market["percent"] is None
 
 
+def test_runtime_activity_record_from_payload_preserves_explicit_contract_fields():
+    from app.services.runtime_activity_contract import RuntimeActivityRecord
+
+    record = RuntimeActivityRecord.from_payload(
+        {
+            "market": "jp",
+            "lifecycle": "bootstrap",
+            "stage_key": "prices",
+            "stage_label": "Live Price Backfill",
+            "status": "running",
+            "progress_mode": "indeterminate",
+            "percent": None,
+            "current": 25,
+            "total": 100,
+            "message": "Waiting on provider",
+            "task_name": "smart_refresh_cache",
+            "task_id": "task-jp",
+            "updated_at": "2026-06-09T01:02:03+00:00",
+        }
+    )
+
+    assert record.market == "JP"
+    assert record.stage_label == "Live Price Backfill"
+    assert record.progress_mode == "indeterminate"
+    assert record.percent is None
+    assert record.current == 25
+    assert record.total == 100
+    assert record.message == "Waiting on provider"
+
+
 def test_mark_market_activity_progress_updates_running_record_with_determinate_progress(
     db_session,
     monkeypatch,

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -161,10 +161,10 @@ def test_runtime_activity_status_marks_running_stage_without_real_percent_as_ind
     assert us_market["percent"] is None
 
 
-def test_runtime_activity_record_from_payload_derives_response_fields():
-    from app.services.runtime_activity_contract import RuntimeActivityRecord
+def test_persisted_runtime_activity_derives_response_fields():
+    from app.services.runtime_activity_contract import PersistedRuntimeActivity
 
-    record = RuntimeActivityRecord.from_payload(
+    record = PersistedRuntimeActivity.from_payload(
         {
             "market": "jp",
             "lifecycle": "bootstrap",
@@ -178,7 +178,7 @@ def test_runtime_activity_record_from_payload_derives_response_fields():
             "task_id": "task-jp",
             "updated_at": "2026-06-09T01:02:03+00:00",
         }
-    )
+    ).to_record()
 
     assert record.market == "JP"
     assert record.stage_label == "Price Refresh"
@@ -189,11 +189,11 @@ def test_runtime_activity_record_from_payload_derives_response_fields():
     assert record.message == "Waiting on provider"
 
 
-def test_runtime_activity_record_from_payload_rejects_missing_persisted_fields():
-    from app.services.runtime_activity_contract import RuntimeActivityRecord
+def test_persisted_runtime_activity_rejects_missing_persisted_fields():
+    from app.services.runtime_activity_contract import PersistedRuntimeActivity
 
     with pytest.raises(ValueError, match="missing required runtime activity fields"):
-        RuntimeActivityRecord.from_payload(
+        PersistedRuntimeActivity.from_payload(
             {
                 "market": "US",
                 "stage_key": "prices",
@@ -203,7 +203,7 @@ def test_runtime_activity_record_from_payload_rejects_missing_persisted_fields()
             }
         )
 
-    record = RuntimeActivityRecord.from_payload(
+    record = PersistedRuntimeActivity.from_payload(
         {
             "market": "US",
             "lifecycle": "bootstrap",
@@ -219,7 +219,7 @@ def test_runtime_activity_record_from_payload_rejects_missing_persisted_fields()
             "task_id": "task-us",
             "updated_at": "2026-06-09T01:02:03+00:00",
         }
-    )
+    ).to_record()
     assert record.stage_label == "Price Refresh"
     assert record.progress_mode == "determinate"
 

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -874,7 +874,7 @@ def test_runtime_activity_status_reports_active_background_bootstrap_progress_af
     assert hk_market["progress_mode"] == "determinate"
 
 
-def test_runtime_activity_status_stage_weights_completed_background_price_refresh(
+def test_runtime_activity_status_does_not_stage_weight_running_price_refresh_at_100(
     db_session,
     monkeypatch,
 ):
@@ -912,9 +912,13 @@ def test_runtime_activity_status_stage_weights_completed_background_price_refres
     assert payload["bootstrap"]["state"] == "ready"
     assert payload["bootstrap"]["app_ready"] is True
     assert payload["bootstrap"]["current_stage"] == "Price Refresh"
-    assert payload["bootstrap"]["percent"] == pytest.approx(33.33)
+    assert payload["bootstrap"]["progress_mode"] == "indeterminate"
+    assert payload["bootstrap"]["percent"] is None
     assert payload["bootstrap"]["current"] == 3750
     assert payload["bootstrap"]["total"] == 3750
+    jp_market = next(item for item in payload["markets"] if item["market"] == "JP")
+    assert jp_market["status"] == "running"
+    assert jp_market["progress_mode"] == "indeterminate"
 
 
 def test_runtime_activity_status_ignores_non_bootstrap_secondary_progress_after_primary_ready(

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -93,6 +93,39 @@ def test_runtime_activity_status_reports_primary_bootstrap_progress(db_session, 
     assert us_market["percent"] == 50.0
 
 
+def test_runtime_activity_status_exposes_bootstrap_run_task_manifest(db_session, monkeypatch):
+    from app.services import market_activity_service as module
+
+    module.save_runtime_bootstrap_run(
+        db_session,
+        primary_market="US",
+        enabled_markets=["US", "HK", "TW"],
+        primary_task_id="primary-task-123",
+        market_task_ids={
+            "US": "primary-task-123",
+            "HK": "background-task-2",
+            "TW": "background-task-3",
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=True, enabled=["US", "HK", "TW"], state="running"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    assert payload["bootstrap"]["task_id"] == "primary-task-123"
+    assert payload["bootstrap"]["market_task_ids"] == {
+        "US": "primary-task-123",
+        "HK": "background-task-2",
+        "TW": "background-task-3",
+    }
+    hk_market = next(item for item in payload["markets"] if item["market"] == "HK")
+    assert hk_market["task_id"] == "background-task-2"
+
+
 def test_runtime_activity_status_marks_running_stage_without_real_percent_as_indeterminate(
     db_session,
     monkeypatch,

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -731,7 +731,7 @@ def test_runtime_activity_status_marks_primary_ready_with_secondary_bootstrap_ru
     assert payload["bootstrap"]["app_ready"] is True
     assert payload["bootstrap"]["progress_mode"] == "determinate"
     assert payload["bootstrap"]["percent"] == 100.0
-    assert "published scan" in payload["bootstrap"]["background_warning"].lower()
+    assert "background" in payload["bootstrap"]["background_warning"].lower()
     assert payload["summary"]["active_market_count"] == 1
     assert payload["summary"]["active_markets"] == ["HK"]
     hk_market = next(item for item in payload["markets"] if item["market"] == "HK")

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -1142,6 +1142,28 @@ def test_runtime_activity_supports_scan_stage_progress(db_session, monkeypatch):
     assert hk_market["percent"] == 25.0
 
 
+def test_runtime_activity_status_exposes_bootstrap_stage_metadata(db_session, monkeypatch):
+    from app.services import market_activity_service as module
+
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=True, enabled=["US"], state="running"),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    assert payload["bootstrap"]["stages"] == [
+        {"key": "universe", "label": "Universe Refresh"},
+        {"key": "prices", "label": "Price Refresh"},
+        {"key": "fundamentals", "label": "Fundamentals Refresh"},
+        {"key": "breadth", "label": "Breadth Calculation"},
+        {"key": "groups", "label": "Group Rankings"},
+        {"key": "scan", "label": "Scan"},
+    ]
+
+
 def test_runtime_activity_status_returns_idle_markets_without_activity(db_session, monkeypatch):
     from app.services import market_activity_service as module
 

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -116,6 +116,7 @@ def test_runtime_activity_status_exposes_bootstrap_run_task_manifest(db_session,
 
     payload = module.get_runtime_activity_status(db_session)
 
+    assert payload["bootstrap"]["queue_state"] == "queued"
     assert payload["bootstrap"]["task_id"] == "primary-task-123"
     assert payload["bootstrap"]["market_task_ids"] == {
         "US": "primary-task-123",
@@ -187,6 +188,40 @@ def test_runtime_activity_record_from_payload_preserves_explicit_contract_fields
     assert record.current == 25
     assert record.total == 100
     assert record.message == "Waiting on provider"
+
+
+def test_runtime_activity_record_from_payload_rejects_invalid_contract_fields():
+    from app.services.runtime_activity_contract import RuntimeActivityRecord
+
+    with pytest.raises(ValueError, match="missing required runtime activity fields"):
+        RuntimeActivityRecord.from_payload(
+            {
+                "market": "US",
+                "stage_key": "prices",
+                "status": "running",
+                "progress_mode": "determinate",
+                "percent": 50,
+            }
+        )
+
+    with pytest.raises(ValueError, match="invalid progress_mode"):
+        RuntimeActivityRecord.from_payload(
+            {
+                "market": "US",
+                "lifecycle": "bootstrap",
+                "stage_key": "prices",
+                "stage_label": "Price Refresh",
+                "status": "running",
+                "progress_mode": "mostly",
+                "percent": 50,
+                "current": 50,
+                "total": 100,
+                "message": "Refreshing prices",
+                "task_name": "smart_refresh_cache",
+                "task_id": "task-us",
+                "updated_at": "2026-06-09T01:02:03+00:00",
+            }
+        )
 
 
 def test_mark_market_activity_progress_updates_running_record_with_determinate_progress(

--- a/backend/tests/unit/test_market_activity_service.py
+++ b/backend/tests/unit/test_market_activity_service.py
@@ -746,6 +746,89 @@ def test_runtime_activity_status_reports_active_background_bootstrap_progress_af
     assert hk_market["progress_mode"] == "determinate"
 
 
+def test_runtime_activity_status_ignores_non_bootstrap_secondary_progress_after_primary_ready(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    module.mark_market_activity_completed(
+        db_session,
+        market="US",
+        stage_key="snapshot",
+        lifecycle="bootstrap",
+        task_name="build_daily_snapshot",
+        task_id="task-us",
+        message="Primary bootstrap complete",
+    )
+    module.mark_market_activity_started(
+        db_session,
+        market="HK",
+        stage_key="prices",
+        lifecycle="daily_refresh",
+        task_name="smart_refresh_cache",
+        task_id="task-hk",
+        current=50,
+        total=100,
+        message="Refreshing daily prices",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(required=False, enabled=["US", "HK"], state="ready"),
+    )
+    monkeypatch.setattr(
+        module,
+        "get_data_fetch_lock",
+        lambda: _FakeLock(
+            {
+                "HK": {
+                    "task_id": "task-hk",
+                    "current": 50,
+                    "total": 100,
+                    "progress": 50.0,
+                }
+            }
+        ),
+    )
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    assert payload["bootstrap"]["state"] == "ready"
+    assert payload["bootstrap"]["progress_mode"] == "determinate"
+    assert payload["bootstrap"]["percent"] == 100.0
+    assert payload["bootstrap"]["current"] is None
+    assert payload["bootstrap"]["total"] is None
+    assert payload["bootstrap"]["message"] == "Primary market is ready."
+    assert payload["bootstrap"]["background_warning"] is None
+    assert payload["summary"]["active_markets"] == ["HK"]
+
+
+def test_runtime_activity_status_uses_bootstrap_queue_copy_for_secondary_markets(
+    db_session,
+    monkeypatch,
+):
+    from app.services import market_activity_service as module
+
+    monkeypatch.setattr(
+        module,
+        "get_runtime_bootstrap_status",
+        lambda _db: _bootstrap_status(
+            required=True,
+            enabled=["US", "HK"],
+            primary="US",
+            state="running",
+        ),
+    )
+    monkeypatch.setattr(module, "get_data_fetch_lock", lambda: _FakeLock())
+
+    payload = module.get_runtime_activity_status(db_session)
+
+    hk_market = next(item for item in payload["markets"] if item["market"] == "HK")
+    assert hk_market["status"] == "queued"
+    assert hk_market["message"] == "Bootstrap queued."
+
+
 def test_mark_market_activity_queued_does_not_overwrite_newer_state_for_same_task(
     db_session,
     monkeypatch,

--- a/backend/tests/unit/test_operations_job_service.py
+++ b/backend/tests/unit/test_operations_job_service.py
@@ -8,7 +8,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from app.services.operations_job_service import OperationsJobService, _JobRecord
+from app.services.operations_job_service import OperationsJobService, _JobRecord, _progress_mode
 
 
 def _queued_message(*, task_id: str, task_name: str, args: list | None = None, kwargs: dict | None = None) -> bytes:
@@ -296,6 +296,12 @@ def test_list_jobs_surfaces_runtime_activity_progress_fields():
     assert job["current"] == 420
     assert job["total"] == 1000
     assert job["message"] == "Batch 5/12 · refreshing prices"
+
+
+def test_operations_progress_mode_keeps_active_100_percent_indeterminate():
+    assert _progress_mode(100.0, 3750, 3750, state="running") == "indeterminate"
+    assert _progress_mode(None, 3750, 3750, state="running") == "indeterminate"
+    assert _progress_mode(100.0, 3750, 3750, state="completed") == "determinate"
 
 
 def test_list_jobs_falls_back_to_job_backend_progress_for_active_worker_task():

--- a/backend/tests/unit/test_operations_job_service.py
+++ b/backend/tests/unit/test_operations_job_service.py
@@ -8,7 +8,8 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from app.services.operations_job_service import OperationsJobService, _JobRecord, _progress_mode
+from app.services.operations_job_service import OperationsJobService, _JobRecord
+from app.services.runtime_activity_contract import progress_mode
 
 
 def _queued_message(*, task_id: str, task_name: str, args: list | None = None, kwargs: dict | None = None) -> bytes:
@@ -87,6 +88,7 @@ def test_list_jobs_marks_data_fetch_queue_as_waiting_for_global_external_lease()
     )
     service._inspect = lambda: _FakeInspect()
     service._runtime_activity_records = lambda _db: []
+    service._job_backend.get_status = MagicMock(return_value=None)
 
     lock = MagicMock()
     lock.get_current_task.return_value = None
@@ -119,6 +121,7 @@ def test_list_jobs_surfaces_stuck_lock_holder_without_worker_inspect():
     service._broker = lambda: _FakeBroker({})
     service._inspect = lambda: _FakeInspect()
     service._runtime_activity_records = lambda _db: []
+    service._job_backend.get_status = MagicMock(return_value=None)
 
     stale_heartbeat = (datetime.now(timezone.utc) - timedelta(minutes=45)).isoformat()
     started_at = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
@@ -157,6 +160,7 @@ def test_list_jobs_marks_orphaned_market_lease_as_stale():
     service._broker = lambda: _FakeBroker({})
     service._inspect = lambda: _FakeInspect()
     service._runtime_activity_records = lambda _db: []
+    service._job_backend.get_status = MagicMock(return_value=None)
 
     lock = MagicMock()
     lock.get_current_task.return_value = None
@@ -190,6 +194,7 @@ def test_list_jobs_marks_near_expiry_market_lease_as_stuck():
     service._broker = lambda: _FakeBroker({})
     service._inspect = lambda: _FakeInspect()
     service._runtime_activity_records = lambda _db: []
+    service._job_backend.get_status = MagicMock(return_value=None)
 
     lock = MagicMock()
     lock.get_current_task.return_value = None
@@ -223,6 +228,7 @@ def test_market_lease_for_data_fetch_task_keeps_data_fetch_queue_label():
     service._broker = lambda: _FakeBroker({})
     service._inspect = lambda: _FakeInspect()
     service._runtime_activity_records = lambda _db: []
+    service._job_backend.get_status = MagicMock(return_value=None)
 
     lock = MagicMock()
     lock.get_current_task.return_value = None
@@ -298,10 +304,11 @@ def test_list_jobs_surfaces_runtime_activity_progress_fields():
     assert job["message"] == "Batch 5/12 · refreshing prices"
 
 
-def test_operations_progress_mode_keeps_active_100_percent_indeterminate():
-    assert _progress_mode(100.0, 3750, 3750, state="running") == "indeterminate"
-    assert _progress_mode(None, 3750, 3750, state="running") == "indeterminate"
-    assert _progress_mode(100.0, 3750, 3750, state="completed") == "determinate"
+def test_progress_mode_keeps_active_100_percent_indeterminate():
+    assert progress_mode("running", 100.0, 3750, 3750) == "indeterminate"
+    assert progress_mode("waiting", None, 3750, 3750) == "indeterminate"
+    assert progress_mode("stale", 100.0, 3750, 3750) == "indeterminate"
+    assert progress_mode("completed", 100.0, 3750, 3750) == "determinate"
 
 
 def test_list_jobs_falls_back_to_job_backend_progress_for_active_worker_task():

--- a/backend/tests/unit/test_price_fetch_failures.py
+++ b/backend/tests/unit/test_price_fetch_failures.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def test_price_fetch_failure_classifier_separates_permanent_and_retryable_errors():
+    from app.services.price_fetch_failures import (
+        PriceFetchFailureKind,
+        classify_price_fetch_error,
+        is_retryable_price_failure,
+    )
+
+    assert (
+        classify_price_fetch_error("possibly delisted; no price data found")
+        is PriceFetchFailureKind.NO_PRICE_DATA
+    )
+    assert (
+        classify_price_fetch_error("429 Too Many Requests")
+        is PriceFetchFailureKind.RATE_LIMIT
+    )
+    assert (
+        classify_price_fetch_error("yf.download returned empty")
+        is PriceFetchFailureKind.TRANSIENT
+    )
+    assert not is_retryable_price_failure(error="delisted")
+    assert is_retryable_price_failure(error="429 Too Many Requests")

--- a/backend/tests/unit/test_price_refresh_actions.py
+++ b/backend/tests/unit/test_price_refresh_actions.py
@@ -13,11 +13,8 @@ def _preparation(*, refresh_plan, all_symbols=None):
     )
 
 
-def test_price_refresh_action_factory_returns_explicit_live_action_when_plan_has_symbols():
-    from app.services.price_refresh_actions import (
-        LivePriceRefreshAction,
-        PriceRefreshActionFactory,
-    )
+def test_price_refresh_action_factory_returns_no_completion_when_plan_has_symbols():
+    from app.services.price_refresh_actions import PriceRefreshActionFactory
     from app.services.price_refresh_planning import PriceRefreshMode, PriceRefreshPlan
 
     factory = PriceRefreshActionFactory(
@@ -26,7 +23,7 @@ def test_price_refresh_action_factory_returns_explicit_live_action_when_plan_has
         )
     )
 
-    action = factory.build(
+    completion = factory.build_terminal_completion(
         mode=PriceRefreshMode.BOOTSTRAP,
         effective_market="JP",
         preparation=_preparation(
@@ -34,17 +31,13 @@ def test_price_refresh_action_factory_returns_explicit_live_action_when_plan_has
         ),
     )
 
-    assert isinstance(action, LivePriceRefreshAction)
-    assert action.preparation.refresh_plan.symbols == ("7203.T",)
+    assert completion is None
 
 
-def test_price_refresh_action_factory_returns_explicit_terminal_action():
+def test_price_refresh_action_factory_returns_terminal_completion():
     from datetime import date
 
-    from app.services.price_refresh_actions import (
-        PriceRefreshActionFactory,
-        TerminalPriceRefreshAction,
-    )
+    from app.services.price_refresh_actions import PriceRefreshActionFactory
     from app.services.price_refresh_planning import (
         GitHubSeedOutcome,
         PriceRefreshMode,
@@ -70,7 +63,7 @@ def test_price_refresh_action_factory_returns_explicit_terminal_action():
         last_completed_trading_day=lambda market: date(2026, 6, 7)
     )
 
-    action = factory.build(
+    completion = factory.build_terminal_completion(
         mode=PriceRefreshMode.BOOTSTRAP,
         effective_market="JP",
         preparation=_preparation(
@@ -79,8 +72,7 @@ def test_price_refresh_action_factory_returns_explicit_terminal_action():
         ),
     )
 
-    assert isinstance(action, TerminalPriceRefreshAction)
-    completion = action.completion
+    assert completion is not None
     assert completion.outcome.source is PriceRefreshSource.GITHUB
     assert completion.outcome.github_seed is github_seed
     assert completion.outcome.message == plan.completion_message

--- a/backend/tests/unit/test_price_refresh_actions.py
+++ b/backend/tests/unit/test_price_refresh_actions.py
@@ -3,22 +3,21 @@ from __future__ import annotations
 import pytest
 
 
-def _preparation(*, refresh_plan, all_symbols=None, symbols=None):
+def _preparation(*, refresh_plan, all_symbols=None):
     from app.services.price_refresh_actions import PriceRefreshPreparation
 
     return PriceRefreshPreparation(
         all_symbols=list(all_symbols or []),
         symbol_markets={},
-        github_seed=refresh_plan.github_seed,
         refresh_plan=refresh_plan,
-        refresh_source=refresh_plan.source,
-        symbols=list(symbols if symbols is not None else refresh_plan.symbols),
-        live_refresh_jobs=list(refresh_plan.jobs),
     )
 
 
-def test_price_refresh_action_requires_live_fetch_when_plan_has_symbols():
-    from app.services.price_refresh_actions import PriceRefreshActionFactory
+def test_price_refresh_action_factory_returns_explicit_live_action_when_plan_has_symbols():
+    from app.services.price_refresh_actions import (
+        LivePriceRefreshAction,
+        PriceRefreshActionFactory,
+    )
     from app.services.price_refresh_planning import PriceRefreshMode, PriceRefreshPlan
 
     factory = PriceRefreshActionFactory(
@@ -35,14 +34,17 @@ def test_price_refresh_action_requires_live_fetch_when_plan_has_symbols():
         ),
     )
 
-    assert action.requires_live_fetch is True
-    assert action.terminal_completion is None
+    assert isinstance(action, LivePriceRefreshAction)
+    assert action.preparation.refresh_plan.symbols == ("7203.T",)
 
 
-def test_price_refresh_action_builds_github_terminal_completion():
+def test_price_refresh_action_factory_returns_explicit_terminal_action():
     from datetime import date
 
-    from app.services.price_refresh_actions import PriceRefreshActionFactory
+    from app.services.price_refresh_actions import (
+        PriceRefreshActionFactory,
+        TerminalPriceRefreshAction,
+    )
     from app.services.price_refresh_planning import (
         GitHubSeedOutcome,
         PriceRefreshMode,
@@ -77,9 +79,8 @@ def test_price_refresh_action_builds_github_terminal_completion():
         ),
     )
 
-    assert action.requires_live_fetch is False
-    assert action.terminal_completion is not None
-    completion = action.terminal_completion
+    assert isinstance(action, TerminalPriceRefreshAction)
+    completion = action.completion
     assert completion.outcome.source is PriceRefreshSource.GITHUB
     assert completion.outcome.github_seed is github_seed
     assert completion.outcome.message == plan.completion_message

--- a/backend/tests/unit/test_price_refresh_actions.py
+++ b/backend/tests/unit/test_price_refresh_actions.py
@@ -1,43 +1,28 @@
 from __future__ import annotations
 
-import pytest
 
-
-def _preparation(*, refresh_plan, all_symbols=None):
-    from app.services.price_refresh_actions import PriceRefreshPreparation
-
-    return PriceRefreshPreparation(
-        all_symbols=list(all_symbols or []),
-        symbol_markets={},
-        refresh_plan=refresh_plan,
-    )
-
-
-def test_price_refresh_action_factory_returns_no_completion_when_plan_has_symbols():
-    from app.services.price_refresh_actions import PriceRefreshActionFactory
+def test_terminal_completion_helper_returns_none_when_plan_has_symbols():
+    from app.services import price_refresh_actions as module
+    from app.services.price_refresh_actions import build_terminal_completion
     from app.services.price_refresh_planning import PriceRefreshMode, PriceRefreshPlan
 
-    factory = PriceRefreshActionFactory(
-        last_completed_trading_day=lambda market: pytest.fail(
-            f"unexpected calendar lookup for {market}"
-        )
-    )
-
-    completion = factory.build_terminal_completion(
+    completion = build_terminal_completion(
         mode=PriceRefreshMode.BOOTSTRAP,
         effective_market="JP",
-        preparation=_preparation(
-            refresh_plan=PriceRefreshPlan(symbols=("7203.T",)),
+        plan=PriceRefreshPlan(symbols=("7203.T",)),
+        last_completed_trading_day=lambda market: (_ for _ in ()).throw(
+            AssertionError(f"unexpected calendar lookup for {market}")
         ),
     )
 
+    assert not hasattr(module, "PriceRefreshActionFactory")
     assert completion is None
 
 
-def test_price_refresh_action_factory_returns_terminal_completion():
+def test_terminal_completion_helper_returns_terminal_completion():
     from datetime import date
 
-    from app.services.price_refresh_actions import PriceRefreshActionFactory
+    from app.services.price_refresh_actions import build_terminal_completion
     from app.services.price_refresh_planning import (
         GitHubSeedOutcome,
         PriceRefreshMode,
@@ -55,21 +40,17 @@ def test_price_refresh_action_factory_returns_terminal_completion():
     assert github_seed is not None
     plan = PriceRefreshPlan(
         symbols=(),
+        all_symbols=("7203.T", "9984.T"),
         github_seed=github_seed,
         github_seed_used=True,
         completion_message="GitHub daily price bundle is current - no live fetch needed",
     )
-    factory = PriceRefreshActionFactory(
-        last_completed_trading_day=lambda market: date(2026, 6, 7)
-    )
 
-    completion = factory.build_terminal_completion(
+    completion = build_terminal_completion(
         mode=PriceRefreshMode.BOOTSTRAP,
         effective_market="JP",
-        preparation=_preparation(
-            refresh_plan=plan,
-            all_symbols=["7203.T", "9984.T"],
-        ),
+        plan=plan,
+        last_completed_trading_day=lambda market: date(2026, 6, 7),
     )
 
     assert completion is not None

--- a/backend/tests/unit/test_price_refresh_actions.py
+++ b/backend/tests/unit/test_price_refresh_actions.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+
+def _preparation(*, refresh_plan, all_symbols=None, symbols=None):
+    from app.services.price_refresh_actions import PriceRefreshPreparation
+
+    return PriceRefreshPreparation(
+        all_symbols=list(all_symbols or []),
+        symbol_markets={},
+        github_seed=refresh_plan.github_seed,
+        refresh_plan=refresh_plan,
+        refresh_source=refresh_plan.source,
+        symbols=list(symbols if symbols is not None else refresh_plan.symbols),
+        live_refresh_jobs=list(refresh_plan.jobs),
+    )
+
+
+def test_price_refresh_action_requires_live_fetch_when_plan_has_symbols():
+    from app.services.price_refresh_actions import PriceRefreshActionFactory
+    from app.services.price_refresh_planning import PriceRefreshMode, PriceRefreshPlan
+
+    factory = PriceRefreshActionFactory(
+        last_completed_trading_day=lambda market: pytest.fail(
+            f"unexpected calendar lookup for {market}"
+        )
+    )
+
+    action = factory.build(
+        mode=PriceRefreshMode.BOOTSTRAP,
+        effective_market="JP",
+        preparation=_preparation(
+            refresh_plan=PriceRefreshPlan(symbols=("7203.T",)),
+        ),
+    )
+
+    assert action.requires_live_fetch is True
+    assert action.terminal_completion is None
+
+
+def test_price_refresh_action_builds_github_terminal_completion():
+    from datetime import date
+
+    from app.services.price_refresh_actions import PriceRefreshActionFactory
+    from app.services.price_refresh_planning import (
+        GitHubSeedOutcome,
+        PriceRefreshMode,
+        PriceRefreshPlan,
+        PriceRefreshSource,
+    )
+
+    github_seed = GitHubSeedOutcome.from_mapping(
+        {
+            "status": "success",
+            "as_of_date": "2026-06-08",
+            "source_revision": "daily_prices_jp:20260608120000",
+        }
+    )
+    assert github_seed is not None
+    plan = PriceRefreshPlan(
+        symbols=(),
+        github_seed=github_seed,
+        github_seed_used=True,
+        completion_message="GitHub daily price bundle is current - no live fetch needed",
+    )
+    factory = PriceRefreshActionFactory(
+        last_completed_trading_day=lambda market: date(2026, 6, 7)
+    )
+
+    action = factory.build(
+        mode=PriceRefreshMode.BOOTSTRAP,
+        effective_market="JP",
+        preparation=_preparation(
+            refresh_plan=plan,
+            all_symbols=["7203.T", "9984.T"],
+        ),
+    )
+
+    assert action.requires_live_fetch is False
+    assert action.terminal_completion is not None
+    completion = action.terminal_completion
+    assert completion.outcome.source is PriceRefreshSource.GITHUB
+    assert completion.outcome.github_seed is github_seed
+    assert completion.outcome.message == plan.completion_message
+    assert completion.finalization.metadata_refreshed == 2
+    assert completion.finalization.metadata_total == 2
+    assert completion.finalization.market_success_rates == {
+        "JP": (date(2026, 6, 8), 1.0),
+    }

--- a/backend/tests/unit/test_price_refresh_execution.py
+++ b/backend/tests/unit/test_price_refresh_execution.py
@@ -92,3 +92,61 @@ def test_iter_price_refresh_batches_marks_unreturned_symbols_failed():
     assert summary.failed == 1
     assert summary.failed_symbols == ["B"]
     assert summary.failed_by_market == Counter({"US": 1})
+
+
+def test_price_refresh_execution_summary_accumulates_batches_incrementally():
+    from app.services.price_refresh_execution import (
+        PriceRefreshBatchOutcome,
+        PriceRefreshExecutionAccumulator,
+    )
+    from app.services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
+
+    stale_job = PriceRefreshJob(
+        kind=PriceRefreshJobKind.STALE,
+        symbols=("A", "B"),
+        period="7d",
+    )
+    missing_history_job = PriceRefreshJob(
+        kind=PriceRefreshJobKind.NO_HISTORY,
+        symbols=("C",),
+        period="2y",
+    )
+    accumulator = PriceRefreshExecutionAccumulator()
+
+    accumulator.add(
+        PriceRefreshBatchOutcome(
+            batch_number=1,
+            total_batches=2,
+            job=stale_job,
+            symbols=("A", "B"),
+            price_data_by_symbol={"A": object()},
+            successes=("A",),
+            failures=("B",),
+            failure_details={"B": "No data returned"},
+            refreshed_by_market=Counter({"US": 1}),
+            failed_by_market=Counter({"US": 1}),
+        )
+    )
+    accumulator.add(
+        PriceRefreshBatchOutcome(
+            batch_number=2,
+            total_batches=2,
+            job=missing_history_job,
+            symbols=("C",),
+            price_data_by_symbol={"C": object()},
+            successes=("C",),
+            failures=(),
+            failure_details={},
+            refreshed_by_market=Counter({"HK": 1}),
+            failed_by_market=Counter(),
+        )
+    )
+
+    summary = accumulator.summary()
+
+    assert summary.processed == 3
+    assert summary.refreshed == 2
+    assert summary.failed == 1
+    assert summary.failed_symbols == ["B"]
+    assert summary.refreshed_by_market == Counter({"US": 1, "HK": 1})
+    assert summary.failed_by_market == Counter({"US": 1})

--- a/backend/tests/unit/test_price_refresh_execution.py
+++ b/backend/tests/unit/test_price_refresh_execution.py
@@ -52,6 +52,8 @@ def test_iter_price_refresh_batches_returns_batch_outcomes_without_side_effect_c
     summary = summarize_price_refresh_batches(batches)
     assert summary.refreshed == 3
     assert summary.failed == 0
+    assert summary.total == 3
+    assert summary.processed == 3
     assert summary.failed_symbols == []
     assert summary.refreshed_by_market == Counter({"US": 2, "HK": 1})
 

--- a/backend/tests/unit/test_price_refresh_execution.py
+++ b/backend/tests/unit/test_price_refresh_execution.py
@@ -96,6 +96,85 @@ def test_iter_price_refresh_batches_marks_unreturned_symbols_failed():
     assert summary.failed_by_market == Counter({"US": 1})
 
 
+def test_iter_price_refresh_batches_can_delegate_provider_batching():
+    from app.services.price_refresh_execution import iter_price_refresh_batches
+    from app.services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
+
+    fetch_calls = []
+
+    def fetch_batch(symbols, *, period, market):
+        fetch_calls.append((tuple(symbols), period, market))
+        return {
+            symbol: {
+                "has_error": False,
+                "price_data": SimpleNamespace(empty=False),
+            }
+            for symbol in symbols
+        }
+
+    list(iter_price_refresh_batches(
+        jobs=(PriceRefreshJob(
+            kind=PriceRefreshJobKind.NO_HISTORY,
+            symbols=("A", "B", "C", "D"),
+            period="2y",
+        ),),
+        batch_size=None,
+        market="JP",
+        fetch_batch=fetch_batch,
+        market_for_symbol=lambda _symbol: "JP",
+        raise_if_transient_database_error=lambda exc: None,
+    ))
+
+    assert fetch_calls == [(("A", "B", "C", "D"), "2y", "JP")]
+
+
+def test_iter_price_refresh_batches_carries_failure_kinds():
+    from app.services.price_refresh_execution import (
+        iter_price_refresh_batches,
+        summarize_price_refresh_batches,
+    )
+    from app.services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
+
+    def fetch_batch(symbols, *, period, market):
+        del symbols, period, market
+        return {
+            "0143.T": {
+                "has_error": True,
+                "price_data": None,
+                "error": "YFPricesMissingError('possibly delisted; no price data found')",
+                "error_kind": "no_price_data",
+            },
+            "7203.T": {
+                "has_error": True,
+                "price_data": None,
+                "error": "429 Too Many Requests",
+                "error_kind": "rate_limit",
+            },
+        }
+
+    batches = list(iter_price_refresh_batches(
+        jobs=(PriceRefreshJob(
+            kind=PriceRefreshJobKind.NO_HISTORY,
+            symbols=("0143.T", "7203.T"),
+            period="2y",
+        ),),
+        batch_size=None,
+        market="JP",
+        fetch_batch=fetch_batch,
+        market_for_symbol=lambda _symbol: "JP",
+        raise_if_transient_database_error=lambda exc: None,
+    ))
+
+    assert batches[0].failure_kinds == {
+        "0143.T": "no_price_data",
+        "7203.T": "rate_limit",
+    }
+    assert summarize_price_refresh_batches(batches).failure_kinds == {
+        "0143.T": "no_price_data",
+        "7203.T": "rate_limit",
+    }
+
+
 def test_price_refresh_execution_summary_accumulates_batches_incrementally():
     from app.services.price_refresh_execution import (
         PriceRefreshBatchOutcome,
@@ -150,5 +229,6 @@ def test_price_refresh_execution_summary_accumulates_batches_incrementally():
     assert summary.refreshed == 2
     assert summary.failed == 1
     assert summary.failed_symbols == ["B"]
+    assert summary.failure_kinds == {}
     assert summary.refreshed_by_market == Counter({"US": 1, "HK": 1})
     assert summary.failed_by_market == Counter({"US": 1})

--- a/backend/tests/unit/test_price_refresh_execution.py
+++ b/backend/tests/unit/test_price_refresh_execution.py
@@ -4,136 +4,91 @@ from collections import Counter
 from types import SimpleNamespace
 
 
-def test_run_price_refresh_jobs_batches_by_plan_period_and_reports_progress():
-    from app.services.price_refresh_execution import run_price_refresh_jobs
-    from app.services.price_refresh_planning import PriceRefreshJob
+def test_iter_price_refresh_batches_returns_batch_outcomes_without_side_effect_context():
+    from app.services.price_refresh_execution import (
+        iter_price_refresh_batches,
+        summarize_price_refresh_batches,
+    )
+    from app.services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
 
     fetch_calls = []
-    stored_batches = []
-    tracked = []
-    progress_updates = []
-    task_updates = []
-    waits = []
-    lock_extensions = []
 
-    class _Context:
-        def fetch_batch(self, symbols, *, period, market):
-            fetch_calls.append((tuple(symbols), period, market))
-            return {
-                symbol: {
-                    "has_error": False,
-                    "price_data": SimpleNamespace(empty=False),
-                }
-                for symbol in symbols
+    def fetch_batch(symbols, *, period, market):
+        fetch_calls.append((tuple(symbols), period, market))
+        return {
+            symbol: {
+                "has_error": False,
+                "price_data": SimpleNamespace(empty=False),
             }
+            for symbol in symbols
+        }
 
-        def store_prices(self, rows):
-            stored_batches.append((dict(rows), True))
-
-        def track_symbol_failures(self, successes, failures, *, failure_details):
-            tracked.append((tuple(successes), tuple(failures), dict(failure_details)))
-
-        def market_for_symbol(self, symbol):
-            return "US" if symbol != "C" else "HK"
-
-        def publish_progress(self, current, total, percent, message, *, refreshed, failed):
-            progress_updates.append((current, total, round(percent, 1), message))
-            task_updates.append((current, total, round(percent, 1), refreshed, failed))
-
-        def extend_lock(self):
-            lock_extensions.append("extended")
-
-        def wait_between_batches(self):
-            waits.append("wait")
-
-        def raise_if_transient_database_error(self, exc):
-            return None
-
-    result = run_price_refresh_jobs(
+    batches = list(iter_price_refresh_batches(
         jobs=(
-            PriceRefreshJob(kind="stale", symbols=("A", "B"), period="7d"),
-            PriceRefreshJob(kind="no_history", symbols=("C",), period="2y"),
+            PriceRefreshJob(kind=PriceRefreshJobKind.STALE, symbols=("A", "B"), period="7d"),
+            PriceRefreshJob(kind=PriceRefreshJobKind.NO_HISTORY, symbols=("C",), period="2y"),
         ),
-        total=3,
         batch_size=2,
         market="US",
-        context=_Context(),
-    )
+        fetch_batch=fetch_batch,
+        market_for_symbol=lambda symbol: "US" if symbol != "C" else "HK",
+        raise_if_transient_database_error=lambda exc: None,
+    ))
 
     assert fetch_calls == [
         (("A", "B"), "7d", "US"),
         (("C",), "2y", "US"),
     ]
-    assert [set(batch.keys()) for batch, _ in stored_batches] == [{"A", "B"}, {"C"}]
-    assert tracked == [
+    assert [set(batch.price_data_by_symbol.keys()) for batch in batches] == [
+        {"A", "B"},
+        {"C"},
+    ]
+    assert [(batch.successes, batch.failures, batch.failure_details) for batch in batches] == [
         (("A", "B"), (), {}),
         (("C",), (), {}),
     ]
-    assert progress_updates == [
-        (2, 3, 66.7, "Batch 1/2 · refreshing prices"),
-        (3, 3, 100.0, "Batch 2/2 · refreshing prices"),
-    ]
-    assert task_updates[-1] == (3, 3, 100.0, 3, 0)
-    assert waits == ["wait"]
-    assert lock_extensions == ["extended", "extended"]
-    assert result.refreshed == 3
-    assert result.failed == 0
-    assert result.failed_symbols == []
-    assert result.refreshed_by_market == Counter({"US": 2, "HK": 1})
+    assert [(batch.batch_number, batch.total_batches) for batch in batches] == [(1, 2), (2, 2)]
+
+    summary = summarize_price_refresh_batches(batches)
+    assert summary.refreshed == 3
+    assert summary.failed == 0
+    assert summary.failed_symbols == []
+    assert summary.refreshed_by_market == Counter({"US": 2, "HK": 1})
 
 
-def test_run_price_refresh_jobs_marks_unreturned_symbols_failed():
-    from app.services.price_refresh_execution import run_price_refresh_jobs
-    from app.services.price_refresh_planning import PriceRefreshJob
+def test_iter_price_refresh_batches_marks_unreturned_symbols_failed():
+    from app.services.price_refresh_execution import (
+        iter_price_refresh_batches,
+        summarize_price_refresh_batches,
+    )
+    from app.services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
 
-    tracked = []
-    task_updates = []
-
-    class _Context:
-        def fetch_batch(self, symbols, *, period, market):
-            del symbols, period, market
-            return {
-                "A": {
-                    "has_error": False,
-                    "price_data": SimpleNamespace(empty=False),
-                }
+    def fetch_batch(symbols, *, period, market):
+        del symbols, period, market
+        return {
+            "A": {
+                "has_error": False,
+                "price_data": SimpleNamespace(empty=False),
             }
+        }
 
-        def store_prices(self, rows):
-            assert set(rows) == {"A"}
-
-        def track_symbol_failures(self, successes, failures, *, failure_details):
-            tracked.append((tuple(successes), tuple(failures), dict(failure_details)))
-
-        def market_for_symbol(self, _symbol):
-            return "US"
-
-        def publish_progress(self, current, total, percent, message, *, refreshed, failed):
-            del message
-            task_updates.append((current, total, round(percent, 1), refreshed, failed))
-
-        def extend_lock(self):
-            return None
-
-        def wait_between_batches(self):
-            return None
-
-        def raise_if_transient_database_error(self, exc):
-            return None
-
-    result = run_price_refresh_jobs(
-        jobs=(PriceRefreshJob(kind="stale", symbols=("A", "B"), period="7d"),),
-        total=2,
+    batches = list(iter_price_refresh_batches(
+        jobs=(PriceRefreshJob(kind=PriceRefreshJobKind.STALE, symbols=("A", "B"), period="7d"),),
         batch_size=2,
         market="US",
-        context=_Context(),
-    )
+        fetch_batch=fetch_batch,
+        market_for_symbol=lambda _symbol: "US",
+        raise_if_transient_database_error=lambda exc: None,
+    ))
 
-    assert tracked == [
-        (("A",), ("B",), {"B": "No data returned"}),
-    ]
-    assert task_updates[-1] == (2, 2, 100.0, 1, 1)
-    assert result.refreshed == 1
-    assert result.failed == 1
-    assert result.failed_symbols == ["B"]
-    assert result.failed_by_market == Counter({"US": 1})
+    assert len(batches) == 1
+    assert batches[0].successes == ("A",)
+    assert batches[0].failures == ("B",)
+    assert batches[0].failure_details == {"B": "No data returned"}
+    assert set(batches[0].price_data_by_symbol) == {"A"}
+
+    summary = summarize_price_refresh_batches(batches)
+    assert summary.refreshed == 1
+    assert summary.failed == 1
+    assert summary.failed_symbols == ["B"]
+    assert summary.failed_by_market == Counter({"US": 1})

--- a/backend/tests/unit/test_price_refresh_execution.py
+++ b/backend/tests/unit/test_price_refresh_execution.py
@@ -16,20 +16,38 @@ def test_run_price_refresh_jobs_batches_by_plan_period_and_reports_progress():
     waits = []
     lock_extensions = []
 
-    class _PriceCache:
-        def store_batch_in_cache(self, rows, *, also_store_db):
-            stored_batches.append((dict(rows), also_store_db))
-
-    def fetch_with_backoff(fetcher, symbols, *, period, market):
-        del fetcher
-        fetch_calls.append((tuple(symbols), period, market))
-        return {
-            symbol: {
-                "has_error": False,
-                "price_data": SimpleNamespace(empty=False),
+    class _Context:
+        def fetch_batch(self, symbols, *, period, market):
+            fetch_calls.append((tuple(symbols), period, market))
+            return {
+                symbol: {
+                    "has_error": False,
+                    "price_data": SimpleNamespace(empty=False),
+                }
+                for symbol in symbols
             }
-            for symbol in symbols
-        }
+
+        def store_prices(self, rows):
+            stored_batches.append((dict(rows), True))
+
+        def track_symbol_failures(self, successes, failures, *, failure_details):
+            tracked.append((tuple(successes), tuple(failures), dict(failure_details)))
+
+        def market_for_symbol(self, symbol):
+            return "US" if symbol != "C" else "HK"
+
+        def publish_progress(self, current, total, percent, message, *, refreshed, failed):
+            progress_updates.append((current, total, round(percent, 1), message))
+            task_updates.append((current, total, round(percent, 1), refreshed, failed))
+
+        def extend_lock(self):
+            lock_extensions.append("extended")
+
+        def wait_between_batches(self):
+            waits.append("wait")
+
+        def raise_if_transient_database_error(self, exc):
+            return None
 
     result = run_price_refresh_jobs(
         jobs=(
@@ -38,24 +56,8 @@ def test_run_price_refresh_jobs_batches_by_plan_period_and_reports_progress():
         ),
         total=3,
         batch_size=2,
-        bulk_fetcher=object(),
-        price_cache=_PriceCache(),
-        db=object(),
         market="US",
-        fetch_with_backoff=fetch_with_backoff,
-        track_symbol_failures=lambda price_cache, successes, failures, db, failure_details: tracked.append(
-            (tuple(successes), tuple(failures), dict(failure_details))
-        ),
-        market_for_symbol=lambda symbol: "US" if symbol != "C" else "HK",
-        mark_progress=lambda current, total, percent, message: progress_updates.append(
-            (current, total, round(percent, 1), message)
-        ),
-        update_task_state=lambda current, total, percent, refreshed, failed: task_updates.append(
-            (current, total, round(percent, 1), refreshed, failed)
-        ),
-        extend_lock=lambda: lock_extensions.append("extended"),
-        wait_between_batches=lambda: waits.append("wait"),
-        raise_if_transient_database_error=lambda exc: None,
+        context=_Context(),
     )
 
     assert fetch_calls == [
@@ -78,3 +80,60 @@ def test_run_price_refresh_jobs_batches_by_plan_period_and_reports_progress():
     assert result.failed == 0
     assert result.failed_symbols == []
     assert result.refreshed_by_market == Counter({"US": 2, "HK": 1})
+
+
+def test_run_price_refresh_jobs_marks_unreturned_symbols_failed():
+    from app.services.price_refresh_execution import run_price_refresh_jobs
+    from app.services.price_refresh_planning import PriceRefreshJob
+
+    tracked = []
+    task_updates = []
+
+    class _Context:
+        def fetch_batch(self, symbols, *, period, market):
+            del symbols, period, market
+            return {
+                "A": {
+                    "has_error": False,
+                    "price_data": SimpleNamespace(empty=False),
+                }
+            }
+
+        def store_prices(self, rows):
+            assert set(rows) == {"A"}
+
+        def track_symbol_failures(self, successes, failures, *, failure_details):
+            tracked.append((tuple(successes), tuple(failures), dict(failure_details)))
+
+        def market_for_symbol(self, _symbol):
+            return "US"
+
+        def publish_progress(self, current, total, percent, message, *, refreshed, failed):
+            del message
+            task_updates.append((current, total, round(percent, 1), refreshed, failed))
+
+        def extend_lock(self):
+            return None
+
+        def wait_between_batches(self):
+            return None
+
+        def raise_if_transient_database_error(self, exc):
+            return None
+
+    result = run_price_refresh_jobs(
+        jobs=(PriceRefreshJob(kind="stale", symbols=("A", "B"), period="7d"),),
+        total=2,
+        batch_size=2,
+        market="US",
+        context=_Context(),
+    )
+
+    assert tracked == [
+        (("A",), ("B",), {"B": "No data returned"}),
+    ]
+    assert task_updates[-1] == (2, 2, 100.0, 1, 1)
+    assert result.refreshed == 1
+    assert result.failed == 1
+    assert result.failed_symbols == ["B"]
+    assert result.failed_by_market == Counter({"US": 1})

--- a/backend/tests/unit/test_price_refresh_execution.py
+++ b/backend/tests/unit/test_price_refresh_execution.py
@@ -4,6 +4,44 @@ from collections import Counter
 from types import SimpleNamespace
 
 
+def test_classify_price_refresh_batch_returns_shared_batch_outcome():
+    from app.services.price_refresh_execution import classify_price_refresh_batch
+    from app.services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
+
+    job = PriceRefreshJob(
+        kind=PriceRefreshJobKind.NO_HISTORY,
+        symbols=("0143.T", "7203.T"),
+        period="2y",
+    )
+
+    outcome = classify_price_refresh_batch(
+        batch_number=1,
+        total_batches=1,
+        job=job,
+        symbols=job.symbols,
+        batch_results={
+            "0143.T": {
+                "has_error": True,
+                "price_data": None,
+                "error": "Provider returned no usable rows",
+                "error_kind": "no_price_data",
+            },
+            "7203.T": {
+                "has_error": False,
+                "price_data": SimpleNamespace(empty=False),
+            },
+        },
+        market_for_symbol=lambda _symbol: "JP",
+    )
+
+    assert outcome.job is job
+    assert outcome.successes == ("7203.T",)
+    assert outcome.failures == ("0143.T",)
+    assert outcome.failure_kinds == {"0143.T": "no_price_data"}
+    assert outcome.refreshed_by_market == Counter({"JP": 1})
+    assert outcome.failed_by_market == Counter({"JP": 1})
+
+
 def test_iter_price_refresh_batches_returns_batch_outcomes_without_side_effect_context():
     from app.services.price_refresh_execution import (
         iter_price_refresh_batches,

--- a/backend/tests/unit/test_price_refresh_execution.py
+++ b/backend/tests/unit/test_price_refresh_execution.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections import Counter
+from types import SimpleNamespace
+
+
+def test_run_price_refresh_jobs_batches_by_plan_period_and_reports_progress():
+    from app.services.price_refresh_execution import run_price_refresh_jobs
+    from app.services.price_refresh_planning import PriceRefreshJob
+
+    fetch_calls = []
+    stored_batches = []
+    tracked = []
+    progress_updates = []
+    task_updates = []
+    waits = []
+    lock_extensions = []
+
+    class _PriceCache:
+        def store_batch_in_cache(self, rows, *, also_store_db):
+            stored_batches.append((dict(rows), also_store_db))
+
+    def fetch_with_backoff(fetcher, symbols, *, period, market):
+        del fetcher
+        fetch_calls.append((tuple(symbols), period, market))
+        return {
+            symbol: {
+                "has_error": False,
+                "price_data": SimpleNamespace(empty=False),
+            }
+            for symbol in symbols
+        }
+
+    result = run_price_refresh_jobs(
+        jobs=(
+            PriceRefreshJob(kind="stale", symbols=("A", "B"), period="7d"),
+            PriceRefreshJob(kind="no_history", symbols=("C",), period="2y"),
+        ),
+        total=3,
+        batch_size=2,
+        bulk_fetcher=object(),
+        price_cache=_PriceCache(),
+        db=object(),
+        market="US",
+        fetch_with_backoff=fetch_with_backoff,
+        track_symbol_failures=lambda price_cache, successes, failures, db, failure_details: tracked.append(
+            (tuple(successes), tuple(failures), dict(failure_details))
+        ),
+        market_for_symbol=lambda symbol: "US" if symbol != "C" else "HK",
+        mark_progress=lambda current, total, percent, message: progress_updates.append(
+            (current, total, round(percent, 1), message)
+        ),
+        update_task_state=lambda current, total, percent, refreshed, failed: task_updates.append(
+            (current, total, round(percent, 1), refreshed, failed)
+        ),
+        extend_lock=lambda: lock_extensions.append("extended"),
+        wait_between_batches=lambda: waits.append("wait"),
+        raise_if_transient_database_error=lambda exc: None,
+    )
+
+    assert fetch_calls == [
+        (("A", "B"), "7d", "US"),
+        (("C",), "2y", "US"),
+    ]
+    assert [set(batch.keys()) for batch, _ in stored_batches] == [{"A", "B"}, {"C"}]
+    assert tracked == [
+        (("A", "B"), (), {}),
+        (("C",), (), {}),
+    ]
+    assert progress_updates == [
+        (2, 3, 66.7, "Batch 1/2 · refreshing prices"),
+        (3, 3, 100.0, "Batch 2/2 · refreshing prices"),
+    ]
+    assert task_updates[-1] == (3, 3, 100.0, 3, 0)
+    assert waits == ["wait"]
+    assert lock_extensions == ["extended", "extended"]
+    assert result.refreshed == 3
+    assert result.failed == 0
+    assert result.failed_symbols == []
+    assert result.refreshed_by_market == Counter({"US": 2, "HK": 1})

--- a/backend/tests/unit/test_price_refresh_live_runner.py
+++ b/backend/tests/unit/test_price_refresh_live_runner.py
@@ -45,7 +45,6 @@ def test_live_price_refresh_runner_raises_interruption_with_partial_summary():
         LivePriceRefreshRunnerDependencies(
             fetch_with_backoff=fetch_with_backoff,
             track_symbol_failures=lambda *_args, **_kwargs: None,
-            rate_limiter_factory=lambda: SimpleNamespace(wait_for_market=lambda *_args: None),
             data_fetch_lock_factory=lambda: _FakeLock(),
             raise_if_transient_database_error=lambda _exc: None,
         )
@@ -78,3 +77,32 @@ def test_live_price_refresh_runner_raises_interruption_with_partial_summary():
     assert raised.value.summary.processed == 1
     assert raised.value.summary.refreshed == 1
     assert raised.value.summary.failed == 0
+
+
+def test_retry_scheduler_skips_permanent_no_price_data_failures():
+    from app.services.price_refresh_live_runner import PriceRefreshRetryScheduler
+
+    calls = []
+    scheduler = PriceRefreshRetryScheduler(
+        schedule_failed_symbol_retry=lambda **kwargs: calls.append(kwargs)
+    )
+
+    scheduler.schedule(
+        ["0143.T", "7203.T"],
+        failure_kinds={
+            "0143.T": "no_price_data",
+            "7203.T": "rate_limit",
+        },
+        effective_market="JP",
+        symbol_markets={"0143.T": "JP", "7203.T": "JP"},
+        activity_lifecycle="bootstrap",
+    )
+
+    assert calls == [
+        {
+            "symbols": ["7203.T"],
+            "market": "JP",
+            "attempt": 1,
+            "countdown": 30,
+        }
+    ]

--- a/backend/tests/unit/test_price_refresh_live_runner.py
+++ b/backend/tests/unit/test_price_refresh_live_runner.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from celery.exceptions import SoftTimeLimitExceeded
+
+
+def test_live_price_refresh_runner_raises_interruption_with_partial_summary():
+    from app.services.price_refresh_live_runner import (
+        LivePriceRefreshRunner,
+        LivePriceRefreshRunnerDependencies,
+        PriceRefreshExecutionError,
+    )
+    from app.services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
+
+    fetch_calls = []
+
+    def fetch_with_backoff(_bulk_fetcher, symbols, *, period, market):
+        del period, market
+        fetch_calls.append(tuple(symbols))
+        if len(fetch_calls) == 2:
+            raise SoftTimeLimitExceeded()
+        return {
+            symbol: {
+                "has_error": False,
+                "price_data": SimpleNamespace(empty=False),
+            }
+            for symbol in symbols
+        }
+
+    class _FakePriceCache:
+        def store_batch_in_cache(self, *_args, **_kwargs):
+            pass
+
+    class _FakeReporter:
+        def publish_progress(self, *_args, **_kwargs):
+            pass
+
+    class _FakeLock:
+        def extend_lock(self, *_args, **_kwargs):
+            pass
+
+    runner = LivePriceRefreshRunner(
+        LivePriceRefreshRunnerDependencies(
+            fetch_with_backoff=fetch_with_backoff,
+            track_symbol_failures=lambda *_args, **_kwargs: None,
+            rate_limiter_factory=lambda: SimpleNamespace(wait_for_market=lambda *_args: None),
+            data_fetch_lock_factory=lambda: _FakeLock(),
+            raise_if_transient_database_error=lambda _exc: None,
+        )
+    )
+
+    with pytest.raises(PriceRefreshExecutionError) as raised:
+        runner.run(
+            task=SimpleNamespace(request=SimpleNamespace(id="task-1")),
+            bulk_fetcher=object(),
+            price_cache=_FakePriceCache(),
+            db=object(),
+            jobs=(
+                PriceRefreshJob(
+                    kind=PriceRefreshJobKind.STALE,
+                    symbols=("A", "B"),
+                    period="7d",
+                ),
+            ),
+            total=2,
+            batch_size=1,
+            market="JP",
+            effective_market="JP",
+            activity_lifecycle="bootstrap",
+            symbol_markets={"A": "JP", "B": "JP"},
+            activity_reporter=_FakeReporter(),
+        )
+
+    assert isinstance(raised.value.cause, SoftTimeLimitExceeded)
+    assert raised.value.summary.total == 2
+    assert raised.value.summary.processed == 1
+    assert raised.value.summary.refreshed == 1
+    assert raised.value.summary.failed == 0

--- a/backend/tests/unit/test_price_refresh_planning.py
+++ b/backend/tests/unit/test_price_refresh_planning.py
@@ -6,22 +6,6 @@ from types import SimpleNamespace
 from app.models.stock import StockPrice
 
 
-class _GithubService:
-    def __init__(self, sync_result, missing_symbols=None):
-        self.sync_calls = []
-        self.missing_calls = []
-        self.sync_result = sync_result
-        self.missing_symbols = list(missing_symbols or [])
-
-    def sync_from_github(self, db, **kwargs):
-        self.sync_calls.append(kwargs)
-        return self.sync_result
-
-    def symbols_missing_as_of(self, db, *, symbols, as_of_date):
-        self.missing_calls.append({"symbols": list(symbols), "as_of_date": as_of_date})
-        return list(self.missing_symbols)
-
-
 def _calendar(day: date):
     return SimpleNamespace(last_completed_trading_day=lambda _market: day)
 
@@ -55,124 +39,136 @@ def test_bootstrap_plan_uses_stale_top_up_and_full_bootstrap_for_no_history(univ
         plan_price_refresh,
     )
 
-    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100))
-    universe_session.commit()
-
-    github = _GithubService(
-        {
-            "status": "success",
-            "as_of_date": "2026-06-05",
-            "source_revision": "daily_prices_hk:20260605090000",
-            "stale_reason": "behind expected session",
-        }
+    universe_session.add_all(
+        [
+            StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100),
+            StockPrice(symbol="0005.HK", date=date(2026, 6, 8), close=50),
+        ]
     )
+    universe_session.commit()
 
     plan = plan_price_refresh(
         universe_session,
         all_symbols=["0700.HK", "9999.HK"],
         mode="bootstrap",
-        activity_lifecycle="bootstrap",
         effective_market="HK",
-        price_bundle_service=github,
         market_calendar_service=_calendar(date(2026, 6, 8)),
+        github_sync={
+            "status": "success",
+            "as_of_date": "2026-06-05",
+            "source_revision": "daily_prices_hk:20260605090000",
+            "stale_reason": "behind expected session",
+        },
     )
 
     assert plan.source == "github+live"
+    assert plan.github_seed_used is True
     assert plan.symbols == ("0700.HK", "9999.HK")
     assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
         ("stale", ("0700.HK",), STALE_PRICE_TOP_UP_PERIOD),
         ("no_history", ("9999.HK",), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD),
     ]
-    assert github.sync_calls == [{"market": "HK", "allow_stale": True}]
 
 
-def test_full_mode_stays_full_even_during_bootstrap_lifecycle(universe_session):
+def test_full_mode_stays_full_even_when_github_sync_result_is_available(universe_session):
     from app.services.price_refresh_planning import (
         NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         plan_price_refresh,
     )
 
-    github = _GithubService({"status": "success", "as_of_date": "2026-06-08"})
-
     plan = plan_price_refresh(
         universe_session,
         all_symbols=["0700.HK", "9999.HK"],
         mode="full",
-        activity_lifecycle="bootstrap",
         effective_market="HK",
-        price_bundle_service=github,
         market_calendar_service=_calendar(date(2026, 6, 8)),
+        github_sync={"status": "success", "as_of_date": "2026-06-08"},
     )
 
     assert plan.source == "live"
+    assert plan.github_seed_used is False
     assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
         ("full", ("0700.HK", "9999.HK"), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD)
     ]
-    assert github.sync_calls == []
 
 
-def test_current_github_bundle_splits_only_missing_symbols_by_history(universe_session):
+def test_current_github_bundle_classifies_history_without_a_second_missing_symbol_api(universe_session):
     from app.services.price_refresh_planning import (
         NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         STALE_PRICE_TOP_UP_PERIOD,
         plan_price_refresh,
     )
 
-    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100))
-    universe_session.commit()
-    github = _GithubService(
-        {
-            "status": "success",
-            "as_of_date": "2026-06-08",
-            "source_revision": "daily_prices_hk:20260608090000",
-        },
-        missing_symbols=["0700.HK", "9999.HK"],
+    universe_session.add_all(
+        [
+            StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100),
+            StockPrice(symbol="0005.HK", date=date(2026, 6, 8), close=50),
+        ]
     )
+    universe_session.commit()
 
     plan = plan_price_refresh(
         universe_session,
         all_symbols=["0700.HK", "0005.HK", "9999.HK"],
         mode="bootstrap",
-        activity_lifecycle="bootstrap",
         effective_market="HK",
-        price_bundle_service=github,
         market_calendar_service=_calendar(date(2026, 6, 8)),
+        github_sync={
+            "status": "success",
+            "as_of_date": "2026-06-08",
+            "source_revision": "daily_prices_hk:20260608090000",
+        },
     )
 
     assert plan.source == "github+live"
+    assert plan.github_seed_used is True
     assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
         ("stale", ("0700.HK",), STALE_PRICE_TOP_UP_PERIOD),
         ("no_history", ("9999.HK",), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD),
-    ]
-    assert github.missing_calls == [
-        {"symbols": ["0700.HK", "0005.HK", "9999.HK"], "as_of_date": "2026-06-08"}
     ]
 
 
 def test_current_github_bundle_accepts_datetime_as_of_date(universe_session):
     from app.services.price_refresh_planning import plan_price_refresh
 
-    github = _GithubService(
-        {
-            "status": "success",
-            "as_of_date": datetime(2026, 6, 8, 9, 0),
-            "source_revision": "daily_prices_hk:20260608090000",
-        },
-        missing_symbols=[],
-    )
+    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 8), close=100))
+    universe_session.commit()
 
     plan = plan_price_refresh(
         universe_session,
         all_symbols=["0700.HK"],
         mode="bootstrap",
-        activity_lifecycle="bootstrap",
         effective_market="HK",
-        price_bundle_service=github,
         market_calendar_service=_calendar(date(2026, 6, 8)),
+        github_sync={
+            "status": "success",
+            "as_of_date": datetime(2026, 6, 8, 9, 0),
+            "source_revision": "daily_prices_hk:20260608090000",
+        },
     )
 
     assert plan.source == "github"
+    assert plan.github_seed_used is True
     assert plan.completion_message == "GitHub daily price bundle is current - no live fetch needed"
-    assert github.missing_calls == [
-        {"symbols": ["0700.HK"], "as_of_date": "2026-06-08"}
+
+
+def test_failed_github_sync_is_live_top_up_not_github_live(universe_session):
+    from app.services.price_refresh_planning import plan_price_refresh
+
+    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100))
+    universe_session.commit()
+
+    plan = plan_price_refresh(
+        universe_session,
+        all_symbols=["0700.HK"],
+        mode="delta",
+        effective_market="HK",
+        market_calendar_service=_calendar(date(2026, 6, 8)),
+        github_sync={"status": "missing", "reason": "not found"},
+    )
+
+    assert plan.source == "live"
+    assert plan.github_seed_used is False
+    assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
+        ("stale", ("0700.HK",), "7d"),
     ]

--- a/backend/tests/unit/test_price_refresh_planning.py
+++ b/backend/tests/unit/test_price_refresh_planning.py
@@ -34,6 +34,10 @@ def test_price_history_coverage_splits_fresh_stale_and_no_history(universe_sessi
 
 def test_bootstrap_plan_uses_stale_top_up_and_full_bootstrap_for_no_history(universe_session):
     from app.services.price_refresh_planning import (
+        GitHubSeedOutcome,
+        PriceRefreshJobKind,
+        PriceRefreshMode,
+        PriceRefreshSource,
         NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         STALE_PRICE_TOP_UP_PERIOD,
         plan_price_refresh,
@@ -50,7 +54,7 @@ def test_bootstrap_plan_uses_stale_top_up_and_full_bootstrap_for_no_history(univ
     plan = plan_price_refresh(
         universe_session,
         all_symbols=["0700.HK", "9999.HK"],
-        mode="bootstrap",
+        mode=PriceRefreshMode.BOOTSTRAP,
         effective_market="HK",
         market_calendar_service=_calendar(date(2026, 6, 8)),
         github_sync={
@@ -61,12 +65,14 @@ def test_bootstrap_plan_uses_stale_top_up_and_full_bootstrap_for_no_history(univ
         },
     )
 
-    assert plan.source == "github+live"
+    assert plan.source is PriceRefreshSource.GITHUB_AND_LIVE
     assert plan.github_seed_used is True
+    assert isinstance(plan.github_seed, GitHubSeedOutcome)
+    assert plan.github_seed.status.value == "success"
     assert plan.symbols == ("0700.HK", "9999.HK")
     assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
-        ("stale", ("0700.HK",), STALE_PRICE_TOP_UP_PERIOD),
-        ("no_history", ("9999.HK",), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD),
+        (PriceRefreshJobKind.STALE, ("0700.HK",), STALE_PRICE_TOP_UP_PERIOD),
+        (PriceRefreshJobKind.NO_HISTORY, ("9999.HK",), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD),
     ]
 
 

--- a/backend/tests/unit/test_price_refresh_planning.py
+++ b/backend/tests/unit/test_price_refresh_planning.py
@@ -16,6 +16,21 @@ def _seed(payload):
     return GitHubSeedOutcome.from_mapping(payload)
 
 
+def _planning_input(**overrides):
+    from app.services.price_history_coverage import PriceHistoryCoverage
+    from app.services.price_refresh_planning import PriceRefreshPlanningInput
+
+    values = {
+        "all_symbols": ("0700.HK",),
+        "mode": "bootstrap",
+        "effective_market": "HK",
+        "target_as_of": date(2026, 6, 8),
+        "coverage": PriceHistoryCoverage(stale=("0700.HK",)),
+    }
+    values.update(overrides)
+    return PriceRefreshPlanningInput(**values)
+
+
 def test_price_history_coverage_splits_fresh_stale_and_no_history(universe_session):
     from app.services.price_history_coverage import classify_price_history
 
@@ -39,37 +54,26 @@ def test_price_history_coverage_splits_fresh_stale_and_no_history(universe_sessi
 
 
 def test_bootstrap_plan_uses_stale_top_up_and_full_bootstrap_for_no_history(universe_session):
+    from app.services.price_history_coverage import PriceHistoryCoverage
     from app.services.price_refresh_planning import (
         GitHubSeedOutcome,
         PriceRefreshJobKind,
-        PriceRefreshMode,
         PriceRefreshSource,
         NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         STALE_PRICE_TOP_UP_PERIOD,
-        plan_price_refresh,
+        plan_price_refresh_from_input,
     )
 
-    universe_session.add_all(
-        [
-            StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100),
-            StockPrice(symbol="0005.HK", date=date(2026, 6, 8), close=50),
-        ]
-    )
-    universe_session.commit()
-
-    plan = plan_price_refresh(
-        universe_session,
+    plan = plan_price_refresh_from_input(_planning_input(
         all_symbols=["0700.HK", "9999.HK"],
-        mode=PriceRefreshMode.BOOTSTRAP,
-        effective_market="HK",
-        market_calendar_service=_calendar(date(2026, 6, 8)),
         github_seed=_seed({
             "status": "success",
             "as_of_date": "2026-06-05",
             "source_revision": "daily_prices_hk:20260605090000",
             "stale_reason": "behind expected session",
         }),
-    )
+        coverage=PriceHistoryCoverage(stale=("0700.HK",), no_history=("9999.HK",)),
+    ))
 
     assert plan.source is PriceRefreshSource.GITHUB_AND_LIVE
     assert plan.github_seed_used is True
@@ -87,17 +91,15 @@ def test_full_mode_stays_full_even_when_github_sync_result_is_available(universe
         NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         PriceRefreshJobKind,
         PriceRefreshSource,
-        plan_price_refresh,
+        plan_price_refresh_from_input,
     )
 
-    plan = plan_price_refresh(
-        universe_session,
+    plan = plan_price_refresh_from_input(_planning_input(
         all_symbols=["0700.HK", "9999.HK"],
         mode="full",
-        effective_market="HK",
-        market_calendar_service=_calendar(date(2026, 6, 8)),
         github_seed=_seed({"status": "success", "as_of_date": "2026-06-08"}),
-    )
+        coverage=None,
+    ))
 
     assert plan.source is PriceRefreshSource.LIVE
     assert plan.github_seed_used is False
@@ -107,34 +109,28 @@ def test_full_mode_stays_full_even_when_github_sync_result_is_available(universe
 
 
 def test_current_github_bundle_classifies_history_without_a_second_missing_symbol_api(universe_session):
+    from app.services.price_history_coverage import PriceHistoryCoverage
     from app.services.price_refresh_planning import (
         NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
         PriceRefreshJobKind,
         PriceRefreshSource,
         STALE_PRICE_TOP_UP_PERIOD,
-        plan_price_refresh,
+        plan_price_refresh_from_input,
     )
 
-    universe_session.add_all(
-        [
-            StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100),
-            StockPrice(symbol="0005.HK", date=date(2026, 6, 8), close=50),
-        ]
-    )
-    universe_session.commit()
-
-    plan = plan_price_refresh(
-        universe_session,
+    plan = plan_price_refresh_from_input(_planning_input(
         all_symbols=["0700.HK", "0005.HK", "9999.HK"],
-        mode="bootstrap",
-        effective_market="HK",
-        market_calendar_service=_calendar(date(2026, 6, 8)),
         github_seed=_seed({
             "status": "success",
             "as_of_date": "2026-06-08",
             "source_revision": "daily_prices_hk:20260608090000",
         }),
-    )
+        coverage=PriceHistoryCoverage(
+            fresh=("0005.HK",),
+            stale=("0700.HK",),
+            no_history=("9999.HK",),
+        ),
+    ))
 
     assert plan.source is PriceRefreshSource.GITHUB_AND_LIVE
     assert plan.github_seed_used is True
@@ -145,23 +141,18 @@ def test_current_github_bundle_classifies_history_without_a_second_missing_symbo
 
 
 def test_current_github_bundle_accepts_datetime_as_of_date(universe_session):
-    from app.services.price_refresh_planning import PriceRefreshSource, plan_price_refresh
+    from app.services.price_history_coverage import PriceHistoryCoverage
+    from app.services.price_refresh_planning import PriceRefreshSource, plan_price_refresh_from_input
 
-    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 8), close=100))
-    universe_session.commit()
-
-    plan = plan_price_refresh(
-        universe_session,
+    plan = plan_price_refresh_from_input(_planning_input(
         all_symbols=["0700.HK"],
-        mode="bootstrap",
-        effective_market="HK",
-        market_calendar_service=_calendar(date(2026, 6, 8)),
         github_seed=_seed({
             "status": "success",
             "as_of_date": datetime(2026, 6, 8, 9, 0),
             "source_revision": "daily_prices_hk:20260608090000",
         }),
-    )
+        coverage=PriceHistoryCoverage(fresh=("0700.HK",)),
+    ))
 
     assert plan.source is PriceRefreshSource.GITHUB
     assert plan.github_seed_used is True
@@ -172,20 +163,14 @@ def test_failed_github_sync_is_live_top_up_not_github_live(universe_session):
     from app.services.price_refresh_planning import (
         PriceRefreshJobKind,
         PriceRefreshSource,
-        plan_price_refresh,
+        plan_price_refresh_from_input,
     )
 
-    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100))
-    universe_session.commit()
-
-    plan = plan_price_refresh(
-        universe_session,
+    plan = plan_price_refresh_from_input(_planning_input(
         all_symbols=["0700.HK"],
         mode="delta",
-        effective_market="HK",
-        market_calendar_service=_calendar(date(2026, 6, 8)),
         github_seed=_seed({"status": "missing", "reason": "not found"}),
-    )
+    ))
 
     assert plan.source is PriceRefreshSource.LIVE
     assert plan.github_seed_used is False
@@ -209,11 +194,46 @@ def test_github_seed_and_plan_do_not_expose_mapping_compatibility_surface():
     assert "github_sync" not in PriceRefreshPlan.__dict__
 
 
+def test_price_refresh_plan_can_be_built_from_precomputed_inputs_without_database():
+    from app.services.price_history_coverage import PriceHistoryCoverage
+    from app.services.price_refresh_planning import (
+        PriceRefreshJobKind,
+        PriceRefreshPlanningInput,
+        PriceRefreshSource,
+        plan_price_refresh_from_input,
+    )
+
+    plan = plan_price_refresh_from_input(
+        PriceRefreshPlanningInput(
+            all_symbols=("0700.HK", "0005.HK", "9999.HK"),
+            mode="bootstrap",
+            effective_market="HK",
+            github_seed=_seed({
+                "status": "success",
+                "as_of_date": "2026-06-08",
+                "source_revision": "daily_prices_hk:20260608090000",
+            }),
+            coverage=PriceHistoryCoverage(
+                fresh=("0005.HK",),
+                stale=("0700.HK",),
+                no_history=("9999.HK",),
+            ),
+        )
+    )
+
+    assert plan.source is PriceRefreshSource.GITHUB_AND_LIVE
+    assert plan.github_seed_used is True
+    assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
+        (PriceRefreshJobKind.STALE, ("0700.HK",), "7d"),
+        (PriceRefreshJobKind.NO_HISTORY, ("9999.HK",), "2y"),
+    ]
+
+
 def test_build_market_price_refresh_plan_owns_universe_and_github_seed(universe_session):
     from app.models.stock_universe import StockUniverse
+    from app.services.price_refresh_plan_builder import build_market_price_refresh_plan
     from app.services.price_refresh_planning import (
         PriceRefreshSource,
-        build_market_price_refresh_plan,
     )
 
     universe_session.add_all(

--- a/backend/tests/unit/test_price_refresh_planning.py
+++ b/backend/tests/unit/test_price_refresh_planning.py
@@ -10,6 +10,12 @@ def _calendar(day: date):
     return SimpleNamespace(last_completed_trading_day=lambda _market: day)
 
 
+def _seed(payload):
+    from app.services.price_refresh_planning import GitHubSeedOutcome
+
+    return GitHubSeedOutcome.from_mapping(payload)
+
+
 def test_price_history_coverage_splits_fresh_stale_and_no_history(universe_session):
     from app.services.price_history_coverage import classify_price_history
 
@@ -57,12 +63,12 @@ def test_bootstrap_plan_uses_stale_top_up_and_full_bootstrap_for_no_history(univ
         mode=PriceRefreshMode.BOOTSTRAP,
         effective_market="HK",
         market_calendar_service=_calendar(date(2026, 6, 8)),
-        github_sync={
+        github_seed=_seed({
             "status": "success",
             "as_of_date": "2026-06-05",
             "source_revision": "daily_prices_hk:20260605090000",
             "stale_reason": "behind expected session",
-        },
+        }),
     )
 
     assert plan.source is PriceRefreshSource.GITHUB_AND_LIVE
@@ -79,6 +85,8 @@ def test_bootstrap_plan_uses_stale_top_up_and_full_bootstrap_for_no_history(univ
 def test_full_mode_stays_full_even_when_github_sync_result_is_available(universe_session):
     from app.services.price_refresh_planning import (
         NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+        PriceRefreshJobKind,
+        PriceRefreshSource,
         plan_price_refresh,
     )
 
@@ -88,19 +96,21 @@ def test_full_mode_stays_full_even_when_github_sync_result_is_available(universe
         mode="full",
         effective_market="HK",
         market_calendar_service=_calendar(date(2026, 6, 8)),
-        github_sync={"status": "success", "as_of_date": "2026-06-08"},
+        github_seed=_seed({"status": "success", "as_of_date": "2026-06-08"}),
     )
 
-    assert plan.source == "live"
+    assert plan.source is PriceRefreshSource.LIVE
     assert plan.github_seed_used is False
     assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
-        ("full", ("0700.HK", "9999.HK"), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD)
+        (PriceRefreshJobKind.FULL, ("0700.HK", "9999.HK"), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD)
     ]
 
 
 def test_current_github_bundle_classifies_history_without_a_second_missing_symbol_api(universe_session):
     from app.services.price_refresh_planning import (
         NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+        PriceRefreshJobKind,
+        PriceRefreshSource,
         STALE_PRICE_TOP_UP_PERIOD,
         plan_price_refresh,
     )
@@ -119,23 +129,23 @@ def test_current_github_bundle_classifies_history_without_a_second_missing_symbo
         mode="bootstrap",
         effective_market="HK",
         market_calendar_service=_calendar(date(2026, 6, 8)),
-        github_sync={
+        github_seed=_seed({
             "status": "success",
             "as_of_date": "2026-06-08",
             "source_revision": "daily_prices_hk:20260608090000",
-        },
+        }),
     )
 
-    assert plan.source == "github+live"
+    assert plan.source is PriceRefreshSource.GITHUB_AND_LIVE
     assert plan.github_seed_used is True
     assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
-        ("stale", ("0700.HK",), STALE_PRICE_TOP_UP_PERIOD),
-        ("no_history", ("9999.HK",), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD),
+        (PriceRefreshJobKind.STALE, ("0700.HK",), STALE_PRICE_TOP_UP_PERIOD),
+        (PriceRefreshJobKind.NO_HISTORY, ("9999.HK",), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD),
     ]
 
 
 def test_current_github_bundle_accepts_datetime_as_of_date(universe_session):
-    from app.services.price_refresh_planning import plan_price_refresh
+    from app.services.price_refresh_planning import PriceRefreshSource, plan_price_refresh
 
     universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 8), close=100))
     universe_session.commit()
@@ -146,20 +156,24 @@ def test_current_github_bundle_accepts_datetime_as_of_date(universe_session):
         mode="bootstrap",
         effective_market="HK",
         market_calendar_service=_calendar(date(2026, 6, 8)),
-        github_sync={
+        github_seed=_seed({
             "status": "success",
             "as_of_date": datetime(2026, 6, 8, 9, 0),
             "source_revision": "daily_prices_hk:20260608090000",
-        },
+        }),
     )
 
-    assert plan.source == "github"
+    assert plan.source is PriceRefreshSource.GITHUB
     assert plan.github_seed_used is True
     assert plan.completion_message == "GitHub daily price bundle is current - no live fetch needed"
 
 
 def test_failed_github_sync_is_live_top_up_not_github_live(universe_session):
-    from app.services.price_refresh_planning import plan_price_refresh
+    from app.services.price_refresh_planning import (
+        PriceRefreshJobKind,
+        PriceRefreshSource,
+        plan_price_refresh,
+    )
 
     universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100))
     universe_session.commit()
@@ -170,11 +184,26 @@ def test_failed_github_sync_is_live_top_up_not_github_live(universe_session):
         mode="delta",
         effective_market="HK",
         market_calendar_service=_calendar(date(2026, 6, 8)),
-        github_sync={"status": "missing", "reason": "not found"},
+        github_seed=_seed({"status": "missing", "reason": "not found"}),
     )
 
-    assert plan.source == "live"
+    assert plan.source is PriceRefreshSource.LIVE
     assert plan.github_seed_used is False
     assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
-        ("stale", ("0700.HK",), "7d"),
+        (PriceRefreshJobKind.STALE, ("0700.HK",), "7d"),
     ]
+
+
+def test_github_seed_and_plan_do_not_expose_mapping_compatibility_surface():
+    from app.services.price_refresh_planning import (
+        GitHubSeedOutcome,
+        GitHubSeedStatus,
+        PriceRefreshPlan,
+    )
+
+    seed = GitHubSeedOutcome(status=GitHubSeedStatus.SUCCESS)
+    plan = PriceRefreshPlan(symbols=(), github_seed=seed)
+
+    assert not hasattr(seed, "get")
+    assert "__getitem__" not in GitHubSeedOutcome.__dict__
+    assert "github_sync" not in PriceRefreshPlan.__dict__

--- a/backend/tests/unit/test_price_refresh_planning.py
+++ b/backend/tests/unit/test_price_refresh_planning.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from types import SimpleNamespace
+
+from app.models.stock import StockPrice
+
+
+class _GithubService:
+    def __init__(self, sync_result, missing_symbols=None):
+        self.sync_calls = []
+        self.missing_calls = []
+        self.sync_result = sync_result
+        self.missing_symbols = list(missing_symbols or [])
+
+    def sync_from_github(self, db, **kwargs):
+        self.sync_calls.append(kwargs)
+        return self.sync_result
+
+    def symbols_missing_as_of(self, db, *, symbols, as_of_date):
+        self.missing_calls.append({"symbols": list(symbols), "as_of_date": as_of_date})
+        return list(self.missing_symbols)
+
+
+def _calendar(day: date):
+    return SimpleNamespace(last_completed_trading_day=lambda _market: day)
+
+
+def test_price_history_coverage_splits_fresh_stale_and_no_history(universe_session):
+    from app.services.price_refresh_planning import classify_price_history
+
+    universe_session.add_all(
+        [
+            StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100),
+            StockPrice(symbol="0005.HK", date=date(2026, 6, 8), close=50),
+        ]
+    )
+    universe_session.commit()
+
+    coverage = classify_price_history(
+        universe_session,
+        symbols=["0700.HK", "0005.HK", "9999.HK"],
+        as_of_date=date(2026, 6, 8),
+    )
+
+    assert coverage.fresh == ("0005.HK",)
+    assert coverage.stale == ("0700.HK",)
+    assert coverage.no_history == ("9999.HK",)
+
+
+def test_bootstrap_plan_uses_stale_top_up_and_full_bootstrap_for_no_history(universe_session):
+    from app.services.price_refresh_planning import (
+        NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+        STALE_PRICE_TOP_UP_PERIOD,
+        plan_price_refresh,
+    )
+
+    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100))
+    universe_session.commit()
+
+    github = _GithubService(
+        {
+            "status": "success",
+            "as_of_date": "2026-06-05",
+            "source_revision": "daily_prices_hk:20260605090000",
+            "stale_reason": "behind expected session",
+        }
+    )
+
+    plan = plan_price_refresh(
+        universe_session,
+        all_symbols=["0700.HK", "9999.HK"],
+        mode="bootstrap",
+        activity_lifecycle="bootstrap",
+        effective_market="HK",
+        price_bundle_service=github,
+        market_calendar_service=_calendar(date(2026, 6, 8)),
+    )
+
+    assert plan.source == "github+live"
+    assert plan.symbols == ("0700.HK", "9999.HK")
+    assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
+        ("stale", ("0700.HK",), STALE_PRICE_TOP_UP_PERIOD),
+        ("no_history", ("9999.HK",), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD),
+    ]
+    assert github.sync_calls == [{"market": "HK", "allow_stale": True}]
+
+
+def test_full_mode_stays_full_even_during_bootstrap_lifecycle(universe_session):
+    from app.services.price_refresh_planning import (
+        NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+        plan_price_refresh,
+    )
+
+    github = _GithubService({"status": "success", "as_of_date": "2026-06-08"})
+
+    plan = plan_price_refresh(
+        universe_session,
+        all_symbols=["0700.HK", "9999.HK"],
+        mode="full",
+        activity_lifecycle="bootstrap",
+        effective_market="HK",
+        price_bundle_service=github,
+        market_calendar_service=_calendar(date(2026, 6, 8)),
+    )
+
+    assert plan.source == "live"
+    assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
+        ("full", ("0700.HK", "9999.HK"), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD)
+    ]
+    assert github.sync_calls == []
+
+
+def test_current_github_bundle_splits_only_missing_symbols_by_history(universe_session):
+    from app.services.price_refresh_planning import (
+        NO_HISTORY_PRICE_BOOTSTRAP_PERIOD,
+        STALE_PRICE_TOP_UP_PERIOD,
+        plan_price_refresh,
+    )
+
+    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 5), close=100))
+    universe_session.commit()
+    github = _GithubService(
+        {
+            "status": "success",
+            "as_of_date": "2026-06-08",
+            "source_revision": "daily_prices_hk:20260608090000",
+        },
+        missing_symbols=["0700.HK", "9999.HK"],
+    )
+
+    plan = plan_price_refresh(
+        universe_session,
+        all_symbols=["0700.HK", "0005.HK", "9999.HK"],
+        mode="bootstrap",
+        activity_lifecycle="bootstrap",
+        effective_market="HK",
+        price_bundle_service=github,
+        market_calendar_service=_calendar(date(2026, 6, 8)),
+    )
+
+    assert plan.source == "github+live"
+    assert [(job.kind, job.symbols, job.period) for job in plan.jobs] == [
+        ("stale", ("0700.HK",), STALE_PRICE_TOP_UP_PERIOD),
+        ("no_history", ("9999.HK",), NO_HISTORY_PRICE_BOOTSTRAP_PERIOD),
+    ]
+    assert github.missing_calls == [
+        {"symbols": ["0700.HK", "0005.HK", "9999.HK"], "as_of_date": "2026-06-08"}
+    ]
+
+
+def test_current_github_bundle_accepts_datetime_as_of_date(universe_session):
+    from app.services.price_refresh_planning import plan_price_refresh
+
+    github = _GithubService(
+        {
+            "status": "success",
+            "as_of_date": datetime(2026, 6, 8, 9, 0),
+            "source_revision": "daily_prices_hk:20260608090000",
+        },
+        missing_symbols=[],
+    )
+
+    plan = plan_price_refresh(
+        universe_session,
+        all_symbols=["0700.HK"],
+        mode="bootstrap",
+        activity_lifecycle="bootstrap",
+        effective_market="HK",
+        price_bundle_service=github,
+        market_calendar_service=_calendar(date(2026, 6, 8)),
+    )
+
+    assert plan.source == "github"
+    assert plan.completion_message == "GitHub daily price bundle is current - no live fetch needed"
+    assert github.missing_calls == [
+        {"symbols": ["0700.HK"], "as_of_date": "2026-06-08"}
+    ]

--- a/backend/tests/unit/test_price_refresh_planning.py
+++ b/backend/tests/unit/test_price_refresh_planning.py
@@ -207,3 +207,42 @@ def test_github_seed_and_plan_do_not_expose_mapping_compatibility_surface():
     assert not hasattr(seed, "get")
     assert "__getitem__" not in GitHubSeedOutcome.__dict__
     assert "github_sync" not in PriceRefreshPlan.__dict__
+
+
+def test_build_market_price_refresh_plan_owns_universe_and_github_seed(universe_session):
+    from app.models.stock_universe import StockUniverse
+    from app.services.price_refresh_planning import (
+        PriceRefreshSource,
+        build_market_price_refresh_plan,
+    )
+
+    universe_session.add_all(
+        [
+            StockUniverse(symbol="0700.HK", market="HK", market_cap=500),
+            StockUniverse(symbol="0005.HK", market="HK", market_cap=100),
+            StockUniverse(symbol="7203.T", market="JP", market_cap=300),
+        ]
+    )
+    universe_session.add(StockPrice(symbol="0700.HK", date=date(2026, 6, 8), close=100))
+    universe_session.commit()
+
+    sync_calls = []
+
+    plan = build_market_price_refresh_plan(
+        universe_session,
+        mode="bootstrap",
+        market="hk",
+        effective_market="HK",
+        normalize_market=lambda market: str(market).upper(),
+        market_calendar_service=_calendar(date(2026, 6, 8)),
+        sync_github_seed=lambda db, *, market, allow_stale: (
+            sync_calls.append((db, market, allow_stale))
+            or {"status": "success", "as_of_date": "2026-06-08"}
+        ),
+    )
+
+    assert sync_calls == [(universe_session, "HK", True)]
+    assert plan.all_symbols == ("0700.HK", "0005.HK")
+    assert plan.symbol_markets == {"0700.HK": "HK", "0005.HK": "HK"}
+    assert plan.source is PriceRefreshSource.GITHUB_AND_LIVE
+    assert plan.symbols == ("0005.HK",)

--- a/backend/tests/unit/test_price_refresh_planning.py
+++ b/backend/tests/unit/test_price_refresh_planning.py
@@ -11,7 +11,7 @@ def _calendar(day: date):
 
 
 def test_price_history_coverage_splits_fresh_stale_and_no_history(universe_session):
-    from app.services.price_refresh_planning import classify_price_history
+    from app.services.price_history_coverage import classify_price_history
 
     universe_session.add_all(
         [

--- a/backend/tests/unit/test_price_refresh_workflow.py
+++ b/backend/tests/unit/test_price_refresh_workflow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 
 def test_price_refresh_outcome_serializes_typed_github_metadata():
@@ -41,3 +43,84 @@ def test_price_refresh_outcome_serializes_typed_github_metadata():
         "mode": "bootstrap",
         "completed_at": "2026-06-08T12:00:00",
     }
+
+
+def test_github_only_terminal_completion_does_not_warm_benchmarks():
+    from app.services.price_refresh_activity import PriceRefreshActivityReporter
+    from app.services.price_refresh_live_runner import PriceRefreshRetryScheduler
+    from app.services.price_refresh_planning import (
+        GitHubSeedOutcome,
+        PriceRefreshPlan,
+    )
+    from app.services.price_refresh_workflow import (
+        PriceRefreshMarketGateway,
+        PriceRefreshWorkflow,
+        PriceRefreshWorkflowDependencies,
+    )
+
+    db = MagicMock()
+    price_cache = MagicMock()
+    activity_reporter = MagicMock(spec=PriceRefreshActivityReporter)
+    live_runner = MagicMock()
+    retry_scheduler = MagicMock(spec=PriceRefreshRetryScheduler)
+    warm_benchmarks = MagicMock(return_value={"status": "ok"})
+    github_seed = GitHubSeedOutcome.from_mapping(
+        {
+            "status": "success",
+            "as_of_date": "2026-06-08",
+            "source_revision": "daily_prices_jp:20260608090000",
+        }
+    )
+    build_refresh_plan = MagicMock(
+        return_value=PriceRefreshPlan(
+            symbols=(),
+            jobs=(),
+            all_symbols=("7203.T", "6758.T"),
+            github_seed=github_seed,
+            github_seed_used=True,
+            completion_message="GitHub daily price bundle is current - no live fetch needed",
+        )
+    )
+    gateway = PriceRefreshMarketGateway(
+        normalize_market=lambda market: str(market).upper(),
+        market_tag=lambda market: f"[{market}]",
+        log_extra=lambda market: {"market": market},
+        get_eastern_now=lambda: SimpleNamespace(
+            weekday=lambda: 1,
+            hour=12,
+            date=lambda: date(2026, 6, 9),
+        ),
+        is_trading_day=lambda _day: True,
+        format_market_status=lambda: "open",
+        is_market_enabled_now=lambda _market: True,
+    )
+    workflow = PriceRefreshWorkflow(
+        PriceRefreshWorkflowDependencies(
+            session_factory=lambda: db,
+            price_cache_factory=lambda: price_cache,
+            bulk_fetcher_factory=MagicMock(),
+            warm_benchmarks=warm_benchmarks,
+            build_refresh_plan=build_refresh_plan,
+            last_completed_trading_day=lambda _market: date(2026, 6, 8),
+            activity_reporter=activity_reporter,
+            live_runner=live_runner,
+            retry_scheduler=retry_scheduler,
+            market_gateway=gateway,
+            raise_if_transient_database_error=MagicMock(),
+            safe_rollback=MagicMock(),
+        )
+    )
+    task = SimpleNamespace(
+        name="app.tasks.cache_tasks.smart_refresh_cache",
+        request=SimpleNamespace(id="task-jp"),
+        update_state=MagicMock(),
+    )
+
+    result = workflow.run(task=task, mode="bootstrap", market="JP", activity_lifecycle="bootstrap")
+
+    assert result["status"] == "completed"
+    assert result["source"] == "github"
+    warm_benchmarks.assert_not_called()
+    live_runner.run.assert_not_called()
+    activity_reporter.finalize_success.assert_called_once()
+    db.close.assert_called_once()

--- a/backend/tests/unit/test_price_refresh_workflow.py
+++ b/backend/tests/unit/test_price_refresh_workflow.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def test_price_refresh_outcome_serializes_typed_github_metadata():
+    from app.services.price_refresh_planning import (
+        GitHubSeedOutcome,
+        PriceRefreshMode,
+        PriceRefreshSource,
+    )
+    from app.services.price_refresh_workflow import PriceRefreshOutcome
+
+    outcome = PriceRefreshOutcome(
+        status="completed",
+        mode=PriceRefreshMode.BOOTSTRAP,
+        source=PriceRefreshSource.GITHUB,
+        message="GitHub daily price bundle is current - no live fetch needed",
+        refreshed=0,
+        failed=0,
+        total=0,
+        completed_at=datetime(2026, 6, 8, 12, 0, 0),
+        github_seed=GitHubSeedOutcome.from_mapping(
+            {
+                "status": "success",
+                "as_of_date": "2026-06-08",
+                "source_revision": "daily_prices_jp:20260608120000",
+            }
+        ),
+    )
+
+    assert outcome.to_task_result() == {
+        "status": "completed",
+        "source": "github",
+        "github_sync_status": "success",
+        "source_revision": "daily_prices_jp:20260608120000",
+        "refreshed": 0,
+        "failed": 0,
+        "total": 0,
+        "message": "GitHub daily price bundle is current - no live fetch needed",
+        "mode": "bootstrap",
+        "completed_at": "2026-06-08T12:00:00",
+    }

--- a/backend/tests/unit/test_runtime_activity_reducer.py
+++ b/backend/tests/unit/test_runtime_activity_reducer.py
@@ -26,7 +26,6 @@ def test_reduce_market_activity_operates_on_typed_records():
     transition = reduce_market_activity(
         existing,
         incoming,
-        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
     assert transition.should_persist is False
@@ -42,8 +41,19 @@ def test_reduce_market_activity_accepts_new_cycle_with_typed_records():
     transition = reduce_market_activity(
         existing,
         incoming,
-        preserve_existing_statuses={"running", "completed", "failed"},
     )
 
     assert transition.should_persist is True
     assert transition.record == incoming
+
+
+def test_reduce_market_activity_rejects_ownerless_progress_over_completed_record():
+    from app.services.runtime_activity_reducer import reduce_market_activity
+
+    existing = _record(status="completed", stage_key="prices", task_id="task-old")
+    incoming = _record(status="running", stage_key="prices", task_id=None)
+
+    transition = reduce_market_activity(existing, incoming)
+
+    assert transition.should_persist is False
+    assert transition.record == existing

--- a/backend/tests/unit/test_runtime_activity_reducer.py
+++ b/backend/tests/unit/test_runtime_activity_reducer.py
@@ -89,3 +89,40 @@ def test_reduce_market_activity_inherits_running_context_from_existing_record():
     assert transition.record.task_id == "task-us"
     assert transition.record.message == "Refreshing fundamentals"
     assert transition.record.percent == 25.0
+
+
+def test_runtime_activity_update_is_a_passive_value_object():
+    from app.services.runtime_activity_contract import RuntimeActivityUpdate
+
+    update = RuntimeActivityUpdate(
+        market="US",
+        stage_key="prices",
+        lifecycle=None,
+        status="running",
+        current=3,
+        total=10,
+    )
+
+    assert not hasattr(RuntimeActivityUpdate, "inherit_context")
+    assert update.to_record().task_id is None
+    assert update.to_record().message == "Running price refresh"
+
+
+def test_ownerless_failure_without_active_context_defaults_to_scan_stage():
+    from app.services.runtime_activity_contract import RuntimeActivityUpdate
+    from app.services.runtime_activity_reducer import reduce_market_activity
+
+    transition = reduce_market_activity(
+        None,
+        RuntimeActivityUpdate(
+            market="US",
+            stage_key=None,
+            lifecycle=None,
+            status="failed",
+            message="Task failed",
+        ),
+    )
+
+    assert transition.should_persist is True
+    assert transition.record.stage_key == "scan"
+    assert transition.record.stage_label == "Scan"

--- a/backend/tests/unit/test_runtime_activity_reducer.py
+++ b/backend/tests/unit/test_runtime_activity_reducer.py
@@ -57,3 +57,35 @@ def test_reduce_market_activity_rejects_ownerless_progress_over_completed_record
 
     assert transition.should_persist is False
     assert transition.record == existing
+
+
+def test_reduce_market_activity_inherits_running_context_from_existing_record():
+    from app.services.runtime_activity_contract import RuntimeActivityUpdate
+    from app.services.runtime_activity_reducer import reduce_market_activity
+
+    existing = _record(
+        status="running",
+        stage_key="fundamentals",
+        lifecycle="bootstrap",
+        task_name="refresh_all_fundamentals",
+        task_id="task-us",
+        message="Refreshing fundamentals",
+    )
+    incoming = RuntimeActivityUpdate(
+        market="US",
+        stage_key="fundamentals",
+        lifecycle=None,
+        status="running",
+        current=25,
+        total=100,
+        message=None,
+    )
+
+    transition = reduce_market_activity(existing, incoming)
+
+    assert transition.should_persist is True
+    assert transition.record.lifecycle == "bootstrap"
+    assert transition.record.task_name == "refresh_all_fundamentals"
+    assert transition.record.task_id == "task-us"
+    assert transition.record.message == "Refreshing fundamentals"
+    assert transition.record.percent == 25.0

--- a/backend/tests/unit/test_runtime_activity_reducer.py
+++ b/backend/tests/unit/test_runtime_activity_reducer.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+
+def _record(**overrides):
+    from app.services.runtime_activity_contract import RuntimeActivityRecord
+
+    values = {
+        "market": "US",
+        "lifecycle": "bootstrap",
+        "stage_key": "prices",
+        "status": "running",
+        "task_name": "smart_refresh_cache",
+        "task_id": "task-us",
+        "message": "Refreshing prices",
+    }
+    values.update(overrides)
+    return RuntimeActivityRecord.create(**values)
+
+
+def test_reduce_market_activity_operates_on_typed_records():
+    from app.services.runtime_activity_reducer import reduce_market_activity
+
+    existing = _record(status="completed", percent=100.0)
+    incoming = _record(status="running", task_id="task-us", percent=50.0)
+
+    transition = reduce_market_activity(
+        existing,
+        incoming,
+        preserve_existing_statuses={"running", "completed", "failed"},
+    )
+
+    assert transition.should_persist is False
+    assert transition.record == existing
+
+
+def test_reduce_market_activity_accepts_new_cycle_with_typed_records():
+    from app.services.runtime_activity_reducer import reduce_market_activity
+
+    existing = _record(status="failed", stage_key="prices", task_id="task-old")
+    incoming = _record(status="queued", stage_key="universe", task_id="task-new")
+
+    transition = reduce_market_activity(
+        existing,
+        incoming,
+        preserve_existing_statuses={"running", "completed", "failed"},
+    )
+
+    assert transition.should_persist is True
+    assert transition.record == incoming

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -24,6 +24,9 @@ class _FakeTask:
     def si(self, *args, **kwargs):
         return _FakeSignature(self.task, args=args, kwargs=kwargs)
 
+    def s(self, *args, **kwargs):
+        return _FakeSignature(self.task, args=args, kwargs=kwargs)
+
 
 def test_non_us_bootstrap_uses_market_feature_snapshot(monkeypatch):
     from app.domain.bootstrap.plan import build_bootstrap_plan
@@ -186,7 +189,7 @@ def test_bootstrap_universe_name_uses_uppercase_market_code():
     assert module._bootstrap_universe_name("us") == "market:US"
 
 
-def test_queue_local_runtime_bootstrap_runs_market_chains_in_chord(monkeypatch):
+def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chains(monkeypatch):
     from app.tasks import runtime_bootstrap_tasks as module
 
     class _FakeAsyncResult:
@@ -194,34 +197,49 @@ def test_queue_local_runtime_bootstrap_runs_market_chains_in_chord(monkeypatch):
             self.id = task_id
 
     market_chains = []
-    captured_header = None
-    captured_body = None
+    applied_chains = []
 
     class _FakeChain:
         def __init__(self, *signatures) -> None:
             self.signatures = signatures
             market_chains.append([signature.task for signature in signatures])
 
-    class _FakeGroup:
-        def __init__(self, chains) -> None:
-            self.chains = list(chains)
-
-    class _FakeChord:
-        def __init__(self, header, body) -> None:
-            nonlocal captured_header, captured_body
-            captured_header = header
-            captured_body = body
-
-        def apply_async(self, **_kwargs):
-            return _FakeAsyncResult("secondary-task-123")
+        def apply_async(self, **kwargs):
+            applied_chains.append(
+                {
+                    "tasks": [signature.task for signature in self.signatures],
+                    "errback": kwargs.get("link_error"),
+                }
+            )
+            return _FakeAsyncResult(
+                "primary-task-123" if len(applied_chains) == 1 else f"background-task-{len(applied_chains)}"
+            )
 
     monkeypatch.setattr(
         module,
         "chain",
         lambda *signatures: _FakeChain(*signatures),
     )
-    monkeypatch.setattr(module, "group", lambda chains: _FakeGroup(chains))
-    monkeypatch.setattr(module, "chord", lambda header, body: _FakeChord(header, body))
+    monkeypatch.setattr(
+        module,
+        "complete_local_runtime_bootstrap",
+        _FakeTask("app.tasks.runtime_bootstrap_tasks.complete_local_runtime_bootstrap"),
+    )
+    monkeypatch.setattr(
+        module,
+        "complete_background_market_bootstrap",
+        _FakeTask("app.tasks.runtime_bootstrap_tasks.complete_background_market_bootstrap"),
+    )
+    monkeypatch.setattr(
+        module,
+        "fail_local_runtime_bootstrap",
+        _FakeTask("app.tasks.runtime_bootstrap_tasks.fail_local_runtime_bootstrap"),
+    )
+    monkeypatch.setattr(
+        module,
+        "fail_background_market_bootstrap",
+        _FakeTask("app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap"),
+    )
     monkeypatch.setattr(
         module,
         "_build_market_bootstrap_signatures",
@@ -233,15 +251,21 @@ def test_queue_local_runtime_bootstrap_runs_market_chains_in_chord(monkeypatch):
         enabled_markets=["HK", "US", "TW"],
     )
 
-    assert result == "secondary-task-123"
-    assert market_chains == [["task:US"], ["task:HK"], ["task:TW"]]
-    assert captured_header is not None
-    assert len(captured_header.chains) == 3
-    assert captured_body.task == "app.tasks.runtime_bootstrap_tasks.complete_local_runtime_bootstrap"
-    assert captured_body.kwargs == {
+    assert result == "primary-task-123"
+    assert market_chains == [
+        ["task:US", "app.tasks.runtime_bootstrap_tasks.complete_local_runtime_bootstrap"],
+        ["task:HK", "app.tasks.runtime_bootstrap_tasks.complete_background_market_bootstrap"],
+        ["task:TW", "app.tasks.runtime_bootstrap_tasks.complete_background_market_bootstrap"],
+    ]
+    assert applied_chains[0]["errback"].task == "app.tasks.runtime_bootstrap_tasks.fail_local_runtime_bootstrap"
+    assert applied_chains[0]["errback"].kwargs == {
         "primary_market": "US",
-        "enabled_markets": ["US", "HK", "TW"],
+        "enabled_markets": ["US"],
     }
+    assert [call["errback"].task for call in applied_chains[1:]] == [
+        "app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap",
+        "app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap",
+    ]
 
 
 def test_fail_local_runtime_bootstrap_preserves_active_task_owner(monkeypatch):
@@ -279,7 +303,7 @@ def test_fail_local_runtime_bootstrap_preserves_active_task_owner(monkeypatch):
     ]
 
 
-def test_complete_local_runtime_bootstrap_uses_readiness_service_for_missing_markets(monkeypatch):
+def test_complete_local_runtime_bootstrap_marks_ready_when_only_secondary_markets_are_missing(monkeypatch):
     from app.services.bootstrap_readiness_service import (
         BootstrapReadiness,
         MarketBootstrapReadiness,
@@ -345,11 +369,12 @@ def test_complete_local_runtime_bootstrap_uses_readiness_service_for_missing_mar
     )
 
     assert calls["evaluate"] == (session, ["US", "HK"], "bootstrap-started-at")
-    assert calls["set_bootstrap_state"] == (session, "failed")
+    assert calls["set_bootstrap_state"] == (session, "ready")
     assert result == {
-        "status": "failed",
+        "status": "ready_with_background_failures",
         "primary_market": "US",
         "enabled_markets": ["US", "HK"],
+        "background_failed_markets": ["HK"],
         "reason": "missing published auto scans for: HK",
     }
     assert failed_markets == [
@@ -443,4 +468,72 @@ def test_complete_local_runtime_bootstrap_reports_core_and_scan_readiness_failur
             "task_id": None,
             "message": "Bootstrap scan did not publish",
         },
+    ]
+
+
+def test_complete_background_market_bootstrap_marks_market_failure_without_global_state(monkeypatch):
+    from app.services.bootstrap_readiness_service import (
+        BootstrapReadiness,
+        MarketBootstrapReadiness,
+    )
+    from app.tasks import runtime_bootstrap_tasks as module
+
+    class _FakeSession:
+        def close(self):
+            pass
+
+    class _FakeReadinessService:
+        def evaluate(self, db, *, enabled_markets, bootstrap_started_at=None):
+            calls["evaluate"] = (db, enabled_markets, bootstrap_started_at)
+            return BootstrapReadiness(
+                empty_system=False,
+                market_results={
+                    "HK": MarketBootstrapReadiness(
+                        market="HK",
+                        core_ready=True,
+                        scan_ready=False,
+                    ),
+                },
+            )
+
+    session = _FakeSession()
+    calls = {}
+    failed_markets = []
+
+    monkeypatch.setattr(module, "SessionLocal", lambda: session)
+    monkeypatch.setattr(
+        "app.services.bootstrap_readiness_service.BootstrapReadinessService",
+        _FakeReadinessService,
+    )
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.get_runtime_preferences",
+        lambda _db: type("Prefs", (), {"bootstrap_started_at": "started-at"})(),
+    )
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.set_bootstrap_state",
+        lambda *_args, **_kwargs: pytest.fail("background completion must not mutate global bootstrap state"),
+    )
+    monkeypatch.setattr(
+        module,
+        "mark_market_activity_failed",
+        lambda _db, **kwargs: failed_markets.append(kwargs),
+    )
+
+    result = module.complete_background_market_bootstrap.run(market="HK")
+
+    assert calls["evaluate"] == (session, ["HK"], "started-at")
+    assert result == {
+        "status": "failed",
+        "market": "HK",
+        "reason": "missing published auto scan",
+    }
+    assert failed_markets == [
+        {
+            "market": "HK",
+            "stage_key": "scan",
+            "lifecycle": "bootstrap",
+            "task_name": "runtime_bootstrap",
+            "task_id": None,
+            "message": "Bootstrap scan did not publish",
+        }
     ]

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -338,6 +338,30 @@ def test_queue_local_runtime_bootstrap_records_partial_manifest_when_background_
     ]
 
 
+def test_queue_local_runtime_bootstrap_surfaces_manifest_recording_failure(monkeypatch):
+    from app.tasks import runtime_bootstrap_tasks as module
+
+    class _FakeAsyncResult:
+        def __init__(self, task_id: str) -> None:
+            self.id = task_id
+
+    def _queue(market_plan, **_kwargs):
+        return _FakeAsyncResult(f"task-{market_plan.market.lower()}")
+
+    monkeypatch.setattr(module, "_queue_market_bootstrap_workflow", _queue)
+    monkeypatch.setattr(
+        module,
+        "record_runtime_bootstrap_run",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("manifest write failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="manifest write failed"):
+        module.queue_local_runtime_bootstrap(
+            primary_market="US",
+            enabled_markets=["US", "HK"],
+        )
+
+
 def test_apply_bootstrap_workflow_does_not_retry_without_errback_on_type_error():
     from app.tasks import runtime_bootstrap_tasks as module
 

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -494,6 +494,13 @@ def test_queue_local_runtime_bootstrap_records_partial_manifest_when_background_
             "market_task_ids": {"US": "primary-task-123"},
             "queue_state": "partial",
         },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK"),
+            "primary_task_id": "primary-task-123",
+            "market_task_ids": {"US": "primary-task-123"},
+            "queue_state": "dispatch_failed",
+        },
     ]
 
 

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -198,6 +198,7 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
 
     market_chains = []
     applied_chains = []
+    recorded_runs = []
 
     class _FakeChain:
         def __init__(self, *signatures) -> None:
@@ -245,6 +246,18 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
         "_build_market_bootstrap_signatures",
         lambda market_plan: [_FakeSignature(f"task:{market_plan.market}")],
     )
+    monkeypatch.setattr(
+        module,
+        "record_runtime_bootstrap_run",
+        lambda *, primary_market, enabled_markets, primary_task_id, market_task_ids: recorded_runs.append(
+            {
+                "primary_market": primary_market,
+                "enabled_markets": tuple(enabled_markets),
+                "primary_task_id": primary_task_id,
+                "market_task_ids": dict(market_task_ids),
+            }
+        ),
+    )
 
     result = module.queue_local_runtime_bootstrap(
         primary_market="US",
@@ -264,6 +277,64 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
     assert [call["errback"].task for call in applied_chains[1:]] == [
         "app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap",
         "app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap",
+    ]
+    assert recorded_runs == [
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK", "TW"),
+            "primary_task_id": "primary-task-123",
+            "market_task_ids": {
+                "US": "primary-task-123",
+                "HK": "background-task-2",
+                "TW": "background-task-3",
+            },
+        }
+    ]
+
+
+def test_queue_local_runtime_bootstrap_records_partial_manifest_when_background_queue_fails(
+    monkeypatch,
+):
+    from app.tasks import runtime_bootstrap_tasks as module
+
+    class _FakeAsyncResult:
+        def __init__(self, task_id: str) -> None:
+            self.id = task_id
+
+    recorded_runs = []
+
+    def _queue(market_plan, **_kwargs):
+        if market_plan.market == "US":
+            return _FakeAsyncResult("primary-task-123")
+        raise RuntimeError(f"queue failed for {market_plan.market}")
+
+    monkeypatch.setattr(module, "_queue_market_bootstrap_workflow", _queue)
+    monkeypatch.setattr(
+        module,
+        "record_runtime_bootstrap_run",
+        lambda *, primary_market, enabled_markets, primary_task_id, market_task_ids: recorded_runs.append(
+            {
+                "primary_market": primary_market,
+                "enabled_markets": tuple(enabled_markets),
+                "primary_task_id": primary_task_id,
+                "market_task_ids": dict(market_task_ids),
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="queue failed for HK"):
+        module.queue_local_runtime_bootstrap(
+            primary_market="US",
+            enabled_markets=["US", "HK"],
+        )
+
+    assert recorded_runs == [
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK"),
+            "primary_task_id": "primary-task-123",
+            "market_task_ids": {"US": "primary-task-123"},
+        }
     ]
 
 

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -309,6 +309,36 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
             "primary_task_id": "primary-task-123",
             "market_task_ids": {
                 "US": "primary-task-123",
+            },
+            "queue_state": "partial",
+        },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK", "TW"),
+            "primary_task_id": "primary-task-123",
+            "market_task_ids": {
+                "US": "primary-task-123",
+                "HK": "background-task-2",
+            },
+            "queue_state": "partial",
+        },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK", "TW"),
+            "primary_task_id": "primary-task-123",
+            "market_task_ids": {
+                "US": "primary-task-123",
+                "HK": "background-task-2",
+                "TW": "background-task-3",
+            },
+            "queue_state": "partial",
+        },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK", "TW"),
+            "primary_task_id": "primary-task-123",
+            "market_task_ids": {
+                "US": "primary-task-123",
                 "HK": "background-task-2",
                 "TW": "background-task-3",
             },
@@ -392,6 +422,20 @@ def test_queue_local_runtime_bootstrap_logs_late_manifest_update_failure(monkeyp
             "primary_market": "US",
             "enabled_markets": ("US", "HK"),
             "primary_task_id": "task-us",
+            "market_task_ids": {"US": "task-us"},
+            "queue_state": "partial",
+        },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK"),
+            "primary_task_id": "task-us",
+            "market_task_ids": {"US": "task-us", "HK": "task-hk"},
+            "queue_state": "partial",
+        },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK"),
+            "primary_task_id": "task-us",
             "market_task_ids": {"US": "task-us", "HK": "task-hk"},
             "queue_state": "queued",
         }
@@ -449,7 +493,7 @@ def test_queue_local_runtime_bootstrap_records_partial_manifest_when_background_
             "primary_task_id": "primary-task-123",
             "market_task_ids": {"US": "primary-task-123"},
             "queue_state": "partial",
-        }
+        },
     ]
 
 

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -199,6 +199,7 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
     market_chains = []
     applied_chains = []
     recorded_runs = []
+    events = []
 
     class _FakeChain:
         def __init__(self, *signatures) -> None:
@@ -206,6 +207,7 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
             market_chains.append([signature.task for signature in signatures])
 
         def apply_async(self, **kwargs):
+            events.append(("apply", self.signatures[0].task))
             applied_chains.append(
                 {
                     "tasks": [signature.task for signature in self.signatures],
@@ -249,13 +251,17 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
     monkeypatch.setattr(
         module,
         "record_runtime_bootstrap_run",
-        lambda *, primary_market, enabled_markets, primary_task_id, market_task_ids: recorded_runs.append(
-            {
-                "primary_market": primary_market,
-                "enabled_markets": tuple(enabled_markets),
-                "primary_task_id": primary_task_id,
-                "market_task_ids": dict(market_task_ids),
-            }
+        lambda *, primary_market, enabled_markets, primary_task_id, market_task_ids, queue_state: (
+            events.append(("record", queue_state, primary_task_id, dict(market_task_ids))),
+            recorded_runs.append(
+                {
+                    "primary_market": primary_market,
+                    "enabled_markets": tuple(enabled_markets),
+                    "primary_task_id": primary_task_id,
+                    "market_task_ids": dict(market_task_ids),
+                    "queue_state": queue_state,
+                }
+            ),
         ),
     )
 
@@ -265,6 +271,17 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
     )
 
     assert result == "primary-task-123"
+    assert events[0] == ("record", "queueing", None, {})
+    assert events[-1] == (
+        "record",
+        "queued",
+        "primary-task-123",
+        {
+            "US": "primary-task-123",
+            "HK": "background-task-2",
+            "TW": "background-task-3",
+        },
+    )
     assert market_chains == [
         ["task:US", "app.tasks.runtime_bootstrap_tasks.complete_local_runtime_bootstrap"],
         ["task:HK", "app.tasks.runtime_bootstrap_tasks.complete_background_market_bootstrap"],
@@ -282,12 +299,101 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
         {
             "primary_market": "US",
             "enabled_markets": ("US", "HK", "TW"),
+            "primary_task_id": None,
+            "market_task_ids": {},
+            "queue_state": "queueing",
+        },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK", "TW"),
             "primary_task_id": "primary-task-123",
             "market_task_ids": {
                 "US": "primary-task-123",
                 "HK": "background-task-2",
                 "TW": "background-task-3",
             },
+            "queue_state": "queued",
+        },
+    ]
+
+
+def test_queue_local_runtime_bootstrap_does_not_dispatch_when_initial_manifest_fails(monkeypatch):
+    from app.tasks import runtime_bootstrap_tasks as module
+
+    applied = []
+
+    class _FakeAsyncResult:
+        def __init__(self, task_id: str) -> None:
+            self.id = task_id
+
+    def _queue(market_plan, **_kwargs):
+        applied.append(market_plan.market)
+        return _FakeAsyncResult(f"task-{market_plan.market.lower()}")
+
+    monkeypatch.setattr(module, "_queue_market_bootstrap_workflow", _queue)
+    monkeypatch.setattr(
+        module,
+        "record_runtime_bootstrap_run",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("manifest write failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="manifest write failed"):
+        module.queue_local_runtime_bootstrap(
+            primary_market="US",
+            enabled_markets=["US", "HK"],
+        )
+
+    assert applied == []
+
+
+def test_queue_local_runtime_bootstrap_logs_late_manifest_update_failure(monkeypatch):
+    from app.tasks import runtime_bootstrap_tasks as module
+
+    class _FakeAsyncResult:
+        def __init__(self, task_id: str) -> None:
+            self.id = task_id
+
+    recorded_runs = []
+
+    def _queue(market_plan, **_kwargs):
+        return _FakeAsyncResult(f"task-{market_plan.market.lower()}")
+
+    def _record(*, primary_market, enabled_markets, primary_task_id, market_task_ids, queue_state):
+        recorded_runs.append(
+            {
+                "primary_market": primary_market,
+                "enabled_markets": tuple(enabled_markets),
+                "primary_task_id": primary_task_id,
+                "market_task_ids": dict(market_task_ids),
+                "queue_state": queue_state,
+            }
+        )
+        if queue_state == "queued":
+            raise RuntimeError("late manifest write failed")
+
+    monkeypatch.setattr(module, "_queue_market_bootstrap_workflow", _queue)
+    monkeypatch.setattr(module, "record_runtime_bootstrap_run", _record)
+
+    result = module.queue_local_runtime_bootstrap(
+        primary_market="US",
+        enabled_markets=["US", "HK"],
+    )
+
+    assert result == "task-us"
+    assert recorded_runs == [
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK"),
+            "primary_task_id": None,
+            "market_task_ids": {},
+            "queue_state": "queueing",
+        },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK"),
+            "primary_task_id": "task-us",
+            "market_task_ids": {"US": "task-us", "HK": "task-hk"},
+            "queue_state": "queued",
         }
     ]
 
@@ -312,12 +418,13 @@ def test_queue_local_runtime_bootstrap_records_partial_manifest_when_background_
     monkeypatch.setattr(
         module,
         "record_runtime_bootstrap_run",
-        lambda *, primary_market, enabled_markets, primary_task_id, market_task_ids: recorded_runs.append(
+        lambda *, primary_market, enabled_markets, primary_task_id, market_task_ids, queue_state: recorded_runs.append(
             {
                 "primary_market": primary_market,
                 "enabled_markets": tuple(enabled_markets),
                 "primary_task_id": primary_task_id,
                 "market_task_ids": dict(market_task_ids),
+                "queue_state": queue_state,
             }
         ),
     )
@@ -332,8 +439,16 @@ def test_queue_local_runtime_bootstrap_records_partial_manifest_when_background_
         {
             "primary_market": "US",
             "enabled_markets": ("US", "HK"),
+            "primary_task_id": None,
+            "market_task_ids": {},
+            "queue_state": "queueing",
+        },
+        {
+            "primary_market": "US",
+            "enabled_markets": ("US", "HK"),
             "primary_task_id": "primary-task-123",
             "market_task_ids": {"US": "primary-task-123"},
+            "queue_state": "partial",
         }
     ]
 

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -452,6 +452,69 @@ def test_complete_local_runtime_bootstrap_reports_primary_readiness_failure(monk
     ]
 
 
+def test_complete_local_runtime_bootstrap_uses_requested_market_readiness(monkeypatch):
+    from app.services.bootstrap_readiness_service import (
+        BootstrapReadiness,
+        MarketBootstrapReadiness,
+    )
+    from app.tasks import runtime_bootstrap_tasks as module
+
+    class _FakeSession:
+        def close(self):
+            pass
+
+    class _FakeReadinessService:
+        def evaluate(self, db, *, enabled_markets, bootstrap_started_at=None):
+            calls["evaluate"] = (db, enabled_markets, bootstrap_started_at)
+            return BootstrapReadiness(
+                empty_system=False,
+                market_results={
+                    "HK": MarketBootstrapReadiness(
+                        market="HK",
+                        core_ready=False,
+                        scan_ready=False,
+                    ),
+                    "US": MarketBootstrapReadiness(
+                        market="US",
+                        core_ready=True,
+                        scan_ready=True,
+                    ),
+                },
+            )
+
+    calls = {}
+
+    monkeypatch.setattr(module, "SessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(
+        "app.services.bootstrap_readiness_service.BootstrapReadinessService",
+        _FakeReadinessService,
+    )
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.get_runtime_preferences",
+        lambda _db: type("Prefs", (), {"bootstrap_started_at": "started-at"})(),
+    )
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.set_bootstrap_state",
+        lambda db, state: calls.setdefault("set_bootstrap_state", (db, state)),
+    )
+    monkeypatch.setattr(
+        module,
+        "mark_market_activity_failed",
+        lambda _db, **kwargs: calls.setdefault("mark_failed", kwargs),
+    )
+
+    result = module.complete_local_runtime_bootstrap.run(primary_market="us")
+
+    assert calls["evaluate"][1] == ["US"]
+    assert calls["set_bootstrap_state"][1] == "ready"
+    assert "mark_failed" not in calls
+    assert result == {
+        "status": "ready",
+        "primary_market": "US",
+        "market": "US",
+    }
+
+
 def test_complete_background_market_bootstrap_marks_market_failure_without_global_state(monkeypatch):
     from app.services.bootstrap_readiness_service import (
         BootstrapReadiness,

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -260,12 +260,29 @@ def test_queue_local_runtime_bootstrap_splits_primary_and_background_market_chai
     assert applied_chains[0]["errback"].task == "app.tasks.runtime_bootstrap_tasks.fail_local_runtime_bootstrap"
     assert applied_chains[0]["errback"].kwargs == {
         "primary_market": "US",
-        "enabled_markets": ["US"],
     }
     assert [call["errback"].task for call in applied_chains[1:]] == [
         "app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap",
         "app.tasks.runtime_bootstrap_tasks.fail_background_market_bootstrap",
     ]
+
+
+def test_apply_bootstrap_workflow_does_not_retry_without_errback_on_type_error():
+    from app.tasks import runtime_bootstrap_tasks as module
+
+    calls = []
+
+    class _BrokenWorkflow:
+        def apply_async(self, **kwargs):
+            calls.append(kwargs)
+            raise TypeError("bad celery signature")
+
+    errback = object()
+
+    with pytest.raises(TypeError, match="bad celery signature"):
+        module._apply_bootstrap_workflow(_BrokenWorkflow(), errback)
+
+    assert calls == [{"link_error": errback}]
 
 
 def test_fail_local_runtime_bootstrap_preserves_active_task_owner(monkeypatch):
@@ -290,20 +307,19 @@ def test_fail_local_runtime_bootstrap_preserves_active_task_owner(monkeypatch):
 
     result = module.fail_local_runtime_bootstrap.run(
         primary_market="US",
-        enabled_markets=["HK"],
     )
 
     assert result["status"] == "failed"
     assert calls == [
         {
-            "market": "HK",
+            "market": "US",
             "lifecycle": "bootstrap",
             "message": "Bootstrap failed",
         }
     ]
 
 
-def test_complete_local_runtime_bootstrap_marks_ready_when_only_secondary_markets_are_missing(monkeypatch):
+def test_complete_local_runtime_bootstrap_evaluates_only_primary_market(monkeypatch):
     from app.services.bootstrap_readiness_service import (
         BootstrapReadiness,
         MarketBootstrapReadiness,
@@ -327,11 +343,6 @@ def test_complete_local_runtime_bootstrap_marks_ready_when_only_secondary_market
                         market="US",
                         core_ready=True,
                         scan_ready=True,
-                    ),
-                    "HK": MarketBootstrapReadiness(
-                        market="HK",
-                        core_ready=True,
-                        scan_ready=False,
                     ),
                 },
             )
@@ -363,34 +374,20 @@ def test_complete_local_runtime_bootstrap_marks_ready_when_only_secondary_market
         lambda _db, **kwargs: failed_markets.append(kwargs),
     )
 
-    result = module.complete_local_runtime_bootstrap.run(
-        primary_market="US",
-        enabled_markets=["US", "HK"],
-    )
+    result = module.complete_local_runtime_bootstrap.run(primary_market="US")
 
-    assert calls["evaluate"] == (session, ["US", "HK"], "bootstrap-started-at")
+    assert calls["evaluate"] == (session, ["US"], "bootstrap-started-at")
     assert calls["set_bootstrap_state"] == (session, "ready")
     assert result == {
-        "status": "ready_with_background_failures",
+        "status": "ready",
         "primary_market": "US",
-        "enabled_markets": ["US", "HK"],
-        "background_failed_markets": ["HK"],
-        "reason": "missing published auto scans for: HK",
+        "market": "US",
     }
-    assert failed_markets == [
-        {
-            "market": "HK",
-            "stage_key": "scan",
-            "lifecycle": "bootstrap",
-            "task_name": "runtime_bootstrap",
-            "task_id": None,
-            "message": "Bootstrap scan did not publish",
-        }
-    ]
+    assert failed_markets == []
     assert session.closed is True
 
 
-def test_complete_local_runtime_bootstrap_reports_core_and_scan_readiness_failures(monkeypatch):
+def test_complete_local_runtime_bootstrap_reports_primary_readiness_failure(monkeypatch):
     from app.services.bootstrap_readiness_service import (
         BootstrapReadiness,
         MarketBootstrapReadiness,
@@ -409,11 +406,6 @@ def test_complete_local_runtime_bootstrap_reports_core_and_scan_readiness_failur
                     "HK": MarketBootstrapReadiness(
                         market="HK",
                         core_ready=False,
-                        scan_ready=False,
-                    ),
-                    "TW": MarketBootstrapReadiness(
-                        market="TW",
-                        core_ready=True,
                         scan_ready=False,
                     ),
                 },
@@ -440,16 +432,13 @@ def test_complete_local_runtime_bootstrap_reports_core_and_scan_readiness_failur
         lambda _db, **kwargs: failed_markets.append(kwargs),
     )
 
-    result = module.complete_local_runtime_bootstrap.run(
-        primary_market="HK",
-        enabled_markets=["HK", "TW"],
-    )
+    result = module.complete_local_runtime_bootstrap.run(primary_market="HK")
 
     assert result == {
         "status": "failed",
         "primary_market": "HK",
-        "enabled_markets": ["HK", "TW"],
-        "reason": "missing core market data for: HK; missing published auto scans for: TW",
+        "market": "HK",
+        "reason": "missing core market data",
     }
     assert failed_markets == [
         {
@@ -459,14 +448,6 @@ def test_complete_local_runtime_bootstrap_reports_core_and_scan_readiness_failur
             "task_name": "runtime_bootstrap",
             "task_id": None,
             "message": "Bootstrap core data incomplete",
-        },
-        {
-            "market": "TW",
-            "stage_key": "scan",
-            "lifecycle": "bootstrap",
-            "task_name": "runtime_bootstrap",
-            "task_id": None,
-            "message": "Bootstrap scan did not publish",
         },
     ]
 

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -28,6 +28,23 @@ class _FakeTask:
         return _FakeSignature(self.task, args=args, kwargs=kwargs)
 
 
+def test_bootstrap_plan_uses_semantic_operations_instead_of_task_name_strings():
+    from app.domain.bootstrap.plan import BootstrapOperation, build_bootstrap_plan
+
+    market_plan = build_bootstrap_plan(primary_market="US", enabled_markets=["US"]).market_plans[0]
+
+    assert [stage.operation for stage in market_plan.stages] == [
+        BootstrapOperation.REFRESH_STOCK_UNIVERSE,
+        BootstrapOperation.LOAD_TRACKED_IBD_INDUSTRY_GROUPS,
+        BootstrapOperation.SMART_REFRESH_CACHE,
+        BootstrapOperation.REFRESH_ALL_FUNDAMENTALS,
+        BootstrapOperation.CALCULATE_DAILY_BREADTH_WITH_GAPFILL,
+        BootstrapOperation.CALCULATE_DAILY_GROUP_RANKINGS_WITH_GAPFILL,
+        BootstrapOperation.BUILD_DAILY_SNAPSHOT,
+    ]
+    assert all(not hasattr(stage, "task_name") for stage in market_plan.stages)
+
+
 def test_non_us_bootstrap_uses_market_feature_snapshot(monkeypatch):
     from app.domain.bootstrap.plan import build_bootstrap_plan
     from app.tasks import runtime_bootstrap_tasks as module

--- a/backend/tests/unit/test_runtime_preferences_service.py
+++ b/backend/tests/unit/test_runtime_preferences_service.py
@@ -52,7 +52,7 @@ def test_non_empty_resume_state_does_not_require_bootstrap(monkeypatch):
     assert status.bootstrap_state == "not_started"
 
 
-def test_running_bootstrap_stays_required_until_all_enabled_markets_have_scans(monkeypatch):
+def test_running_bootstrap_becomes_ready_when_primary_market_has_scan(monkeypatch):
     from app.services import runtime_preferences_service as module
 
     prefs = module.RuntimePreferences(
@@ -78,11 +78,11 @@ def test_running_bootstrap_stays_required_until_all_enabled_markets_have_scans(m
     status = module.get_runtime_bootstrap_status(object())
 
     assert status.empty_system is False
-    assert status.bootstrap_required is True
-    assert status.bootstrap_state == "running"
+    assert status.bootstrap_required is False
+    assert status.bootstrap_state == "ready"
 
 
-def test_failed_bootstrap_stays_required_until_all_enabled_markets_have_scans(monkeypatch):
+def test_failed_bootstrap_stays_required_until_primary_market_has_scan(monkeypatch):
     from app.services import runtime_preferences_service as module
 
     prefs = module.RuntimePreferences(
@@ -99,7 +99,7 @@ def test_failed_bootstrap_stays_required_until_all_enabled_markets_have_scans(mo
             module,
             empty_system=False,
             market_results=[
-                ("US", True, True),
+                ("US", True, False),
                 ("HK", True, False),
             ],
         ),
@@ -112,7 +112,7 @@ def test_failed_bootstrap_stays_required_until_all_enabled_markets_have_scans(mo
     assert status.bootstrap_state == "failed"
 
 
-def test_bootstrap_ready_requires_completed_auto_scans_for_every_enabled_market(monkeypatch):
+def test_bootstrap_ready_does_not_wait_for_secondary_market_scans(monkeypatch):
     from app.services import runtime_preferences_service as module
 
     prefs = module.RuntimePreferences(
@@ -130,7 +130,7 @@ def test_bootstrap_ready_requires_completed_auto_scans_for_every_enabled_market(
             empty_system=False,
             market_results=[
                 ("US", True, True),
-                ("HK", True, True),
+                ("HK", True, False),
             ],
         ),
     )
@@ -170,8 +170,8 @@ def test_bootstrap_status_uses_readiness_service(monkeypatch):
     status = module.get_runtime_bootstrap_status(db)
 
     assert calls == [(db, ["US", "HK"], None)]
-    assert status.bootstrap_required is True
-    assert status.bootstrap_state == "running"
+    assert status.bootstrap_required is False
+    assert status.bootstrap_state == "ready"
 
 
 def test_bootstrap_status_passes_bootstrap_start_boundary_to_readiness(monkeypatch):

--- a/backend/tests/unit/test_yahoo_batch_ingestion.py
+++ b/backend/tests/unit/test_yahoo_batch_ingestion.py
@@ -197,6 +197,66 @@ def test_fetch_price_batch_with_retries_uses_in_market_backoff(monkeypatch):
     assert sleeps == [60, 120, 240]
 
 
+def test_fetch_price_batch_with_retries_does_not_retry_permanent_no_data(monkeypatch):
+    fetcher = BulkDataFetcher()
+    calls: list[list[str]] = []
+    sleeps: list[float] = []
+    symbols = ["0143.T", "0194.T", "0190.T"]
+
+    def fake_fetch_batch_prices(batch_symbols, period="2y"):
+        calls.append(list(batch_symbols))
+        return {
+            symbol: {
+                "symbol": symbol,
+                "price_data": None,
+                "info": None,
+                "fundamentals": None,
+                "has_error": True,
+                "error": "YFPricesMissingError('possibly delisted; no price data found')",
+            }
+            for symbol in batch_symbols
+        }
+
+    monkeypatch.setattr(fetcher, "fetch_batch_prices", fake_fetch_batch_prices)
+    monkeypatch.setattr("app.services.bulk_data_fetcher.time.sleep", lambda seconds: sleeps.append(seconds))
+
+    results = fetcher._fetch_price_batch_with_retries(
+        symbols,
+        period="2y",
+        initial_batch_size=50,
+        market="JP",
+    )
+
+    assert calls == [symbols]
+    assert sleeps == []
+    assert set(results) == set(symbols)
+
+
+def test_fetch_batch_prices_tags_yfinance_missing_price_errors(monkeypatch):
+    import app.services.bulk_data_fetcher as module
+
+    symbols = ["0143.T", "0194.T"]
+    monkeypatch.setattr(module.yf.shared, "_ERRORS", {}, raising=False)
+
+    def fake_download(**kwargs):
+        assert kwargs["tickers"] == symbols
+        module.yf.shared._ERRORS.update(
+            {
+                "0143.T": "YFPricesMissingError('possibly delisted; no price data found')",
+                "0194.T": 'No data found, symbol may be delisted',
+            }
+        )
+        return pd.DataFrame()
+
+    monkeypatch.setattr(module.yf, "download", fake_download)
+
+    results = BulkDataFetcher().fetch_batch_prices(symbols, period="2y")
+
+    assert results["0143.T"]["error_kind"] == "no_price_data"
+    assert "possibly delisted" in results["0143.T"]["error"]
+    assert results["0194.T"]["error_kind"] == "no_price_data"
+
+
 def test_fetch_price_batch_with_retries_keeps_legacy_schedule_without_market():
     """When no market is supplied (legacy shared callers), the retry schedule
     stays at the original 30/60/120s so we don't slow down code paths that

--- a/frontend/src/components/App/BootstrapSetupScreen.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.jsx
@@ -27,7 +27,6 @@ const STATUS_COLOR = {
   failed: 'error',
   idle: 'default',
 };
-const ACTIVE_MARKET_STATUSES = new Set(['running', 'queued']);
 
 function formatCount(value) {
   return new Intl.NumberFormat('en-US').format(value);
@@ -93,30 +92,9 @@ export default function BootstrapSetupScreen({
   const running = bootstrapState === 'running';
   const activityQuery = useRuntimeActivity({ enabled: running || isStartingBootstrap });
   const bootstrap = activityQuery.data?.bootstrap ?? null;
-  const marketActivity = useMemo(() => {
-    const markets = activityQuery.data?.markets ?? [];
-    const byMarket = new Map(markets.map((item) => [item.market, item]));
-    return normalizedSelection.map((market) => (
-      byMarket.get(market) ?? {
-        market,
-        lifecycle: running ? 'bootstrap' : 'idle',
-        stage_label: running ? 'Queued' : 'Idle',
-        status: running && market === (bootstrap?.primary_market || primaryMarket) ? 'running' : 'queued',
-        message: running ? 'Waiting for bootstrap task' : 'Idle',
-      }
-    ));
-  }, [activityQuery.data?.markets, bootstrap?.primary_market, normalizedSelection, primaryMarket, running]);
-  const primaryActivity = useMemo(
-    () => marketActivity.find((market) => market.market === (primaryMarket || selectedPrimary)) ?? marketActivity[0],
-    [marketActivity, primaryMarket, selectedPrimary]
-  );
-  const focusedActivity = useMemo(
-    () => (
-      marketActivity.find((market) => market.status === 'running')
-      ?? marketActivity.find((market) => ACTIVE_MARKET_STATUSES.has(market.status))
-      ?? primaryActivity
-    ),
-    [marketActivity, primaryActivity]
+  const marketActivity = useMemo(
+    () => activityQuery.data?.markets ?? [],
+    [activityQuery.data?.markets]
   );
   const bootstrapResolvedPercent = resolveDeterminatePercent(
     bootstrap?.percent,
@@ -125,7 +103,6 @@ export default function BootstrapSetupScreen({
   );
   const requestedBootstrapProgressMode = (
     bootstrap?.progress_mode
-    || focusedActivity?.progress_mode
     || 'indeterminate'
   );
   const bootstrapProgressMode = (
@@ -146,7 +123,7 @@ export default function BootstrapSetupScreen({
   )
     ? `${formatCount(bootstrap.current)} / ${formatCount(bootstrap.total)} stocks`
     : null;
-  const bootstrapMessage = bootstrap?.message || focusedActivity?.message || 'Preparing market data.';
+  const bootstrapMessage = bootstrap?.message || 'Preparing market data.';
 
   const toggleMarket = (market) => {
     if (market === selectedPrimary) {
@@ -225,7 +202,7 @@ export default function BootstrapSetupScreen({
                   <Stack spacing={1.5}>
                     <Stack direction="row" justifyContent="space-between" alignItems="center">
                       <Typography variant="subtitle2">
-                        {bootstrap?.current_stage || focusedActivity?.stage_label || 'Preparing bootstrap'}
+                        {bootstrap?.current_stage || 'Preparing bootstrap'}
                       </Typography>
                       {bootstrapProgressMode === 'determinate' && bootstrapPercent !== null && (
                         <Typography variant="body2" color="text.secondary">
@@ -253,44 +230,46 @@ export default function BootstrapSetupScreen({
                     {bootstrap.background_warning}
                   </Alert>
                 )}
-                <Box>
-                  <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                    Enabled market queue
-                  </Typography>
-                  <Stack spacing={1}>
-                    {marketActivity.map((market) => (
-                      <Box
-                        key={market.market}
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'space-between',
-                          gap: 2,
-                          px: 1.5,
-                          py: 1,
-                          borderRadius: 1.5,
-                          border: 1,
-                          borderColor: 'divider',
-                        }}
-                      >
-                        <Box>
-                          <Typography variant="body2" sx={{ fontWeight: 700 }}>
-                            {market.market}
-                            {market.market === (bootstrap?.primary_market || primaryMarket) ? ' (primary)' : ''}
-                          </Typography>
-                          <Typography variant="caption" color="text.secondary">
-                            {market.stage_label || 'Queued'}{market.message ? ` · ${market.message}` : ''}
-                          </Typography>
+                {marketActivity.length > 0 && (
+                  <Box>
+                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                      Enabled market queue
+                    </Typography>
+                    <Stack spacing={1}>
+                      {marketActivity.map((market) => (
+                        <Box
+                          key={market.market}
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            gap: 2,
+                            px: 1.5,
+                            py: 1,
+                            borderRadius: 1.5,
+                            border: 1,
+                            borderColor: 'divider',
+                          }}
+                        >
+                          <Box>
+                            <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                              {market.market}
+                              {market.market === (bootstrap?.primary_market || primaryMarket) ? ' (primary)' : ''}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary">
+                              {market.stage_label || 'Queued'}{market.message ? ` · ${market.message}` : ''}
+                            </Typography>
+                          </Box>
+                          <Chip
+                            size="small"
+                            color={STATUS_COLOR[market.status] || 'default'}
+                            label={market.status || 'idle'}
+                          />
                         </Box>
-                        <Chip
-                          size="small"
-                          color={STATUS_COLOR[market.status] || 'default'}
-                          label={market.status || 'idle'}
-                        />
-                      </Box>
-                    ))}
-                  </Stack>
-                </Box>
+                      ))}
+                    </Stack>
+                  </Box>
+                )}
               </Stack>
             )}
 

--- a/frontend/src/components/App/BootstrapSetupScreen.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.jsx
@@ -28,7 +28,6 @@ const STATUS_COLOR = {
   idle: 'default',
 };
 const ACTIVE_MARKET_STATUSES = new Set(['running', 'queued']);
-const STAGE_LOCAL_PROGRESS_KEYS = new Set(['prices', 'fundamentals', 'scan']);
 
 function formatCount(value) {
   return new Intl.NumberFormat('en-US').format(value);
@@ -42,31 +41,6 @@ function resolveDeterminatePercent(percent, current, total) {
     return Math.max(0, Math.min(100, (Number(current) / Number(total)) * 100));
   }
   return null;
-}
-
-function resolveStageLocalProgress(activity) {
-  if (!activity) {
-    return null;
-  }
-  const stageKey = activity.stage_key || '';
-  if (!STAGE_LOCAL_PROGRESS_KEYS.has(stageKey)) {
-    return null;
-  }
-  const percent = resolveDeterminatePercent(activity.percent, activity.current, activity.total);
-  if (percent === null) {
-    return null;
-  }
-  return {
-    percent,
-    detail: (
-      activity.current !== null
-      && activity.current !== undefined
-      && activity.total !== null
-      && activity.total !== undefined
-    )
-      ? `${formatCount(activity.current)} / ${formatCount(activity.total)} stocks`
-      : null,
-  };
 }
 
 function normalizeEnabled(primaryMarket, enabledMarkets) {
@@ -144,35 +118,35 @@ export default function BootstrapSetupScreen({
     ),
     [marketActivity, primaryActivity]
   );
-  const stageLocalProgress = resolveStageLocalProgress(focusedActivity);
-  const bootstrapProgressMode = (
-    stageLocalProgress ? 'determinate' : (
-      bootstrap?.progress_mode
-      || focusedActivity?.progress_mode
-      || 'indeterminate'
-    )
-  );
   const bootstrapResolvedPercent = resolveDeterminatePercent(
     bootstrap?.percent,
     bootstrap?.current,
     bootstrap?.total,
   );
-  const focusedActivityResolvedPercent = resolveDeterminatePercent(
-    focusedActivity?.percent,
-    focusedActivity?.current,
-    focusedActivity?.total,
+  const requestedBootstrapProgressMode = (
+    bootstrap?.progress_mode
+    || focusedActivity?.progress_mode
+    || 'indeterminate'
+  );
+  const bootstrapProgressMode = (
+    requestedBootstrapProgressMode === 'determinate' && bootstrapResolvedPercent === null
+      ? 'indeterminate'
+      : requestedBootstrapProgressMode
   );
   const bootstrapPercent = (
     bootstrapProgressMode === 'determinate'
-      ? (stageLocalProgress?.percent
-        ?? focusedActivityResolvedPercent
-        ?? bootstrapResolvedPercent
-        ?? 0)
+      ? bootstrapResolvedPercent
       : null
   );
-  const bootstrapMessage = stageLocalProgress
-    ? (focusedActivity?.message || bootstrap?.message || 'Preparing market data.')
-    : (bootstrap?.message || focusedActivity?.message || 'Preparing market data.');
+  const bootstrapProgressDetail = (
+    bootstrap?.current !== null
+    && bootstrap?.current !== undefined
+    && bootstrap?.total !== null
+    && bootstrap?.total !== undefined
+  )
+    ? `${formatCount(bootstrap.current)} / ${formatCount(bootstrap.total)} stocks`
+    : null;
+  const bootstrapMessage = bootstrap?.message || focusedActivity?.message || 'Preparing market data.';
 
   const toggleMarket = (market) => {
     if (market === selectedPrimary) {
@@ -264,9 +238,9 @@ export default function BootstrapSetupScreen({
                       value={bootstrapProgressMode === 'determinate' ? bootstrapPercent : undefined}
                       aria-label="Bootstrap progress"
                     />
-                    {stageLocalProgress?.detail && (
+                    {bootstrapProgressDetail && (
                       <Typography variant="caption" color="text.secondary">
-                        {stageLocalProgress.detail}
+                        {bootstrapProgressDetail}
                       </Typography>
                     )}
                     <Typography variant="body2" color="text.secondary">

--- a/frontend/src/components/App/BootstrapSetupScreen.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.jsx
@@ -274,10 +274,11 @@ export default function BootstrapSetupScreen({
                     </Typography>
                   </Stack>
                 </Box>
-                <Alert severity="warning">
-                  {bootstrap?.background_warning
-                    || 'Additional enabled markets may continue loading after the workspace opens.'}
-                </Alert>
+                {bootstrap?.background_warning && (
+                  <Alert severity="warning">
+                    {bootstrap.background_warning}
+                  </Alert>
+                )}
                 <Box>
                   <Typography variant="subtitle2" sx={{ mb: 1 }}>
                     Enabled market queue

--- a/frontend/src/components/App/BootstrapSetupScreen.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.jsx
@@ -32,14 +32,15 @@ function formatCount(value) {
   return new Intl.NumberFormat('en-US').format(value);
 }
 
-function resolveDeterminatePercent(percent, current, total) {
-  if (Number.isFinite(percent)) {
-    return Math.max(0, Math.min(100, Number(percent)));
+function normalizeProgressPercent(percent) {
+  if (percent === null || percent === undefined) {
+    return null;
   }
-  if (current != null && total != null && total > 0) {
-    return Math.max(0, Math.min(100, (Number(current) / Number(total)) * 100));
+  const value = Number(percent);
+  if (!Number.isFinite(value)) {
+    return null;
   }
-  return null;
+  return Math.max(0, Math.min(100, value));
 }
 
 function normalizeEnabled(primaryMarket, enabledMarkets) {
@@ -96,11 +97,7 @@ export default function BootstrapSetupScreen({
     () => activityQuery.data?.markets ?? [],
     [activityQuery.data?.markets]
   );
-  const bootstrapResolvedPercent = resolveDeterminatePercent(
-    bootstrap?.percent,
-    bootstrap?.current,
-    bootstrap?.total,
-  );
+  const bootstrapResolvedPercent = normalizeProgressPercent(bootstrap?.percent);
   const requestedBootstrapProgressMode = (
     bootstrap?.progress_mode
     || 'indeterminate'

--- a/frontend/src/components/App/BootstrapSetupScreen.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.jsx
@@ -222,8 +222,8 @@ export default function BootstrapSetupScreen({
                 First-run market bootstrap
               </Typography>
               <Typography color="text.secondary">
-                Pick the primary market for startup defaults. The workspace opens after every
-                enabled market finishes its first scan-backed snapshot.
+                Pick the primary market for startup defaults. The workspace opens after the
+                primary market finishes its first scan-backed snapshot.
               </Typography>
             </Box>
 
@@ -236,8 +236,8 @@ export default function BootstrapSetupScreen({
             {running && (
               <Stack spacing={2}>
                 <Alert severity="info">
-                  Initial sync is running. The workspace will open after all enabled markets have
-                  current data and a published scan.
+                  Initial sync is running. The workspace will open after the primary market has
+                  current data and a published scan. Additional markets continue loading in the background.
                 </Alert>
                 <Box
                   sx={{
@@ -276,7 +276,7 @@ export default function BootstrapSetupScreen({
                 </Box>
                 <Alert severity="warning">
                   {bootstrap?.background_warning
-                    || 'Keep this setup screen open until every enabled market finishes its bootstrap pipeline.'}
+                    || 'Additional enabled markets may continue loading after the workspace opens.'}
                 </Alert>
                 <Box>
                   <Typography variant="subtitle2" sx={{ mb: 1 }}>

--- a/frontend/src/components/App/BootstrapSetupScreen.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.jsx
@@ -28,6 +28,15 @@ const STATUS_COLOR = {
   idle: 'default',
 };
 
+const FALLBACK_BOOTSTRAP_STAGES = [
+  { key: 'universe', label: 'Universe Refresh' },
+  { key: 'prices', label: 'Price Refresh' },
+  { key: 'fundamentals', label: 'Fundamentals Refresh' },
+  { key: 'breadth', label: 'Breadth Calculation' },
+  { key: 'groups', label: 'Group Rankings' },
+  { key: 'scan', label: 'Scan' },
+];
+
 function formatCount(value) {
   return new Intl.NumberFormat('en-US').format(value);
 }
@@ -48,6 +57,19 @@ function normalizeEnabled(primaryMarket, enabledMarkets) {
     ? enabledMarkets
     : [primaryMarket, ...enabledMarkets];
   return Array.from(new Set(next));
+}
+
+function normalizeStages(stages) {
+  if (!Array.isArray(stages) || stages.length === 0) {
+    return FALLBACK_BOOTSTRAP_STAGES;
+  }
+  const normalized = stages
+    .map((stage) => ({
+      key: stage?.key,
+      label: stage?.label || stage?.key,
+    }))
+    .filter((stage) => stage.key && stage.label);
+  return normalized.length > 0 ? normalized : FALLBACK_BOOTSTRAP_STAGES;
 }
 
 export default function BootstrapSetupScreen({
@@ -121,6 +143,10 @@ export default function BootstrapSetupScreen({
     ? `${formatCount(bootstrap.current)} / ${formatCount(bootstrap.total)} stocks`
     : null;
   const bootstrapMessage = bootstrap?.message || 'Preparing market data.';
+  const bootstrapStages = useMemo(
+    () => normalizeStages(bootstrap?.stages),
+    [bootstrap?.stages]
+  );
 
   const toggleMarket = (market) => {
     if (market === selectedPrimary) {
@@ -316,21 +342,11 @@ export default function BootstrapSetupScreen({
               <Typography variant="subtitle2" sx={{ mb: 1 }}>
                 Bootstrap order
               </Typography>
-              <Typography color="text.secondary">
-                1. Universe refresh
-              </Typography>
-              <Typography color="text.secondary">
-                2. Benchmark and price refresh
-              </Typography>
-              <Typography color="text.secondary">
-                3. Fundamentals refresh
-              </Typography>
-              <Typography color="text.secondary">
-                4. Breadth and group rankings
-              </Typography>
-              <Typography color="text.secondary">
-                5. Initial autoscan snapshot
-              </Typography>
+              {bootstrapStages.map((stage, index) => (
+                <Typography key={stage.key} color="text.secondary">
+                  {index + 1}. {stage.label}
+                </Typography>
+              ))}
             </Box>
 
             <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>

--- a/frontend/src/components/App/BootstrapSetupScreen.test.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.test.jsx
@@ -430,14 +430,14 @@ describe('BootstrapSetupScreen', () => {
     expect(screen.queryByText('0%')).not.toBeInTheDocument();
   });
 
-  it('uses the active secondary market for stage-local progress after the primary market completes', () => {
+  it('uses backend stage-weighted secondary bootstrap progress after the primary market completes', () => {
     useRuntimeActivityMock.mockReturnValue({
       data: {
         bootstrap: {
           primary_market: 'US',
           current_stage: 'Price Refresh',
           progress_mode: 'determinate',
-          percent: 32,
+          percent: 22,
           current: 1200,
           total: 3750,
           message: 'Refreshing market prices',
@@ -482,7 +482,7 @@ describe('BootstrapSetupScreen', () => {
       />
     );
 
-    expect(screen.getByText('32%')).toBeInTheDocument();
+    expect(screen.getByText('22%')).toBeInTheDocument();
     expect(screen.getByText('1,200 / 3,750 stocks')).toBeInTheDocument();
     expect(screen.queryByText('100%')).not.toBeInTheDocument();
     expect(screen.getAllByText(/Refreshing market prices/).length).toBeGreaterThan(0);

--- a/frontend/src/components/App/BootstrapSetupScreen.test.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.test.jsx
@@ -488,6 +488,37 @@ describe('BootstrapSetupScreen', () => {
     expect(screen.getAllByText(/Refreshing market prices/).length).toBeGreaterThan(0);
   });
 
+  it('does not synthesize queued market rows when runtime activity has no markets', () => {
+    useRuntimeActivityMock.mockReturnValue({
+      data: {
+        bootstrap: {
+          primary_market: 'US',
+          current_stage: 'Preparing bootstrap',
+          progress_mode: 'indeterminate',
+          percent: null,
+          message: 'Bootstrap queued.',
+          background_warning: null,
+        },
+        markets: [],
+      },
+    });
+
+    renderWithProviders(
+      <BootstrapSetupScreen
+        primaryMarket="US"
+        enabledMarkets={['US', 'HK']}
+        supportedMarkets={['US', 'HK', 'JP', 'TW']}
+        bootstrapState="running"
+        isStartingBootstrap={false}
+        bootstrapError={null}
+        onStartBootstrap={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Enabled market queue')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Waiting for bootstrap task/)).not.toBeInTheDocument();
+  });
+
   it('renders Market Catalog labels while submitting Market codes', () => {
     useRuntimeActivityMock.mockReturnValue({ data: null });
     const onStartBootstrap = vi.fn().mockResolvedValue();

--- a/frontend/src/components/App/BootstrapSetupScreen.test.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.test.jsx
@@ -23,6 +23,8 @@ describe('BootstrapSetupScreen', () => {
           current_stage: 'Price Refresh',
           progress_mode: 'determinate',
           percent: 25,
+          current: 250,
+          total: 1000,
           message: 'Refreshing prices',
           background_warning: 'Additional data loading continues in the background.',
         },
@@ -62,8 +64,8 @@ describe('BootstrapSetupScreen', () => {
     );
 
     expect(screen.getByText('Price Refresh')).toBeInTheDocument();
-    expect(screen.getByText('42%')).toBeInTheDocument();
-    expect(screen.getByText('420 / 1,000 stocks')).toBeInTheDocument();
+    expect(screen.getByText('25%')).toBeInTheDocument();
+    expect(screen.getByText('250 / 1,000 stocks')).toBeInTheDocument();
     expect(screen.getAllByText(/Refreshing prices/).length).toBeGreaterThan(0);
     expect(screen.getByText(/Additional data loading continues in the background/)).toBeInTheDocument();
     expect(screen.getByText('Enabled market queue')).toBeInTheDocument();
@@ -159,7 +161,7 @@ describe('BootstrapSetupScreen', () => {
     expect(screen.queryByText('0%')).not.toBeInTheDocument();
   });
 
-  it('renders determinate fundamentals progress from the primary market activity row', () => {
+  it('renders determinate fundamentals progress from the bootstrap summary', () => {
     useRuntimeActivityMock.mockReturnValue({
       data: {
         bootstrap: {
@@ -167,6 +169,8 @@ describe('BootstrapSetupScreen', () => {
           current_stage: 'Fundamentals Refresh',
           progress_mode: 'determinate',
           percent: 40,
+          current: 400,
+          total: 1000,
           message: 'Refreshing fundamentals',
           background_warning: 'Additional data loading continues in the background.',
         },
@@ -198,12 +202,12 @@ describe('BootstrapSetupScreen', () => {
       />
     );
 
-    expect(screen.getByText('75%')).toBeInTheDocument();
-    expect(screen.getByText('750 / 1,000 stocks')).toBeInTheDocument();
+    expect(screen.getByText('40%')).toBeInTheDocument();
+    expect(screen.getByText('400 / 1,000 stocks')).toBeInTheDocument();
     expect(screen.getByText('Fundamentals Refresh')).toBeInTheDocument();
   });
 
-  it('derives stage-local bootstrap percent from counts when percent is absent', () => {
+  it('derives bootstrap summary percent from bootstrap counts when percent is absent', () => {
     useRuntimeActivityMock.mockReturnValue({
       data: {
         bootstrap: {
@@ -211,6 +215,8 @@ describe('BootstrapSetupScreen', () => {
           current_stage: 'Price Refresh',
           progress_mode: 'determinate',
           percent: null,
+          current: 250,
+          total: 1000,
           message: 'Refreshing prices',
           background_warning: 'Additional data loading continues in the background.',
         },
@@ -242,12 +248,12 @@ describe('BootstrapSetupScreen', () => {
       />
     );
 
-    expect(screen.getByText('55%')).toBeInTheDocument();
-    expect(screen.getByText('550 / 1,000 stocks')).toBeInTheDocument();
+    expect(screen.getByText('25%')).toBeInTheDocument();
+    expect(screen.getByText('250 / 1,000 stocks')).toBeInTheDocument();
     expect(screen.getAllByText(/Batch 2\/4 · refreshing prices/).length).toBeGreaterThan(0);
   });
 
-  it('derives stage-local progress from counts even when progress_mode is stale', () => {
+  it('does not override backend indeterminate progress with market row counts', () => {
     useRuntimeActivityMock.mockReturnValue({
       data: {
         bootstrap: {
@@ -286,11 +292,11 @@ describe('BootstrapSetupScreen', () => {
       />
     );
 
-    expect(screen.getByText('55%')).toBeInTheDocument();
-    expect(screen.getByText('550 / 1,000 stocks')).toBeInTheDocument();
+    expect(screen.queryByText('55%')).not.toBeInTheDocument();
+    expect(screen.queryByText('550 / 1,000 stocks')).not.toBeInTheDocument();
   });
 
-  it('uses stage_key instead of the display label to unlock primary-market stage progress', () => {
+  it('keeps bootstrap progress independent from market-row stage labels', () => {
     useRuntimeActivityMock.mockReturnValue({
       data: {
         bootstrap: {
@@ -298,6 +304,8 @@ describe('BootstrapSetupScreen', () => {
           current_stage: 'Refreshing market data',
           progress_mode: 'determinate',
           percent: 30,
+          current: 300,
+          total: 1000,
           message: 'Batch 2/4 · refreshing prices',
           background_warning: 'Additional data loading continues in the background.',
         },
@@ -329,12 +337,12 @@ describe('BootstrapSetupScreen', () => {
       />
     );
 
-    expect(screen.getByText('55%')).toBeInTheDocument();
-    expect(screen.getByText('550 / 1,000 stocks')).toBeInTheDocument();
+    expect(screen.getByText('30%')).toBeInTheDocument();
+    expect(screen.getByText('300 / 1,000 stocks')).toBeInTheDocument();
     expect(screen.getAllByText(/Batch 2\/4 · refreshing prices/).length).toBeGreaterThan(0);
   });
 
-  it('prefers the primary market activity message over the bootstrap summary when stage-local progress is active', () => {
+  it('uses the bootstrap summary message instead of replacing it from market rows', () => {
     useRuntimeActivityMock.mockReturnValue({
       data: {
         bootstrap: {
@@ -373,8 +381,7 @@ describe('BootstrapSetupScreen', () => {
       />
     );
 
-    expect(screen.getAllByText(/Batch 2\/4 · refreshing prices/).length).toBeGreaterThan(0);
-    expect(screen.queryByText('Preparing bootstrap')).not.toBeInTheDocument();
+    expect(screen.getByText('Preparing bootstrap')).toBeInTheDocument();
   });
 
   it('keeps bootstrap percent sourced from a complete tuple', () => {
@@ -418,8 +425,9 @@ describe('BootstrapSetupScreen', () => {
       />
     );
 
-    expect(screen.getByText('55%')).toBeInTheDocument();
+    expect(screen.queryByText('55%')).not.toBeInTheDocument();
     expect(screen.queryByText('25%')).not.toBeInTheDocument();
+    expect(screen.queryByText('0%')).not.toBeInTheDocument();
   });
 
   it('uses the active secondary market for stage-local progress after the primary market completes', () => {
@@ -429,8 +437,10 @@ describe('BootstrapSetupScreen', () => {
           primary_market: 'US',
           current_stage: 'Price Refresh',
           progress_mode: 'determinate',
-          percent: 100,
-          message: 'Primary market is ready while additional market loading continues.',
+          percent: 32,
+          current: 1200,
+          total: 3750,
+          message: 'Refreshing market prices',
           background_warning: 'Additional enabled markets are still loading in the background.',
         },
         markets: [

--- a/frontend/src/components/App/BootstrapSetupScreen.test.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.test.jsx
@@ -72,6 +72,49 @@ describe('BootstrapSetupScreen', () => {
     expect(screen.getByRole('progressbar', { name: 'Bootstrap progress' })).toBeInTheDocument();
   });
 
+  it('does not invent a background warning when the API omits one', () => {
+    useRuntimeActivityMock.mockReturnValue({
+      data: {
+        bootstrap: {
+          primary_market: 'US',
+          current_stage: 'Price Refresh',
+          progress_mode: 'determinate',
+          percent: 25,
+          message: 'Refreshing prices',
+          background_warning: null,
+        },
+        markets: [
+          {
+            market: 'US',
+            stage_key: 'prices',
+            stage_label: 'Price Refresh',
+            status: 'running',
+            progress_mode: 'determinate',
+            percent: 25,
+            current: 250,
+            total: 1000,
+            message: 'Refreshing prices',
+          },
+        ],
+      },
+    });
+
+    renderWithProviders(
+      <BootstrapSetupScreen
+        primaryMarket="US"
+        enabledMarkets={['US']}
+        supportedMarkets={['US', 'HK', 'JP', 'TW']}
+        bootstrapState="running"
+        isStartingBootstrap={false}
+        bootstrapError={null}
+        onStartBootstrap={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/Additional enabled markets/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/continue loading after the workspace opens/i)).not.toBeInTheDocument();
+  });
+
   it('renders indeterminate bootstrap progress when no real percent is available yet', () => {
     useRuntimeActivityMock.mockReturnValue({
       data: {

--- a/frontend/src/components/App/BootstrapSetupScreen.test.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.test.jsx
@@ -519,6 +519,42 @@ describe('BootstrapSetupScreen', () => {
     expect(screen.queryByText(/Waiting for bootstrap task/)).not.toBeInTheDocument();
   });
 
+  it('renders bootstrap order from runtime activity stage metadata', () => {
+    useRuntimeActivityMock.mockReturnValue({
+      data: {
+        bootstrap: {
+          primary_market: 'US',
+          current_stage: 'Preparing bootstrap',
+          progress_mode: 'indeterminate',
+          percent: null,
+          message: 'Bootstrap queued.',
+          background_warning: null,
+          stages: [
+            { key: 'seed', label: 'Seed Import' },
+            { key: 'top_up', label: 'Live Top-Up' },
+          ],
+        },
+        markets: [],
+      },
+    });
+
+    renderWithProviders(
+      <BootstrapSetupScreen
+        primaryMarket="US"
+        enabledMarkets={['US']}
+        supportedMarkets={['US']}
+        bootstrapState="not_started"
+        isStartingBootstrap={false}
+        bootstrapError={null}
+        onStartBootstrap={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('1. Seed Import')).toBeInTheDocument();
+    expect(screen.getByText('2. Live Top-Up')).toBeInTheDocument();
+    expect(screen.queryByText('1. Universe refresh')).not.toBeInTheDocument();
+  });
+
   it('renders Market Catalog labels while submitting Market codes', () => {
     useRuntimeActivityMock.mockReturnValue({ data: null });
     const onStartBootstrap = vi.fn().mockResolvedValue();

--- a/frontend/src/components/App/BootstrapSetupScreen.test.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.test.jsx
@@ -207,7 +207,7 @@ describe('BootstrapSetupScreen', () => {
     expect(screen.getByText('Fundamentals Refresh')).toBeInTheDocument();
   });
 
-  it('derives bootstrap summary percent from bootstrap counts when percent is absent', () => {
+  it('does not derive bootstrap summary percent from counts when percent is absent', () => {
     useRuntimeActivityMock.mockReturnValue({
       data: {
         bootstrap: {
@@ -248,7 +248,7 @@ describe('BootstrapSetupScreen', () => {
       />
     );
 
-    expect(screen.getByText('25%')).toBeInTheDocument();
+    expect(screen.queryByText('25%')).not.toBeInTheDocument();
     expect(screen.getByText('250 / 1,000 stocks')).toBeInTheDocument();
     expect(screen.getAllByText(/Batch 2\/4 · refreshing prices/).length).toBeGreaterThan(0);
   });

--- a/frontend/src/components/App/BootstrapSetupScreen.test.jsx
+++ b/frontend/src/components/App/BootstrapSetupScreen.test.jsx
@@ -388,7 +388,7 @@ describe('BootstrapSetupScreen', () => {
           progress_mode: 'determinate',
           percent: 100,
           message: 'Primary market is ready while additional market loading continues.',
-          background_warning: 'Bootstrap remains active until every enabled market has a published scan.',
+          background_warning: 'Additional enabled markets are still loading in the background.',
         },
         markets: [
           {

--- a/frontend/src/contexts/RuntimeContext.jsx
+++ b/frontend/src/contexts/RuntimeContext.jsx
@@ -142,6 +142,15 @@ const DEFAULT_SUPPORTED_MARKETS = DEFAULT_MARKET_CATALOG.markets
   .map((market) => market.code)
   .filter(Boolean);
 
+export const DEFAULT_BOOTSTRAP_STAGES = [
+  { key: 'universe', label: 'Universe Refresh' },
+  { key: 'prices', label: 'Price Refresh' },
+  { key: 'fundamentals', label: 'Fundamentals Refresh' },
+  { key: 'breadth', label: 'Breadth Calculation' },
+  { key: 'groups', label: 'Group Rankings' },
+  { key: 'scan', label: 'Scan' },
+];
+
 export const DEFAULT_CAPABILITIES = {
   features: {
     themes: true,
@@ -167,6 +176,7 @@ export const DEFAULT_CAPABILITIES = {
   primary_market: 'US',
   enabled_markets: ['US'],
   bootstrap_state: 'not_started',
+  bootstrap_stages: DEFAULT_BOOTSTRAP_STAGES,
   market_catalog: DEFAULT_MARKET_CATALOG,
   supported_markets: DEFAULT_SUPPORTED_MARKETS,
   universe_options: null,
@@ -179,12 +189,26 @@ const BOOTSTRAP_BACKGROUND_WARNING = (
   + 'Additional enabled markets keep syncing after the app becomes usable.'
 );
 
-function buildBootstrapSeed(primaryMarket, enabledMarkets, taskId) {
+function normalizeBootstrapStages(stages) {
+  if (!Array.isArray(stages) || stages.length === 0) {
+    return DEFAULT_BOOTSTRAP_STAGES;
+  }
+  const normalized = stages
+    .map((stage) => ({
+      key: stage?.key,
+      label: stage?.label || stage?.key,
+    }))
+    .filter((stage) => stage.key && stage.label);
+  return normalized.length > 0 ? normalized : DEFAULT_BOOTSTRAP_STAGES;
+}
+
+function buildBootstrapSeed(primaryMarket, enabledMarkets, taskId, stages) {
+  const [firstStage] = normalizeBootstrapStages(stages);
   return enabledMarkets.map((market) => ({
     market,
     lifecycle: 'bootstrap',
-    stage_key: 'universe',
-    stage_label: 'Universe Refresh',
+    stage_key: firstStage.key,
+    stage_label: firstStage.label,
     status: 'queued',
     progress_mode: 'indeterminate',
     percent: null,
@@ -214,6 +238,9 @@ export function mergeBootstrapCapabilities(previous, data) {
     primary_market: data.primary_market ?? previous?.primary_market ?? 'US',
     enabled_markets: data.enabled_markets ?? previous?.enabled_markets ?? ['US'],
     bootstrap_state: data.bootstrap_state ?? 'running',
+    bootstrap_stages: normalizeBootstrapStages(
+      data.bootstrap_stages ?? previous?.bootstrap_stages
+    ),
     market_catalog: data.market_catalog
       ?? previous?.market_catalog
       ?? DEFAULT_CAPABILITIES.market_catalog,
@@ -281,6 +308,8 @@ export function RuntimeProvider({ children }) {
       queryClient.setQueryData(['runtimeActivity'], (previous) => {
         const primaryMarket = data.primary_market ?? 'US';
         const enabledMarkets = data.enabled_markets ?? [primaryMarket];
+        const bootstrapStages = normalizeBootstrapStages(data.bootstrap_stages);
+        const [firstStage] = bootstrapStages;
         return {
           ...(previous ?? DEFAULT_RUNTIME_ACTIVITY),
           bootstrap: {
@@ -289,10 +318,11 @@ export function RuntimeProvider({ children }) {
             app_ready: !data.bootstrap_required,
             primary_market: primaryMarket,
             enabled_markets: enabledMarkets,
-            current_stage: 'Universe Refresh',
+            current_stage: firstStage.label,
             progress_mode: 'indeterminate',
             percent: null,
             message: 'Bootstrap queued.',
+            stages: bootstrapStages,
             background_warning: enabledMarkets.length > 1
               ? BOOTSTRAP_BACKGROUND_WARNING
               : null,
@@ -302,7 +332,12 @@ export function RuntimeProvider({ children }) {
             active_markets: enabledMarkets,
             status: 'active',
           },
-          markets: buildBootstrapSeed(primaryMarket, enabledMarkets, data.task_id),
+          markets: buildBootstrapSeed(
+            primaryMarket,
+            enabledMarkets,
+            data.task_id,
+            bootstrapStages
+          ),
         };
       });
       queryClient.invalidateQueries({ queryKey: ['appCapabilities'] });

--- a/frontend/src/contexts/RuntimeContext.test.jsx
+++ b/frontend/src/contexts/RuntimeContext.test.jsx
@@ -191,6 +191,10 @@ describe('RuntimeProvider', () => {
       enabled_markets: ['HK', 'US'],
       bootstrap_state: 'running',
       supported_markets: ['US', 'HK', 'IN', 'JP', 'KR', 'TW', 'CN', 'CA', 'DE', 'SG', 'AU', 'MY'],
+      bootstrap_stages: [
+        { key: 'seed', label: 'Seed Import' },
+        { key: 'scan', label: 'First Scan' },
+      ],
       task_id: 'task-bootstrap-123',
     });
 
@@ -217,9 +221,23 @@ describe('RuntimeProvider', () => {
     });
 
     await waitFor(() => {
+      expect(queryClient.getQueryData(['runtimeActivity'])?.bootstrap.stages).toEqual([
+        { key: 'seed', label: 'Seed Import' },
+        { key: 'scan', label: 'First Scan' },
+      ]);
       expect(queryClient.getQueryData(['runtimeActivity'])?.markets).toEqual([
-        expect.objectContaining({ market: 'HK', task_id: 'task-bootstrap-123' }),
-        expect.objectContaining({ market: 'US', task_id: null }),
+        expect.objectContaining({
+          market: 'HK',
+          stage_key: 'seed',
+          stage_label: 'Seed Import',
+          task_id: 'task-bootstrap-123',
+        }),
+        expect.objectContaining({
+          market: 'US',
+          stage_key: 'seed',
+          stage_label: 'Seed Import',
+          task_id: null,
+        }),
       ]);
       expect(queryClient.getQueryData(['appCapabilities'])?.market_catalog).toEqual(
         DEFAULT_CAPABILITIES.market_catalog

--- a/frontend/src/hooks/useRuntimeActivity.js
+++ b/frontend/src/hooks/useRuntimeActivity.js
@@ -12,6 +12,7 @@ export const DEFAULT_RUNTIME_ACTIVITY = {
     percent: null,
     message: null,
     background_warning: null,
+    stages: [],
   },
   summary: {
     active_market_count: 0,


### PR DESCRIPTION
## Summary
- Preserve `bootstrap_state=running` when bootstrap dispatch partially succeeds and Celery work is already queued.
- Reuse the shared price refresh batch classifier from failed-symbol retry handling.
- Consolidate operations/runtime progress-mode semantics in the shared runtime activity contract.
- Replace bootstrap plan task-name strings with semantic `BootstrapOperation` enum values.

## Verification
- `git diff --check`
- `python -m py_compile backend/app/api/v1/app_runtime.py backend/app/domain/bootstrap/plan.py backend/app/services/operations_job_service.py backend/app/services/price_refresh_execution.py backend/app/services/runtime_activity_contract.py backend/app/tasks/cache_tasks.py backend/app/tasks/runtime_bootstrap_tasks.py`
- Focused regression tests for findings 1-4 passed.
- Impacted backend group passed: 98 tests.
- `pytest backend/tests/unit/test_operations_job_service.py` passed: 14 tests.

## Notes
- Full `pytest` from `backend/` is currently blocked during integration collection because `tests/integration/test_production_performance.py` calls `localhost:8000` at import time when no server is running.
- Full `pytest tests/unit` was stopped after reproducing unrelated existing failures in `tests/unit/golden/test_mcp_market_copilot.py::test_market_overview_snapshot` and `tests/unit/test_cleanup_orphaned_scans.py::test_run_orphaned_scan_cleanup_deletes_cancelled_and_stale_scans`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated bootstrap workflow to use GitHub daily price bundles with intelligent gap-filling (7d for recent data, 2y for no history) instead of legacy cache strategy.
  * Enhanced bootstrap progress tracking with stage visibility and per-market task identifiers.
  * Added FX rate fallback mechanism with staleness suppression cooldown.

* **Improvements**
  * Bootstrap UI now displays aggregated progress from centralized summary data.
  * Price refresh now operates in multiple modes (full/delta/auto) with GitHub seed fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->