### PR TITLE
RRG readability: spline trails, drag-to-zoom, larger plot; move stock-chart toggles beside OHLC

### DIFF
--- a/frontend/src/components/Charts/CandlestickChart.jsx
+++ b/frontend/src/components/Charts/CandlestickChart.jsx
@@ -32,7 +32,7 @@ const debounce = (fn, ms) => {
  * @param {Array|null} props.priceData - Optional static OHLCV payload to render without API calls
  * @param {number|null} props.dataUpdatedAtOverride - Optional timestamp (ms) for static bundles
  * @param {boolean} props.compact - When true, hides overlays (Daily/Weekly toggle, OHLC legend, updated-at indicator) for dense grid layouts
- * @param {boolean} props.hideTimeframeToggle - When true, hides only the Daily/Weekly toggle (other overlays stay) and forces the daily timeframe
+ * @param {boolean} props.hideTimeframeToggle - When true, hides the Daily/Weekly and RS toggle cluster (other overlays stay) and forces the daily timeframe
  * @param {boolean} props.interactive - When false, disables time-axis pan/zoom (mouse wheel, drag, pinch) until re-enabled
  */
 function CandlestickChart({

--- a/frontend/src/components/Charts/CandlestickChart.jsx
+++ b/frontend/src/components/Charts/CandlestickChart.jsx
@@ -487,91 +487,100 @@ function CandlestickChart({
         flexDirection: 'column',
       }}
     >
-      {/* Timeframe Toggle - only show when chart has data */}
-      {!compact && !hideTimeframeToggle && !showLoading && !showError && !showNoData && (
-        <Box
-          sx={{
-            position: 'absolute',
-            top: 10,
-            right: 10,
-            zIndex: 10,
-            bgcolor: 'background.paper',
-            borderRadius: 1,
-            boxShadow: 1,
-          }}
-        >
-          <Box sx={{ display: 'flex', gap: 0.5 }}>
-            <ToggleButtonGroup
-              value={timeframe}
-              exclusive
-              onChange={(e, newTimeframe) => {
-                if (newTimeframe !== null) {
-                  setTimeframe(newTimeframe);
-                }
-              }}
-              size="small"
-            >
-              <ToggleButton value="daily">Daily</ToggleButton>
-              <ToggleButton value="weekly">Weekly</ToggleButton>
-            </ToggleButtonGroup>
-            {/* RS line overlay toggle — shown only where RS data can load
-                (live charts, or static charts whose bundle carries rs_line). */}
-            {rsAvailable && (
-              <ToggleButtonGroup size="small">
-                <ToggleButton
-                  value="rs"
-                  selected={showRSLine}
-                  disabled={effectiveTimeframe !== 'daily'}
-                  onClick={() => setShowRSLine((prev) => !prev)}
-                  title="RS line (stock vs. benchmark) with blue-dot leadership signals"
-                >
-                  RS
-                </ToggleButton>
-              </ToggleButtonGroup>
-            )}
-          </Box>
-        </Box>
-      )}
-
-      {/* OHLC Legend - show when hovering over chart */}
-      {!compact && !showLoading && !showError && !showNoData && legendData && (
+      {/* Top-left overlay row: OHLC legend with the timeframe/RS toggles
+          immediately to its right, so the buttons never cover the price. */}
+      {!compact && !showLoading && !showError && !showNoData && (
         <Box
           sx={{
             position: 'absolute',
             top: 10,
             left: 10,
             zIndex: 10,
-            bgcolor: 'rgba(30, 30, 30, 0.85)',
-            borderRadius: 1,
-            px: 1.5,
-            py: 0.5,
             display: 'flex',
-            gap: 2,
-            fontFamily: 'monospace',
-            fontSize: '0.8rem',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 1,
           }}
         >
-          <span style={{ color: '#999' }}>
-            O <span style={{ color: '#fff' }}>{legendData.open.toFixed(2)}</span>
-          </span>
-          <span style={{ color: '#999' }}>
-            H <span style={{ color: '#fff' }}>{legendData.high.toFixed(2)}</span>
-          </span>
-          <span style={{ color: '#999' }}>
-            L <span style={{ color: '#fff' }}>{legendData.low.toFixed(2)}</span>
-          </span>
-          <span style={{ color: '#999' }}>
-            C <span style={{ color: '#fff' }}>{legendData.close.toFixed(2)}</span>
-          </span>
-          {legendData.changePercent !== null && (
-            <span
-              style={{
-                color: legendData.changePercent >= 0 ? '#4CF64D' : '#E619CD',
-                fontWeight: 500,
+          {/* OHLC Legend - tracks the hovered candle */}
+          {legendData && (
+            <Box
+              sx={{
+                bgcolor: 'rgba(30, 30, 30, 0.85)',
+                borderRadius: 1,
+                px: 1.5,
+                py: 0.5,
+                display: 'flex',
+                gap: 2,
+                fontFamily: 'monospace',
+                fontSize: '0.8rem',
               }}
             >
-              {legendData.changePercent >= 0 ? '+' : ''}{legendData.changePercent.toFixed(2)}%
-            </span>
+              <span style={{ color: '#999' }}>
+                O <span style={{ color: '#fff' }}>{legendData.open.toFixed(2)}</span>
+              </span>
+              <span style={{ color: '#999' }}>
+                H <span style={{ color: '#fff' }}>{legendData.high.toFixed(2)}</span>
+              </span>
+              <span style={{ color: '#999' }}>
+                L <span style={{ color: '#fff' }}>{legendData.low.toFixed(2)}</span>
+              </span>
+              <span style={{ color: '#999' }}>
+                C <span style={{ color: '#fff' }}>{legendData.close.toFixed(2)}</span>
+              </span>
+              {legendData.changePercent !== null && (
+                <span
+                  style={{
+                    color: legendData.changePercent >= 0 ? '#4CF64D' : '#E619CD',
+                    fontWeight: 500,
+                  }}
+                >
+                  {legendData.changePercent >= 0 ? '+' : ''}{legendData.changePercent.toFixed(2)}%
+                </span>
+              )}
+            </Box>
+          )}
+
+          {/* Timeframe toggle */}
+          {!hideTimeframeToggle && (
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 0.5,
+                bgcolor: 'background.paper',
+                borderRadius: 1,
+                boxShadow: 1,
+              }}
+            >
+              <ToggleButtonGroup
+                value={timeframe}
+                exclusive
+                onChange={(e, newTimeframe) => {
+                  if (newTimeframe !== null) {
+                    setTimeframe(newTimeframe);
+                  }
+                }}
+                size="small"
+              >
+                <ToggleButton value="daily">Daily</ToggleButton>
+                <ToggleButton value="weekly">Weekly</ToggleButton>
+              </ToggleButtonGroup>
+              {/* RS line overlay toggle — shown only where RS data can load
+                  (live charts, or static charts whose bundle carries rs_line). */}
+              {rsAvailable && (
+                <ToggleButtonGroup size="small">
+                  <ToggleButton
+                    value="rs"
+                    selected={showRSLine}
+                    disabled={effectiveTimeframe !== 'daily'}
+                    onClick={() => setShowRSLine((prev) => !prev)}
+                    title="RS line (stock vs. benchmark) with blue-dot leadership signals"
+                  >
+                    RS
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              )}
+            </Box>
           )}
         </Box>
       )}

--- a/frontend/src/components/Charts/RRGChart.jsx
+++ b/frontend/src/components/Charts/RRGChart.jsx
@@ -19,7 +19,7 @@
  * component is purely presentational. It is shared by the live Group Rankings
  * page and the static-site Groups page — both pass the same `{ groups: [...] }`.
  */
-import { useEffect, useId, useMemo, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import {
   ScatterChart,
   Scatter,
@@ -45,8 +45,9 @@ import {
   FormControlLabel,
   Switch,
 } from '@mui/material';
-import { QUADRANT_COLORS, QUADRANT_FILLS, quadrantColor } from './rrgColors';
+import { QUADRANT_COLORS, QUADRANT_FILLS, QUADRANT_LAYOUT, quadrantColor } from './rrgColors';
 import { buildTailPoints, catmullRomPath, splineSegmentMidpoint, layoutLabels } from './rrgTrace';
+import { useDragZoom } from './useDragZoom';
 import { useRRGFilters } from './useRRGFilters';
 import RRGFilters from './RRGFilters';
 
@@ -164,18 +165,17 @@ const RRGOverlay = ({ shown, perSegment, showLabels, xAxisMap, yAxisMap }) => {
       if (cx < clip.x || cx > clip.x + clip.width || cy < clip.y || cy > clip.y + clip.height) return;
       anchors.push({ cx, cy, text: g.industry_group, color: quadrantColor(g.quadrant) });
     });
-    const positions = layoutLabels(anchors);
-    labels = anchors.map((a, i) => (
+    labels = layoutLabels(anchors).map((l) => (
       <text
-        key={`label-${a.text}`}
-        x={positions[i].x}
-        y={positions[i].y}
+        key={`label-${l.text}`}
+        x={l.x}
+        y={l.y}
         fontSize={10}
         fontWeight={600}
-        fill={a.color}
+        fill={l.color}
         pointerEvents="none"
       >
-        {a.text}
+        {l.text}
       </text>
     ));
   }
@@ -250,21 +250,13 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
   // scope/market switches, unlike the filters in useRRGFilters.
   const [showLabels, setShowLabels] = useState(false);
 
-  // Drag-to-zoom: `drag` is the in-progress selection rectangle (data coords),
-  // `zoom` the committed axis domains. A zoom into another dataset would be
-  // meaningless, so it resets when the scope or market switches.
-  const [drag, setDrag] = useState(null);
-  const [zoom, setZoom] = useState(null);
-  useEffect(() => {
-    setZoom(null);
-  }, [data?.scope, data?.market]);
-
   const bound = useMemo(() => computeBound(shown), [shown]);
   const lo = 100 - bound;
   const hi = 100 + bound;
 
-  const [xLo, xHi] = zoom?.x ?? [lo, hi];
-  const [yLo, yHi] = zoom?.y ?? [lo, hi];
+  const zoom = useDragZoom({ x: [lo, hi], y: [lo, hi] }, `${data?.scope}|${data?.market}`);
+  const [xLo, xHi] = zoom.xDomain;
+  const [yLo, yHi] = zoom.yDomain;
   // The 100/100 cross, clamped into the visible window so the quadrant
   // backdrops always tile exactly the visible plot area when zoomed.
   const xMid = Math.min(Math.max(100, xLo), xHi);
@@ -276,29 +268,6 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
   const tickDecimals = span > 8 ? 0 : span > 2 ? 1 : 2;
   const formatTick = (v) => v.toFixed(tickDecimals);
 
-  // Drags smaller than this (in axis units) are treated as clicks, so the
-  // head-dot click-to-select behaviour survives the zoom handlers.
-  const MIN_DRAG = 0.4;
-
-  const handleChartMouseDown = (e) => {
-    if (e?.xValue == null || e?.yValue == null) return;
-    setDrag({ x1: e.xValue, y1: e.yValue, x2: e.xValue, y2: e.yValue });
-  };
-  const handleChartMouseMove = (e) => {
-    if (!drag || e?.xValue == null || e?.yValue == null) return;
-    setDrag((d) => (d ? { ...d, x2: e.xValue, y2: e.yValue } : d));
-  };
-  const handleChartMouseUp = () => {
-    if (!drag) return;
-    const { x1, y1, x2, y2 } = drag;
-    setDrag(null);
-    if (Math.abs(x2 - x1) < MIN_DRAG || Math.abs(y2 - y1) < MIN_DRAG) return;
-    setZoom({
-      x: [Math.min(x1, x2), Math.max(x1, x2)],
-      y: [Math.min(y1, y2), Math.max(y1, y2)],
-    });
-  };
-
   // Single "detail level" driving both tail-dot richness and arrow density, so
   // the default (all-series) view stays light and the filtered view gets the
   // full per-week detail.
@@ -308,9 +277,12 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
     () => shown.map((g) => ({ ...g, ...g.current, isCurrent: true })),
     [shown],
   );
+  // Hoverable per-week tail dots exist only in the detailed view (the trail
+  // itself is RRGOverlay's spline), so the point enrichment is skipped — and
+  // no tail Scatters are mounted — when many series are shown.
   const tails = useMemo(
-    () => shown.map((g) => ({ name: g.industry_group, points: buildTailPoints(g, asOf) })),
-    [shown, asOf],
+    () => (detailed ? shown.map((g) => ({ name: g.industry_group, points: buildTailPoints(g, asOf) })) : []),
+    [detailed, shown, asOf],
   );
 
   if (isLoading) {
@@ -359,8 +331,8 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
             drag to zoom
           </Typography>
           <Box sx={{ flexGrow: 1 }} />
-          {zoom && (
-            <Button size="small" variant="outlined" onClick={() => setZoom(null)}>
+          {zoom.isZoomed && (
+            <Button size="small" variant="outlined" onClick={zoom.reset}>
               Reset zoom
             </Button>
           )}
@@ -394,32 +366,30 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
           <ResponsiveContainer width="100%" height={height}>
             <ScatterChart
               margin={{ top: 20, right: 30, bottom: 20, left: 10 }}
-              onMouseDown={handleChartMouseDown}
-              onMouseMove={handleChartMouseMove}
-              onMouseUp={handleChartMouseUp}
-              onMouseLeave={() => setDrag(null)}
+              {...zoom.mouseHandlers}
               style={{ cursor: 'crosshair', userSelect: 'none' }}
             >
               <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
 
               {/* Quadrant backdrops, clamped to the (possibly zoomed) window.
                   A quadrant fully outside the window collapses and is skipped. */}
-              {xMid < xHi && yMid < yHi && (
-                <ReferenceArea x1={xMid} x2={xHi} y1={yMid} y2={yHi} fill={QUADRANT_FILLS.Leading} fillOpacity={1}
-                  label={{ value: 'Leading', position: 'insideTopRight', fill: QUADRANT_COLORS.Leading, fontSize: 12 }} />
-              )}
-              {xMid < xHi && yLo < yMid && (
-                <ReferenceArea x1={xMid} x2={xHi} y1={yLo} y2={yMid} fill={QUADRANT_FILLS.Weakening} fillOpacity={1}
-                  label={{ value: 'Weakening', position: 'insideBottomRight', fill: QUADRANT_COLORS.Weakening, fontSize: 12 }} />
-              )}
-              {xLo < xMid && yLo < yMid && (
-                <ReferenceArea x1={xLo} x2={xMid} y1={yLo} y2={yMid} fill={QUADRANT_FILLS.Lagging} fillOpacity={1}
-                  label={{ value: 'Lagging', position: 'insideBottomLeft', fill: QUADRANT_COLORS.Lagging, fontSize: 12 }} />
-              )}
-              {xLo < xMid && yMid < yHi && (
-                <ReferenceArea x1={xLo} x2={xMid} y1={yMid} y2={yHi} fill={QUADRANT_FILLS.Improving} fillOpacity={1}
-                  label={{ value: 'Improving', position: 'insideTopLeft', fill: QUADRANT_COLORS.Improving, fontSize: 12 }} />
-              )}
+              {QUADRANT_LAYOUT.map(({ name, x, y, labelPosition }) => {
+                const [x1, x2] = x === 'hi' ? [xMid, xHi] : [xLo, xMid];
+                const [y1, y2] = y === 'hi' ? [yMid, yHi] : [yLo, yMid];
+                if (!(x1 < x2 && y1 < y2)) return null;
+                return (
+                  <ReferenceArea
+                    key={name}
+                    x1={x1}
+                    x2={x2}
+                    y1={y1}
+                    y2={y2}
+                    fill={QUADRANT_FILLS[name]}
+                    fillOpacity={1}
+                    label={{ value: name, position: labelPosition, fill: QUADRANT_COLORS[name], fontSize: 12 }}
+                  />
+                );
+              })}
 
               {xLo < 100 && 100 < xHi && <ReferenceLine x={100} stroke="#9e9e9e" strokeDasharray="4 4" />}
               {yLo < 100 && 100 < yHi && <ReferenceLine y={100} stroke="#9e9e9e" strokeDasharray="4 4" />}
@@ -447,14 +417,13 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
               <ZAxis type="number" dataKey="num_stocks" range={[60, 500]} name="Constituents" />
               <Tooltip content={<RRGTooltip />} cursor={{ strokeDasharray: '3 3' }} />
 
-              {/* Tails: graduated hoverable per-week dots in the detailed
-                  (filtered) view. The connecting trail itself is the smoothed
-                  spline drawn by RRGOverlay below. */}
+              {/* Graduated hoverable per-week tail dots (empty unless detailed).
+                  The connecting trail itself is RRGOverlay's spline below. */}
               {tails.map((t) => (
                 <Scatter
                   key={`tail-${t.name}`}
                   data={t.points}
-                  shape={detailed ? <TailDot /> : () => null}
+                  shape={<TailDot />}
                   isAnimationActive={false}
                   legendType="none"
                 />
@@ -469,12 +438,12 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
               />
 
               {/* In-progress drag-to-zoom selection rectangle. */}
-              {drag && (
+              {zoom.drag && (
                 <ReferenceArea
-                  x1={drag.x1}
-                  x2={drag.x2}
-                  y1={drag.y1}
-                  y2={drag.y2}
+                  x1={zoom.drag.x1}
+                  x2={zoom.drag.x2}
+                  y1={zoom.drag.y1}
+                  y2={zoom.drag.y2}
                   fill="#90caf9"
                   fillOpacity={0.2}
                   stroke="#90caf9"

--- a/frontend/src/components/Charts/RRGChart.jsx
+++ b/frontend/src/components/Charts/RRGChart.jsx
@@ -9,15 +9,17 @@
  *     Lagging   (x<100,  y<100)   red
  *     Improving (x<100,  y>=100)  blue
  *
- * Each tail vertex is a hoverable dot (date + weeks-ago), the trace is graduated
- * oldest->newest, and direction arrows point the way each series is travelling.
- * A filter narrows the plot to the groups/sectors of interest.
+ * Each tail vertex is a hoverable dot (date + weeks-ago), the trace is a
+ * Catmull-Rom spline graduated oldest->newest, and direction arrows point the
+ * way each series is travelling. A filter narrows the plot to the groups/
+ * sectors of interest, and dragging a rectangle zooms into it (Reset zoom to
+ * restore the full view).
  *
  * Coordinates are pre-computed server-side (see backend rrg_service.py), so this
  * component is purely presentational. It is shared by the live Group Rankings
  * page and the static-site Groups page — both pass the same `{ groups: [...] }`.
  */
-import { useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 import {
   ScatterChart,
   Scatter,
@@ -34,6 +36,7 @@ import {
 } from 'recharts';
 import {
   Box,
+  Button,
   Card,
   CardContent,
   Typography,
@@ -43,7 +46,7 @@ import {
   Switch,
 } from '@mui/material';
 import { QUADRANT_COLORS, QUADRANT_FILLS, quadrantColor } from './rrgColors';
-import { buildTailPoints } from './rrgTrace';
+import { buildTailPoints, catmullRomPath, splineSegmentMidpoint, layoutLabels } from './rrgTrace';
 import { useRRGFilters } from './useRRGFilters';
 import RRGFilters from './RRGFilters';
 
@@ -93,74 +96,102 @@ const ArrowHead = ({ x, y, angle, color }) => {
   );
 };
 
-/** Recharts <Customized> child: draws direction arrows in pixel space using the
- *  axis scales. Degrades to nothing if scales aren't ready (e.g. SSR/jsdom). */
-const TailArrows = ({ shown, perSegment, xAxisMap, yAxisMap }) => {
+/** Recharts <Customized> child: draws everything that lives in pixel space —
+ *  the smoothed Catmull-Rom trail per series, direction arrows riding the
+ *  curve, and (when toggled) collision-avoiding head labels. All of it is
+ *  clipped to the plot area so nothing spills over the axes when zoomed.
+ *  Degrades to nothing if scales aren't ready (e.g. SSR/jsdom). */
+const RRGOverlay = ({ shown, perSegment, showLabels, xAxisMap, yAxisMap }) => {
+  const clipId = useId();
   const xAxis = xAxisMap && xAxisMap[Object.keys(xAxisMap)[0]];
   const yAxis = yAxisMap && yAxisMap[Object.keys(yAxisMap)[0]];
   const xScale = xAxis?.scale;
   const yScale = yAxis?.scale;
   if (typeof xScale !== 'function' || typeof yScale !== 'function') return null;
 
+  const [rx0, rx1] = xScale.range();
+  const [ry0, ry1] = yScale.range();
+  const clip = {
+    x: Math.min(rx0, rx1),
+    y: Math.min(ry0, ry1),
+    width: Math.abs(rx1 - rx0),
+    height: Math.abs(ry1 - ry0),
+  };
+
+  const splines = [];
   const arrows = [];
   shown.forEach((g) => {
     const tail = g.tail || [];
     if (tail.length < 2) return;
-    const from = perSegment ? 1 : tail.length - 1;
-    for (let i = from; i < tail.length; i += 1) {
-      const a = tail[i - 1];
-      const b = tail[i];
-      const x1 = xScale(a.x);
-      const y1 = yScale(a.y);
-      const x2 = xScale(b.x);
-      const y2 = yScale(b.y);
-      if ([x1, y1, x2, y2].some((v) => v == null || Number.isNaN(v))) continue;
+    const pts = tail.map((p) => ({ x: xScale(p.x), y: yScale(p.y) }));
+    if (pts.some((p) => p.x == null || p.y == null || Number.isNaN(p.x) || Number.isNaN(p.y))) return;
+    const color = quadrantColor(g.quadrant);
+    splines.push(
+      <path
+        key={`spline-${g.industry_group}`}
+        d={catmullRomPath(pts)}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeOpacity={0.5}
+      />,
+    );
+    const from = perSegment ? 1 : pts.length - 1;
+    for (let i = from; i < pts.length; i += 1) {
+      const mid = splineSegmentMidpoint(pts[i - 2], pts[i - 1], pts[i], pts[i + 1]);
       arrows.push(
         <ArrowHead
           key={`${g.industry_group}-${i}`}
-          x={(x1 + x2) / 2}
-          y={(y1 + y2) / 2}
-          angle={Math.atan2(y2 - y1, x2 - x1)}
-          color={quadrantColor(g.quadrant)}
+          x={mid.x}
+          y={mid.y}
+          angle={mid.angle}
+          color={color}
         />,
       );
     }
   });
-  return <g>{arrows}</g>;
-};
 
-/** Recharts <Customized> child: draws the group/sector name next to each current
- *  head dot, tinted by quadrant. Uses the axis scales like TailArrows, and
- *  degrades to nothing if scales aren't ready (e.g. SSR/jsdom). */
-const GroupLabels = ({ shown, xAxisMap, yAxisMap }) => {
-  const xAxis = xAxisMap && xAxisMap[Object.keys(xAxisMap)[0]];
-  const yAxis = yAxisMap && yAxisMap[Object.keys(yAxisMap)[0]];
-  const xScale = xAxis?.scale;
-  const yScale = yAxis?.scale;
-  if (typeof xScale !== 'function' || typeof yScale !== 'function') return null;
+  let labels = null;
+  if (showLabels) {
+    const anchors = [];
+    shown.forEach((g) => {
+      const cur = g.current;
+      if (!cur) return;
+      const cx = xScale(cur.x);
+      const cy = yScale(cur.y);
+      if ([cx, cy].some((v) => v == null || Number.isNaN(v))) return;
+      // Heads zoomed out of view get no label (it would be clipped anyway).
+      if (cx < clip.x || cx > clip.x + clip.width || cy < clip.y || cy > clip.y + clip.height) return;
+      anchors.push({ cx, cy, text: g.industry_group, color: quadrantColor(g.quadrant) });
+    });
+    const positions = layoutLabels(anchors);
+    labels = anchors.map((a, i) => (
+      <text
+        key={`label-${a.text}`}
+        x={positions[i].x}
+        y={positions[i].y}
+        fontSize={10}
+        fontWeight={600}
+        fill={a.color}
+        pointerEvents="none"
+      >
+        {a.text}
+      </text>
+    ));
+  }
 
   return (
     <g>
-      {shown.map((g) => {
-        const cur = g.current;
-        if (!cur) return null;
-        const cx = xScale(cur.x);
-        const cy = yScale(cur.y);
-        if ([cx, cy].some((v) => v == null || Number.isNaN(v))) return null;
-        return (
-          <text
-            key={`label-${g.industry_group}`}
-            x={cx + 7}
-            y={cy - 7}
-            fontSize={10}
-            fontWeight={600}
-            fill={quadrantColor(g.quadrant)}
-            pointerEvents="none"
-          >
-            {g.industry_group}
-          </text>
-        );
-      })}
+      <defs>
+        <clipPath id={clipId}>
+          <rect {...clip} />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${clipId})`}>
+        {splines}
+        {arrows}
+        {labels}
+      </g>
     </g>
   );
 };
@@ -208,7 +239,7 @@ const RRGTooltip = ({ active, payload }) => {
 /**
  * @param {Object[]} props.data.groups - RRGGroupResponse[] from the API
  */
-export default function RRGChart({ data, isLoading, error, onSelectGroup, height = 560 }) {
+export default function RRGChart({ data, isLoading, error, onSelectGroup, height = 720 }) {
   const groups = useMemo(() => (data?.groups ?? []), [data]);
   const asOf = data?.date ?? null;
   const scopeLabel = data?.scope === 'sectors' ? 'Sectors' : 'Groups';
@@ -219,9 +250,54 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
   // scope/market switches, unlike the filters in useRRGFilters.
   const [showLabels, setShowLabels] = useState(false);
 
+  // Drag-to-zoom: `drag` is the in-progress selection rectangle (data coords),
+  // `zoom` the committed axis domains. A zoom into another dataset would be
+  // meaningless, so it resets when the scope or market switches.
+  const [drag, setDrag] = useState(null);
+  const [zoom, setZoom] = useState(null);
+  useEffect(() => {
+    setZoom(null);
+  }, [data?.scope, data?.market]);
+
   const bound = useMemo(() => computeBound(shown), [shown]);
   const lo = 100 - bound;
   const hi = 100 + bound;
+
+  const [xLo, xHi] = zoom?.x ?? [lo, hi];
+  const [yLo, yHi] = zoom?.y ?? [lo, hi];
+  // The 100/100 cross, clamped into the visible window so the quadrant
+  // backdrops always tile exactly the visible plot area when zoomed.
+  const xMid = Math.min(Math.max(100, xLo), xHi);
+  const yMid = Math.min(Math.max(100, yLo), yHi);
+
+  // Zoomed domains land on arbitrary floats, so ticks need explicit rounding —
+  // with decimals adapted to the window size so narrow zooms stay distinct.
+  const span = Math.max(xHi - xLo, yHi - yLo);
+  const tickDecimals = span > 8 ? 0 : span > 2 ? 1 : 2;
+  const formatTick = (v) => v.toFixed(tickDecimals);
+
+  // Drags smaller than this (in axis units) are treated as clicks, so the
+  // head-dot click-to-select behaviour survives the zoom handlers.
+  const MIN_DRAG = 0.4;
+
+  const handleChartMouseDown = (e) => {
+    if (e?.xValue == null || e?.yValue == null) return;
+    setDrag({ x1: e.xValue, y1: e.yValue, x2: e.xValue, y2: e.yValue });
+  };
+  const handleChartMouseMove = (e) => {
+    if (!drag || e?.xValue == null || e?.yValue == null) return;
+    setDrag((d) => (d ? { ...d, x2: e.xValue, y2: e.yValue } : d));
+  };
+  const handleChartMouseUp = () => {
+    if (!drag) return;
+    const { x1, y1, x2, y2 } = drag;
+    setDrag(null);
+    if (Math.abs(x2 - x1) < MIN_DRAG || Math.abs(y2 - y1) < MIN_DRAG) return;
+    setZoom({
+      x: [Math.min(x1, x2), Math.max(x1, x2)],
+      y: [Math.min(y1, y2), Math.max(y1, y2)],
+    });
+  };
 
   // Single "detail level" driving both tail-dot richness and arrow density, so
   // the default (all-series) view stays light and the filtered view gets the
@@ -233,7 +309,7 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
     [shown],
   );
   const tails = useMemo(
-    () => shown.map((g) => ({ name: g.industry_group, color: quadrantColor(g.quadrant), points: buildTailPoints(g, asOf) })),
+    () => shown.map((g) => ({ name: g.industry_group, points: buildTailPoints(g, asOf) })),
     [shown, asOf],
   );
 
@@ -279,7 +355,15 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
             Relative Rotation Graph — {scopeLabel}
             {asOf ? ` · ${asOf}` : ''}
           </Typography>
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            drag to zoom
+          </Typography>
           <Box sx={{ flexGrow: 1 }} />
+          {zoom && (
+            <Button size="small" variant="outlined" onClick={() => setZoom(null)}>
+              Reset zoom
+            </Button>
+          )}
           <FormControlLabel
             control={
               <Switch
@@ -308,66 +392,93 @@ export default function RRGChart({ data, isLoading, error, onSelectGroup, height
           <Alert severity="info">No {scopeLabel.toLowerCase()} match the current filter.</Alert>
         ) : (
           <ResponsiveContainer width="100%" height={height}>
-            <ScatterChart margin={{ top: 20, right: 30, bottom: 20, left: 10 }}>
+            <ScatterChart
+              margin={{ top: 20, right: 30, bottom: 20, left: 10 }}
+              onMouseDown={handleChartMouseDown}
+              onMouseMove={handleChartMouseMove}
+              onMouseUp={handleChartMouseUp}
+              onMouseLeave={() => setDrag(null)}
+              style={{ cursor: 'crosshair', userSelect: 'none' }}
+            >
               <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
 
-              {/* Quadrant backdrops */}
-              <ReferenceArea x1={100} x2={hi} y1={100} y2={hi} fill={QUADRANT_FILLS.Leading} fillOpacity={1}
-                label={{ value: 'Leading', position: 'insideTopRight', fill: QUADRANT_COLORS.Leading, fontSize: 12 }} />
-              <ReferenceArea x1={100} x2={hi} y1={lo} y2={100} fill={QUADRANT_FILLS.Weakening} fillOpacity={1}
-                label={{ value: 'Weakening', position: 'insideBottomRight', fill: QUADRANT_COLORS.Weakening, fontSize: 12 }} />
-              <ReferenceArea x1={lo} x2={100} y1={lo} y2={100} fill={QUADRANT_FILLS.Lagging} fillOpacity={1}
-                label={{ value: 'Lagging', position: 'insideBottomLeft', fill: QUADRANT_COLORS.Lagging, fontSize: 12 }} />
-              <ReferenceArea x1={lo} x2={100} y1={100} y2={hi} fill={QUADRANT_FILLS.Improving} fillOpacity={1}
-                label={{ value: 'Improving', position: 'insideTopLeft', fill: QUADRANT_COLORS.Improving, fontSize: 12 }} />
+              {/* Quadrant backdrops, clamped to the (possibly zoomed) window.
+                  A quadrant fully outside the window collapses and is skipped. */}
+              {xMid < xHi && yMid < yHi && (
+                <ReferenceArea x1={xMid} x2={xHi} y1={yMid} y2={yHi} fill={QUADRANT_FILLS.Leading} fillOpacity={1}
+                  label={{ value: 'Leading', position: 'insideTopRight', fill: QUADRANT_COLORS.Leading, fontSize: 12 }} />
+              )}
+              {xMid < xHi && yLo < yMid && (
+                <ReferenceArea x1={xMid} x2={xHi} y1={yLo} y2={yMid} fill={QUADRANT_FILLS.Weakening} fillOpacity={1}
+                  label={{ value: 'Weakening', position: 'insideBottomRight', fill: QUADRANT_COLORS.Weakening, fontSize: 12 }} />
+              )}
+              {xLo < xMid && yLo < yMid && (
+                <ReferenceArea x1={xLo} x2={xMid} y1={yLo} y2={yMid} fill={QUADRANT_FILLS.Lagging} fillOpacity={1}
+                  label={{ value: 'Lagging', position: 'insideBottomLeft', fill: QUADRANT_COLORS.Lagging, fontSize: 12 }} />
+              )}
+              {xLo < xMid && yMid < yHi && (
+                <ReferenceArea x1={xLo} x2={xMid} y1={yMid} y2={yHi} fill={QUADRANT_FILLS.Improving} fillOpacity={1}
+                  label={{ value: 'Improving', position: 'insideTopLeft', fill: QUADRANT_COLORS.Improving, fontSize: 12 }} />
+              )}
 
-              <ReferenceLine x={100} stroke="#9e9e9e" strokeDasharray="4 4" />
-              <ReferenceLine y={100} stroke="#9e9e9e" strokeDasharray="4 4" />
+              {xLo < 100 && 100 < xHi && <ReferenceLine x={100} stroke="#9e9e9e" strokeDasharray="4 4" />}
+              {yLo < 100 && 100 < yHi && <ReferenceLine y={100} stroke="#9e9e9e" strokeDasharray="4 4" />}
 
               <XAxis
                 type="number"
                 dataKey="x"
                 name="RS-Ratio"
-                domain={[lo, hi]}
+                domain={[xLo, xHi]}
+                allowDataOverflow
                 tickCount={5}
+                tickFormatter={formatTick}
                 label={{ value: 'RS-Ratio', position: 'insideBottom', offset: -10, fontSize: 12 }}
               />
               <YAxis
                 type="number"
                 dataKey="y"
                 name="RS-Momentum"
-                domain={[lo, hi]}
+                domain={[yLo, yHi]}
+                allowDataOverflow
                 tickCount={5}
+                tickFormatter={formatTick}
                 label={{ value: 'RS-Momentum', angle: -90, position: 'insideLeft', fontSize: 12 }}
               />
               <ZAxis type="number" dataKey="num_stocks" range={[60, 500]} name="Constituents" />
               <Tooltip content={<RRGTooltip />} cursor={{ strokeDasharray: '3 3' }} />
 
-              {/* Tails: connecting line, plus graduated hoverable per-week dots
-                  in the detailed (filtered) view; line-only when many series. */}
+              {/* Tails: graduated hoverable per-week dots in the detailed
+                  (filtered) view. The connecting trail itself is the smoothed
+                  spline drawn by RRGOverlay below. */}
               {tails.map((t) => (
                 <Scatter
                   key={`tail-${t.name}`}
                   data={t.points}
-                  line={{ stroke: t.color, strokeWidth: 1.25, strokeOpacity: 0.45 }}
-                  lineType="joint"
                   shape={detailed ? <TailDot /> : () => null}
                   isAnimationActive={false}
                   legendType="none"
                 />
               ))}
 
-              {/* Direction arrows along each trace (per-segment when detailed). */}
+              {/* Spline trails, direction arrows (per-segment when detailed),
+                  and collision-avoiding head labels (toggle). */}
               <Customized
                 component={(props) => (
-                  <TailArrows shown={shown} perSegment={detailed} {...props} />
+                  <RRGOverlay shown={shown} perSegment={detailed} showLabels={showLabels} {...props} />
                 )}
               />
 
-              {/* Group/sector name labels next to each head dot (toggle). */}
-              {showLabels && (
-                <Customized
-                  component={(props) => <GroupLabels shown={shown} {...props} />}
+              {/* In-progress drag-to-zoom selection rectangle. */}
+              {drag && (
+                <ReferenceArea
+                  x1={drag.x1}
+                  x2={drag.x2}
+                  y1={drag.y1}
+                  y2={drag.y2}
+                  fill="#90caf9"
+                  fillOpacity={0.2}
+                  stroke="#90caf9"
+                  strokeOpacity={0.7}
                 />
               )}
 

--- a/frontend/src/components/Charts/rrgColors.js
+++ b/frontend/src/components/Charts/rrgColors.js
@@ -23,3 +23,15 @@ export const quadrantColor = (q) => QUADRANT_COLORS[q] || '#9e9e9e';
  * for the quadrant filter buttons so they stay consistent with the colors above.
  */
 export const QUADRANTS = ['Improving', 'Leading', 'Weakening', 'Lagging'];
+
+/**
+ * Per-quadrant plot geometry: which half of each axis the quadrant occupies
+ * relative to the 100/100 cross ('lo' below, 'hi' above) and where its
+ * backdrop label sits. Drives the RRG quadrant backdrops.
+ */
+export const QUADRANT_LAYOUT = [
+  { name: 'Leading', x: 'hi', y: 'hi', labelPosition: 'insideTopRight' },
+  { name: 'Weakening', x: 'hi', y: 'lo', labelPosition: 'insideBottomRight' },
+  { name: 'Lagging', x: 'lo', y: 'lo', labelPosition: 'insideBottomLeft' },
+  { name: 'Improving', x: 'lo', y: 'hi', labelPosition: 'insideTopLeft' },
+];

--- a/frontend/src/components/Charts/rrgTrace.js
+++ b/frontend/src/components/Charts/rrgTrace.js
@@ -52,3 +52,81 @@ export const buildTailPoints = (group, asOfISO) => {
     t: last > 0 ? i / last : 1,
   }));
 };
+
+/**
+ * Catmull-Rom control points for the spline segment p1 -> p2 (p0/p3 are the
+ * neighbouring vertices, or the segment endpoints at the ends of the tail).
+ * The uniform variant interpolates *through* every vertex, so the smoothed
+ * trail still passes exactly where the series was each week.
+ */
+const splineControls = (p0, p1, p2, p3) => ({
+  c1: { x: p1.x + (p2.x - p0.x) / 6, y: p1.y + (p2.y - p0.y) / 6 },
+  c2: { x: p2.x - (p3.x - p1.x) / 6, y: p2.y - (p3.y - p1.y) / 6 },
+});
+
+/** SVG path string for a Catmull-Rom spline through `pts` ({x,y} pixel coords). */
+export const catmullRomPath = (pts) => {
+  if (!pts || pts.length < 2) return '';
+  let d = `M${pts[0].x},${pts[0].y}`;
+  for (let i = 0; i < pts.length - 1; i += 1) {
+    const p0 = pts[i - 1] ?? pts[i];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[i + 2] ?? p2;
+    const { c1, c2 } = splineControls(p0, p1, p2, p3);
+    d += ` C${c1.x},${c1.y} ${c2.x},${c2.y} ${p2.x},${p2.y}`;
+  }
+  return d;
+};
+
+/**
+ * Point and tangent angle at the middle (t=0.5) of the spline segment
+ * p1 -> p2, so direction arrows sit on the curve rather than the chord.
+ */
+export const splineSegmentMidpoint = (p0, p1, p2, p3) => {
+  const { c1, c2 } = splineControls(p0 ?? p1, p1, p2, p3 ?? p2);
+  const x = (p1.x + 3 * c1.x + 3 * c2.x + p2.x) / 8;
+  const y = (p1.y + 3 * c1.y + 3 * c2.y + p2.y) / 8;
+  const dx = 0.75 * (c1.x - p1.x) + 1.5 * (c2.x - c1.x) + 0.75 * (p2.x - c2.x);
+  const dy = 0.75 * (c1.y - p1.y) + 1.5 * (c2.y - c1.y) + 0.75 * (p2.y - c2.y);
+  return { x, y, angle: Math.atan2(dy, dx) };
+};
+
+// Label collision layout: estimated glyph metrics for fontSize=10, weight 600.
+const LABEL_HEIGHT = 12;
+const LABEL_CHAR_WIDTH = 6;
+
+const boxesOverlap = (a, b) =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+
+/**
+ * Greedy collision-avoiding placement for head-dot labels. Each anchor is
+ * `{cx, cy, text}` in pixel space; the default spot is above-right of the dot,
+ * falling back to below-right / above-left / below-left / further out until a
+ * spot free of already-placed labels is found. Returns `{x, y}` text positions
+ * (SVG baseline coords) in the same order as the input.
+ */
+export const layoutLabels = (anchors) => {
+  const placed = [];
+  return (anchors ?? []).map(({ cx, cy, text }) => {
+    const w = String(text ?? '').length * LABEL_CHAR_WIDTH;
+    const candidates = [
+      { x: cx + 7, y: cy - 7 },
+      { x: cx + 7, y: cy + 14 },
+      { x: cx - w - 7, y: cy - 7 },
+      { x: cx - w - 7, y: cy + 14 },
+      { x: cx + 7, y: cy - 20 },
+      { x: cx + 7, y: cy + 27 },
+    ];
+    let pick = candidates[0];
+    for (const c of candidates) {
+      const box = { x: c.x, y: c.y - LABEL_HEIGHT, w, h: LABEL_HEIGHT + 2 };
+      if (!placed.some((p) => boxesOverlap(p, box))) {
+        pick = c;
+        break;
+      }
+    }
+    placed.push({ x: pick.x, y: pick.y - LABEL_HEIGHT, w, h: LABEL_HEIGHT + 2 });
+    return { x: pick.x, y: pick.y };
+  });
+};

--- a/frontend/src/components/Charts/rrgTrace.js
+++ b/frontend/src/components/Charts/rrgTrace.js
@@ -101,14 +101,16 @@ const boxesOverlap = (a, b) =>
 
 /**
  * Greedy collision-avoiding placement for head-dot labels. Each anchor is
- * `{cx, cy, text}` in pixel space; the default spot is above-right of the dot,
- * falling back to below-right / above-left / below-left / further out until a
- * spot free of already-placed labels is found. Returns `{x, y}` text positions
- * (SVG baseline coords) in the same order as the input.
+ * `{cx, cy, text, ...}` in pixel space; the default spot is above-right of the
+ * dot, falling back to below-right / above-left / below-left / further out
+ * until a spot free of already-placed labels is found. Returns the anchors
+ * (extra fields preserved) with `{x, y}` text positions (SVG baseline coords)
+ * added, in input order.
  */
 export const layoutLabels = (anchors) => {
   const placed = [];
-  return (anchors ?? []).map(({ cx, cy, text }) => {
+  return (anchors ?? []).map((anchor) => {
+    const { cx, cy, text } = anchor;
     const w = String(text ?? '').length * LABEL_CHAR_WIDTH;
     const candidates = [
       { x: cx + 7, y: cy - 7 },
@@ -127,6 +129,6 @@ export const layoutLabels = (anchors) => {
       }
     }
     placed.push({ x: pick.x, y: pick.y - LABEL_HEIGHT, w, h: LABEL_HEIGHT + 2 });
-    return { x: pick.x, y: pick.y };
+    return { ...anchor, x: pick.x, y: pick.y };
   });
 };

--- a/frontend/src/components/Charts/rrgTrace.test.js
+++ b/frontend/src/components/Charts/rrgTrace.test.js
@@ -144,8 +144,9 @@ describe('splineSegmentMidpoint', () => {
 });
 
 describe('layoutLabels', () => {
-  it('places an unobstructed label above-right of its dot', () => {
-    expect(layoutLabels([{ cx: 100, cy: 100, text: 'Solo' }])).toEqual([{ x: 107, y: 93 }]);
+  it('places an unobstructed label above-right of its dot, preserving anchor fields', () => {
+    const [solo] = layoutLabels([{ cx: 100, cy: 100, text: 'Solo', color: '#4caf50' }]);
+    expect(solo).toEqual({ cx: 100, cy: 100, text: 'Solo', color: '#4caf50', x: 107, y: 93 });
   });
 
   it('moves the second of two coincident labels to a non-overlapping spot', () => {
@@ -153,8 +154,7 @@ describe('layoutLabels', () => {
       { cx: 100, cy: 100, text: 'First' },
       { cx: 100, cy: 100, text: 'Second' },
     ]);
-    expect(a).toEqual({ x: 107, y: 93 });
-    expect(b).not.toEqual(a);
+    expect(a).toMatchObject({ x: 107, y: 93 });
     // Vertical separation: boxes are 12px tall, so the fallback spot clears it.
     expect(Math.abs(b.y - a.y)).toBeGreaterThanOrEqual(12);
   });

--- a/frontend/src/components/Charts/rrgTrace.test.js
+++ b/frontend/src/components/Charts/rrgTrace.test.js
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { weeksAgo, buildTailPoints, filterGroups } from './rrgTrace';
+import {
+  weeksAgo,
+  buildTailPoints,
+  filterGroups,
+  catmullRomPath,
+  splineSegmentMidpoint,
+  layoutLabels,
+} from './rrgTrace';
 
 describe('weeksAgo', () => {
   it('is 0 for the as-of date itself', () => {
@@ -90,5 +97,70 @@ describe('filterGroups', () => {
   it('combines name, quadrant, and rank filters with AND', () => {
     expect(filterGroups(groups, { names: ['A', 'C'], rankRange: [1, 10] }).map((g) => g.industry_group)).toEqual(['A']);
     expect(filterGroups(groups, { quadrants: ['Leading'], rankRange: [1, 10] }).map((g) => g.industry_group)).toEqual(['A']);
+  });
+});
+
+describe('catmullRomPath', () => {
+  it('returns an empty path for fewer than 2 points', () => {
+    expect(catmullRomPath([])).toBe('');
+    expect(catmullRomPath([{ x: 1, y: 2 }])).toBe('');
+    expect(catmullRomPath(null)).toBe('');
+  });
+
+  it('starts at the first point and emits one cubic segment per pair', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 5 }, { x: 20, y: 0 }];
+    const d = catmullRomPath(pts);
+    expect(d.startsWith('M0,0')).toBe(true);
+    expect(d.match(/C/g)).toHaveLength(2);
+    expect(d.endsWith('20,0')).toBe(true); // interpolates through the last vertex
+  });
+
+  it('degenerates to the straight chord for collinear points', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 10 }, { x: 20, y: 20 }];
+    const d = catmullRomPath(pts);
+    // Every emitted coordinate (control points included) lies on y = x.
+    const nums = d.match(/-?\d+(\.\d+)?/g).map(Number);
+    for (let i = 0; i < nums.length; i += 2) {
+      expect(nums[i + 1]).toBeCloseTo(nums[i], 8);
+    }
+  });
+});
+
+describe('splineSegmentMidpoint', () => {
+  it('returns the chord midpoint and heading for a straight run', () => {
+    const p = (x, y) => ({ x, y });
+    const mid = splineSegmentMidpoint(p(0, 0), p(10, 0), p(20, 0), p(30, 0));
+    expect(mid.x).toBeCloseTo(15, 5);
+    expect(mid.y).toBeCloseTo(0, 5);
+    expect(mid.angle).toBeCloseTo(0, 5);
+  });
+
+  it('tolerates missing neighbours at the ends of the tail', () => {
+    const mid = splineSegmentMidpoint(undefined, { x: 0, y: 0 }, { x: 10, y: 10 }, undefined);
+    expect(mid.x).toBeCloseTo(5, 5);
+    expect(mid.y).toBeCloseTo(5, 5);
+    expect(mid.angle).toBeCloseTo(Math.PI / 4, 5);
+  });
+});
+
+describe('layoutLabels', () => {
+  it('places an unobstructed label above-right of its dot', () => {
+    expect(layoutLabels([{ cx: 100, cy: 100, text: 'Solo' }])).toEqual([{ x: 107, y: 93 }]);
+  });
+
+  it('moves the second of two coincident labels to a non-overlapping spot', () => {
+    const [a, b] = layoutLabels([
+      { cx: 100, cy: 100, text: 'First' },
+      { cx: 100, cy: 100, text: 'Second' },
+    ]);
+    expect(a).toEqual({ x: 107, y: 93 });
+    expect(b).not.toEqual(a);
+    // Vertical separation: boxes are 12px tall, so the fallback spot clears it.
+    expect(Math.abs(b.y - a.y)).toBeGreaterThanOrEqual(12);
+  });
+
+  it('returns positions in input order and handles empty input', () => {
+    expect(layoutLabels([])).toEqual([]);
+    expect(layoutLabels(null)).toEqual([]);
   });
 });

--- a/frontend/src/components/Charts/useDragZoom.js
+++ b/frontend/src/components/Charts/useDragZoom.js
@@ -1,16 +1,20 @@
 import { useEffect, useState } from 'react';
 
-// Drags smaller than this (in axis units) are treated as clicks, so click
-// handlers on chart elements (e.g. head-dot selection) survive the zoom
-// handlers wired to the same surface.
-const MIN_DRAG = 0.4;
+// Pointer movements smaller than this (in chart pixels, per axis) are treated
+// as clicks, so click handlers on chart elements (e.g. head-dot selection)
+// survive the zoom handlers wired to the same surface. Pixel-space so the
+// gesture feels the same at any zoom depth — a domain-unit threshold would
+// inflate as the window narrows, swallowing follow-up zooms.
+const MIN_DRAG_PX = 8;
 
 /**
  * Drag-to-zoom state for a recharts chart with two numeric axes. Spread
  * `mouseHandlers` onto the chart: recharts mouse events carry `xValue`/
- * `yValue` (the axis scales inverted at the cursor) on ScatterChart, which
- * feed the in-progress selection rectangle; releasing the mouse commits it
- * as the new axis domains.
+ * `yValue` (the axis scales inverted at the cursor) plus `chartX`/`chartY`
+ * (pixel coords) on ScatterChart. The data coords feed the in-progress
+ * selection rectangle and the committed domains; the pixel coords decide
+ * click-vs-drag. Releasing the mouse commits the rectangle as the new axis
+ * domains.
  *
  * Kept out of the chart component (like useRRGFilters) so the chart stays a
  * pure visualization and the click-vs-drag contract is testable in isolation.
@@ -29,21 +33,27 @@ export function useDragZoom(defaultDomain, resetKey) {
     setDrag(null);
   }, [resetKey]);
 
+  // The selection rectangle is tracked in both spaces: data coords (x/y) feed
+  // the rendered rectangle and the committed domains; chart-pixel coords
+  // (px/py) feed the click-vs-drag decision.
   const onMouseDown = (e) => {
-    if (e?.xValue == null || e?.yValue == null) return;
-    setDrag({ x1: e.xValue, y1: e.yValue, x2: e.xValue, y2: e.yValue });
+    if (e?.xValue == null || e?.yValue == null || e?.chartX == null || e?.chartY == null) return;
+    setDrag({
+      x1: e.xValue, y1: e.yValue, x2: e.xValue, y2: e.yValue,
+      px1: e.chartX, py1: e.chartY, px2: e.chartX, py2: e.chartY,
+    });
   };
 
   const onMouseMove = (e) => {
-    if (!drag || e?.xValue == null || e?.yValue == null) return;
-    setDrag((d) => (d ? { ...d, x2: e.xValue, y2: e.yValue } : d));
+    if (!drag || e?.xValue == null || e?.yValue == null || e?.chartX == null || e?.chartY == null) return;
+    setDrag((d) => (d ? { ...d, x2: e.xValue, y2: e.yValue, px2: e.chartX, py2: e.chartY } : d));
   };
 
   const onMouseUp = () => {
     if (!drag) return;
-    const { x1, y1, x2, y2 } = drag;
+    const { x1, y1, x2, y2, px1, py1, px2, py2 } = drag;
     setDrag(null);
-    if (Math.abs(x2 - x1) < MIN_DRAG || Math.abs(y2 - y1) < MIN_DRAG) return;
+    if (Math.abs(px2 - px1) < MIN_DRAG_PX || Math.abs(py2 - py1) < MIN_DRAG_PX) return;
     setZoom({
       x: [Math.min(x1, x2), Math.max(x1, x2)],
       y: [Math.min(y1, y2), Math.max(y1, y2)],

--- a/frontend/src/components/Charts/useDragZoom.js
+++ b/frontend/src/components/Charts/useDragZoom.js
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+
+// Drags smaller than this (in axis units) are treated as clicks, so click
+// handlers on chart elements (e.g. head-dot selection) survive the zoom
+// handlers wired to the same surface.
+const MIN_DRAG = 0.4;
+
+/**
+ * Drag-to-zoom state for a recharts chart with two numeric axes. Spread
+ * `mouseHandlers` onto the chart: recharts mouse events carry `xValue`/
+ * `yValue` (the axis scales inverted at the cursor) on ScatterChart, which
+ * feed the in-progress selection rectangle; releasing the mouse commits it
+ * as the new axis domains.
+ *
+ * Kept out of the chart component (like useRRGFilters) so the chart stays a
+ * pure visualization and the click-vs-drag contract is testable in isolation.
+ *
+ * @param {{x: number[], y: number[]}} defaultDomain - domains when not zoomed
+ * @param {string} resetKey - dataset identity; zoom/drag reset when it changes
+ */
+export function useDragZoom(defaultDomain, resetKey) {
+  const [drag, setDrag] = useState(null);
+  const [zoom, setZoom] = useState(null);
+
+  // A zoom into another dataset would be meaningless, so both the committed
+  // zoom and any in-progress drag reset when the dataset identity changes.
+  useEffect(() => {
+    setZoom(null);
+    setDrag(null);
+  }, [resetKey]);
+
+  const onMouseDown = (e) => {
+    if (e?.xValue == null || e?.yValue == null) return;
+    setDrag({ x1: e.xValue, y1: e.yValue, x2: e.xValue, y2: e.yValue });
+  };
+
+  const onMouseMove = (e) => {
+    if (!drag || e?.xValue == null || e?.yValue == null) return;
+    setDrag((d) => (d ? { ...d, x2: e.xValue, y2: e.yValue } : d));
+  };
+
+  const onMouseUp = () => {
+    if (!drag) return;
+    const { x1, y1, x2, y2 } = drag;
+    setDrag(null);
+    if (Math.abs(x2 - x1) < MIN_DRAG || Math.abs(y2 - y1) < MIN_DRAG) return;
+    setZoom({
+      x: [Math.min(x1, x2), Math.max(x1, x2)],
+      y: [Math.min(y1, y2), Math.max(y1, y2)],
+    });
+  };
+
+  const onMouseLeave = () => setDrag(null);
+
+  return {
+    xDomain: zoom?.x ?? defaultDomain.x,
+    yDomain: zoom?.y ?? defaultDomain.y,
+    drag,
+    isZoomed: zoom != null,
+    reset: () => setZoom(null),
+    mouseHandlers: { onMouseDown, onMouseMove, onMouseUp, onMouseLeave },
+  };
+}

--- a/frontend/src/components/Charts/useDragZoom.test.js
+++ b/frontend/src/components/Charts/useDragZoom.test.js
@@ -4,12 +4,16 @@ import { useDragZoom } from './useDragZoom';
 
 const DEFAULT = { x: [88, 112], y: [88, 112] };
 
+// recharts chart-level mouse events carry both data coords (xValue/yValue)
+// and chart-pixel coords (chartX/chartY).
+const evt = (xValue, yValue, chartX, chartY) => ({ xValue, yValue, chartX, chartY });
+
 const renderZoom = (resetKey = 'groups|US') =>
   renderHook(({ key }) => useDragZoom(DEFAULT, key), { initialProps: { key: resetKey } });
 
-const dragRect = (result, { x1, y1, x2, y2 }) => {
-  act(() => result.current.mouseHandlers.onMouseDown({ xValue: x1, yValue: y1 }));
-  act(() => result.current.mouseHandlers.onMouseMove({ xValue: x2, yValue: y2 }));
+const dragRect = (result, from, to) => {
+  act(() => result.current.mouseHandlers.onMouseDown(evt(...from)));
+  act(() => result.current.mouseHandlers.onMouseMove(evt(...to)));
   act(() => result.current.mouseHandlers.onMouseUp());
 };
 
@@ -24,28 +28,37 @@ describe('useDragZoom', () => {
 
   it('tracks the in-progress selection rectangle during a drag', () => {
     const { result } = renderZoom();
-    act(() => result.current.mouseHandlers.onMouseDown({ xValue: 100, yValue: 100 }));
-    act(() => result.current.mouseHandlers.onMouseMove({ xValue: 104, yValue: 96 }));
-    expect(result.current.drag).toEqual({ x1: 100, y1: 100, x2: 104, y2: 96 });
+    act(() => result.current.mouseHandlers.onMouseDown(evt(100, 100, 500, 300)));
+    act(() => result.current.mouseHandlers.onMouseMove(evt(104, 96, 700, 450)));
+    expect(result.current.drag).toMatchObject({ x1: 100, y1: 100, x2: 104, y2: 96 });
   });
 
   it('commits a drag as ordered min/max domains', () => {
     const { result } = renderZoom();
-    dragRect(result, { x1: 104, y1: 96, x2: 100, y2: 103 }); // dragged "backwards"
+    dragRect(result, [104, 96, 700, 450], [100, 103, 500, 300]); // dragged "backwards"
     expect(result.current.xDomain).toEqual([100, 104]);
     expect(result.current.yDomain).toEqual([96, 103]);
     expect(result.current.isZoomed).toBe(true);
     expect(result.current.drag).toBeNull();
   });
 
-  it('treats a drag below the threshold as a click (no zoom)', () => {
+  it('treats sub-threshold pointer movement as a click (no zoom)', () => {
     const { result } = renderZoom();
-    dragRect(result, { x1: 100, y1: 100, x2: 100.2, y2: 100.2 });
+    dragRect(result, [100, 100, 500, 300], [100.2, 100.2, 504, 304]); // 4px each way
     expect(result.current.isZoomed).toBe(false);
     expect(result.current.xDomain).toEqual([88, 112]);
   });
 
-  it('ignores mouse events without axis values (outside the plot)', () => {
+  it('judges click-vs-drag in pixel space, not domain units', () => {
+    const { result } = renderZoom();
+    // Deep-zoom scenario: a clearly visible 200px drag spans only 0.2 domain
+    // units. A domain-unit threshold would swallow it; pixels must win.
+    dragRect(result, [100.0, 100.0, 400, 200], [100.2, 100.2, 600, 400]);
+    expect(result.current.isZoomed).toBe(true);
+    expect(result.current.xDomain).toEqual([100.0, 100.2]);
+  });
+
+  it('ignores mouse events without coordinates (outside the plot)', () => {
     const { result } = renderZoom();
     act(() => result.current.mouseHandlers.onMouseDown({ xValue: null, yValue: null }));
     expect(result.current.drag).toBeNull();
@@ -55,7 +68,7 @@ describe('useDragZoom', () => {
 
   it('cancels an in-progress drag when the mouse leaves the chart', () => {
     const { result } = renderZoom();
-    act(() => result.current.mouseHandlers.onMouseDown({ xValue: 100, yValue: 100 }));
+    act(() => result.current.mouseHandlers.onMouseDown(evt(100, 100, 500, 300)));
     act(() => result.current.mouseHandlers.onMouseLeave());
     expect(result.current.drag).toBeNull();
     act(() => result.current.mouseHandlers.onMouseUp());
@@ -64,7 +77,7 @@ describe('useDragZoom', () => {
 
   it('reset() restores the default domains', () => {
     const { result } = renderZoom();
-    dragRect(result, { x1: 100, y1: 96, x2: 104, y2: 103 });
+    dragRect(result, [100, 96, 500, 300], [104, 103, 700, 450]);
     expect(result.current.isZoomed).toBe(true);
     act(() => result.current.reset());
     expect(result.current.isZoomed).toBe(false);
@@ -73,7 +86,7 @@ describe('useDragZoom', () => {
 
   it('resets the zoom when the dataset identity (resetKey) changes', () => {
     const { result, rerender } = renderZoom('groups|US');
-    dragRect(result, { x1: 100, y1: 96, x2: 104, y2: 103 });
+    dragRect(result, [100, 96, 500, 300], [104, 103, 700, 450]);
     expect(result.current.isZoomed).toBe(true);
     rerender({ key: 'sectors|US' });
     expect(result.current.isZoomed).toBe(false);

--- a/frontend/src/components/Charts/useDragZoom.test.js
+++ b/frontend/src/components/Charts/useDragZoom.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useDragZoom } from './useDragZoom';
+
+const DEFAULT = { x: [88, 112], y: [88, 112] };
+
+const renderZoom = (resetKey = 'groups|US') =>
+  renderHook(({ key }) => useDragZoom(DEFAULT, key), { initialProps: { key: resetKey } });
+
+const dragRect = (result, { x1, y1, x2, y2 }) => {
+  act(() => result.current.mouseHandlers.onMouseDown({ xValue: x1, yValue: y1 }));
+  act(() => result.current.mouseHandlers.onMouseMove({ xValue: x2, yValue: y2 }));
+  act(() => result.current.mouseHandlers.onMouseUp());
+};
+
+describe('useDragZoom', () => {
+  it('passes the default domains through when not zoomed', () => {
+    const { result } = renderZoom();
+    expect(result.current.xDomain).toEqual([88, 112]);
+    expect(result.current.yDomain).toEqual([88, 112]);
+    expect(result.current.isZoomed).toBe(false);
+    expect(result.current.drag).toBeNull();
+  });
+
+  it('tracks the in-progress selection rectangle during a drag', () => {
+    const { result } = renderZoom();
+    act(() => result.current.mouseHandlers.onMouseDown({ xValue: 100, yValue: 100 }));
+    act(() => result.current.mouseHandlers.onMouseMove({ xValue: 104, yValue: 96 }));
+    expect(result.current.drag).toEqual({ x1: 100, y1: 100, x2: 104, y2: 96 });
+  });
+
+  it('commits a drag as ordered min/max domains', () => {
+    const { result } = renderZoom();
+    dragRect(result, { x1: 104, y1: 96, x2: 100, y2: 103 }); // dragged "backwards"
+    expect(result.current.xDomain).toEqual([100, 104]);
+    expect(result.current.yDomain).toEqual([96, 103]);
+    expect(result.current.isZoomed).toBe(true);
+    expect(result.current.drag).toBeNull();
+  });
+
+  it('treats a drag below the threshold as a click (no zoom)', () => {
+    const { result } = renderZoom();
+    dragRect(result, { x1: 100, y1: 100, x2: 100.2, y2: 100.2 });
+    expect(result.current.isZoomed).toBe(false);
+    expect(result.current.xDomain).toEqual([88, 112]);
+  });
+
+  it('ignores mouse events without axis values (outside the plot)', () => {
+    const { result } = renderZoom();
+    act(() => result.current.mouseHandlers.onMouseDown({ xValue: null, yValue: null }));
+    expect(result.current.drag).toBeNull();
+    act(() => result.current.mouseHandlers.onMouseUp());
+    expect(result.current.isZoomed).toBe(false);
+  });
+
+  it('cancels an in-progress drag when the mouse leaves the chart', () => {
+    const { result } = renderZoom();
+    act(() => result.current.mouseHandlers.onMouseDown({ xValue: 100, yValue: 100 }));
+    act(() => result.current.mouseHandlers.onMouseLeave());
+    expect(result.current.drag).toBeNull();
+    act(() => result.current.mouseHandlers.onMouseUp());
+    expect(result.current.isZoomed).toBe(false);
+  });
+
+  it('reset() restores the default domains', () => {
+    const { result } = renderZoom();
+    dragRect(result, { x1: 100, y1: 96, x2: 104, y2: 103 });
+    expect(result.current.isZoomed).toBe(true);
+    act(() => result.current.reset());
+    expect(result.current.isZoomed).toBe(false);
+    expect(result.current.xDomain).toEqual([88, 112]);
+  });
+
+  it('resets the zoom when the dataset identity (resetKey) changes', () => {
+    const { result, rerender } = renderZoom('groups|US');
+    dragRect(result, { x1: 100, y1: 96, x2: 104, y2: 103 });
+    expect(result.current.isZoomed).toBe(true);
+    rerender({ key: 'sectors|US' });
+    expect(result.current.isZoomed).toBe(false);
+    expect(result.current.xDomain).toEqual([88, 112]);
+  });
+});


### PR DESCRIPTION
## Summary

Improves Relative Rotation Graph readability and fixes the stock-chart toggle placement.

**RRG (`RRGChart`)**
- Tails render as Catmull-Rom splines that still interpolate through every weekly vertex (no more piecewise segments); direction arrows ride the curve via its tangent instead of the straight chord
- Drag a rectangle to zoom into clustered regions (repeatable for deeper zoom); a **Reset zoom** button restores the full view, and tick precision adapts to the window. Sub-threshold drags still pass through as head-dot clicks
- Quadrant backdrops/100-lines clamp to the zoom window; splines, arrows, and labels clip to the plot area
- Head labels get greedy collision avoidance (above/below, left/right fallbacks) so dense clusters stay legible
- Default plot height 560px → 720px

**Stock chart (`CandlestickChart`)**
- Daily/Weekly/RS toggles moved from the top-right corner (where they covered the price scale) to sit just right of the OHLC legend in the top-left

**Code quality (second commit, from review)**
- Drag-to-zoom state machine extracted to a `useDragZoom` hook (mirrors the `useRRGFilters` convention) with 8 unit tests pinning the click-vs-drag threshold, domain ordering, and dataset-identity reset
- Four quadrant-backdrop copies collapsed into one map over a `QUADRANT_LAYOUT` table in `rrgColors`
- Tail `Scatter`s mount only in the detailed (≤20 series) view — in the ~197-series default view they rendered nothing once the spline took over the trail
- `layoutLabels` returns enriched anchors instead of a parallel positions array

## Test plan

- [x] `vitest`: 439 passing — includes 17 new unit tests for spline geometry, label layout, and the zoom hook (the single failure, `ValidationPage.test.jsx`, is pre-existing on `main`)
- [x] ESLint clean (4 pre-existing warnings in unrelated files)
- [x] Production build succeeds
- [x] Browser-verified with fixture data: spline rendering, drag-zoom + reset, label collision avoidance, clamped quadrant backdrops, and the relocated toggle row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-to-zoom with reset control for RRG charts; zoom-aware axis ticks and increased default chart height.
  * New spline-based tail rendering with direction arrows and collision-avoiding head labels.
  * Exposed quadrant layout metadata for consistent quadrant rendering.

* **Enhancements**
  * Candlestick chart: unified top-left overlay for OHLC legend and timeframe/RS controls; clarified timeframe toggle behavior.

* **Tests**
  * Added unit tests for zoom hook and spline/label helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->