### PR TITLE
fix(frontend): avoid persisting auth capability state

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,10 @@ import { MarketProvider } from './contexts/MarketContext';
 import { RuntimeProvider, useRuntime } from './contexts/RuntimeContext';
 import { StrategyProfileProvider } from './contexts/StrategyProfileContext';
 import { ColorModeContext } from './contexts/ColorModeContext';
+import {
+  PERSISTED_QUERY_CACHE_BUSTER,
+  shouldDehydratePersistedQuery,
+} from './appQueryPersistence';
 
 // All pages are lazy-loaded so the initial bundle stays free of heavy
 // page-specific chunks (MarketScanPage alone pulls in recharts, ~400KB).
@@ -60,8 +64,8 @@ const PageLoadingFallback = () => (
 // Renders only static header chrome — no nav links, no providers, no data
 // queries — so it's safe to show before auth state is known, while still giving
 // the user immediate visual structure instead of a bare spinner. On refresh,
-// persisted capabilities make runtimeReady true synchronously, so this is only
-// seen on a genuinely cold first load.
+// persisted page data can still paint quickly once live capabilities confirm
+// whether the app shell, login screen, or bootstrap setup should render.
 const AppLoadingScreen = () => (
   <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
     <AppBar position="static" sx={{ minHeight: 48 }}>
@@ -115,25 +119,14 @@ const queryCachePersister = createSyncStoragePersister({
   throttleTime: 1000,
 });
 
-// High-churn or bulky query families that are cheap to refetch are excluded:
-// persisting them would re-serialize the whole cache on every poll/prefetch
-// and risk blowing the localStorage quota.
-const NON_PERSISTED_QUERY_ROOTS = new Set([
-  'priceHistory',
-  'runtimeActivity',
-  'allFilteredSymbols',
-  'calculationStatus',
-  'setupDetails',
-]);
-
+// Keep persistence policy outside this component file so Fast Refresh remains
+// limited to React component exports.
 const persistOptions = {
   persister: queryCachePersister,
   maxAge: 24 * 60 * 60 * 1000,
-  buster: 'v1',
+  buster: PERSISTED_QUERY_CACHE_BUSTER,
   dehydrateOptions: {
-    shouldDehydrateQuery: (query) =>
-      query.state.status === 'success'
-      && !NON_PERSISTED_QUERY_ROOTS.has(query.queryKey[0]),
+    shouldDehydrateQuery: shouldDehydratePersistedQuery,
   },
 };
 

--- a/frontend/src/App.persistence.test.jsx
+++ b/frontend/src/App.persistence.test.jsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldDehydratePersistedQuery } from './appQueryPersistence';
+
+const successfulQuery = (queryKey) => ({
+  queryKey,
+  state: { status: 'success' },
+});
+
+const failedQuery = (queryKey) => ({
+  queryKey,
+  state: { status: 'error' },
+});
+
+describe('app query persistence', () => {
+  it('does not persist volatile runtime or auth state', () => {
+    expect(shouldDehydratePersistedQuery(successfulQuery(['appCapabilities']))).toBe(false);
+    expect(shouldDehydratePersistedQuery(successfulQuery(['runtimeActivity']))).toBe(false);
+  });
+
+  it('persists ordinary successful data queries only', () => {
+    expect(shouldDehydratePersistedQuery(successfulQuery(['scanHistory', 'US']))).toBe(true);
+    expect(shouldDehydratePersistedQuery(failedQuery(['scanHistory', 'US']))).toBe(false);
+  });
+});

--- a/frontend/src/appQueryPersistence.js
+++ b/frontend/src/appQueryPersistence.js
@@ -1,0 +1,18 @@
+// App capabilities include auth state and must always be confirmed live.
+// High-churn or bulky query families are cheap to refetch and expensive to
+// serialize on every poll or prefetch.
+const NON_PERSISTED_QUERY_ROOTS = new Set([
+  'appCapabilities',
+  'priceHistory',
+  'runtimeActivity',
+  'allFilteredSymbols',
+  'calculationStatus',
+  'setupDetails',
+]);
+
+export const PERSISTED_QUERY_CACHE_BUSTER = 'v2';
+
+export const shouldDehydratePersistedQuery = (query) => (
+  query.state.status === 'success'
+  && !NON_PERSISTED_QUERY_ROOTS.has(query.queryKey[0])
+);

--- a/frontend/src/contexts/RuntimeContext.jsx
+++ b/frontend/src/contexts/RuntimeContext.jsx
@@ -273,6 +273,7 @@ export function RuntimeProvider({ children }) {
     placeholderData: DEFAULT_CAPABILITIES,
     retry: 1,
     staleTime: 60_000,
+    refetchOnMount: 'always',
     refetchInterval: (query) => {
       const bootstrapRequired = Boolean(query.state.data?.bootstrap_required);
       const bootstrapState = query.state.data?.bootstrap_state;

--- a/frontend/src/contexts/RuntimeContext.test.jsx
+++ b/frontend/src/contexts/RuntimeContext.test.jsx
@@ -75,8 +75,8 @@ function RuntimeProbe() {
   );
 }
 
-function renderRuntime() {
-  const queryClient = new QueryClient({
+function createTestQueryClient() {
+  return new QueryClient({
     defaultOptions: {
       queries: {
         retryDelay: 1,
@@ -84,7 +84,9 @@ function renderRuntime() {
       },
     },
   });
+}
 
+function renderRuntime(queryClient = createTestQueryClient()) {
   const rendered = render(
     <QueryClientProvider client={queryClient}>
       <RuntimeProvider>
@@ -123,6 +125,35 @@ describe('RuntimeProvider', () => {
 
     expect(screen.getByTestId('auth-required')).toHaveTextContent('false');
     expect(getAppCapabilities).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches app capabilities on mount even when cached auth state is fresh', async () => {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(['appCapabilities'], {
+      ...DEFAULT_CAPABILITIES,
+      auth: {
+        ...DEFAULT_CAPABILITIES.auth,
+        required: true,
+        authenticated: false,
+      },
+    });
+    getAppCapabilities.mockResolvedValue({
+      ...DEFAULT_CAPABILITIES,
+      auth: {
+        ...DEFAULT_CAPABILITIES.auth,
+        required: true,
+        authenticated: true,
+      },
+    });
+
+    renderRuntime(queryClient);
+
+    expect(screen.getByTestId('auth-required')).toHaveTextContent('true');
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['appCapabilities'])?.auth.authenticated).toBe(true);
+    });
+    expect(getAppCapabilities).toHaveBeenCalledTimes(1);
   });
 
   it('exposes bootstrap metadata from app capabilities', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Runtime capabilities now refetch automatically on app initialization to ensure fresh data loads.
  * Query persistence refined to prevent caching of volatile runtime and authentication data.

* **Tests**
  * Added comprehensive test coverage for query persistence behavior and cache management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->