### PR TITLE
Fix JP bootstrap Yahoo retry pacing for invalid symbols

### DIFF
--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -563,7 +563,7 @@ class BulkDataFetcher:
                     )
             else:
                 # Multi-symbol: split by ticker
-                for symbol in symbols:
+                for symbol in fetch_symbols:
                     try:
                         if symbol in raw.columns.get_level_values(0):
                             df = raw[symbol].copy()

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -11,7 +11,7 @@ docs/learning_loop/adr_ll2_e1_canonical_price_contract_v1.md
 import logging
 import math
 from collections.abc import Callable
-from typing import TYPE_CHECKING, List, Dict, Optional, Any
+from typing import TYPE_CHECKING, List, Dict, Optional, Any, NamedTuple
 from threading import RLock
 import yfinance as yf
 from datetime import datetime
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
     from .rate_limiter import RedisRateLimiter
 
 logger = logging.getLogger(__name__)
+
+
+class _PriceFailureMetric(NamedTuple):
+    provider_signal_count: int
+    transient_failure_rate: float
 
 
 def _finite_or_none(value: Any) -> Any:
@@ -187,18 +192,24 @@ class BulkDataFetcher:
             )
         return fetchable, permanent_failures
 
-    def _transient_failure_rate(self, results: Dict[str, Dict[str, Any]]) -> float:
+    def _price_failure_metric(
+        self,
+        results: Dict[str, Dict[str, Any]],
+    ) -> _PriceFailureMetric:
         if not results:
-            return 1.0
+            return _PriceFailureMetric(
+                provider_signal_count=1,
+                transient_failure_rate=1.0,
+            )
 
-        retryable_results = 0
+        provider_signal_count = 0
         transient_failures = 0
         for data in results.values():
             error = data.get("error", "")
             error_kind = normalize_price_fetch_failure_kind(data.get("error_kind"))
             if not is_retryable_price_failure(kind=error_kind, error=error):
                 continue
-            retryable_results += 1
+            provider_signal_count += 1
             if not data.get("has_error"):
                 continue
             if (
@@ -207,9 +218,15 @@ class BulkDataFetcher:
                 or "empty" in error.lower()
             ):
                 transient_failures += 1
-        if retryable_results == 0:
-            return 0.0
-        return transient_failures / retryable_results
+        if provider_signal_count == 0:
+            return _PriceFailureMetric(
+                provider_signal_count=0,
+                transient_failure_rate=0.0,
+            )
+        return _PriceFailureMetric(
+            provider_signal_count=provider_signal_count,
+            transient_failure_rate=transient_failures / provider_signal_count,
+        )
 
     def fetch_batch_data(
         self,
@@ -742,7 +759,8 @@ class BulkDataFetcher:
             )
             combined_results.update(batch_results)
 
