### PR TITLE
Adjust bootstrap coverage by market and add RRG group ranking support

### DIFF
--- a/backend/app/api/v1/groups.py
+++ b/backend/app/api/v1/groups.py
@@ -19,6 +19,7 @@ from ...schemas.groups import (
     GroupRankingsResponse,
     GroupDetailResponse,
     MoversResponse,
+    RRGBundleResponse,
     RRGResponse,
     CalculationRequest,
     CalculationResponse,
@@ -30,6 +31,7 @@ from ...schemas.ui_view_snapshot import UISnapshotEnvelope
 from ...domain.analytics.scope import market_scope_tag
 from ...domain.markets.catalog import get_market_catalog
 from ...services.market_group_ranking_service import get_market_group_ranking_service
+from ...services.market_taxonomy_service import get_market_taxonomy_service
 from ...services.rrg_service import RRGService
 from ...services.ui_snapshot_service import GroupsBootstrapUnavailableError
 from ...wiring.bootstrap import get_group_rank_service, get_ui_snapshot_service
@@ -49,6 +51,14 @@ def _get_group_rank_service():
 
 def _get_market_group_service():
     return get_market_group_ranking_service()
+
+
+def _get_rrg_service():
+    return RRGService(
+        group_rank_service=_get_group_rank_service(),
+        market_group_ranking_service=_get_market_group_service(),
+        taxonomy_service=get_market_taxonomy_service(),
+    )
 
 
 def _normalize_market_param(market: str | None) -> str:
@@ -141,6 +151,76 @@ async def get_current_rankings(
     )
 
 
+def _build_rrg_response(
+    payload: dict,
+    *,
+    market: str,
+    scope: str,
+    tail_weeks: int,
+    limit: int,
+) -> RRGResponse:
+    groups = (payload.get("groups") or [])[:limit]
+    return RRGResponse(
+        date=payload.get("date"),
+        market=market,
+        scope=scope,
+        tail_weeks=tail_weeks,
+        total_groups=len(groups),
+        groups=groups,
+        **market_scope_tag(market),
+    )
+
+
+@router.get("/rrg/scopes", response_model=RRGBundleResponse)
+async def get_rrg_scopes(
+    tail_weeks: int = Query(8, ge=2, le=20, description="Number of weekly tail points"),
+    limit: int = Query(197, ge=1, le=197, description="Top-N series by rank"),
+    market: str = Query("US", description=MARKET_QUERY_DESCRIPTION),
+    db: Session = Depends(get_db),
+):
+    """Relative Rotation Graph coordinates for all scopes available to a market."""
+    normalized_market = _normalize_market_param(market)
+    service = _get_rrg_service()
+    scopes = service.get_rrg_scopes(
+        db,
+        market=normalized_market,
+        scopes=("groups", "sectors"),
+        tail_weeks=tail_weeks,
+    )
+    if not (scopes.get("groups") or {}).get("groups"):
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "No RRG data available for this market. "
+                "Run a group-ranking backfill first."
+            ),
+        )
+
+    responses = {
+        scope: _build_rrg_response(
+            scope_payload,
+            market=normalized_market,
+            scope=scope,
+            tail_weeks=tail_weeks,
+            limit=limit,
+        )
+        for scope, scope_payload in scopes.items()
+    }
+    available_scopes = [
+        scope for scope in ("groups", "sectors")
+        if responses.get(scope) and responses[scope].total_groups > 0
+    ]
+
+    return RRGBundleResponse(
+        date=responses["groups"].date,
+        market=normalized_market,
+        tail_weeks=tail_weeks,
+        available_scopes=available_scopes,
+        payload=responses,
+        **market_scope_tag(normalized_market),
+    )
+
+
 @router.get("/rrg", response_model=RRGResponse)
 async def get_rrg(
     tail_weeks: int = Query(8, ge=2, le=20, description="Number of weekly tail points"),
@@ -158,13 +238,12 @@ async def get_rrg(
     quadrants. Math is computed server-side (see ``services/rrg_service.py``).
     """
     normalized_market = _normalize_market_param(market)
-    service = RRGService(group_rank_service=_get_group_rank_service())
+    service = _get_rrg_service()
     payload = service.get_rrg(
         db, market=normalized_market, scope=scope, tail_weeks=tail_weeks
     )
 
-    groups = payload["groups"][:limit]
-    if not groups:
+    if not payload.get("groups"):
         raise HTTPException(
             status_code=404,
             detail=(
@@ -173,15 +252,15 @@ async def get_rrg(
             ),
         )
 
-    return RRGResponse(
-        date=payload["date"],
+    response = _build_rrg_response(
+        payload,
         market=normalized_market,
         scope=scope,
         tail_weeks=tail_weeks,
-        total_groups=len(groups),
-        groups=groups,
-        **market_scope_tag(normalized_market),
+        limit=limit,
     )
+
+    return response
 
 
 @router.get("/bootstrap", response_model=UISnapshotEnvelope)

--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -712,7 +712,6 @@ def build_daily_snapshot(
     from app.services.market_calendar_service import MarketCalendarService
     from app.services.universe_resolver import normalize_universe_definition
     from app.services.bootstrap_cache_coverage import (
-        BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
         evaluate_bootstrap_cache_coverage,
     )
     from app.tasks.market_queues import log_extra, normalize_market

--- a/backend/app/schemas/groups.py
+++ b/backend/app/schemas/groups.py
@@ -1,7 +1,7 @@
 """Pydantic schemas for IBD Industry Group Rankings API endpoints"""
 from pydantic import BaseModel, Field, field_validator
 from datetime import date as Date
-from typing import Any, Optional, List
+from typing import Any, Dict, Optional, List
 
 from ..infra.serialization import sanitize_sparkline
 from .scope import ScopedResponseMixin
@@ -154,6 +154,16 @@ class RRGResponse(ScopedResponseMixin):
     tail_weeks: int = Field(..., description="Number of weekly tail points requested")
     total_groups: int = Field(..., description="Number of plotted groups/sectors")
     groups: List[RRGGroupResponse] = Field(..., description="Plotted series")
+
+
+class RRGBundleResponse(ScopedResponseMixin):
+    """Relative Rotation Graph payload for all available scopes in one market."""
+
+    date: str = Field(..., description="As-of date (latest ranking date)")
+    market: str = Field(..., description="Market code")
+    tail_weeks: int = Field(..., description="Number of weekly tail points requested")
+    available_scopes: List[str] = Field(..., description="Scopes with plotted series")
+    payload: Dict[str, RRGResponse] = Field(..., description="Scope -> RRG payload")
 
 
 class CalculationRequest(BaseModel):

--- a/backend/app/services/bootstrap_cache_coverage.py
+++ b/backend/app/services/bootstrap_cache_coverage.py
@@ -19,6 +19,24 @@ from app.models.stock import StockFundamental, StockPrice
 from app.services.provider_snapshot_service import WEEKLY_REFERENCE_SNAPSHOT_KEYS
 
 BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE = 0.95
+BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE = 0.95
+# Price coverage thresholds are aligned to observed daily-price static bundle
+# availability, rounded down to conservative 5-point floors. They gate whether
+# bootstrap can build a cache-only snapshot without falling back to live fetches.
+BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET: dict[str, float] = {
+    "AU": 0.90,
+    "CA": 0.75,
+    "CN": 0.90,
+    "DE": 0.90,
+    "HK": 0.80,
+    "IN": 0.50,
+    "JP": 0.90,
+    "KR": 0.95,
+    "MY": 0.85,
+    "SG": 0.60,
+    "TW": 0.50,
+    "US": 0.95,
+}
 MISSING_SYMBOL_PREVIEW_LIMIT = 20
 
 
@@ -77,6 +95,7 @@ class BootstrapPriceCoverageReport(Mapping[str, Any]):
 class BootstrapCacheCoverageReport(Mapping[str, Any]):
     market: str
     threshold: float
+    fundamentals_threshold: float
     price_report: BootstrapPriceCoverageReport
     fundamentals_coverage_date: str | None
     fundamentals_total_symbols: int
@@ -93,7 +112,10 @@ class BootstrapCacheCoverageReport(Mapping[str, Any]):
 
     @property
     def eligible(self) -> bool:
-        return self.price_report.eligible and self.fundamentals_coverage_ratio >= self.threshold
+        return (
+            self.price_report.eligible
+            and self.fundamentals_coverage_ratio >= self.fundamentals_threshold
+        )
 
     @property
     def mode(self) -> str:
@@ -104,6 +126,8 @@ class BootstrapCacheCoverageReport(Mapping[str, Any]):
         return {
             "market": self.market,
             "threshold": self.threshold,
+            "price_threshold": self.price_report.threshold,
+            "fundamentals_threshold": self.fundamentals_threshold,
             "eligible": self.eligible,
             "mode": self.mode,
             "price_coverage_date": price_payload["price_coverage_date"],
@@ -138,6 +162,23 @@ def _normalize_symbols(symbols: Sequence[str]) -> list[str]:
     return sorted({str(symbol).upper() for symbol in symbols if symbol})
 
 
+def _normalize_market_code(market: str | None) -> str:
+    return str(market or "US").strip().upper() or "US"
+
+
+def bootstrap_price_min_coverage_for_market(market: str | None) -> float:
+    normalized_market = _normalize_market_code(market)
+    return BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET.get(
+        normalized_market,
+        BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+    )
+
+
+def bootstrap_fundamentals_min_coverage_for_market(market: str | None) -> float:
+    _normalize_market_code(market)
+    return BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE
+
+
 def _ratio(covered: int, total: int) -> float:
     return covered / total if total > 0 else 0.0
 
@@ -162,7 +203,7 @@ def evaluate_bootstrap_price_cache_coverage(
     as_of_date: date,
 ) -> BootstrapPriceCoverageReport:
     """Return bootstrap price coverage without requiring later fundamentals stages."""
-    normalized_market = str(market or "US").strip().upper() or "US"
+    normalized_market = _normalize_market_code(market)
     normalized_symbols = _normalize_symbols(symbols)
     total = len(normalized_symbols)
 
@@ -185,7 +226,7 @@ def evaluate_bootstrap_price_cache_coverage(
     )
     return BootstrapPriceCoverageReport(
         market=normalized_market,
-        threshold=BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+        threshold=bootstrap_price_min_coverage_for_market(normalized_market),
         price_coverage_date=as_of_date,
         price_total_symbols=total,
         price_covered_symbols=total - len(price_missing),
@@ -201,7 +242,7 @@ def evaluate_bootstrap_cache_coverage(
     as_of_date: date,
 ) -> BootstrapCacheCoverageReport:
     """Return a JSON-ready coverage report for bootstrap cache-only eligibility."""
-    normalized_market = str(market or "US").strip().upper() or "US"
+    normalized_market = _normalize_market_code(market)
     normalized_symbols = _normalize_symbols(symbols)
     total = len(normalized_symbols)
     price_report = evaluate_bootstrap_price_cache_coverage(
@@ -256,10 +297,13 @@ def evaluate_bootstrap_cache_coverage(
     elif fundamentals_dates:
         fundamentals_coverage_date = _date_string(max(fundamentals_dates))
 
-    threshold = BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE
+    threshold = bootstrap_price_min_coverage_for_market(normalized_market)
     return BootstrapCacheCoverageReport(
         market=normalized_market,
         threshold=threshold,
+        fundamentals_threshold=bootstrap_fundamentals_min_coverage_for_market(
+            normalized_market
+        ),
         price_report=price_report,
         fundamentals_coverage_date=fundamentals_coverage_date,
         fundamentals_total_symbols=total,

--- a/backend/app/services/market_group_ranking_service.py
+++ b/backend/app/services/market_group_ranking_service.py
@@ -81,6 +81,59 @@ class MarketGroupRankingService:
             if row.get("industry_group") and row.get("rank") is not None
         }
 
+    def get_all_groups_history(
+        self,
+        db: Session,
+        *,
+        market: str,
+        days: int = 400,
+    ) -> tuple[str | None, dict[str, dict[str, Any]], dict[str, list[tuple[date, float, int]]]]:
+        """Return RRG-ready avg-RS history for every group in one market.
+
+        This loads full FeatureRun snapshots once per run, not once per group,
+        then computes the same group-ranking rows used by the live rankings page.
+        """
+        latest_run = self._get_latest_published_run(db, market=market)
+        if latest_run is None:
+            return None, {}, {}
+
+        cutoff_date = latest_run.as_of_date - timedelta(days=days)
+        market_runs = self._get_market_run_series(
+            db,
+            market=market,
+            latest_run=latest_run,
+            cutoff_date=cutoff_date,
+            min_runs=0,
+        )
+
+        rankings_by_run: dict[int, list[dict[str, Any]]] = {}
+        for run in market_runs:
+            rows = self._load_run_rows(db, run.id, include_sparklines=False)
+            rankings_by_run[run.id] = self.compute_group_rankings_from_rows(
+                rows,
+                ranking_date=run.as_of_date,
+            )
+
+        latest_rankings = rankings_by_run.get(latest_run.id, [])
+        meta = self._group_rank_map(latest_rankings)
+
+        series: dict[str, list[tuple[date, float, int]]] = defaultdict(list)
+        for run in reversed(market_runs):
+            for ranking in rankings_by_run.get(run.id, []):
+                group = ranking.get("industry_group")
+                avg_rs = ranking.get("avg_rs_rating")
+                if not group or avg_rs is None:
+                    continue
+                series[str(group)].append(
+                    (
+                        run.as_of_date,
+                        float(avg_rs),
+                        int(ranking.get("num_stocks") or 0),
+                    )
+                )
+
+        return latest_run.as_of_date.isoformat(), meta, dict(series)
+
     def get_rank_movers(
         self,
         db: Session,
@@ -356,13 +409,19 @@ class MarketGroupRankingService:
                 historical = reference_map.get(ranking["industry_group"])
                 ranking[key] = historical["rank"] - ranking["rank"] if historical is not None else None
 
-    def _load_run_rows(self, db: Session, run_id: int) -> list[Any]:
+    def _load_run_rows(
+        self,
+        db: Session,
+        run_id: int,
+        *,
+        include_sparklines: bool = True,
+    ) -> list[Any]:
         repo = SqlFeatureStoreRepository(db)
         return repo.query_all_as_scan_results(
             run_id,
             FilterSpec(),
             SortSpec(field="composite_score", order=SortOrder.DESC),
-            include_sparklines=True,
+            include_sparklines=include_sparklines,
         )
 
     def _get_latest_published_run(

--- a/backend/app/services/market_taxonomy_service.py
+++ b/backend/app/services/market_taxonomy_service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import csv
 import logging
 import re
+from collections import Counter, defaultdict
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Iterable
@@ -204,6 +205,25 @@ class MarketTaxonomyService:
             if entry.industry_group == group
         )
 
+    def sector_map_for_market(self, market: str) -> dict[str, str]:
+        """Return industry_group -> dominant native sector for one market."""
+        self._ensure_loaded()
+        normalized = security_master_resolver.normalize_market(market) or market.upper()
+        entries = self._entries.get(normalized, {})
+        votes: dict[str, Counter[str]] = defaultdict(Counter)
+        for entry in entries.values():
+            if entry.industry_group and entry.sector:
+                votes[entry.industry_group][entry.sector] += 1
+
+        result: dict[str, str] = {}
+        for group, counter in votes.items():
+            result[group] = sorted(counter.items(), key=lambda item: (-item[1], item[0]))[0][0]
+        return result
+
+    def sector_for_group(self, market: str, group: str) -> str | None:
+        """Return the dominant native sector for a group, if the taxonomy has one."""
+        return self.sector_map_for_market(market).get(group)
+
     def entry_count_for_market(self, market: str) -> int:
         """Return the committed taxonomy row count loaded for one market."""
         self._ensure_loaded()
@@ -298,7 +318,11 @@ class MarketTaxonomyService:
         path = self._data_dir / "hk-deep.csv"
         with path.open("r", encoding="utf-8-sig", newline="") as handle:
             reader = csv.DictReader(handle)
-            self._require_columns(path, reader, ("Symbol", "EM Industry (EN)", "Theme (EN)"))
+            self._require_columns(
+                path,
+                reader,
+                ("Symbol", "HSICS Sector", "EM Industry (EN)", "Theme (EN)"),
+            )
             for row in reader:
                 symbol = self._canonicalize_hk_symbol(row.get("Symbol"))
                 if symbol is None:
@@ -307,7 +331,7 @@ class MarketTaxonomyService:
                     market="HK",
                     symbol=symbol,
                     industry_group=self._normalize_text(row.get("EM Industry (EN)")),
-                    sector=None,
+                    sector=self._normalize_text(row.get("HSICS Sector")),
                     industry=None,
                     themes=[row.get("Theme (EN)") or ""],
                 )

--- a/backend/app/services/rrg_service.py
+++ b/backend/app/services/rrg_service.py
@@ -52,6 +52,9 @@ EPS = 1e-6
 DEFAULT_TAIL_WEEKS = 8
 DEFAULT_LOOKBACK_DAYS = 400  # enough daily rows to build Z_WINDOW + tail weeks
 
+RRG_GROUPS_ENABLED_MARKETS = frozenset({"US", "HK", "JP", "IN", "TW"})
+RRG_SECTORS_ENABLED_MARKETS = frozenset({"US", "HK", "JP", "IN"})
+
 
 @dataclass(frozen=True)
 class RRGParams:
@@ -235,8 +238,30 @@ class RRGService:
     dominant GICS sector and aggregates the same series.
     """
 
-    def __init__(self, *, group_rank_service: Any) -> None:
+    def __init__(
+        self,
+        *,
+        group_rank_service: Any,
+        market_group_ranking_service: Any | None = None,
+        taxonomy_service: Any | None = None,
+    ) -> None:
         self._group_rank_service = group_rank_service
+        self._market_group_ranking_service = market_group_ranking_service
+        self._taxonomy_service = taxonomy_service
+
+    def _get_market_group_ranking_service(self) -> Any:
+        if self._market_group_ranking_service is None:
+            from .market_group_ranking_service import get_market_group_ranking_service
+
+            self._market_group_ranking_service = get_market_group_ranking_service()
+        return self._market_group_ranking_service
+
+    def _get_taxonomy_service(self) -> Any:
+        if self._taxonomy_service is None:
+            from .market_taxonomy_service import get_market_taxonomy_service
+
+            self._taxonomy_service = get_market_taxonomy_service()
+        return self._taxonomy_service
 
     def get_group_sector_map(self, db: Any, market: str = "US") -> Dict[str, str]:
         """Map each IBD industry group -> its constituents' dominant GICS sector.
@@ -244,6 +269,12 @@ class RRGService:
         Derived from ``StockUniverse.sector`` (fully populated) via a majority
         vote, since the codebase has no IBD-native sector taxonomy.
         """
+        market = (market or "US").upper()
+        if market != "US" and market in RRG_SECTORS_ENABLED_MARKETS:
+            sector_map = self._get_taxonomy_service().sector_map_for_market(market)
+            if sector_map:
+                return sector_map
+
         from collections import Counter, defaultdict
 
         from ..models.industry import IBDIndustryGroup
@@ -299,17 +330,32 @@ class RRGService:
         sectors without re-querying. ``get_rrg`` is the single-scope shorthand.
         """
         market = (market or "US").upper()
+        if market not in RRG_GROUPS_ENABLED_MARKETS:
+            return self._empty_scopes(market, scopes)
+
+        if all(scope == "sectors" and market not in RRG_SECTORS_ENABLED_MARKETS for scope in scopes):
+            return self._empty_scopes(market, scopes)
+
         params = RRGParams(tail_weeks=tail_weeks)
         latest_date, meta, group_series = self._fetch_inputs(db, market, lookback_days)
         if latest_date is None:
-            return {
-                scope: {"date": None, "market": market, "scope": scope, "groups": []}
-                for scope in scopes
-            }
+            return self._empty_scopes(market, scopes)
         return {
             scope: self._build_scope_payload(
                 db, market, scope, latest_date, meta, group_series, params
             )
+            for scope in scopes
+        }
+
+    @staticmethod
+    def _empty_scopes(
+        market: str,
+        scopes: Sequence[str],
+        *,
+        latest_date: str | None = None,
+    ) -> Dict[str, Dict[str, Any]]:
+        return {
+            scope: {"date": latest_date, "market": market, "scope": scope, "groups": []}
             for scope in scopes
         }
 
@@ -321,6 +367,22 @@ class RRGService:
         Dict[str, List[Tuple[date, float, int]]],
     ]:
         """Read the current rankings (metadata) + batched group history (one query)."""
+        if market != "US":
+            return self._get_market_group_ranking_service().get_all_groups_history(
+                db,
+                market=market,
+                days=lookback_days,
+            )
+
+        return self._fetch_us_inputs(db, market, lookback_days)
+
+    def _fetch_us_inputs(
+        self, db: Any, market: str, lookback_days: int
+    ) -> Tuple[
+        Optional[str],
+        Dict[str, Dict[str, Any]],
+        Dict[str, List[Tuple[date, float, int]]],
+    ]:
         from datetime import date as _date
 
         from ..models.industry import IBDGroupRank
@@ -359,6 +421,8 @@ class RRGService:
         params: RRGParams,
     ) -> Dict[str, Any]:
         if scope == "sectors":
+            if market not in RRG_SECTORS_ENABLED_MARKETS:
+                return {"date": latest_date, "market": market, "scope": scope, "groups": []}
             series, scope_meta = self._aggregate_sectors(db, market, group_series)
         else:
             series = {

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -15,6 +15,7 @@ from typing import Any
 from urllib.parse import quote
 
 import pandas as pd
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.analysis.patterns.rs_line import blue_dot_series, compute_rs_line
@@ -39,6 +40,8 @@ from app.services.preset_screens import (
     resolve_preset_screens_for_defaults,
 )
 from app.services.rrg_service import RRGService
+from app.services.market_group_ranking_service import get_market_group_ranking_service
+from app.services.market_taxonomy_service import get_market_taxonomy_service
 from app.services.ui_snapshot_service import UISnapshotService
 from app.wiring.bootstrap import (
     get_benchmark_cache,
@@ -626,16 +629,30 @@ class StaticSiteExportService:
         groups[]}`` shape the shared ``RRGChart`` consumes. Both scopes
         (groups + sectors) are stored so the static page's toggle works offline.
 
-        US reads ``ibd_group_ranks`` directly; non-US markets have no such
-        history yet, so the section is reported unavailable (handled gracefully
-        by the caller). RRG tails want ~30 weekly points (~7 months) of
+        RRG tails want ~30 weekly points (~7 months) of
         ``avg_rs_rating`` history — when the exported DB is shallower, the math
         flags ``is_provisional`` / omits thin groups rather than fabricating.
+        If a lightweight export database lacks the RRG source tables entirely,
+        this optional section is reported unavailable without aborting export.
         """
-        service = RRGService(group_rank_service=get_group_rank_service())
-        scopes = service.get_rrg_scopes(db, market=market, scopes=("groups", "sectors"))
+        service = RRGService(
+            group_rank_service=get_group_rank_service(),
+            market_group_ranking_service=get_market_group_ranking_service(),
+            taxonomy_service=get_market_taxonomy_service(),
+        )
+        try:
+            scopes = service.get_rrg_scopes(db, market=market, scopes=("groups", "sectors"))
+        except SQLAlchemyError as exc:
+            raise StaticSiteSectionUnavailableError(
+                section=f"{market} rrg",
+                reason="RRG source tables are unavailable for this export database.",
+            ) from exc
         groups_rrg = scopes["groups"]
         sectors_rrg = scopes["sectors"]
+        available_scopes = [
+            scope for scope in ("groups", "sectors")
+            if scopes.get(scope, {}).get("groups")
+        ]
 
         if not groups_rrg.get("groups"):
             raise StaticSiteSectionUnavailableError(
@@ -652,6 +669,7 @@ class StaticSiteExportService:
             "available": True,
             "market": market,
             "as_of_date": groups_rrg.get("date") or expected_as_of_date.isoformat(),
+            "available_scopes": available_scopes,
             "payload": {
                 "groups": groups_rrg,
                 "sectors": sectors_rrg,

--- a/backend/app/use_cases/feature_store/build_daily_snapshot.py
+++ b/backend/app/use_cases/feature_store/build_daily_snapshot.py
@@ -52,8 +52,9 @@ from app.domain.scanning.ports import (
     StockScanner,
 )
 from app.services.bootstrap_cache_coverage import (
-    BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+    BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE,
     MISSING_SYMBOL_PREVIEW_LIMIT,
+    bootstrap_price_min_coverage_for_market,
     evaluate_bootstrap_cache_coverage,
 )
 from app.domain.providers.price_symbol_support import split_supported_price_symbols
@@ -373,9 +374,20 @@ class BuildDailyFeatureSnapshotUseCase:
                 elif not bootstrap_gate_report:
                     bootstrap_gate_report = {"eligible": False}
                 eligible = bool(bootstrap_gate_report.get("eligible"))
+                price_threshold = float(
+                    bootstrap_gate_report.get("price_threshold")
+                    or bootstrap_gate_report.get("threshold")
+                    or bootstrap_price_min_coverage_for_market(cmd.market)
+                )
+                fundamentals_threshold = float(
+                    bootstrap_gate_report.get("fundamentals_threshold")
+                    or BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE
+                )
                 bootstrap_gate_report.update(
                     {
-                        "threshold": BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+                        "threshold": price_threshold,
+                        "price_threshold": price_threshold,
+                        "fundamentals_threshold": fundamentals_threshold,
                         "mode": (
                             "cache_only"
                             if eligible

--- a/backend/tests/unit/test_bootstrap_cache_coverage.py
+++ b/backend/tests/unit/test_bootstrap_cache_coverage.py
@@ -16,9 +16,12 @@ from app.models.provider_snapshot import (
 from app.models.stock import StockFundamental, StockPrice
 from app.services.bootstrap_cache_coverage import (
     BootstrapPriceCoverageReport,
+    bootstrap_fundamentals_min_coverage_for_market,
+    bootstrap_price_min_coverage_for_market,
     evaluate_bootstrap_cache_coverage,
     evaluate_bootstrap_price_cache_coverage,
 )
+from app.domain.markets.catalog import get_market_catalog
 
 
 def _session():
@@ -182,6 +185,80 @@ def test_bootstrap_price_cache_coverage_ignores_fundamentals_before_later_bootst
     assert report["price_covered_symbols"] == 19
     assert report["price_missing_symbols"] == 1
     assert report["price_missing_symbols_preview"] == ["SYM19"]
+
+
+def test_bootstrap_price_cache_coverage_uses_market_specific_threshold():
+    db = _session()
+    symbols = [f"SYM{i}" for i in range(20)]
+    as_of = date(2026, 4, 24)
+    db.add_all([_price(symbol, as_of) for symbol in symbols[:11]])
+    db.commit()
+
+    report = evaluate_bootstrap_price_cache_coverage(
+        db,
+        market="TW",
+        symbols=symbols,
+        as_of_date=as_of,
+    )
+
+    assert report["threshold"] == 0.50
+    assert report["price_coverage_ratio"] == 0.55
+    assert report["eligible"] is True
+
+
+def test_bootstrap_cache_coverage_keeps_fundamentals_threshold_strict_for_partial_price_markets():
+    db = _session()
+    symbols = [f"SYM{i}" for i in range(20)]
+    as_of = date(2026, 4, 24)
+    db.add_all([_price(symbol, as_of) for symbol in symbols[:11]])
+    db.add_all(
+        [
+            _fundamental(symbol, datetime(2026, 4, 21, tzinfo=timezone.utc))
+            for symbol in symbols[:18]
+        ]
+    )
+    db.commit()
+
+    report = evaluate_bootstrap_cache_coverage(
+        db,
+        market="TW",
+        symbols=symbols,
+        as_of_date=as_of,
+    )
+
+    assert report["price_threshold"] == 0.50
+    assert report["fundamentals_threshold"] == 0.95
+    assert report["price_coverage_ratio"] == 0.55
+    assert report["fundamentals_coverage_ratio"] == 0.90
+    assert report["eligible"] is False
+
+
+def test_bootstrap_price_thresholds_cover_every_supported_market():
+    expected_price_thresholds = {
+        "AU": 0.90,
+        "CA": 0.75,
+        "CN": 0.90,
+        "DE": 0.90,
+        "HK": 0.80,
+        "IN": 0.50,
+        "JP": 0.90,
+        "KR": 0.95,
+        "MY": 0.85,
+        "SG": 0.60,
+        "TW": 0.50,
+        "US": 0.95,
+    }
+
+    assert set(expected_price_thresholds) == set(
+        get_market_catalog().supported_market_codes()
+    )
+
+    for market, expected_threshold in expected_price_thresholds.items():
+        price_threshold = bootstrap_price_min_coverage_for_market(market)
+        fundamentals_threshold = bootstrap_fundamentals_min_coverage_for_market(market)
+
+        assert price_threshold == expected_threshold, market
+        assert fundamentals_threshold == 0.95, market
 
 
 def test_bootstrap_price_cache_coverage_rejects_empty_candidate_set():

--- a/backend/tests/unit/test_groups_api_no_data.py
+++ b/backend/tests/unit/test_groups_api_no_data.py
@@ -296,3 +296,55 @@ async def test_get_groups_bootstrap_supports_non_us_market_scope(monkeypatch, cl
     payload = response.json()
     assert payload["snapshot_revision"].startswith("groups:HK:")
     assert payload["payload"]["rankings"]["market_scope"] == "HK"
+
+
+@pytest.mark.asyncio
+async def test_get_rrg_scopes_returns_bundle_with_available_scopes(monkeypatch, client):
+    from app.services import server_auth
+
+    monkeypatch.setattr(server_auth.settings, "server_auth_enabled", False)
+
+    class _FakeRRGService:
+        def __init__(self, **kwargs):  # noqa: ANN003
+            self.kwargs = kwargs
+
+        def get_rrg_scopes(self, db, *, market, scopes, tail_weeks=8, lookback_days=400):  # noqa: ARG002
+            assert market == "HK"
+            assert scopes == ("groups", "sectors")
+            return {
+                "groups": {
+                    "date": "2026-04-18",
+                    "market": "HK",
+                    "scope": "groups",
+                    "groups": [
+                        {
+                            "industry_group": "Internet Services",
+                            "rank": 1,
+                            "num_stocks": 9,
+                            "avg_rs_rating": 82.0,
+                            "quadrant": "Leading",
+                            "is_provisional": False,
+                            "current": {"date": "2026-04-12", "x": 104.0, "y": 103.0},
+                            "tail": [{"date": "2026-04-12", "x": 104.0, "y": 103.0}],
+                        }
+                    ],
+                },
+                "sectors": {
+                    "date": "2026-04-18",
+                    "market": "HK",
+                    "scope": "sectors",
+                    "groups": [],
+                },
+            }
+
+    monkeypatch.setattr("app.api.v1.groups.RRGService", _FakeRRGService)
+
+    response = await client.get("/api/v1/groups/rrg/scopes", params={"market": "HK"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["market"] == "HK"
+    assert payload["available_scopes"] == ["groups"]
+    assert payload["payload"]["groups"]["total_groups"] == 1
+    assert payload["payload"]["sectors"]["total_groups"] == 0
+    assert payload["payload"]["groups"]["market_scope"] == "HK"

--- a/backend/tests/unit/test_market_group_ranking_service.py
+++ b/backend/tests/unit/test_market_group_ranking_service.py
@@ -118,3 +118,67 @@ def test_get_current_rank_map_skips_historical_rank_change_work(monkeypatch):
     rank_map = service.get_current_rank_map(Session(), market="HK")
 
     assert rank_map == {"Internet Services": 4, "Software": 7}
+
+
+def test_get_all_groups_history_loads_each_run_once_and_returns_ascending_series(monkeypatch):
+    service = MarketGroupRankingService()
+    latest_run = SimpleNamespace(id=3, as_of_date=date(2026, 4, 3))
+    middle_run = SimpleNamespace(id=2, as_of_date=date(2026, 4, 2))
+    oldest_run = SimpleNamespace(id=1, as_of_date=date(2026, 4, 1))
+    load_calls: list[int] = []
+
+    monkeypatch.setattr(
+        service,
+        "_get_latest_published_run",
+        lambda db, *, market, calculation_date=None: latest_run,  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        service,
+        "_get_market_run_series",
+        lambda db, *, market, latest_run, cutoff_date, min_runs=0: [  # noqa: ARG005
+            latest_run,
+            middle_run,
+            oldest_run,
+        ],
+    )
+
+    def _load_rows(db, run_id, *, include_sparklines=True):  # noqa: ANN001, ARG001
+        assert include_sparklines is False
+        load_calls.append(run_id)
+        return [f"rows-{run_id}"]
+
+    def _rankings(rows, *, ranking_date):  # noqa: ANN001
+        run_id = int(str(rows[0]).split("-")[-1])
+        return [
+            {
+                "industry_group": "Internet Services",
+                "date": ranking_date.isoformat(),
+                "rank": 1,
+                "avg_rs_rating": 70.0 + run_id,
+                "num_stocks": 10 + run_id,
+            },
+            {
+                "industry_group": "Banks",
+                "date": ranking_date.isoformat(),
+                "rank": 2,
+                "avg_rs_rating": 55.0 + run_id,
+                "num_stocks": 5 + run_id,
+            },
+        ]
+
+    monkeypatch.setattr(service, "_load_run_rows", _load_rows)
+    monkeypatch.setattr(service, "compute_group_rankings_from_rows", _rankings)
+
+    latest_date, meta, series = service.get_all_groups_history(
+        Session(), market="HK", days=30
+    )
+
+    assert load_calls == [3, 2, 1]
+    assert latest_date == "2026-04-03"
+    assert meta["Internet Services"]["rank"] == 1
+    assert series["Internet Services"] == [
+        (date(2026, 4, 1), 71.0, 11),
+        (date(2026, 4, 2), 72.0, 12),
+        (date(2026, 4, 3), 73.0, 13),
+    ]
+    assert series["Banks"][-1] == (date(2026, 4, 3), 58.0, 8)

--- a/backend/tests/unit/test_market_taxonomy_service.py
+++ b/backend/tests/unit/test_market_taxonomy_service.py
@@ -13,7 +13,10 @@ def test_market_taxonomy_service_normalizes_hk_jp_and_tw_symbols(tmp_path):
     _write_csv(tmp_path / "IBD_industry_group.csv", "AAPL,Computer-Hardware/Peripherals\n")
     _write_csv(
         tmp_path / "hk-deep.csv",
-        "Symbol,EM Industry (EN),Theme (EN)\n700,Internet Services,AI Infrastructure\n",
+        (
+            "Symbol,HSICS Sector,EM Industry (EN),Theme (EN)\n"
+            "700,Information Technology,Internet Services,AI Infrastructure\n"
+        ),
     )
     _write_csv(
         tmp_path / "india-deep.csv",
@@ -56,6 +59,7 @@ def test_market_taxonomy_service_normalizes_hk_jp_and_tw_symbols(tmp_path):
     assert hk is not None
     assert hk.symbol == "0700.HK"
     assert hk.industry_group == "Internet Services"
+    assert hk.sector == "Information Technology"
     assert hk.themes_list() == ["AI Infrastructure"]
 
     hk_unpadded = service.get("700", market="HK")
@@ -144,11 +148,11 @@ def test_groups_for_market_and_symbols_for_group(tmp_path):
     _write_csv(
         tmp_path / "hk-deep.csv",
         (
-            "Symbol,EM Industry (EN),Theme (EN)\n"
-            "700,Internet Services,AI Infrastructure\n"
-            "1,Conglomerates,\n"
-            "5,Banks,\n"
-            "11,Banks,\n"
+            "Symbol,HSICS Sector,EM Industry (EN),Theme (EN)\n"
+            "700,Information Technology,Internet Services,AI Infrastructure\n"
+            "1,Industrials,Conglomerates,\n"
+            "5,Financials,Banks,\n"
+            "11,Financials,Banks,\n"
         ),
     )
     # Other CSVs still need to be present so `refresh()` can load them.
@@ -178,9 +182,43 @@ def test_groups_for_market_and_symbols_for_group(tmp_path):
     assert service.groups_for_market("XX") == []
 
 
+def test_sector_map_for_market_majority_votes_native_taxonomy_sectors(tmp_path):
+    _write_csv(tmp_path / "IBD_industry_group.csv", "AAPL,Computer-Hardware/Peripherals\n")
+    _write_csv(
+        tmp_path / "hk-deep.csv",
+        (
+            "Symbol,HSICS Sector,EM Industry (EN),Theme (EN)\n"
+            "700,Information Technology,Internet Services,AI Infrastructure\n"
+            "9988,Information Technology,Internet Services,E-Commerce\n"
+            "388,Financials,Internet Services,Exchange Operators\n"
+            "5,Financials,Banks,\n"
+            "11,Financials,Banks,\n"
+        ),
+    )
+    _write_csv(
+        tmp_path / "india-deep.csv",
+        "Symbol,Exchange,Industry (Sector),Subgroup (Theme),Sub-industry\n",
+    )
+    _write_csv(
+        tmp_path / "kabutan_themes_en.csv",
+        "Symbol,TSE 33-Sector,TSE 17-Sector,Theme (EN)\n",
+    )
+    _write_csv(tmp_path / "taiwan-deep.csv", "Symbol,Market,Industry (EN)\n")
+    _write_csv(tmp_path / "korea-deep.csv", "Symbol,Market,Sector,Industry Group,Industry,Sub-Industry\n")
+    _write_csv(tmp_path / "china-deep.csv", "Symbol,Exchange,Sector,Industry Group,Industry,Sub-Industry\n")
+
+    service = MarketTaxonomyService(data_dir=tmp_path)
+
+    assert service.sector_for_group("HK", "Internet Services") == "Information Technology"
+    assert service.sector_map_for_market("HK") == {
+        "Banks": "Financials",
+        "Internet Services": "Information Technology",
+    }
+
+
 def test_entry_count_for_market_counts_loaded_rows_before_symbol_merge(tmp_path):
     _write_csv(tmp_path / "IBD_industry_group.csv", "AAPL,Computer-Hardware/Peripherals\n")
-    _write_csv(tmp_path / "hk-deep.csv", "Symbol,EM Industry (EN),Theme (EN)\n")
+    _write_csv(tmp_path / "hk-deep.csv", "Symbol,HSICS Sector,EM Industry (EN),Theme (EN)\n")
     _write_csv(
         tmp_path / "india-deep.csv",
         "Symbol,Exchange,Industry (Sector),Subgroup (Theme),Sub-industry\n",
@@ -251,7 +289,7 @@ def _write_minimum_required_csvs(tmp_path) -> None:
     """Write the seven CSVs required by the pre-CA loaders so a test can
     isolate CA-specific behaviour without tripping required-CSV errors."""
     _write_csv(tmp_path / "IBD_industry_group.csv", "AAPL,Computer-Hardware/Peripherals\n")
-    _write_csv(tmp_path / "hk-deep.csv", "Symbol,EM Industry (EN),Theme (EN)\n")
+    _write_csv(tmp_path / "hk-deep.csv", "Symbol,HSICS Sector,EM Industry (EN),Theme (EN)\n")
     _write_csv(
         tmp_path / "india-deep.csv",
         "Symbol,Exchange,Industry (Sector),Subgroup (Theme),Sub-industry\n",
@@ -329,7 +367,13 @@ def test_market_taxonomy_service_default_data_dir_prefers_container_app_data(tmp
     app_data = runtime_root / "app" / "data"
     app_data.mkdir(parents=True)
     _write_csv(app_data / "IBD_industry_group.csv", "AAPL,Computer-Hardware/Peripherals\n")
-    _write_csv(app_data / "hk-deep.csv", "Symbol,EM Industry (EN),Theme (EN)\n700,Internet Services,AI Infrastructure\n")
+    _write_csv(
+        app_data / "hk-deep.csv",
+        (
+            "Symbol,HSICS Sector,EM Industry (EN),Theme (EN)\n"
+            "700,Information Technology,Internet Services,AI Infrastructure\n"
+        ),
+    )
     _write_csv(app_data / "india-deep.csv", "Symbol,Exchange,Industry (Sector),Subgroup (Theme),Sub-industry\nRELIANCE.NS,XNSE,ENERGY (STOCKS),Oil & Gas,Integrated Oil & Gas\n")
     _write_csv(app_data / "kabutan_themes_en.csv", "Symbol,TSE 33-Sector,TSE 17-Sector,Theme (EN)\n7203,Transportation Equipment,Automobiles,Hybrid Vehicles\n")
     _write_csv(app_data / "taiwan-deep.csv", "Symbol,Market,Industry (EN)\n2330,TWSE,Semiconductors\n")

--- a/backend/tests/unit/test_rrg_service.py
+++ b/backend/tests/unit/test_rrg_service.py
@@ -58,6 +58,11 @@ class _StubRankService:
         return [r for r in self._rows if r["market"] == market][:limit]
 
 
+class _ExplodingRankService:
+    def get_current_rankings(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("US IBDGroupRankService path should not be used")
+
+
 def test_get_rrg_groups_scope_returns_quadrants_and_tails():
     session = _session()
     dates = _weekly_fridays(40)
@@ -163,3 +168,71 @@ def test_get_group_sector_map_majority_vote():
         session, market="US"
     )
     assert mapping["AlphaTech"] == "Technology"  # 2 vs 1
+
+
+def test_get_rrg_non_us_uses_feature_run_history_provider():
+    session = _session()
+    dates = _weekly_fridays(40)
+
+    class _FakeMarketHistoryService:
+        def get_all_groups_history(self, db, *, market, days):  # noqa: ARG002
+            assert market == "HK"
+            latest = dates[-1].isoformat()
+            return (
+                latest,
+                {
+                    "Internet Services": {
+                        "industry_group": "Internet Services",
+                        "date": latest,
+                        "rank": 1,
+                        "num_stocks": 9,
+                        "avg_rs_rating": 80.0,
+                    }
+                },
+                {
+                    "Internet Services": [
+                        (d, 40.0 + index, 9)
+                        for index, d in enumerate(dates)
+                    ]
+                },
+            )
+
+    payload = RRGService(
+        group_rank_service=_ExplodingRankService(),
+        market_group_ranking_service=_FakeMarketHistoryService(),
+    ).get_rrg(session, market="HK")
+
+    assert payload["market"] == "HK"
+    assert [g["industry_group"] for g in payload["groups"]] == ["Internet Services"]
+
+
+def test_get_rrg_disabled_non_us_market_returns_empty_without_history_lookup():
+    session = _session()
+
+    class _FakeMarketHistoryService:
+        def get_all_groups_history(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            raise AssertionError("disabled RRG markets should not load history")
+
+    payload = RRGService(
+        group_rank_service=_ExplodingRankService(),
+        market_group_ranking_service=_FakeMarketHistoryService(),
+    ).get_rrg_scopes(session, market="KR", scopes=("groups", "sectors"))
+
+    assert payload["groups"]["groups"] == []
+    assert payload["sectors"]["groups"] == []
+
+
+def test_get_group_sector_map_uses_taxonomy_for_curated_rrg_market():
+    session = _session()
+
+    class _FakeTaxonomyService:
+        def sector_map_for_market(self, market):
+            assert market == "HK"
+            return {"Internet Services": "Information Technology"}
+
+    mapping = RRGService(
+        group_rank_service=_StubRankService([]),
+        taxonomy_service=_FakeTaxonomyService(),
+    ).get_group_sector_map(session, market="HK")
+
+    assert mapping == {"Internet Services": "Information Technology"}

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -69,6 +69,42 @@ class _FakePriceCache:
         return self.get_many_cached_only([symbol], period=period).get(symbol.upper())
 
 
+def _static_rrg_payload(market: str, as_of_date: str) -> dict:
+    return {
+        "schema_version": STATIC_SITE_SCHEMA_VERSION,
+        "generated_at": f"{as_of_date}T22:00:00Z",
+        "available": True,
+        "market": market,
+        "as_of_date": as_of_date,
+        "available_scopes": ["groups"],
+        "payload": {
+            "groups": {
+                "date": as_of_date,
+                "market": market,
+                "scope": "groups",
+                "groups": [
+                    {
+                        "industry_group": "Semiconductors",
+                        "rank": 1,
+                        "num_stocks": 14,
+                        "avg_rs_rating": 92.5,
+                        "quadrant": "Leading",
+                        "is_provisional": False,
+                        "current": {"date": as_of_date, "x": 104.0, "y": 103.0},
+                        "tail": [{"date": as_of_date, "x": 104.0, "y": 103.0}],
+                    }
+                ],
+            },
+            "sectors": {
+                "date": as_of_date,
+                "market": market,
+                "scope": "sectors",
+                "groups": [],
+            },
+        },
+    }
+
+
 def test_get_latest_published_run_prefers_latest_published_pointer(service_and_session_factory):
     service, session_factory = service_and_session_factory
     _insert_runs(
@@ -238,6 +274,7 @@ def test_export_writes_serializable_manifest_and_page_bundles(
     monkeypatch.setattr(service, "_export_chart_bundle", lambda **_kwargs: chart_manifest)
     monkeypatch.setattr(service, "_build_breadth_payload", lambda **_kwargs: breadth_payload)
     monkeypatch.setattr(service, "_build_groups_payload", lambda **_kwargs: groups_payload)
+    monkeypatch.setattr(service, "_build_groups_rrg_payload", lambda **_kwargs: _static_rrg_payload("US", "2026-03-31"))
     monkeypatch.setattr(service, "_build_home_payload", lambda **_kwargs: home_payload)
 
     output_dir = tmp_path / "static-data"
@@ -255,8 +292,10 @@ def test_export_writes_serializable_manifest_and_page_bundles(
     assert manifest["features"]["charts"] is True
     assert manifest["pages"]["scan"]["path"] == "markets/us/scan/manifest.json"
     assert manifest["assets"]["charts"]["path"] == "charts/index.json"
+    assert manifest["assets"]["groups_rrg"]["path"] == "markets/us/groups_rrg.json"
     assert manifest["markets"]["US"]["pages"]["scan"]["path"] == "markets/us/scan/manifest.json"
     assert manifest["markets"]["US"]["assets"]["charts"]["path"] == "charts/index.json"
+    assert manifest["markets"]["US"]["assets"]["groups_rrg"]["path"] == "markets/us/groups_rrg.json"
     assert "themes" not in manifest["features"]
     assert "themes" not in manifest["pages"]
     assert manifest["warnings"] == []
@@ -332,6 +371,7 @@ def test_export_writes_india_market_bundle_and_root_manifest(
     monkeypatch.setattr(service, "_export_chart_bundle", lambda **_kwargs: chart_manifest)
     monkeypatch.setattr(service, "_build_breadth_payload", lambda **_kwargs: breadth_payload)
     monkeypatch.setattr(service, "_build_groups_payload", lambda **_kwargs: groups_payload)
+    monkeypatch.setattr(service, "_build_groups_rrg_payload", lambda **_kwargs: _static_rrg_payload("HK", "2026-03-31"))
     monkeypatch.setattr(service, "_build_home_payload", lambda **_kwargs: home_payload)
 
     output_dir = tmp_path / "static-data"
@@ -424,6 +464,7 @@ def test_export_can_write_single_market_artifact_without_root_manifest(
     monkeypatch.setattr(service, "_export_chart_bundle", lambda **_kwargs: chart_manifest)
     monkeypatch.setattr(service, "_build_breadth_payload", lambda **_kwargs: breadth_payload)
     monkeypatch.setattr(service, "_build_groups_payload", lambda **_kwargs: groups_payload)
+    monkeypatch.setattr(service, "_build_groups_rrg_payload", lambda **_kwargs: _static_rrg_payload("HK", "2026-03-31"))
     monkeypatch.setattr(service, "_build_home_payload", lambda **_kwargs: home_payload)
 
     output_dir = tmp_path / "market-artifact"
@@ -438,6 +479,7 @@ def test_export_can_write_single_market_artifact_without_root_manifest(
     assert metadata["market"] == "HK"
     assert metadata["entry"]["pages"]["scan"]["path"] == "markets/hk/scan/manifest.json"
     assert metadata["entry"]["assets"]["charts"]["path"] == "markets/hk/charts/index.json"
+    assert metadata["entry"]["assets"]["groups_rrg"]["path"] == "markets/hk/groups_rrg.json"
     assert metadata["warnings"] == []
 
 
@@ -1203,7 +1245,8 @@ def test_export_marks_optional_sections_unavailable_without_aborting(
     assert manifest["features"]["groups"] is False
     assert manifest["markets"]["US"]["features"]["breadth"] is False
     assert manifest["markets"]["US"]["features"]["groups"] is False
-    assert len(manifest["warnings"]) == 2
+    assert len(manifest["warnings"]) == 3
+    assert any("Static US rrg data unavailable" in warning for warning in manifest["warnings"])
     assert breadth["available"] is False
     assert breadth["expected_as_of_date"] == "2026-04-02"
     assert "No breadth snapshot is available" in breadth["message"]
@@ -1619,6 +1662,57 @@ def test_build_groups_payload_requires_target_date(service_and_session_factory, 
 
     assert rankings_calls == [(197, date(2026, 4, 2))]
     assert movers_calls == []
+
+
+def test_build_groups_rrg_payload_emits_available_scopes(service_and_session_factory, monkeypatch):
+    service, session_factory = service_and_session_factory
+
+    class _FakeRRGService:
+        def __init__(self, **kwargs):  # noqa: ANN003
+            self.kwargs = kwargs
+
+        def get_rrg_scopes(self, db, *, market, scopes):  # noqa: ARG002
+            assert market == "HK"
+            assert scopes == ("groups", "sectors")
+            return {
+                "groups": {
+                    "date": "2026-04-18",
+                    "market": "HK",
+                    "scope": "groups",
+                    "groups": [
+                        {
+                            "industry_group": "Internet Services",
+                            "rank": 1,
+                            "num_stocks": 9,
+                            "avg_rs_rating": 82.0,
+                            "quadrant": "Leading",
+                            "is_provisional": False,
+                            "current": {"date": "2026-04-12", "x": 104.0, "y": 103.0},
+                            "tail": [{"date": "2026-04-12", "x": 104.0, "y": 103.0}],
+                        }
+                    ],
+                },
+                "sectors": {
+                    "date": "2026-04-18",
+                    "market": "HK",
+                    "scope": "sectors",
+                    "groups": [],
+                },
+            }
+
+    monkeypatch.setattr(export_module, "RRGService", _FakeRRGService)
+    monkeypatch.setattr(export_module, "get_group_rank_service", lambda: SimpleNamespace())
+
+    with session_factory() as db:
+        payload = service._build_groups_rrg_payload(  # noqa: SLF001
+            db=db,
+            generated_at="2026-04-18T22:00:00Z",
+            expected_as_of_date=date(2026, 4, 18),
+            market="HK",
+        )
+
+    assert payload["available_scopes"] == ["groups"]
+    assert payload["payload"]["groups"]["groups"][0]["industry_group"] == "Internet Services"
 
 
 def test_export_chart_bundle_writes_top_ranked_payloads_with_sidebar_metadata(

--- a/frontend/src/api/groups.js
+++ b/frontend/src/api/groups.js
@@ -71,6 +71,21 @@ export const getRRG = async (scope = 'groups', tailWeeks = 8, limit = 197, marke
 };
 
 /**
+ * Get a bundled Relative Rotation Graph payload with all available scopes.
+ *
+ * @param {number} tailWeeks - Number of weekly tail points (default: 8)
+ * @param {number} limit - Top-N series by rank (default: 197)
+ * @param {string} market - Market code (default: 'US')
+ * @returns {Promise<Object>} RRG bundle: { date, market, available_scopes, payload }
+ */
+export const getRRGBundle = async (tailWeeks = 8, limit = 197, market = 'US') => {
+  const response = await apiClient.get('/v1/groups/rrg/scopes', {
+    params: { tail_weeks: tailWeeks, limit, market }
+  });
+  return response.data;
+};
+
+/**
  * Get summary statistics for ranking data.
  *
  * @returns {Promise<Object>} Summary with total_records, date range, etc.

--- a/frontend/src/components/Charts/RRGViewToggle.jsx
+++ b/frontend/src/components/Charts/RRGViewToggle.jsx
@@ -3,18 +3,35 @@
  * Group Rankings pages, so the control can't drift between the two trees.
  */
 import { Box, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { RRG_SCOPE_LABELS, normalizeRrgScopes } from '../../utils/rrgScopes';
 
-export default function RRGViewToggle({ view, onView, scope, onScope, sx }) {
+export default function RRGViewToggle({
+  view,
+  onView,
+  scope,
+  onScope,
+  sx,
+  rrgAvailable = true,
+  availableScopes,
+}) {
+  const scopes = normalizeRrgScopes(availableScopes);
+  const canShowRRG = rrgAvailable && scopes.length > 0;
+  const viewValue = canShowRRG ? view : 'table';
+  const showScopeToggle = canShowRRG && view === 'rrg' && scopes.length > 1;
+
   return (
     <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center', ...sx }}>
-      <ToggleButtonGroup size="small" exclusive value={view} onChange={(e, v) => v && onView(v)}>
+      <ToggleButtonGroup size="small" exclusive value={viewValue} onChange={(e, v) => v && onView(v)}>
         <ToggleButton value="table">Table</ToggleButton>
-        <ToggleButton value="rrg">RRG</ToggleButton>
+        {canShowRRG && <ToggleButton value="rrg">RRG</ToggleButton>}
       </ToggleButtonGroup>
-      {view === 'rrg' && (
+      {showScopeToggle && (
         <ToggleButtonGroup size="small" exclusive value={scope} onChange={(e, v) => v && onScope(v)}>
-          <ToggleButton value="groups">Groups</ToggleButton>
-          <ToggleButton value="sectors">Sectors</ToggleButton>
+          {scopes.map((availableScope) => (
+            <ToggleButton key={availableScope} value={availableScope}>
+              {RRG_SCOPE_LABELS[availableScope]}
+            </ToggleButton>
+          ))}
         </ToggleButtonGroup>
       )}
     </Box>

--- a/frontend/src/components/Charts/RRGViewToggle.test.jsx
+++ b/frontend/src/components/Charts/RRGViewToggle.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../test/renderWithProviders';
+import RRGViewToggle from './RRGViewToggle';
+
+describe('RRGViewToggle', () => {
+  it('hides the RRG view option when no bundle is available', () => {
+    renderWithProviders(
+      <RRGViewToggle view="table" onView={vi.fn()} scope="groups" onScope={vi.fn()} rrgAvailable={false} />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Table' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'RRG' })).not.toBeInTheDocument();
+  });
+
+  it('hides scope controls when only one scope is available', () => {
+    renderWithProviders(
+      <RRGViewToggle
+        view="rrg"
+        onView={vi.fn()}
+        scope="groups"
+        onScope={vi.fn()}
+        availableScopes={['groups']}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'RRG' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Groups' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sectors' })).not.toBeInTheDocument();
+  });
+
+  it('renders only available scopes and reports scope changes', async () => {
+    const onScope = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RRGViewToggle
+        view="rrg"
+        onView={vi.fn()}
+        scope="groups"
+        onScope={onScope}
+        availableScopes={['groups', 'sectors']}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Groups' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Sectors' }));
+
+    expect(onScope).toHaveBeenCalledWith('sectors');
+  });
+});

--- a/frontend/src/pages/GroupRankingsPage.jsx
+++ b/frontend/src/pages/GroupRankingsPage.jsx
@@ -38,7 +38,7 @@ import {
   getCurrentRankings,
   getRankMovers,
   getGroupDetail,
-  getRRG,
+  getRRGBundle,
   triggerCalculation,
   getCalculationStatus,
 } from '../api/groups';
@@ -62,6 +62,7 @@ import {
   marketOptionsForCapability,
   normalizeMarketCode,
 } from '../utils/marketCapabilities';
+import { availableRrgScopesFromBundle } from '../utils/rrgScopes';
 
 const MARKET_LABELS = {
   US: 'US',
@@ -624,17 +625,32 @@ function GroupRankingsPage() {
     staleTime: 60_000,
   });
 
-  // Fetch RRG coordinates (only when the RRG view is active)
+  // Fetch RRG coordinates for all available scopes (only when the RRG view is active).
   const {
-    data: rrgData,
+    data: rrgBundle,
     isLoading: isLoadingRRG,
     error: errorRRG,
   } = useQuery({
-    queryKey: ['groupRRG', selectedMarket, rrgScope],
-    queryFn: () => getRRG(rrgScope, 8, 197, selectedMarket),
+    queryKey: ['groupRRGBundle', selectedMarket],
+    queryFn: () => getRRGBundle(8, 197, selectedMarket),
     enabled: liveQueriesEnabled && view === 'rrg',
     staleTime: 60_000,
   });
+  const availableRrgScopes = useMemo(() => availableRrgScopesFromBundle(rrgBundle), [rrgBundle]);
+  const rrgData = rrgBundle?.payload?.[rrgScope] ?? null;
+
+  useEffect(() => {
+    if (!isRrgView || !availableRrgScopes) {
+      return;
+    }
+    if (availableRrgScopes.length === 0) {
+      setView('table');
+      return;
+    }
+    if (!availableRrgScopes.includes(rrgScope)) {
+      setRrgScope(availableRrgScopes[0]);
+    }
+  }, [availableRrgScopes, isRrgView, rrgScope]);
 
   // Poll calculation status while task is running
   const { data: calcStatus } = useQuery({
@@ -817,6 +833,7 @@ function GroupRankingsPage() {
         onView={setView}
         scope={rrgScope}
         onScope={setRrgScope}
+        availableScopes={availableRrgScopes}
         sx={{ mb: 1.5 }}
       />
 

--- a/frontend/src/pages/GroupRankingsPage.test.jsx
+++ b/frontend/src/pages/GroupRankingsPage.test.jsx
@@ -9,6 +9,7 @@ const getGroupsBootstrap = vi.fn();
 const getCurrentRankings = vi.fn();
 const getRankMovers = vi.fn();
 const getGroupDetail = vi.fn();
+const getRRGBundle = vi.fn();
 const triggerCalculation = vi.fn();
 const getCalculationStatus = vi.fn();
 const fetchPriceHistoryBatch = vi.fn();
@@ -42,6 +43,7 @@ vi.mock('../api/groups', () => ({
   getCurrentRankings: (...args) => getCurrentRankings(...args),
   getRankMovers: (...args) => getRankMovers(...args),
   getGroupDetail: (...args) => getGroupDetail(...args),
+  getRRGBundle: (...args) => getRRGBundle(...args),
   triggerCalculation: (...args) => triggerCalculation(...args),
   getCalculationStatus: (...args) => getCalculationStatus(...args),
 }));
@@ -95,6 +97,7 @@ describe('GroupRankingsPage', () => {
     getCurrentRankings.mockReset();
     getRankMovers.mockReset();
     getGroupDetail.mockReset();
+    getRRGBundle.mockReset();
     triggerCalculation.mockReset();
     getCalculationStatus.mockReset();
     fetchPriceHistoryBatch.mockReset();
@@ -121,6 +124,40 @@ describe('GroupRankingsPage', () => {
       history: [],
       stocks: [],
     });
+    getRRGBundle.mockImplementation(async (tailWeeks = 8, _limit = 197, market = 'US') => ({
+      date: '2026-04-18',
+      market,
+      tail_weeks: tailWeeks,
+      available_scopes: ['groups'],
+      payload: {
+        groups: {
+          date: '2026-04-18',
+          market,
+          scope: 'groups',
+          groups: [
+            {
+              industry_group: `${market} Internet Services`,
+              rank: 3,
+              num_stocks: 7,
+              avg_rs_rating: 82.1,
+              quadrant: 'Leading',
+              is_provisional: false,
+              current: { date: '2026-04-18', x: 105.5, y: 103.2 },
+              tail: [
+                { date: '2026-04-11', x: 103.5, y: 101.1 },
+                { date: '2026-04-18', x: 105.5, y: 103.2 },
+              ],
+            },
+          ],
+        },
+        sectors: {
+          date: '2026-04-18',
+          market,
+          scope: 'sectors',
+          groups: [],
+        },
+      },
+    }));
     getCalculationStatus.mockResolvedValue({ status: 'queued' });
   });
 
@@ -187,6 +224,21 @@ describe('GroupRankingsPage', () => {
     expect(getCurrentRankings).not.toHaveBeenCalledWith(197, 'AU');
     expect(screen.getByRole('button', { name: 'US' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'AU' })).not.toBeInTheDocument();
+  });
+
+  it('loads bundled RRG scopes and hides unavailable scope controls', async () => {
+    renderWithProviders(<GroupRankingsPage />);
+
+    expect(await screen.findByText('HK Internet Services')).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'RRG' }));
+
+    await waitFor(() => {
+      expect(getRRGBundle).toHaveBeenCalledWith(8, 197, 'HK');
+    });
+    expect(await screen.findByText(/Relative Rotation Graph/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sectors' })).not.toBeInTheDocument();
   });
 
   it('loads batch price history when the Charts tab is opened in the group modal', async () => {

--- a/frontend/src/static/pages/StaticGroupsPage.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.jsx
@@ -27,6 +27,7 @@ import RRGViewToggle from '../../components/Charts/RRGViewToggle';
 import RankChangeCell from '../../components/shared/RankChangeCell';
 import TickerCell from '../../components/common/TickerCell';
 import { useStaticMarket } from '../StaticMarketContext';
+import { availableRrgScopesFromBundle } from '../../utils/rrgScopes';
 
 function MoversCard({ title, rows }) {
   return (
@@ -143,6 +144,7 @@ function StaticGroupsPage() {
   const chartIndexQuery = useStaticChartIndex(marketEntry.assets?.charts?.path);
   const rrgQuery = useStaticGroupsRRG(marketEntry);
   const rrgAvailable = Boolean(marketEntry.assets?.groups_rrg?.path);
+  const availableRrgScopes = useMemo(() => availableRrgScopesFromBundle(rrgQuery.data), [rrgQuery.data]);
   const [selectedGroup, setSelectedGroup] = useState(null);
   const [view, setView] = useState('table'); // 'table' | 'rrg'
   const [rrgScope, setRrgScope] = useState('groups'); // 'groups' | 'sectors'
@@ -154,6 +156,19 @@ function StaticGroupsPage() {
       setView('table');
     }
   }, [rrgAvailable, view]);
+
+  useEffect(() => {
+    if (!availableRrgScopes || view !== 'rrg') {
+      return;
+    }
+    if (availableRrgScopes.length === 0) {
+      setView('table');
+      return;
+    }
+    if (!availableRrgScopes.includes(rrgScope)) {
+      setRrgScope(availableRrgScopes[0]);
+    }
+  }, [availableRrgScopes, rrgScope, view]);
 
   if (manifestQuery.isLoading || groupsQuery.isLoading) {
     return (
@@ -192,6 +207,7 @@ function StaticGroupsPage() {
           onView={setView}
           scope={rrgScope}
           onScope={setRrgScope}
+          availableScopes={availableRrgScopes}
           sx={{ mb: 2 }}
         />
       )}

--- a/frontend/src/static/pages/StaticGroupsPage.test.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.test.jsx
@@ -131,6 +131,7 @@ describe('StaticGroupsPage', () => {
           status: 200,
           json: async () => ({
             available: true,
+            available_scopes: ['groups'],
             payload: {
               groups: {
                 date: '2026-03-31',
@@ -165,5 +166,6 @@ describe('StaticGroupsPage', () => {
     // Switch from the table view to the Relative Rotation Graph.
     fireEvent.click(screen.getByRole('button', { name: 'RRG' }));
     expect(await screen.findByText(/Relative Rotation Graph/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sectors' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/utils/rrgScopes.js
+++ b/frontend/src/utils/rrgScopes.js
@@ -1,0 +1,33 @@
+export const RRG_SCOPE_LABELS = {
+  groups: 'Groups',
+  sectors: 'Sectors',
+};
+
+export const RRG_SCOPE_ORDER = Object.keys(RRG_SCOPE_LABELS);
+
+export const normalizeRrgScopes = (scopes, fallback = RRG_SCOPE_ORDER) => {
+  const source = Array.isArray(scopes) ? scopes : fallback;
+  const seen = new Set();
+  return source.filter((scope) => {
+    if (!RRG_SCOPE_LABELS[scope] || seen.has(scope)) {
+      return false;
+    }
+    seen.add(scope);
+    return true;
+  });
+};
+
+export const availableRrgScopesFromBundle = (bundle) => {
+  if (!bundle) {
+    return null;
+  }
+
+  if (Array.isArray(bundle.available_scopes)) {
+    return normalizeRrgScopes(bundle.available_scopes, []);
+  }
+
+  return normalizeRrgScopes(
+    RRG_SCOPE_ORDER.filter((scope) => (bundle.payload?.[scope]?.groups ?? []).length > 0),
+    [],
+  );
+};


### PR DESCRIPTION
## Summary
- Tune bootstrap cache-only price thresholds per market to match observed static price coverage, while keeping fundamentals gating strict.
- Extend snapshot and task metadata so bootstrap waits and diagnostics report price and fundamentals thresholds explicitly.
- Add backend and frontend support for market group rankings and RRG scope handling across API, services, and static site pages.
- Update and expand unit coverage for bootstrap gating, market taxonomy, RRG behavior, export logic, and group-ranking UI/API flows.

## Testing
- Focused unit tests for bootstrap coverage and related feature-store snapshot paths passed.
- Added/updated service and API tests for market taxonomy, RRG group ranking, groups endpoints, and static site export behavior.
- Frontend tests for the RRG toggle and group rankings pages were updated alongside the new scope utilities.
- Broader backend test runs still surface unrelated existing failures outside this change set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bundled Relative Rotation Graph (RRG) endpoint that retrieves RRG data across multiple scopes (groups and sectors) in a single request.
  * Expanded RRG functionality to international markets including Hong Kong.

* **Enhancements**
  * RRG scope toggle now dynamically displays only available scopes based on actual data availability for the selected market.
  * Enhanced market-specific data coverage thresholds for improved data quality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->