### PR TITLE
Adjust bootstrap price coverage gates by market

### DIFF
--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -712,7 +712,6 @@ def build_daily_snapshot(
     from app.services.market_calendar_service import MarketCalendarService
     from app.services.universe_resolver import normalize_universe_definition
     from app.services.bootstrap_cache_coverage import (
-        BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
         evaluate_bootstrap_cache_coverage,
     )
     from app.tasks.market_queues import log_extra, normalize_market

--- a/backend/app/services/bootstrap_cache_coverage.py
+++ b/backend/app/services/bootstrap_cache_coverage.py
@@ -205,13 +205,27 @@ def bootstrap_coverage_policy_for_market(market: str | None) -> BootstrapCoverag
     )
 
 
-def _float_or_default(value: object, default: float) -> float:
+def _optional_float(value: object) -> float | None:
     if value is None:
-        return default
+        return None
     try:
         return float(value)
     except (TypeError, ValueError):
-        return default
+        return None
+
+
+def _report_meets_policy(
+    payload: Mapping[str, Any],
+    policy: BootstrapCoveragePolicy,
+) -> bool:
+    price_ratio = _optional_float(payload.get("price_coverage_ratio"))
+    fundamentals_ratio = _optional_float(payload.get("fundamentals_coverage_ratio"))
+    if price_ratio is None or fundamentals_ratio is None:
+        return False
+    return (
+        price_ratio >= policy.price_min_coverage
+        and fundamentals_ratio >= policy.fundamentals_min_coverage
+    )
 
 
 def normalize_bootstrap_gate_report(
@@ -222,20 +236,13 @@ def normalize_bootstrap_gate_report(
 ) -> dict[str, Any]:
     payload = dict(report or {})
     policy = bootstrap_coverage_policy_for_market(market)
-    eligible = bool(payload.get("eligible"))
-    price_threshold = _float_or_default(
-        payload.get("price_threshold", payload.get("threshold")),
-        policy.price_min_coverage,
-    )
-    fundamentals_threshold = _float_or_default(
-        payload.get("fundamentals_threshold"),
-        policy.fundamentals_min_coverage,
-    )
+    eligible = _report_meets_policy(payload, policy)
     payload.update(
         {
-            "threshold": price_threshold,
-            "price_threshold": price_threshold,
-            "fundamentals_threshold": fundamentals_threshold,
+            "eligible": eligible,
+            "threshold": policy.price_min_coverage,
+            "price_threshold": policy.price_min_coverage,
+            "fundamentals_threshold": policy.fundamentals_min_coverage,
             "mode": "cache_only" if eligible else "waiting_for_cache_coverage",
             "unsupported_skipped_count": len(unsupported_symbols) if eligible else 0,
             "unsupported_symbols_preview": (

--- a/backend/app/services/bootstrap_cache_coverage.py
+++ b/backend/app/services/bootstrap_cache_coverage.py
@@ -19,6 +19,24 @@ from app.models.stock import StockFundamental, StockPrice
 from app.services.provider_snapshot_service import WEEKLY_REFERENCE_SNAPSHOT_KEYS
 
 BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE = 0.95
+BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE = 0.95
+# Price coverage thresholds are aligned to observed daily-price static bundle
+# availability, rounded down to conservative 5-point floors. They gate whether
+# bootstrap can build a cache-only snapshot without falling back to live fetches.
+BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET: dict[str, float] = {
+    "AU": 0.90,
+    "CA": 0.75,
+    "CN": 0.90,
+    "DE": 0.90,
+    "HK": 0.80,
+    "IN": 0.50,
+    "JP": 0.90,
+    "KR": 0.95,
+    "MY": 0.85,
+    "SG": 0.60,
+    "TW": 0.50,
+    "US": 0.95,
+}
 MISSING_SYMBOL_PREVIEW_LIMIT = 20
 
 
@@ -77,6 +95,7 @@ class BootstrapPriceCoverageReport(Mapping[str, Any]):
 class BootstrapCacheCoverageReport(Mapping[str, Any]):
     market: str
     threshold: float
+    fundamentals_threshold: float
     price_report: BootstrapPriceCoverageReport
     fundamentals_coverage_date: str | None
     fundamentals_total_symbols: int
@@ -93,7 +112,10 @@ class BootstrapCacheCoverageReport(Mapping[str, Any]):
 
     @property
     def eligible(self) -> bool:
-        return self.price_report.eligible and self.fundamentals_coverage_ratio >= self.threshold
+        return (
+            self.price_report.eligible
+            and self.fundamentals_coverage_ratio >= self.fundamentals_threshold
+        )
 
     @property
     def mode(self) -> str:
@@ -104,6 +126,8 @@ class BootstrapCacheCoverageReport(Mapping[str, Any]):
         return {
             "market": self.market,
             "threshold": self.threshold,
+            "price_threshold": self.price_report.threshold,
+            "fundamentals_threshold": self.fundamentals_threshold,
             "eligible": self.eligible,
             "mode": self.mode,
             "price_coverage_date": price_payload["price_coverage_date"],
@@ -138,6 +162,23 @@ def _normalize_symbols(symbols: Sequence[str]) -> list[str]:
     return sorted({str(symbol).upper() for symbol in symbols if symbol})
 
 
+def _normalize_market_code(market: str | None) -> str:
+    return str(market or "US").strip().upper() or "US"
+
+
+def bootstrap_price_min_coverage_for_market(market: str | None) -> float:
+    normalized_market = _normalize_market_code(market)
+    return BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET.get(
+        normalized_market,
+        BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+    )
+
+
+def bootstrap_fundamentals_min_coverage_for_market(market: str | None) -> float:
+    _normalize_market_code(market)
+    return BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE
+
+
 def _ratio(covered: int, total: int) -> float:
     return covered / total if total > 0 else 0.0
 
@@ -162,7 +203,7 @@ def evaluate_bootstrap_price_cache_coverage(
     as_of_date: date,
 ) -> BootstrapPriceCoverageReport:
     """Return bootstrap price coverage without requiring later fundamentals stages."""
-    normalized_market = str(market or "US").strip().upper() or "US"
+    normalized_market = _normalize_market_code(market)
     normalized_symbols = _normalize_symbols(symbols)
     total = len(normalized_symbols)
 
@@ -185,7 +226,7 @@ def evaluate_bootstrap_price_cache_coverage(
     )
     return BootstrapPriceCoverageReport(
         market=normalized_market,
-        threshold=BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+        threshold=bootstrap_price_min_coverage_for_market(normalized_market),
         price_coverage_date=as_of_date,
         price_total_symbols=total,
         price_covered_symbols=total - len(price_missing),
@@ -201,7 +242,7 @@ def evaluate_bootstrap_cache_coverage(
     as_of_date: date,
 ) -> BootstrapCacheCoverageReport:
     """Return a JSON-ready coverage report for bootstrap cache-only eligibility."""
-    normalized_market = str(market or "US").strip().upper() or "US"
+    normalized_market = _normalize_market_code(market)
     normalized_symbols = _normalize_symbols(symbols)
     total = len(normalized_symbols)
     price_report = evaluate_bootstrap_price_cache_coverage(
@@ -256,10 +297,13 @@ def evaluate_bootstrap_cache_coverage(
     elif fundamentals_dates:
         fundamentals_coverage_date = _date_string(max(fundamentals_dates))
 
-    threshold = BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE
+    threshold = bootstrap_price_min_coverage_for_market(normalized_market)
     return BootstrapCacheCoverageReport(
         market=normalized_market,
         threshold=threshold,
+        fundamentals_threshold=bootstrap_fundamentals_min_coverage_for_market(
+            normalized_market
+        ),
         price_report=price_report,
         fundamentals_coverage_date=fundamentals_coverage_date,
         fundamentals_total_symbols=total,

--- a/backend/app/services/bootstrap_cache_coverage.py
+++ b/backend/app/services/bootstrap_cache_coverage.py
@@ -41,13 +41,27 @@ MISSING_SYMBOL_PREVIEW_LIMIT = 20
 
 
 @dataclass(frozen=True)
-class BootstrapPriceCoverageReport(Mapping[str, Any]):
+class BootstrapCoveragePolicy:
     market: str
-    threshold: float
+    price_min_coverage: float
+    fundamentals_min_coverage: float
+
+
+@dataclass(frozen=True)
+class BootstrapPriceCoverageReport(Mapping[str, Any]):
+    policy: BootstrapCoveragePolicy
     price_coverage_date: date | str
     price_total_symbols: int
     price_covered_symbols: int
     price_missing_symbols: tuple[str, ...]
+
+    @property
+    def market(self) -> str:
+        return self.policy.market
+
+    @property
+    def threshold(self) -> float:
+        return self.policy.price_min_coverage
 
     @property
     def price_missing_symbol_count(self) -> int:
@@ -93,14 +107,27 @@ class BootstrapPriceCoverageReport(Mapping[str, Any]):
 
 @dataclass(frozen=True)
 class BootstrapCacheCoverageReport(Mapping[str, Any]):
-    market: str
-    threshold: float
-    fundamentals_threshold: float
     price_report: BootstrapPriceCoverageReport
     fundamentals_coverage_date: str | None
     fundamentals_total_symbols: int
     fundamentals_covered_symbols: int
     fundamentals_missing_symbols: tuple[str, ...]
+
+    @property
+    def market(self) -> str:
+        return self.price_report.market
+
+    @property
+    def threshold(self) -> float:
+        return self.price_report.threshold
+
+    @property
+    def price_threshold(self) -> float:
+        return self.price_report.threshold
+
+    @property
+    def fundamentals_threshold(self) -> float:
+        return self.price_report.policy.fundamentals_min_coverage
 
     @property
     def fundamentals_missing_symbol_count(self) -> int:
@@ -166,17 +193,59 @@ def _normalize_market_code(market: str | None) -> str:
     return str(market or "US").strip().upper() or "US"
 
 
-def bootstrap_price_min_coverage_for_market(market: str | None) -> float:
+def bootstrap_coverage_policy_for_market(market: str | None) -> BootstrapCoveragePolicy:
     normalized_market = _normalize_market_code(market)
-    return BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET.get(
-        normalized_market,
-        BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+    return BootstrapCoveragePolicy(
+        market=normalized_market,
+        price_min_coverage=BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET.get(
+            normalized_market,
+            BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+        ),
+        fundamentals_min_coverage=BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE,
     )
 
 
-def bootstrap_fundamentals_min_coverage_for_market(market: str | None) -> float:
-    _normalize_market_code(market)
-    return BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE
+def _float_or_default(value: object, default: float) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def normalize_bootstrap_gate_report(
+    *,
+    market: str | None,
+    report: Mapping[str, Any] | None,
+    unsupported_symbols: Sequence[str],
+) -> dict[str, Any]:
+    payload = dict(report or {})
+    policy = bootstrap_coverage_policy_for_market(market)
+    eligible = bool(payload.get("eligible"))
+    price_threshold = _float_or_default(
+        payload.get("price_threshold", payload.get("threshold")),
+        policy.price_min_coverage,
+    )
+    fundamentals_threshold = _float_or_default(
+        payload.get("fundamentals_threshold"),
+        policy.fundamentals_min_coverage,
+    )
+    payload.update(
+        {
+            "threshold": price_threshold,
+            "price_threshold": price_threshold,
+            "fundamentals_threshold": fundamentals_threshold,
+            "mode": "cache_only" if eligible else "waiting_for_cache_coverage",
+            "unsupported_skipped_count": len(unsupported_symbols) if eligible else 0,
+            "unsupported_symbols_preview": (
+                list(unsupported_symbols[:MISSING_SYMBOL_PREVIEW_LIMIT])
+                if eligible
+                else []
+            ),
+        }
+    )
+    return payload
 
 
 def _ratio(covered: int, total: int) -> float:
@@ -224,9 +293,9 @@ def evaluate_bootstrap_price_cache_coverage(
         if latest_price_by_symbol.get(symbol) is None
         or latest_price_by_symbol[symbol] < as_of_date
     )
+    policy = bootstrap_coverage_policy_for_market(normalized_market)
     return BootstrapPriceCoverageReport(
-        market=normalized_market,
-        threshold=bootstrap_price_min_coverage_for_market(normalized_market),
+        policy=policy,
         price_coverage_date=as_of_date,
         price_total_symbols=total,
         price_covered_symbols=total - len(price_missing),
@@ -297,13 +366,7 @@ def evaluate_bootstrap_cache_coverage(
     elif fundamentals_dates:
         fundamentals_coverage_date = _date_string(max(fundamentals_dates))
 
-    threshold = bootstrap_price_min_coverage_for_market(normalized_market)
     return BootstrapCacheCoverageReport(
-        market=normalized_market,
-        threshold=threshold,
-        fundamentals_threshold=bootstrap_fundamentals_min_coverage_for_market(
-            normalized_market
-        ),
         price_report=price_report,
         fundamentals_coverage_date=fundamentals_coverage_date,
         fundamentals_total_symbols=total,

--- a/backend/app/use_cases/feature_store/build_daily_snapshot.py
+++ b/backend/app/use_cases/feature_store/build_daily_snapshot.py
@@ -52,10 +52,8 @@ from app.domain.scanning.ports import (
     StockScanner,
 )
 from app.services.bootstrap_cache_coverage import (
-    BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE,
-    MISSING_SYMBOL_PREVIEW_LIMIT,
-    bootstrap_price_min_coverage_for_market,
     evaluate_bootstrap_cache_coverage,
+    normalize_bootstrap_gate_report,
 )
 from app.domain.providers.price_symbol_support import split_supported_price_symbols
 from app.use_cases.feature_store.publish_run import (
@@ -373,36 +371,12 @@ class BuildDailyFeatureSnapshotUseCase:
                     )
                 elif not bootstrap_gate_report:
                     bootstrap_gate_report = {"eligible": False}
+                bootstrap_gate_report = normalize_bootstrap_gate_report(
+                    market=cmd.market,
+                    report=bootstrap_gate_report,
+                    unsupported_symbols=unsupported_symbols,
+                )
                 eligible = bool(bootstrap_gate_report.get("eligible"))
-                price_threshold = float(
-                    bootstrap_gate_report.get("price_threshold")
-                    or bootstrap_gate_report.get("threshold")
-                    or bootstrap_price_min_coverage_for_market(cmd.market)
-                )
-                fundamentals_threshold = float(
-                    bootstrap_gate_report.get("fundamentals_threshold")
-                    or BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE
-                )
-                bootstrap_gate_report.update(
-                    {
-                        "threshold": price_threshold,
-                        "price_threshold": price_threshold,
-                        "fundamentals_threshold": fundamentals_threshold,
-                        "mode": (
-                            "cache_only"
-                            if eligible
-                            else "waiting_for_cache_coverage"
-                        ),
-                        "unsupported_skipped_count": (
-                            len(unsupported_symbols) if eligible else 0
-                        ),
-                        "unsupported_symbols_preview": (
-                            unsupported_symbols[:MISSING_SYMBOL_PREVIEW_LIMIT]
-                            if eligible
-                            else []
-                        ),
-                    }
-                )
                 if eligible:
                     if not supported_symbols:
                         raise ValidationError(

--- a/backend/app/use_cases/feature_store/build_daily_snapshot.py
+++ b/backend/app/use_cases/feature_store/build_daily_snapshot.py
@@ -52,8 +52,9 @@ from app.domain.scanning.ports import (
     StockScanner,
 )
 from app.services.bootstrap_cache_coverage import (
-    BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+    BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE,
     MISSING_SYMBOL_PREVIEW_LIMIT,
+    bootstrap_price_min_coverage_for_market,
     evaluate_bootstrap_cache_coverage,
 )
 from app.domain.providers.price_symbol_support import split_supported_price_symbols
@@ -373,9 +374,20 @@ class BuildDailyFeatureSnapshotUseCase:
                 elif not bootstrap_gate_report:
                     bootstrap_gate_report = {"eligible": False}
                 eligible = bool(bootstrap_gate_report.get("eligible"))
+                price_threshold = float(
+                    bootstrap_gate_report.get("price_threshold")
+                    or bootstrap_gate_report.get("threshold")
+                    or bootstrap_price_min_coverage_for_market(cmd.market)
+                )
+                fundamentals_threshold = float(
+                    bootstrap_gate_report.get("fundamentals_threshold")
+                    or BOOTSTRAP_CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE
+                )
                 bootstrap_gate_report.update(
                     {
-                        "threshold": BOOTSTRAP_CACHE_ONLY_MIN_COVERAGE,
+                        "threshold": price_threshold,
+                        "price_threshold": price_threshold,
+                        "fundamentals_threshold": fundamentals_threshold,
                         "mode": (
                             "cache_only"
                             if eligible

--- a/backend/tests/unit/test_bootstrap_cache_coverage.py
+++ b/backend/tests/unit/test_bootstrap_cache_coverage.py
@@ -273,9 +273,45 @@ def test_normalize_bootstrap_gate_report_owns_threshold_and_unsupported_metadata
 
     assert report["threshold"] == report["price_threshold"] == 0.50
     assert report["fundamentals_threshold"] == 0.95
+    assert report["eligible"] is True
     assert report["mode"] == "cache_only"
     assert report["unsupported_skipped_count"] == 2
     assert report["unsupported_symbols_preview"] == ["1234.BAD", "5678.BAD"]
+
+
+def test_normalize_bootstrap_gate_report_derives_eligibility_from_ratios_not_claim():
+    report = normalize_bootstrap_gate_report(
+        market="TW",
+        report={
+            "eligible": True,
+            "threshold": 0.10,
+            "price_threshold": 0.10,
+            "fundamentals_threshold": 0.10,
+            "price_coverage_ratio": 0.49,
+            "fundamentals_coverage_ratio": 1.0,
+        },
+        unsupported_symbols=["1234.BAD"],
+    )
+
+    assert report["threshold"] == report["price_threshold"] == 0.50
+    assert report["fundamentals_threshold"] == 0.95
+    assert report["eligible"] is False
+    assert report["mode"] == "waiting_for_cache_coverage"
+    assert report["unsupported_skipped_count"] == 0
+    assert report["unsupported_symbols_preview"] == []
+
+
+def test_normalize_bootstrap_gate_report_defaults_closed_when_ratios_are_missing():
+    report = normalize_bootstrap_gate_report(
+        market="TW",
+        report={"eligible": True},
+        unsupported_symbols=["1234.BAD"],
+    )
+
+    assert report["eligible"] is False
+    assert report["mode"] == "waiting_for_cache_coverage"
+    assert report["unsupported_skipped_count"] == 0
+    assert report["unsupported_symbols_preview"] == []
 
 
 def test_normalize_bootstrap_gate_report_hides_unsupported_symbols_until_gate_passes():

--- a/backend/tests/unit/test_bootstrap_cache_coverage.py
+++ b/backend/tests/unit/test_bootstrap_cache_coverage.py
@@ -16,9 +16,12 @@ from app.models.provider_snapshot import (
 from app.models.stock import StockFundamental, StockPrice
 from app.services.bootstrap_cache_coverage import (
     BootstrapPriceCoverageReport,
+    bootstrap_fundamentals_min_coverage_for_market,
+    bootstrap_price_min_coverage_for_market,
     evaluate_bootstrap_cache_coverage,
     evaluate_bootstrap_price_cache_coverage,
 )
+from app.domain.markets.catalog import get_market_catalog
 
 
 def _session():
@@ -182,6 +185,80 @@ def test_bootstrap_price_cache_coverage_ignores_fundamentals_before_later_bootst
     assert report["price_covered_symbols"] == 19
     assert report["price_missing_symbols"] == 1
     assert report["price_missing_symbols_preview"] == ["SYM19"]
+
+
+def test_bootstrap_price_cache_coverage_uses_market_specific_threshold():
+    db = _session()
+    symbols = [f"SYM{i}" for i in range(20)]
+    as_of = date(2026, 4, 24)
+    db.add_all([_price(symbol, as_of) for symbol in symbols[:11]])
+    db.commit()
+
+    report = evaluate_bootstrap_price_cache_coverage(
+        db,
+        market="TW",
+        symbols=symbols,
+        as_of_date=as_of,
+    )
+
+    assert report["threshold"] == 0.50
+    assert report["price_coverage_ratio"] == 0.55
+    assert report["eligible"] is True
+
+
+def test_bootstrap_cache_coverage_keeps_fundamentals_threshold_strict_for_partial_price_markets():
+    db = _session()
+    symbols = [f"SYM{i}" for i in range(20)]
+    as_of = date(2026, 4, 24)
+    db.add_all([_price(symbol, as_of) for symbol in symbols[:11]])
+    db.add_all(
+        [
+            _fundamental(symbol, datetime(2026, 4, 21, tzinfo=timezone.utc))
+            for symbol in symbols[:18]
+        ]
+    )
+    db.commit()
+
+    report = evaluate_bootstrap_cache_coverage(
+        db,
+        market="TW",
+        symbols=symbols,
+        as_of_date=as_of,
+    )
+
+    assert report["price_threshold"] == 0.50
+    assert report["fundamentals_threshold"] == 0.95
+    assert report["price_coverage_ratio"] == 0.55
+    assert report["fundamentals_coverage_ratio"] == 0.90
+    assert report["eligible"] is False
+
+
+def test_bootstrap_price_thresholds_cover_every_supported_market():
+    expected_price_thresholds = {
+        "AU": 0.90,
+        "CA": 0.75,
+        "CN": 0.90,
+        "DE": 0.90,
+        "HK": 0.80,
+        "IN": 0.50,
+        "JP": 0.90,
+        "KR": 0.95,
+        "MY": 0.85,
+        "SG": 0.60,
+        "TW": 0.50,
+        "US": 0.95,
+    }
+
+    assert set(expected_price_thresholds) == set(
+        get_market_catalog().supported_market_codes()
+    )
+
+    for market, expected_threshold in expected_price_thresholds.items():
+        price_threshold = bootstrap_price_min_coverage_for_market(market)
+        fundamentals_threshold = bootstrap_fundamentals_min_coverage_for_market(market)
+
+        assert price_threshold == expected_threshold, market
+        assert fundamentals_threshold == 0.95, market
 
 
 def test_bootstrap_price_cache_coverage_rejects_empty_candidate_set():

--- a/backend/tests/unit/test_bootstrap_cache_coverage.py
+++ b/backend/tests/unit/test_bootstrap_cache_coverage.py
@@ -15,11 +15,12 @@ from app.models.provider_snapshot import (
 )
 from app.models.stock import StockFundamental, StockPrice
 from app.services.bootstrap_cache_coverage import (
+    BootstrapCacheCoverageReport,
     BootstrapPriceCoverageReport,
-    bootstrap_fundamentals_min_coverage_for_market,
-    bootstrap_price_min_coverage_for_market,
+    bootstrap_coverage_policy_for_market,
     evaluate_bootstrap_cache_coverage,
     evaluate_bootstrap_price_cache_coverage,
+    normalize_bootstrap_gate_report,
 )
 from app.domain.markets.catalog import get_market_catalog
 
@@ -233,6 +234,62 @@ def test_bootstrap_cache_coverage_keeps_fundamentals_threshold_strict_for_partia
     assert report["eligible"] is False
 
 
+def test_bootstrap_cache_report_uses_price_threshold_as_compatibility_alias_without_duplicate_state():
+    assert "threshold" not in BootstrapCacheCoverageReport.__dataclass_fields__
+
+    db = _session()
+    symbols = [f"SYM{i}" for i in range(20)]
+    as_of = date(2026, 4, 24)
+    db.add_all([_price(symbol, as_of) for symbol in symbols[:11]])
+    db.add_all(
+        [
+            _fundamental(symbol, datetime(2026, 4, 21, tzinfo=timezone.utc))
+            for symbol in symbols
+        ]
+    )
+    db.commit()
+
+    report = evaluate_bootstrap_cache_coverage(
+        db,
+        market="TW",
+        symbols=symbols,
+        as_of_date=as_of,
+    )
+
+    assert report["threshold"] == report["price_threshold"] == 0.50
+    assert report["fundamentals_threshold"] == 0.95
+
+
+def test_normalize_bootstrap_gate_report_owns_threshold_and_unsupported_metadata():
+    report = normalize_bootstrap_gate_report(
+        market="TW",
+        report={
+            "eligible": True,
+            "price_coverage_ratio": 0.55,
+            "fundamentals_coverage_ratio": 1.0,
+        },
+        unsupported_symbols=["1234.BAD", "5678.BAD"],
+    )
+
+    assert report["threshold"] == report["price_threshold"] == 0.50
+    assert report["fundamentals_threshold"] == 0.95
+    assert report["mode"] == "cache_only"
+    assert report["unsupported_skipped_count"] == 2
+    assert report["unsupported_symbols_preview"] == ["1234.BAD", "5678.BAD"]
+
+
+def test_normalize_bootstrap_gate_report_hides_unsupported_symbols_until_gate_passes():
+    report = normalize_bootstrap_gate_report(
+        market="TW",
+        report={"eligible": False},
+        unsupported_symbols=["1234.BAD"],
+    )
+
+    assert report["mode"] == "waiting_for_cache_coverage"
+    assert report["unsupported_skipped_count"] == 0
+    assert report["unsupported_symbols_preview"] == []
+
+
 def test_bootstrap_price_thresholds_cover_every_supported_market():
     expected_price_thresholds = {
         "AU": 0.90,
@@ -254,11 +311,11 @@ def test_bootstrap_price_thresholds_cover_every_supported_market():
     )
 
     for market, expected_threshold in expected_price_thresholds.items():
-        price_threshold = bootstrap_price_min_coverage_for_market(market)
-        fundamentals_threshold = bootstrap_fundamentals_min_coverage_for_market(market)
+        policy = bootstrap_coverage_policy_for_market(market)
 
-        assert price_threshold == expected_threshold, market
-        assert fundamentals_threshold == 0.95, market
+        assert policy.market == market
+        assert policy.price_min_coverage == expected_threshold, market
+        assert policy.fundamentals_min_coverage == 0.95, market
 
 
 def test_bootstrap_price_cache_coverage_rejects_empty_candidate_set():


### PR DESCRIPTION
## Summary
- adjust bootstrap cache-only price coverage gates by market based on available daily static price bundle coverage
- keep fundamentals coverage strict at 95%
- expose separate `price_threshold` and `fundamentals_threshold` diagnostics while preserving the existing `threshold` field as the price gate

## Price gates
| Market | Gate |
| --- | ---: |
| AU | 90% |
| CA | 75% |
| CN | 90% |
| DE | 90% |
| HK | 80% |
| IN | 50% |
| JP | 90% |
| KR | 95% |
| MY | 85% |
| SG | 60% |
| TW | 50% |
| US | 95% |

## Verification
- `cd backend && source venv/bin/activate && pytest tests/unit/test_bootstrap_cache_coverage.py tests/unit/use_cases/feature_store/test_build_daily_snapshot.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bootstrap cache gating now uses market-specific minimums for price coverage and a separate minimum for fundamentals coverage.
  * Reports and gate inputs are normalized so eligibility reflects both price and fundamentals thresholds consistently.

* **Tests**
  * Added tests validating per-market price thresholds, fundamentals gating behavior, report normalization, and coverage for all supported markets.

* **Chores**
  * Feature snapshot flow now delegates bootstrap gate normalization to a centralized helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->