-            failure_rate = self._transient_failure_rate(batch_results)
+            failure_metric = self._price_failure_metric(batch_results)
+            failure_rate = failure_metric.transient_failure_rate
             if failure_rate > 0.20:
                 success_streak = 0
                 batch_size = max(self.MIN_PRICE_BATCH_SIZE, batch_size // 2)
@@ -750,7 +768,7 @@ class BulkDataFetcher:
                 # Sustained transient failure → pulse the breaker. Threshold
                 # tripping is done after consecutive batches.
                 breaker.record_429("yfinance", market)
-            else:
+            elif failure_metric.provider_signal_count > 0:
                 if growth_cooldown_remaining > 0:
                     growth_cooldown_remaining -= 1
                 if failure_rate < 0.02:
@@ -880,8 +898,13 @@ class BulkDataFetcher:
 
             attempt_results = {**permanent_failures, **fetch_results}
             last_results = attempt_results
-            failure_rate = self._transient_failure_rate(attempt_results)
-            if failure_rate <= 0.20 or attempt == len(backoff_schedule):
+            failure_metric = self._price_failure_metric(attempt_results)
+            failure_rate = failure_metric.transient_failure_rate
+            if (
+                failure_metric.provider_signal_count == 0
+                or failure_rate <= 0.20
+                or attempt == len(backoff_schedule)
+            ):
                 return attempt_results
 
             current_batch_size = max(self.MIN_PRICE_BATCH_SIZE, current_batch_size // 2)

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -165,6 +165,29 @@ class BulkDataFetcher:
             if symbol in errors and errors[symbol]
         }
 
+    @staticmethod
+    def _is_zero_prefixed_jp_symbol(symbol: str) -> bool:
+        normalized = str(symbol or "").strip().upper()
+        if normalized.endswith(".T"):
+            local_code = normalized[:-2]
+        elif normalized.endswith(".JP"):
+            local_code = normalized[:-3]
+        else:
+            return False
+        if not local_code:
+            return False
+        numeric_part = local_code[:-1] if local_code[-1].isalpha() else local_code
+        return numeric_part.startswith("0") and numeric_part.isdigit()
+
+    @classmethod
+    def _empty_download_error_for_symbol(cls, symbol: str) -> str:
+        if cls._is_zero_prefixed_jp_symbol(symbol):
+            return (
+                "JP local code is zero-prefixed; no price data expected "
+                "from Yahoo"
+            )
+        return "yf.download returned empty"
+
     def _transient_failure_rate(self, results: Dict[str, Dict[str, Any]]) -> float:
         if not results:
             return 1.0
@@ -507,7 +530,10 @@ class BulkDataFetcher:
             if raw is None or raw.empty:
                 logger.warning("yf.download returned empty DataFrame")
                 for symbol in symbols:
-                    error = download_errors.get(symbol) or 'yf.download returned empty'
+                    error = (
+                        download_errors.get(symbol)
+                        or self._empty_download_error_for_symbol(symbol)
+                    )
                     results[symbol] = self._build_error_result(
                         symbol,
                         error,

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -25,6 +25,7 @@ from .price_fetch_failures import (
     classify_price_fetch_error,
     is_no_data_price_failure,
     is_rate_limit_error,
+    is_retryable_price_failure,
     normalize_price_fetch_failure_kind,
 )
 from .price_symbol_validation import yahoo_price_no_data_error_for_symbol
@@ -190,15 +191,15 @@ class BulkDataFetcher:
         if not results:
             return 1.0
 
+        retryable_results = 0
         transient_failures = 0
         for data in results.values():
-            if not data.get("has_error"):
-                continue
             error = data.get("error", "")
             error_kind = normalize_price_fetch_failure_kind(data.get("error_kind"))
-            if error_kind is not None and error_kind.value == "no_price_data":
+            if not is_retryable_price_failure(kind=error_kind, error=error):
                 continue
-            if error_kind is None and self._is_permanent_missing_price_error(error):
+            retryable_results += 1
+            if not data.get("has_error"):
                 continue
             if (
                 (error_kind is not None and error_kind.value in {"rate_limit", "transient"})
@@ -206,7 +207,9 @@ class BulkDataFetcher:
                 or "empty" in error.lower()
             ):
                 transient_failures += 1
-        return transient_failures / len(results)
+        if retryable_results == 0:
+            return 0.0
+        return transient_failures / retryable_results
 
     def fetch_batch_data(
         self,
@@ -877,7 +880,7 @@ class BulkDataFetcher:
 
             attempt_results = {**permanent_failures, **fetch_results}
             last_results = attempt_results
-            failure_rate = self._transient_failure_rate(fetch_results)
+            failure_rate = self._transient_failure_rate(attempt_results)
             if failure_rate <= 0.20 or attempt == len(backoff_schedule):
                 return attempt_results
 

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -716,6 +716,12 @@ class BulkDataFetcher:
         start_batch_size: Optional[int] = None,
         market: Optional[str] = None,
     ) -> Dict[str, Dict]:
+        fetch_symbols, combined_results = self._split_fetchable_price_symbols(
+            symbols
+        )
+        if not fetch_symbols:
+            return combined_results
+
         # Per-market initial batch size from RateBudgetPolicy when caller
         # didn't pass an explicit ``start_batch_size``.
         if start_batch_size is None and market is not None:
@@ -731,9 +737,8 @@ class BulkDataFetcher:
         )
         success_streak = 0
         growth_cooldown_remaining = 0
-        combined_results: Dict[str, Dict] = {}
         batch_start = 0
-        while batch_start < len(symbols):
+        while batch_start < len(fetch_symbols):
             # Bail out early when the per-market circuit is open — no point
             # spinning through 30+ second internal retries when we know the
             # provider is throttling this market.
@@ -741,16 +746,18 @@ class BulkDataFetcher:
                 logger.warning(
                     "Yahoo circuit open for market=%s; aborting price fetch "
                     "(remaining %d/%d symbols)",
-                    market, len(symbols) - batch_start, len(symbols),
+                    market,
+                    len(fetch_symbols) - batch_start,
+                    len(fetch_symbols),
                 )
-                for symbol in symbols[batch_start:]:
+                for symbol in fetch_symbols[batch_start:]:
                     combined_results.setdefault(
                         symbol,
                         {**self._build_error_result(symbol, "circuit_open"), "error_kind": "circuit_open"},
                     )
                 break
 
-            batch_symbols = symbols[batch_start:batch_start + batch_size]
+            batch_symbols = fetch_symbols[batch_start:batch_start + batch_size]
             batch_results = self._fetch_price_batch_with_retries(
                 batch_symbols,
                 period=period,
@@ -783,7 +790,7 @@ class BulkDataFetcher:
                 else:
                     success_streak = 0
 
-            if batch_start + len(batch_symbols) < len(symbols):
+            if batch_start + len(batch_symbols) < len(fetch_symbols):
                 # Per-market batch interval when market is supplied; falls
                 # back to the legacy global key for shared/unmarked calls.
                 if market is not None:

--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -21,11 +21,13 @@ import time
 from ..config import settings
 from .growth_cadence_service import compute_cadence_aware_growth
 from .price_fetch_failures import (
+    PriceFetchFailureKind,
     classify_price_fetch_error,
     is_no_data_price_failure,
     is_rate_limit_error,
     normalize_price_fetch_failure_kind,
 )
+from .price_symbol_validation import yahoo_price_no_data_error_for_symbol
 
 if TYPE_CHECKING:
     from .eps_rating_service import EPSRatingService
@@ -165,28 +167,24 @@ class BulkDataFetcher:
             if symbol in errors and errors[symbol]
         }
 
-    @staticmethod
-    def _is_zero_prefixed_jp_symbol(symbol: str) -> bool:
-        normalized = str(symbol or "").strip().upper()
-        if normalized.endswith(".T"):
-            local_code = normalized[:-2]
-        elif normalized.endswith(".JP"):
-            local_code = normalized[:-3]
-        else:
-            return False
-        if not local_code:
-            return False
-        numeric_part = local_code[:-1] if local_code[-1].isalpha() else local_code
-        return numeric_part.startswith("0") and numeric_part.isdigit()
-
     @classmethod
-    def _empty_download_error_for_symbol(cls, symbol: str) -> str:
-        if cls._is_zero_prefixed_jp_symbol(symbol):
-            return (
-                "JP local code is zero-prefixed; no price data expected "
-                "from Yahoo"
+    def _split_fetchable_price_symbols(
+        cls,
+        symbols: List[str],
+    ) -> tuple[List[str], Dict[str, Dict[str, Any]]]:
+        fetchable: List[str] = []
+        permanent_failures: Dict[str, Dict[str, Any]] = {}
+        for symbol in symbols:
+            error = yahoo_price_no_data_error_for_symbol(symbol)
+            if error is None:
+                fetchable.append(symbol)
+                continue
+            permanent_failures[symbol] = cls._build_error_result(
+                symbol,
+                error,
+                error_kind=PriceFetchFailureKind.NO_PRICE_DATA.value,
             )
-        return "yf.download returned empty"
+        return fetchable, permanent_failures
 
     def _transient_failure_rate(self, results: Dict[str, Dict[str, Any]]) -> float:
         if not results:
@@ -504,16 +502,21 @@ class BulkDataFetcher:
         if not symbols:
             return {}
 
-        logger.info(f"Batch fetching prices for {len(symbols)} symbols using yf.download()")
+        fetch_symbols, results = self._split_fetchable_price_symbols(symbols)
+        if not fetch_symbols:
+            return results
 
-        results = {}
+        logger.info(
+            "Batch fetching prices for %d symbols using yf.download()",
+            len(fetch_symbols),
+        )
 
         try:
             # yf.download with group_by='ticker' returns MultiIndex columns: (ticker, OHLCV)
             # threads=False avoids threading issues inside Celery workers
             # progress=False suppresses the tqdm progress bar
             download_kwargs = dict(
-                tickers=symbols,
+                tickers=fetch_symbols,
                 period=period,
                 group_by='ticker',
                 threads=False,
@@ -525,15 +528,12 @@ class BulkDataFetcher:
             if session is not None:
                 download_kwargs["session"] = session
             raw = yf.download(**download_kwargs)
-            download_errors = self._yfinance_download_errors(symbols)
+            download_errors = self._yfinance_download_errors(fetch_symbols)
 
             if raw is None or raw.empty:
                 logger.warning("yf.download returned empty DataFrame")
-                for symbol in symbols:
-                    error = (
-                        download_errors.get(symbol)
-                        or self._empty_download_error_for_symbol(symbol)
-                    )
+                for symbol in fetch_symbols:
+                    error = download_errors.get(symbol) or "yf.download returned empty"
                     results[symbol] = self._build_error_result(
                         symbol,
                         error,
@@ -543,8 +543,8 @@ class BulkDataFetcher:
 
             # Single symbol: yf.download returns flat columns (Open, High, etc.)
             # Multi-symbol: returns MultiIndex columns (AAPL/Open, AAPL/High, etc.)
-            if len(symbols) == 1:
-                symbol = symbols[0]
+            if len(fetch_symbols) == 1:
+                symbol = fetch_symbols[0]
                 df = raw.copy()
                 if df is not None and not df.empty:
                     results[symbol] = {
@@ -599,7 +599,7 @@ class BulkDataFetcher:
             logger.info(f"Batch price download: {success} successful, {failed} failed")
 
             # Add missing symbols as errors
-            for symbol in symbols:
+            for symbol in fetch_symbols:
                 if symbol not in results:
                     error = download_errors.get(symbol) or 'Missing from results'
                     results[symbol] = self._build_error_result(
@@ -613,14 +613,15 @@ class BulkDataFetcher:
         except Exception as e:
             logger.error(f"yf.download batch failed: {e}", exc_info=True)
             error = f"Batch download error: {str(e)}"
-            return {
+            failed_results = {
                 symbol: self._build_error_result(
                     symbol,
                     error,
                     error_kind=self._price_error_kind(error),
                 )
-                for symbol in symbols
+                for symbol in fetch_symbols
             }
+            return {**results, **failed_results}
 
     def fetch_prices_in_batches(
         self,
@@ -855,19 +856,28 @@ class BulkDataFetcher:
             self.MIN_PRICE_BATCH_SIZE,
             min(initial_batch_size, self.MAX_PRICE_BATCH_SIZE),
         )
+        fetch_symbols, permanent_failures = self._split_fetchable_price_symbols(
+            symbols
+        )
+        if not fetch_symbols:
+            return permanent_failures
         last_results: Dict[str, Dict] = {
-            symbol: self._build_error_result(symbol, "Batch not attempted")
-            for symbol in symbols
+            **permanent_failures,
+            **{
+                symbol: self._build_error_result(symbol, "Batch not attempted")
+                for symbol in fetch_symbols
+            },
         }
 
         for attempt in range(len(backoff_schedule) + 1):
-            attempt_results: Dict[str, Dict] = {}
-            for chunk_start in range(0, len(symbols), current_batch_size):
-                chunk_symbols = symbols[chunk_start:chunk_start + current_batch_size]
-                attempt_results.update(self.fetch_batch_prices(chunk_symbols, period=period))
+            fetch_results: Dict[str, Dict] = {}
+            for chunk_start in range(0, len(fetch_symbols), current_batch_size):
+                chunk_symbols = fetch_symbols[chunk_start:chunk_start + current_batch_size]
+                fetch_results.update(self.fetch_batch_prices(chunk_symbols, period=period))
 
+            attempt_results = {**permanent_failures, **fetch_results}
             last_results = attempt_results
-            failure_rate = self._transient_failure_rate(attempt_results)
+            failure_rate = self._transient_failure_rate(fetch_results)
             if failure_rate <= 0.20 or attempt == len(backoff_schedule):
                 return attempt_results
 

--- a/backend/app/services/jp_universe_ingestion_adapter.py
+++ b/backend/app/services/jp_universe_ingestion_adapter.py
@@ -130,6 +130,12 @@ class JPUniverseIngestionAdapter:
                 f"Invalid JP symbol '{source_symbol}'. "
                 "Expected JP local code with optional .T/.JP suffix."
             )
+        numeric_part = token[:-1] if token[-1].isalpha() else token
+        if numeric_part.startswith("0"):
+            raise ValueError(
+                f"Invalid JP symbol '{source_symbol}'. "
+                "JP local codes must not be zero-prefixed."
+            )
         return token
 
     @staticmethod

--- a/backend/app/services/jp_universe_ingestion_adapter.py
+++ b/backend/app/services/jp_universe_ingestion_adapter.py
@@ -8,6 +8,7 @@ import json
 import re
 from typing import Any, Iterable, Mapping
 
+from .price_symbol_validation import is_zero_prefixed_jp_local_code
 from .security_master_service import security_master_resolver
 
 _JP_EXCHANGE_ALIASES: dict[str, str] = {
@@ -130,8 +131,7 @@ class JPUniverseIngestionAdapter:
                 f"Invalid JP symbol '{source_symbol}'. "
                 "Expected JP local code with optional .T/.JP suffix."
             )
-        numeric_part = token[:-1] if token[-1].isalpha() else token
-        if numeric_part.startswith("0"):
+        if is_zero_prefixed_jp_local_code(token):
             raise ValueError(
                 f"Invalid JP symbol '{source_symbol}'. "
                 "JP local codes must not be zero-prefixed."

--- a/backend/app/services/price_symbol_validation.py
+++ b/backend/app/services/price_symbol_validation.py
@@ -1,0 +1,38 @@
+"""Provider price-symbol validation helpers.
+
+These helpers describe symbols that should never be sent to a price provider.
+They intentionally do not normalize invalid symbols into a different ticker:
+for JP, stripping a leading zero can resolve a different Yahoo instrument.
+"""
+
+from __future__ import annotations
+
+
+YAHOO_ZERO_PREFIXED_JP_SYMBOL_ERROR = (
+    "JP local code is zero-prefixed; no price data expected from Yahoo. "
+    "Do not strip the leading zero because that can resolve a different security."
+)
+
+
+def is_zero_prefixed_jp_local_code(local_code: str | None) -> bool:
+    token = str(local_code or "").strip().upper()
+    if not token:
+        return False
+    numeric_part = token[:-1] if token[-1].isalpha() else token
+    return numeric_part.startswith("0") and numeric_part.isdigit()
+
+
+def _jp_local_code_from_yahoo_symbol(symbol: str | None) -> str | None:
+    normalized = str(symbol or "").strip().upper()
+    if normalized.endswith(".T"):
+        return normalized[:-2]
+    if normalized.endswith(".JP"):
+        return normalized[:-3]
+    return None
+
+
+def yahoo_price_no_data_error_for_symbol(symbol: str | None) -> str | None:
+    local_code = _jp_local_code_from_yahoo_symbol(symbol)
+    if local_code is not None and is_zero_prefixed_jp_local_code(local_code):
+        return YAHOO_ZERO_PREFIXED_JP_SYMBOL_ERROR
+    return None

--- a/backend/tests/unit/test_stock_universe_service.py
+++ b/backend/tests/unit/test_stock_universe_service.py
@@ -1471,6 +1471,33 @@ def test_ingest_jp_from_csv_reports_rejected_rows_in_non_strict_mode():
     db.close()
 
 
+def test_ingest_jp_from_csv_rejects_zero_prefixed_local_codes():
+    TestingSessionLocal = _make_session()
+    db = TestingSessionLocal()
+    csv_content = "\n".join(
+        [
+            "symbol,name,exchange",
+            "0130,Invalid Zero Prefixed,TSE",
+            "7203,Toyota,TSE",
+        ]
+    )
+
+    stats = stock_universe_service.ingest_jp_from_csv(
+        db,
+        csv_content,
+        source_name="tse_official",
+        snapshot_id="jp-20260412",
+        strict=False,
+    )
+
+    assert stats["added"] == 1
+    assert stats["total"] == 1
+    assert stats["rejected"] == 1
+    assert stats["rejected_rows"][0]["source_symbol"] == "0130"
+    assert "zero-prefixed" in stats["rejected_rows"][0]["reason"]
+    db.close()
+
+
 def test_ingest_jp_from_csv_merges_duplicate_rows_to_keep_richer_metadata():
     TestingSessionLocal = _make_session()
     db = TestingSessionLocal()

--- a/backend/tests/unit/test_yahoo_batch_ingestion.py
+++ b/backend/tests/unit/test_yahoo_batch_ingestion.py
@@ -277,6 +277,33 @@ def test_fetch_batch_prices_short_circuits_zero_prefixed_jp_symbols(monkeypatch)
     assert "zero-prefixed" in results["0130.T"]["error"]
 
 
+def test_fetch_batch_prices_preserves_invalid_jp_result_in_mixed_multi_symbol_batch(monkeypatch):
+    import app.services.bulk_data_fetcher as module
+
+    def fake_download(**kwargs):
+        assert kwargs["tickers"] == ["7203.T", "6758.T"]
+        return pd.concat(
+            {
+                "7203.T": _price_df(date(2026, 3, 18), 100.0),
+                "6758.T": _price_df(date(2026, 3, 18), 200.0),
+            },
+            axis=1,
+        )
+
+    monkeypatch.setattr(module.yf.shared, "_ERRORS", {}, raising=False)
+    monkeypatch.setattr(module.yf, "download", fake_download)
+
+    results = BulkDataFetcher().fetch_batch_prices(
+        ["0130.T", "7203.T", "6758.T"],
+        period="2y",
+    )
+
+    assert results["0130.T"]["error_kind"] == "no_price_data"
+    assert "zero-prefixed" in results["0130.T"]["error"]
+    assert results["7203.T"]["has_error"] is False
+    assert results["6758.T"]["has_error"] is False
+
+
 def test_fetch_price_batch_with_retries_does_not_retry_zero_prefixed_jp_empty_batch(monkeypatch):
     import app.services.bulk_data_fetcher as module
 

--- a/backend/tests/unit/test_yahoo_batch_ingestion.py
+++ b/backend/tests/unit/test_yahoo_batch_ingestion.py
@@ -363,7 +363,13 @@ def test_fetch_prices_in_batches_delays_growth_until_cooldown_expires(monkeypatc
     fetcher = BulkDataFetcher()
     observed_batch_sizes = []
 
-    def fake_fetch_price_batch_with_retries(batch_symbols, *, period, initial_batch_size, market=None):
+    def fake_fetch_price_batch_with_retries(
+        batch_symbols,
+        *,
+        period,
+        initial_batch_size,
+        market=None,
+    ):
         _ = period
         _ = market
         observed_batch_sizes.append(initial_batch_size)
@@ -398,7 +404,11 @@ def test_fetch_prices_in_batches_delays_growth_until_cooldown_expires(monkeypatc
         def wait(*args, **kwargs):
             return None
 
-    monkeypatch.setattr(fetcher, "_fetch_price_batch_with_retries", fake_fetch_price_batch_with_retries)
+    monkeypatch.setattr(
+        fetcher,
+        "_fetch_price_batch_with_retries",
+        fake_fetch_price_batch_with_retries,
+    )
     monkeypatch.setattr(fetcher, "_rate_limiter", _StubRateLimiter())
     monkeypatch.setattr("app.services.bulk_data_fetcher.settings.yfinance_batch_rate_limit_interval", 0)
 
@@ -406,6 +416,64 @@ def test_fetch_prices_in_batches_delays_growth_until_cooldown_expires(monkeypatc
     fetcher.fetch_prices_in_batches(symbols, period="2y", start_batch_size=100)
 
     assert observed_batch_sizes[:8] == [100, 50, 50, 50, 50, 50, 50, 75]
+
+
+def test_fetch_prices_in_batches_shrinks_on_attempted_transient_failures(monkeypatch):
+    fetcher = BulkDataFetcher()
+    observed_batch_sizes = []
+    breaker = MagicMock()
+    breaker.check.return_value = "closed"
+
+    def fake_fetch_price_batch_with_retries(batch_symbols, *, period, initial_batch_size, market=None):
+        _ = period
+        _ = market
+        observed_batch_sizes.append(initial_batch_size)
+        if len(observed_batch_sizes) == 1:
+            results = {}
+            for symbol in batch_symbols:
+                if symbol.startswith("0"):
+                    results[symbol] = fetcher._build_error_result(
+                        symbol,
+                        "JP local code is zero-prefixed",
+                        error_kind="no_price_data",
+                    )
+                else:
+                    results[symbol] = fetcher._build_error_result(
+                        symbol,
+                        "429 rate limited",
+                        error_kind="rate_limit",
+                    )
+            return results
+        return {symbol: _success_result(symbol) for symbol in batch_symbols}
+
+    class _StubRateLimiter:
+        @staticmethod
+        def wait(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def wait_for_market(*args, **kwargs):
+            return None
+
+    invalid_symbols = [f"{index:04d}.T" for index in range(1, 50)]
+    symbols = [*invalid_symbols, "7203.T", *[f"NEXT{index}" for index in range(25)]]
+
+    monkeypatch.setattr(fetcher, "_fetch_price_batch_with_retries", fake_fetch_price_batch_with_retries)
+    monkeypatch.setattr(fetcher, "_rate_limiter", _StubRateLimiter())
+    monkeypatch.setattr(
+        "app.services.provider_circuit_breaker.get_circuit_breaker",
+        lambda: breaker,
+    )
+
+    fetcher._fetch_yfinance_prices_in_batches(
+        symbols,
+        period="2y",
+        start_batch_size=50,
+        market="JP",
+    )
+
+    assert observed_batch_sizes[:2] == [50, 25]
+    breaker.record_429.assert_called_once_with("yfinance", "JP")
 
 
 def test_fetch_prices_in_batches_uses_krx_first_for_korea(monkeypatch):

--- a/backend/tests/unit/test_yahoo_batch_ingestion.py
+++ b/backend/tests/unit/test_yahoo_batch_ingestion.py
@@ -257,6 +257,47 @@ def test_fetch_batch_prices_tags_yfinance_missing_price_errors(monkeypatch):
     assert results["0194.T"]["error_kind"] == "no_price_data"
 
 
+def test_fetch_batch_prices_tags_zero_prefixed_jp_empty_batch_as_no_price_data(monkeypatch):
+    import app.services.bulk_data_fetcher as module
+
+    symbols = ["0130.T", "0246.T"]
+    monkeypatch.setattr(module.yf.shared, "_ERRORS", {}, raising=False)
+    monkeypatch.setattr(module.yf, "download", lambda **kwargs: pd.DataFrame())
+
+    results = BulkDataFetcher().fetch_batch_prices(symbols, period="2y")
+
+    assert {results[symbol]["error_kind"] for symbol in symbols} == {"no_price_data"}
+    assert "zero-prefixed" in results["0130.T"]["error"]
+
+
+def test_fetch_price_batch_with_retries_does_not_retry_zero_prefixed_jp_empty_batch(monkeypatch):
+    import app.services.bulk_data_fetcher as module
+
+    fetcher = BulkDataFetcher()
+    symbols = ["0130.T", "0246.T"]
+    calls = []
+    sleeps = []
+
+    def fake_download(**kwargs):
+        calls.append(list(kwargs["tickers"]))
+        return pd.DataFrame()
+
+    monkeypatch.setattr(module.yf.shared, "_ERRORS", {}, raising=False)
+    monkeypatch.setattr(module.yf, "download", fake_download)
+    monkeypatch.setattr("app.services.bulk_data_fetcher.time.sleep", lambda seconds: sleeps.append(seconds))
+
+    results = fetcher._fetch_price_batch_with_retries(
+        symbols,
+        period="2y",
+        initial_batch_size=50,
+        market="JP",
+    )
+
+    assert calls == [symbols]
+    assert sleeps == []
+    assert {results[symbol]["error_kind"] for symbol in symbols} == {"no_price_data"}
+
+
 def test_fetch_price_batch_with_retries_keeps_legacy_schedule_without_market():
     """When no market is supplied (legacy shared callers), the retry schedule
     stays at the original 30/60/120s so we don't slow down code paths that

--- a/backend/tests/unit/test_yahoo_batch_ingestion.py
+++ b/backend/tests/unit/test_yahoo_batch_ingestion.py
@@ -503,6 +503,72 @@ def test_fetch_prices_in_batches_shrinks_on_attempted_transient_failures(monkeyp
     breaker.record_429.assert_called_once_with("yfinance", "JP")
 
 
+def test_fetch_prices_in_batches_ignores_invalid_only_batches_for_growth(monkeypatch):
+    fetcher = BulkDataFetcher()
+    observed_batches: list[tuple[list[str], int]] = []
+    breaker = MagicMock()
+    breaker.check.return_value = "closed"
+
+    def fake_fetch_price_batch_with_retries(
+        batch_symbols,
+        *,
+        period,
+        initial_batch_size,
+        market=None,
+    ):
+        _ = period
+        _ = market
+        observed_batches.append((list(batch_symbols), initial_batch_size))
+        if all(symbol.startswith("0") for symbol in batch_symbols):
+            return {
+                symbol: fetcher._build_error_result(
+                    symbol,
+                    "JP local code is zero-prefixed",
+                    error_kind="no_price_data",
+                )
+                for symbol in batch_symbols
+            }
+        return {symbol: _success_result(symbol) for symbol in batch_symbols}
+
+    class _StubRateLimiter:
+        @staticmethod
+        def wait(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def wait_for_market(*args, **kwargs):
+            return None
+
+    invalid_symbols = [f"{index:04d}.T" for index in range(1, 126)]
+    valid_symbols = [f"SYM{index}" for index in range(25)]
+
+    monkeypatch.setattr(
+        fetcher,
+        "_fetch_price_batch_with_retries",
+        fake_fetch_price_batch_with_retries,
+    )
+    monkeypatch.setattr(fetcher, "_rate_limiter", _StubRateLimiter())
+    monkeypatch.setattr(
+        "app.services.provider_circuit_breaker.get_circuit_breaker",
+        lambda: breaker,
+    )
+
+    fetcher._fetch_yfinance_prices_in_batches(
+        [*invalid_symbols, *valid_symbols],
+        period="2y",
+        start_batch_size=25,
+        market="JP",
+    )
+
+    valid_batch_sizes = [
+        batch_size
+        for batch_symbols, batch_size in observed_batches
+        if batch_symbols[0].startswith("SYM")
+    ]
+    assert valid_batch_sizes == [25]
+    breaker.record_success.assert_called_once_with("yfinance", "JP")
+
+
 def test_fetch_prices_in_batches_uses_krx_first_for_korea(monkeypatch):
     price_frame = _price_df(date(2026, 4, 29), 105.0)
     krx_service = MagicMock()

--- a/backend/tests/unit/test_yahoo_batch_ingestion.py
+++ b/backend/tests/unit/test_yahoo_batch_ingestion.py
@@ -201,7 +201,7 @@ def test_fetch_price_batch_with_retries_does_not_retry_permanent_no_data(monkeyp
     fetcher = BulkDataFetcher()
     calls: list[list[str]] = []
     sleeps: list[float] = []
-    symbols = ["0143.T", "0194.T", "0190.T"]
+    symbols = ["7203.T", "6758.T", "9984.T"]
 
     def fake_fetch_batch_prices(batch_symbols, period="2y"):
         calls.append(list(batch_symbols))
@@ -235,15 +235,15 @@ def test_fetch_price_batch_with_retries_does_not_retry_permanent_no_data(monkeyp
 def test_fetch_batch_prices_tags_yfinance_missing_price_errors(monkeypatch):
     import app.services.bulk_data_fetcher as module
 
-    symbols = ["0143.T", "0194.T"]
+    symbols = ["7203.T", "6758.T"]
     monkeypatch.setattr(module.yf.shared, "_ERRORS", {}, raising=False)
 
     def fake_download(**kwargs):
         assert kwargs["tickers"] == symbols
         module.yf.shared._ERRORS.update(
             {
-                "0143.T": "YFPricesMissingError('possibly delisted; no price data found')",
-                "0194.T": 'No data found, symbol may be delisted',
+                "7203.T": "YFPricesMissingError('possibly delisted; no price data found')",
+                "6758.T": 'No data found, symbol may be delisted',
             }
         )
         return pd.DataFrame()
@@ -252,20 +252,27 @@ def test_fetch_batch_prices_tags_yfinance_missing_price_errors(monkeypatch):
 
     results = BulkDataFetcher().fetch_batch_prices(symbols, period="2y")
 
-    assert results["0143.T"]["error_kind"] == "no_price_data"
-    assert "possibly delisted" in results["0143.T"]["error"]
-    assert results["0194.T"]["error_kind"] == "no_price_data"
+    assert results["7203.T"]["error_kind"] == "no_price_data"
+    assert "possibly delisted" in results["7203.T"]["error"]
+    assert results["6758.T"]["error_kind"] == "no_price_data"
 
 
-def test_fetch_batch_prices_tags_zero_prefixed_jp_empty_batch_as_no_price_data(monkeypatch):
+def test_fetch_batch_prices_short_circuits_zero_prefixed_jp_symbols(monkeypatch):
     import app.services.bulk_data_fetcher as module
 
     symbols = ["0130.T", "0246.T"]
+    calls = []
+
+    def fake_download(**kwargs):
+        calls.append(list(kwargs["tickers"]))
+        return pd.DataFrame()
+
     monkeypatch.setattr(module.yf.shared, "_ERRORS", {}, raising=False)
-    monkeypatch.setattr(module.yf, "download", lambda **kwargs: pd.DataFrame())
+    monkeypatch.setattr(module.yf, "download", fake_download)
 
     results = BulkDataFetcher().fetch_batch_prices(symbols, period="2y")
 
+    assert calls == []
     assert {results[symbol]["error_kind"] for symbol in symbols} == {"no_price_data"}
     assert "zero-prefixed" in results["0130.T"]["error"]
 
@@ -284,7 +291,10 @@ def test_fetch_price_batch_with_retries_does_not_retry_zero_prefixed_jp_empty_ba
 
     monkeypatch.setattr(module.yf.shared, "_ERRORS", {}, raising=False)
     monkeypatch.setattr(module.yf, "download", fake_download)
-    monkeypatch.setattr("app.services.bulk_data_fetcher.time.sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(
+        "app.services.bulk_data_fetcher.time.sleep",
+        lambda seconds: sleeps.append(seconds),
+    )
 
     results = fetcher._fetch_price_batch_with_retries(
         symbols,
@@ -293,9 +303,43 @@ def test_fetch_price_batch_with_retries_does_not_retry_zero_prefixed_jp_empty_ba
         market="JP",
     )
 
-    assert calls == [symbols]
+    assert calls == []
     assert sleeps == []
     assert {results[symbol]["error_kind"] for symbol in symbols} == {"no_price_data"}
+
+
+def test_fetch_price_batch_with_retries_ignores_invalid_jp_symbols_in_retry_rate(monkeypatch):
+    import app.services.bulk_data_fetcher as module
+
+    fetcher = BulkDataFetcher()
+    symbols = ["0130.T", "7203.T"]
+    calls = []
+    sleeps = []
+
+    def fake_download(**kwargs):
+        calls.append(list(kwargs["tickers"]))
+        if len(calls) == 1:
+            return pd.DataFrame()
+        return _price_df(date(2026, 3, 18), 100.0)
+
+    monkeypatch.setattr(module.yf.shared, "_ERRORS", {}, raising=False)
+    monkeypatch.setattr(module.yf, "download", fake_download)
+    monkeypatch.setattr(
+        "app.services.bulk_data_fetcher.time.sleep",
+        lambda seconds: sleeps.append(seconds),
+    )
+
+    results = fetcher._fetch_price_batch_with_retries(
+        symbols,
+        period="2y",
+        initial_batch_size=50,
+        market="JP",
+    )
+
+    assert calls == [["7203.T"], ["7203.T"]]
+    assert sleeps == [60]
+    assert results["0130.T"]["error_kind"] == "no_price_data"
+    assert results["7203.T"]["has_error"] is False
 
 
 def test_fetch_price_batch_with_retries_keeps_legacy_schedule_without_market():

--- a/backend/tests/unit/test_yahoo_batch_ingestion.py
+++ b/backend/tests/unit/test_yahoo_batch_ingestion.py
@@ -483,7 +483,7 @@ def test_fetch_prices_in_batches_shrinks_on_attempted_transient_failures(monkeyp
             return None
 
     invalid_symbols = [f"{index:04d}.T" for index in range(1, 50)]
-    symbols = [*invalid_symbols, "7203.T", *[f"NEXT{index}" for index in range(25)]]
+    symbols = [*invalid_symbols, *[f"SYM{index}" for index in range(60)]]
 
     monkeypatch.setattr(fetcher, "_fetch_price_batch_with_retries", fake_fetch_price_batch_with_retries)
     monkeypatch.setattr(fetcher, "_rate_limiter", _StubRateLimiter())
@@ -492,7 +492,7 @@ def test_fetch_prices_in_batches_shrinks_on_attempted_transient_failures(monkeyp
         lambda: breaker,
     )
 
-    fetcher._fetch_yfinance_prices_in_batches(
+    results = fetcher._fetch_yfinance_prices_in_batches(
         symbols,
         period="2y",
         start_batch_size=50,
@@ -500,12 +500,14 @@ def test_fetch_prices_in_batches_shrinks_on_attempted_transient_failures(monkeyp
     )
 
     assert observed_batch_sizes[:2] == [50, 25]
+    assert results["0001.T"]["error_kind"] == "no_price_data"
     breaker.record_429.assert_called_once_with("yfinance", "JP")
 
 
 def test_fetch_prices_in_batches_ignores_invalid_only_batches_for_growth(monkeypatch):
     fetcher = BulkDataFetcher()
     observed_batches: list[tuple[list[str], int]] = []
+    waits: list[tuple[tuple, dict]] = []
     breaker = MagicMock()
     breaker.check.return_value = "closed"
 
@@ -535,8 +537,8 @@ def test_fetch_prices_in_batches_ignores_invalid_only_batches_for_growth(monkeyp
         def wait(*args, **kwargs):
             return None
 
-        @staticmethod
-        def wait_for_market(*args, **kwargs):
+        def wait_for_market(self, *args, **kwargs):
+            waits.append((args, kwargs))
             return None
 
     invalid_symbols = [f"{index:04d}.T" for index in range(1, 126)]
@@ -553,13 +555,16 @@ def test_fetch_prices_in_batches_ignores_invalid_only_batches_for_growth(monkeyp
         lambda: breaker,
     )
 
-    fetcher._fetch_yfinance_prices_in_batches(
+    results = fetcher._fetch_yfinance_prices_in_batches(
         [*invalid_symbols, *valid_symbols],
         period="2y",
         start_batch_size=25,
         market="JP",
     )
 
+    assert observed_batches == [(valid_symbols, 25)]
+    assert waits == []
+    assert results["0001.T"]["error_kind"] == "no_price_data"
     valid_batch_sizes = [
         batch_size
         for batch_symbols, batch_size in observed_batches


### PR DESCRIPTION
## Summary
- prefilter zero-prefixed JP Yahoo symbols before price download, retry, adaptive batch sizing, and rate-limit pacing
- preserve permanent no-price-data failures without stripping leading zeroes into different securities
- add regression coverage for invalid-only, mixed valid/invalid, retry-rate, adaptive growth, and JP universe ingestion paths

## Verification
- backend/venv/bin/pytest backend/tests/unit/test_yahoo_batch_ingestion.py -q
- backend/venv/bin/pytest backend/tests/unit/test_yahoo_batch_ingestion.py backend/tests/unit/test_stock_universe_service.py::test_ingest_jp_from_csv_rejects_zero_prefixed_local_codes -q
- python -m py_compile backend/app/services/bulk_data_fetcher.py backend/tests/unit/test_yahoo_batch_ingestion.py
- git diff --check

## Known issue
- Full backend pytest is still blocked by existing issue StockScreenClaude-o94z: tests/integration/test_production_performance.py calls localhost:8000 during collection when no server is running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Yahoo price data ingestion with better error classification, distinguishing permanent failures from transient ones to optimize retry logic.
  * Added validation to reject zero-prefixed Japanese stock local codes during ingestion, preventing invalid symbols from being processed.
  * Enhanced batch price-fetching error handling to reduce unnecessary retry attempts and improve overall data ingestion reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->