### PR TITLE
feat(celery): sync IBD classification to live site from GitHub release

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -297,6 +297,7 @@ _MARKET_SCOPED_DATA_FETCH_TASKS = (
 
 _MARKET_JOB_TASKS = (
     'app.tasks.industry_tasks.load_tracked_ibd_industry_groups',
+    'app.tasks.industry_tasks.sync_ibd_classification',
     'app.tasks.breadth_tasks.calculate_daily_breadth',
     'app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill',
     'app.tasks.group_rank_tasks.calculate_daily_group_rankings',
@@ -386,6 +387,19 @@ if settings.cache_warmup_enabled:
             ),
             'schedule': crontab(hour=3, minute=0, day_of_week=0),
             'options': {'queue': _qname},
+            'kwargs': {'market': _market},
+        }
+
+        # Weekly IBD classification sync from the published GitHub bundle.
+        # Sunday 6 AM ET — after the Saturday GitHub classifier publishes and
+        # after the Sunday 3 AM universe refresh. Non-US markets get the IBD
+        # coverage they otherwise lack on the live site.
+        # ponytail: fixed Sun 6am, no new config knob — the task no-ops for
+        # live_only deployments and swallows GitHub outages.
+        beat_schedule[f'weekly-ibd-classification-sync-{_m_lower}'] = {
+            'task': 'app.tasks.industry_tasks.sync_ibd_classification',
+            'schedule': crontab(hour=6, minute=0, day_of_week=0),
+            'options': {'queue': market_jobs_queue_for_market(_market)},
             'kwargs': {'market': _market},
         }
 

--- a/backend/app/scripts/sync_ibd_classification_from_github.py
+++ b/backend/app/scripts/sync_ibd_classification_from_github.py
@@ -1,9 +1,11 @@
-"""Sync the latest IBD classification bundle from the GitHub release into the DB.
+"""CLI: sync the latest IBD classification bundle from the GitHub release.
 
-Downloads ``ibd-classification-latest-<market>.json`` + its bundle from the
-``ibd-classification-data`` release (validating sha256) and imports the
-classifications, preserving authoritative CSV/manual rows. Used by the daily
-static-site build after the curated CSV is loaded.
+Thin wrapper around
+``app.services.ibd_classification_bundle.sync_ibd_classification_from_github`` —
+the same service the live-site Celery task uses. Imports the per-market bundle
+published to the ``ibd-classification-data`` release (validating sha256),
+preserving authoritative CSV/manual rows. Used by the daily static-site build
+after the curated CSV is loaded.
 
 Usage:
     python -m app.scripts.sync_ibd_classification_from_github --market SG [--allow-stale]
@@ -13,16 +15,11 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from app.config import settings
 from app.database import SessionLocal
 from app.scripts._runtime import prepare_runtime
-from app.services.github_release_sync_service import GitHubReleaseSyncService
 from app.services.ibd_classification_bundle import (
-    IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION,
-    RELEASE_TAG,
-    import_classifications,
-    latest_manifest_name,
-    read_bundle,
+    NON_FATAL_SYNC_STATUSES,
+    sync_ibd_classification_from_github,
 )
 
 
@@ -34,44 +31,26 @@ def main() -> int:
     args = parser.parse_args()
 
     prepare_runtime()
-    market = args.market.strip().upper()
-
-    repository = getattr(settings, "github_data_repository", "") or ""
-    api_base = getattr(settings, "github_data_api_base", "https://api.github.com")
-    token = getattr(settings, "github_data_token", "") or None
-    timeout = int(getattr(settings, "github_data_timeout_seconds", 60) or 60)
-    source_mode = getattr(settings, "market_data_source_mode", "github_first")
-
-    sync = GitHubReleaseSyncService(api_base=api_base)
-    result = sync.fetch_latest_bundle(
-        repository_full_name=repository,
-        release_tag=RELEASE_TAG,
-        manifest_asset_name=latest_manifest_name(market),
-        source_mode=source_mode,
-        expected_manifest_schema=IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION,
-        required_manifest_keys=("bundle_asset_name", "sha256"),
-        allow_stale=args.allow_stale,
-        github_token=token,
-        request_timeout_seconds=timeout,
-        output_dir=args.output_dir,
-    )
-
-    status = result.get("status")
-    print(f"IBD classification GitHub sync: status={status}")
-    if status != "success":
-        for key in ("reason", "error", "stale_reason"):
-            if result.get(key):
-                print(f"  - {key}: {result[key]}")
-        # live_only / up_to_date are non-fatal; anything else is a soft failure.
-        return 0 if status in {"live_only", "up_to_date"} else 1
-
-    payload = read_bundle(Path(result["bundle_path"]))
     with SessionLocal() as db:
-        stats = import_classifications(db, payload)
-    print("Imported:")
-    for key, value in stats.items():
-        print(f"  - {key}: {value}")
-    return 0
+        result = sync_ibd_classification_from_github(
+            db,
+            market=args.market,
+            allow_stale=args.allow_stale,
+            output_dir=args.output_dir,
+        )
+
+    status = result["status"]
+    print(f"IBD classification GitHub sync: status={status}")
+    if status == "success":
+        print("Imported:")
+        for key, value in result["imported"].items():
+            print(f"  - {key}: {value}")
+        return 0
+
+    if result.get("reason"):
+        print(f"  - reason: {result['reason']}")
+    # live_only / up_to_date are non-fatal; anything else is a soft failure.
+    return 0 if status in NON_FATAL_SYNC_STATUSES else 1
 
 
 if __name__ == "__main__":

--- a/backend/app/services/ibd_classification_bundle.py
+++ b/backend/app/services/ibd_classification_bundle.py
@@ -15,8 +15,14 @@ from typing import Any, Iterable
 
 from sqlalchemy.orm import Session
 
+from ..config import settings
 from ..models.industry import IBDIndustryGroup
+from .github_release_sync_service import GitHubReleaseSyncService
 from .ibd_industry_service import IBDIndustryService
+
+# fetch_latest_bundle statuses that are not a hard failure: there was simply no
+# bundle to import (live_only deployment, or already up to date).
+NON_FATAL_SYNC_STATUSES = frozenset({"live_only", "up_to_date"})
 
 # String schema identifiers, matching the weekly-reference convention. The
 # GitHub release-sync service compares the manifest's schema_version against the
@@ -163,3 +169,46 @@ def import_classifications(db: Session, payload: dict) -> dict:
         "updated": updated,
         "skipped_authoritative": skipped_authoritative,
     }
+
+
+def sync_ibd_classification_from_github(
+    db: Session,
+    *,
+    market: str,
+    allow_stale: bool = True,
+    output_dir: str | None = None,
+    github_sync_service: GitHubReleaseSyncService | None = None,
+) -> dict:
+    """Fetch the latest per-market IBD bundle from the release and import it.
+
+    Mirrors ``DailyPriceBundleService.sync_from_github``: the caller owns ``db``.
+    Returns ``{"market", "status", "imported"|None, "reason"|None}``. ``live_only``
+    and ``up_to_date`` are non-fatal — there is simply no bundle to import (see
+    ``NON_FATAL_SYNC_STATUSES``). Authoritative csv/manual rows are preserved by
+    ``import_classifications``.
+    """
+    normalized_market = market.strip().upper()
+    sync_service = github_sync_service or GitHubReleaseSyncService(
+        api_base=settings.github_data_api_base
+    )
+    result = sync_service.fetch_latest_bundle(
+        repository_full_name=settings.github_data_repository,
+        release_tag=RELEASE_TAG,
+        manifest_asset_name=latest_manifest_name(normalized_market),
+        source_mode=settings.market_data_source_mode,
+        expected_manifest_schema=IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION,
+        required_manifest_keys=("bundle_asset_name", "sha256"),
+        allow_stale=allow_stale,
+        github_token=settings.github_data_token,
+        request_timeout_seconds=settings.github_data_timeout_seconds,
+        output_dir=output_dir or str(Path(".tmp") / "ibd-classification"),
+    )
+
+    status = result.get("status")
+    if status != "success":
+        reason = result.get("reason") or result.get("stale_reason") or result.get("error")
+        return {"market": normalized_market, "status": status, "imported": None, "reason": reason}
+
+    payload = read_bundle(Path(result["bundle_path"]))
+    stats = import_classifications(db, payload)
+    return {"market": normalized_market, "status": status, "imported": stats, "reason": None}

--- a/backend/app/services/ibd_classification_bundle.py
+++ b/backend/app/services/ibd_classification_bundle.py
@@ -209,18 +209,26 @@ def sync_ibd_classification_from_github(
         reason = result.get("reason") or result.get("stale_reason") or result.get("error")
         return {"market": normalized_market, "status": status, "imported": None, "reason": reason}
 
-    payload = read_bundle(Path(result["bundle_path"]))
-    # Guard the download/trust boundary: the manifest asset is market-specific, so
-    # a market mismatch means a mispublished bundle. Mirror
-    # DailyPriceBundleService.sync_from_github, which rejects the same case.
-    payload_market = str(payload.get("market") or "").strip().upper()
-    if payload_market and payload_market != normalized_market:
-        return {
-            "market": normalized_market,
-            "status": "market_mismatch",
-            "imported": None,
-            "reason": f"bundle market {payload_market!r} does not match requested {normalized_market!r}",
-        }
+    # The downloaded bundle is transient: read it, import, then delete it so
+    # long-lived live workers don't accumulate one gzip per market per run.
+    # (DailyPriceBundleService uses a temp dir + rmtree; here output_dir is
+    # shared/default, so we unlink just this run's file.)
+    bundle_path = Path(result["bundle_path"])
+    try:
+        payload = read_bundle(bundle_path)
+        # Guard the download/trust boundary: the manifest asset is market-specific,
+        # so a market mismatch means a mispublished bundle. Mirror
+        # DailyPriceBundleService.sync_from_github, which rejects the same case.
+        payload_market = str(payload.get("market") or "").strip().upper()
+        if payload_market and payload_market != normalized_market:
+            return {
+                "market": normalized_market,
+                "status": "market_mismatch",
+                "imported": None,
+                "reason": f"bundle market {payload_market!r} does not match requested {normalized_market!r}",
+            }
 
-    stats = import_classifications(db, payload)
-    return {"market": normalized_market, "status": status, "imported": stats, "reason": None}
+        stats = import_classifications(db, payload)
+        return {"market": normalized_market, "status": status, "imported": stats, "reason": None}
+    finally:
+        bundle_path.unlink(missing_ok=True)

--- a/backend/app/services/ibd_classification_bundle.py
+++ b/backend/app/services/ibd_classification_bundle.py
@@ -210,5 +210,17 @@ def sync_ibd_classification_from_github(
         return {"market": normalized_market, "status": status, "imported": None, "reason": reason}
 
     payload = read_bundle(Path(result["bundle_path"]))
+    # Guard the download/trust boundary: the manifest asset is market-specific, so
+    # a market mismatch means a mispublished bundle. Mirror
+    # DailyPriceBundleService.sync_from_github, which rejects the same case.
+    payload_market = str(payload.get("market") or "").strip().upper()
+    if payload_market and payload_market != normalized_market:
+        return {
+            "market": normalized_market,
+            "status": "market_mismatch",
+            "imported": None,
+            "reason": f"bundle market {payload_market!r} does not match requested {normalized_market!r}",
+        }
+
     stats = import_classifications(db, payload)
     return {"market": normalized_market, "status": status, "imported": stats, "reason": None}

--- a/backend/app/tasks/industry_tasks.py
+++ b/backend/app/tasks/industry_tasks.py
@@ -9,7 +9,10 @@ from pathlib import Path
 from ..celery_app import celery_app
 from ..config import settings
 from ..database import SessionLocal
-from ..services.ibd_classification_bundle import sync_ibd_classification_from_github
+from ..services.ibd_classification_bundle import (
+    NON_FATAL_SYNC_STATUSES,
+    sync_ibd_classification_from_github,
+)
 from ..services.ibd_industry_service import IBDIndustryService
 from .market_queues import log_extra, normalize_market
 from .workload_coordination import serialized_market_workload
@@ -81,14 +84,25 @@ def sync_ibd_classification(
 
     Unlike the US-only CSV loader above, this runs for every market — it is how
     non-US markets without a curated CSV get IBD coverage on the live site.
-    Errors propagate to ``@serialized_market_workload`` (transient-DB retry /
-    fail), matching the sibling tasks; a failed run does not stop Celery beat.
+
+    Hard failures (invalid_manifest, checksum_mismatch, missing_*) raise so the
+    run is recorded as failed and alerting fires — otherwise the live site would
+    silently keep stale classifications. ``live_only``/``up_to_date`` are clean
+    no-ops. Errors propagate to ``@serialized_market_workload`` like the siblings;
+    a failed run does not stop Celery beat.
     """
     del activity_lifecycle  # reserved for parity with bootstrap task signatures
 
     effective_market = normalize_market(market)
     with SessionLocal() as db:
         result = sync_ibd_classification_from_github(db, market=effective_market)
+
+    status = result["status"]
+    if status != "success" and status not in NON_FATAL_SYNC_STATUSES:
+        raise RuntimeError(
+            f"IBD classification sync for {effective_market} failed: {status}"
+            + (f" ({result['reason']})" if result.get("reason") else "")
+        )
 
     result["timestamp"] = datetime.now().isoformat()
     logger.info(

--- a/backend/app/tasks/industry_tasks.py
+++ b/backend/app/tasks/industry_tasks.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from ..celery_app import celery_app
 from ..config import settings
 from ..database import SessionLocal
+from ..services.ibd_classification_bundle import sync_ibd_classification_from_github
 from ..services.ibd_industry_service import IBDIndustryService
 from .market_queues import log_extra, normalize_market
 from .workload_coordination import serialized_market_workload
@@ -62,3 +63,36 @@ def load_tracked_ibd_industry_groups(
         }
     finally:
         db.close()
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.industry_tasks.sync_ibd_classification",
+)
+@serialized_market_workload("sync_ibd_classification")
+def sync_ibd_classification(
+    self,
+    *,
+    market: str = "US",
+    activity_lifecycle: str | None = None,
+) -> dict:
+    """Pull the latest per-market IBD classification bundle published by the
+    weekly GitHub job and import it (preserving authoritative csv/manual rows).
+
+    Unlike the US-only CSV loader above, this runs for every market — it is how
+    non-US markets without a curated CSV get IBD coverage on the live site.
+    Errors propagate to ``@serialized_market_workload`` (transient-DB retry /
+    fail), matching the sibling tasks; a failed run does not stop Celery beat.
+    """
+    del activity_lifecycle  # reserved for parity with bootstrap task signatures
+
+    effective_market = normalize_market(market)
+    with SessionLocal() as db:
+        result = sync_ibd_classification_from_github(db, market=effective_market)
+
+    result["timestamp"] = datetime.now().isoformat()
+    logger.info(
+        "Synced IBD classification from GitHub",
+        extra={**log_extra(market), "status": result.get("status"), "imported": result.get("imported")},
+    )
+    return result

--- a/backend/tests/unit/test_ibd_classification_sync_task.py
+++ b/backend/tests/unit/test_ibd_classification_sync_task.py
@@ -32,9 +32,11 @@ def test_sync_returns_non_fatal_for_live_only():
     assert out == {"market": "SG", "status": "live_only", "imported": None, "reason": None}
 
 
-def test_sync_imports_bundle_on_success(monkeypatch):
+def test_sync_imports_bundle_on_success(tmp_path, monkeypatch):
     """On success the bundle is read and imported, and stats are returned."""
-    fake = _FakeSyncService({"status": "success", "bundle_path": "/tmp/bundle.json.gz"})
+    bundle_file = tmp_path / "bundle.json.gz"
+    bundle_file.write_bytes(b"gz")
+    fake = _FakeSyncService({"status": "success", "bundle_path": str(bundle_file)})
     monkeypatch.setattr(bundle, "read_bundle", lambda _path: {"classifications": []})
     monkeypatch.setattr(
         bundle, "import_classifications", lambda _db, _payload: {"inserted": 3, "updated": 1}
@@ -48,9 +50,11 @@ def test_sync_imports_bundle_on_success(monkeypatch):
     assert out["imported"] == {"inserted": 3, "updated": 1}
 
 
-def test_sync_rejects_market_mismatch(monkeypatch):
+def test_sync_rejects_market_mismatch(tmp_path, monkeypatch):
     """A mispublished bundle (wrong market) is rejected before import."""
-    fake = _FakeSyncService({"status": "success", "bundle_path": "/tmp/bundle.json.gz"})
+    bundle_file = tmp_path / "bundle.json.gz"
+    bundle_file.write_bytes(b"gz")
+    fake = _FakeSyncService({"status": "success", "bundle_path": str(bundle_file)})
     monkeypatch.setattr(bundle, "read_bundle", lambda _path: {"market": "HK", "classifications": []})
 
     def _must_not_import(*_args, **_kwargs):

--- a/backend/tests/unit/test_ibd_classification_sync_task.py
+++ b/backend/tests/unit/test_ibd_classification_sync_task.py
@@ -1,0 +1,100 @@
+"""Unit tests for the live-site IBD classification GitHub sync.
+
+Covers the service function ``sync_ibd_classification_from_github`` (network
+boundary injected) and the Celery task that delegates to it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services import ibd_classification_bundle as bundle
+
+
+class _FakeSyncService:
+    """Stand-in for GitHubReleaseSyncService returning a canned fetch result."""
+
+    def __init__(self, result: dict):
+        self._result = result
+
+    def fetch_latest_bundle(self, **kwargs):
+        return self._result
+
+
+def test_sync_returns_non_fatal_for_live_only():
+    """live_only is a clean no-op: no import, no error, no reason."""
+    fake = _FakeSyncService({"status": "live_only"})
+
+    out = bundle.sync_ibd_classification_from_github(
+        db=None, market="sg", github_sync_service=fake
+    )
+
+    assert out == {"market": "SG", "status": "live_only", "imported": None, "reason": None}
+
+
+def test_sync_imports_bundle_on_success(monkeypatch):
+    """On success the bundle is read and imported, and stats are returned."""
+    fake = _FakeSyncService({"status": "success", "bundle_path": "/tmp/bundle.json.gz"})
+    monkeypatch.setattr(bundle, "read_bundle", lambda _path: {"classifications": []})
+    monkeypatch.setattr(
+        bundle, "import_classifications", lambda _db, _payload: {"inserted": 3, "updated": 1}
+    )
+
+    out = bundle.sync_ibd_classification_from_github(
+        db=object(), market="US", github_sync_service=fake
+    )
+
+    assert out["status"] == "success"
+    assert out["imported"] == {"inserted": 3, "updated": 1}
+
+
+class _DummySession:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_task_delegates_to_service_and_stamps_timestamp(monkeypatch):
+    """The Celery task opens a session, calls the service, and adds a timestamp."""
+    from app.tasks import industry_tasks
+    from app.tasks.workload_coordination import disable_serialized_market_workload
+
+    def _fake_service(db, *, market):
+        return {"market": market, "status": "success", "imported": {"inserted": 1}, "reason": None}
+
+    monkeypatch.setattr(industry_tasks, "sync_ibd_classification_from_github", _fake_service)
+    monkeypatch.setattr(industry_tasks, "SessionLocal", lambda: _DummySession())
+
+    with disable_serialized_market_workload():
+        out = industry_tasks.sync_ibd_classification.run(market="hk")
+
+    assert out["market"] == "HK"
+    assert out["status"] == "success"
+    assert "timestamp" in out
+
+
+def test_task_is_registered_routed_and_scheduled():
+    """The sync task must be registered, routed to a market jobs queue, and have
+    one weekly beat entry per supported market."""
+    import app.tasks.industry_tasks  # noqa: F401 - force task registration
+    from app.celery_app import celery_app
+    from app.tasks.market_queues import SUPPORTED_MARKETS
+
+    name = "app.tasks.industry_tasks.sync_ibd_classification"
+    assert name in celery_app.tasks
+    assert celery_app.conf.task_routes.get(name) is not None
+
+    beat = celery_app.conf.beat_schedule or {}
+    entries = {k for k in beat if k.startswith("weekly-ibd-classification-sync-")}
+    # cache_warmup_enabled gates the schedule; only assert when entries exist.
+    if entries:
+        assert len(entries) == len(SUPPORTED_MARKETS)
+        sample = beat[next(iter(entries))]
+        assert sample["task"] == name
+        assert "market" in sample["kwargs"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/backend/tests/unit/test_ibd_classification_sync_task.py
+++ b/backend/tests/unit/test_ibd_classification_sync_task.py
@@ -48,6 +48,24 @@ def test_sync_imports_bundle_on_success(monkeypatch):
     assert out["imported"] == {"inserted": 3, "updated": 1}
 
 
+def test_sync_rejects_market_mismatch(monkeypatch):
+    """A mispublished bundle (wrong market) is rejected before import."""
+    fake = _FakeSyncService({"status": "success", "bundle_path": "/tmp/bundle.json.gz"})
+    monkeypatch.setattr(bundle, "read_bundle", lambda _path: {"market": "HK", "classifications": []})
+
+    def _must_not_import(*_args, **_kwargs):
+        raise AssertionError("import_classifications must not run on market mismatch")
+
+    monkeypatch.setattr(bundle, "import_classifications", _must_not_import)
+
+    out = bundle.sync_ibd_classification_from_github(
+        db=object(), market="US", github_sync_service=fake
+    )
+
+    assert out["status"] == "market_mismatch"
+    assert out["imported"] is None
+
+
 class _DummySession:
     def __enter__(self):
         return self
@@ -72,6 +90,40 @@ def test_task_delegates_to_service_and_stamps_timestamp(monkeypatch):
 
     assert out["market"] == "HK"
     assert out["status"] == "success"
+    assert "timestamp" in out
+
+
+def test_task_raises_on_hard_failure(monkeypatch):
+    """Hard failures (e.g. invalid_manifest) must fail the task, not return clean."""
+    from app.tasks import industry_tasks
+    from app.tasks.workload_coordination import disable_serialized_market_workload
+
+    def _hard_fail(db, *, market):
+        return {"market": market, "status": "invalid_manifest", "imported": None, "reason": "bad sha"}
+
+    monkeypatch.setattr(industry_tasks, "sync_ibd_classification_from_github", _hard_fail)
+    monkeypatch.setattr(industry_tasks, "SessionLocal", lambda: _DummySession())
+
+    with disable_serialized_market_workload():
+        with pytest.raises(RuntimeError, match="invalid_manifest"):
+            industry_tasks.sync_ibd_classification.run(market="US")
+
+
+def test_task_does_not_raise_on_non_fatal(monkeypatch):
+    """live_only / up_to_date are clean no-ops — returned, not raised."""
+    from app.tasks import industry_tasks
+    from app.tasks.workload_coordination import disable_serialized_market_workload
+
+    def _non_fatal(db, *, market):
+        return {"market": market, "status": "live_only", "imported": None, "reason": None}
+
+    monkeypatch.setattr(industry_tasks, "sync_ibd_classification_from_github", _non_fatal)
+    monkeypatch.setattr(industry_tasks, "SessionLocal", lambda: _DummySession())
+
+    with disable_serialized_market_workload():
+        out = industry_tasks.sync_ibd_classification.run(market="US")
+
+    assert out["status"] == "live_only"
     assert "timestamp" in out
 
 

--- a/backend/tests/unit/test_ibd_classification_sync_task.py
+++ b/backend/tests/unit/test_ibd_classification_sync_task.py
@@ -66,6 +66,22 @@ def test_sync_rejects_market_mismatch(monkeypatch):
     assert out["imported"] is None
 
 
+def test_sync_unlinks_bundle_after_import(tmp_path, monkeypatch):
+    """The transient download is deleted so workers don't accumulate gzips."""
+    bundle_file = tmp_path / "ibd-classification-us-20260615-x.json.gz"
+    bundle_file.write_bytes(b"gz")
+    fake = _FakeSyncService({"status": "success", "bundle_path": str(bundle_file)})
+    monkeypatch.setattr(bundle, "read_bundle", lambda _path: {"classifications": []})
+    monkeypatch.setattr(bundle, "import_classifications", lambda _db, _payload: {"inserted": 0})
+
+    out = bundle.sync_ibd_classification_from_github(
+        db=object(), market="US", github_sync_service=fake
+    )
+
+    assert out["status"] == "success"
+    assert not bundle_file.exists()
+
+
 class _DummySession:
     def __enter__(self):
         return self


### PR DESCRIPTION
## Context

The hybrid IBD industry-group classifier (crosswalk → embedding → optional LLM tiebreaker) runs **weekly on GitHub Actions** (`.github/workflows/ibd-classification.yml`) and publishes per-market bundles to the `ibd-classification-data` release. The **static site** imports these during its daily build via `sync_ibd_classification_from_github`.

The **live site never did.** It only seeded the curated US `data/IBD_industry_group.csv` once at bootstrap. As a result:
- Non-US markets without a curated CSV (CA/DE/SG/MY/…) had **no IBD data** on live.
- New/changed US listings classified by the weekly job never reached live.

## What this does

Wires the live site to the already-published bundle on a weekly schedule, reusing the existing GitHub-sync infrastructure (live already defaults to `market_data_source_mode = "github_first"`). No classifier, HF model, or LLM keys on production — it just imports what GitHub already computed.

The change follows the established `sync_…_from_github` family (daily price, weekly reference):

- **Service** — `sync_ibd_classification_from_github(db, *, market, allow_stale=…)` added to `services/ibd_classification_bundle.py`, mirroring `DailyPriceBundleService.sync_from_github`: caller-owned session, direct `settings` access, injectable sync service. Preserves authoritative `csv`/`manual` rows via `import_classifications`.
- **CLI + task share it** — the existing static-site CLI script and the new per-market Celery task (`app.tasks.industry_tasks.sync_ibd_classification`) both call the service function. The task delegates and lets errors propagate to `@serialized_market_workload` (transient-DB retry / fail), matching its sibling `load_tracked_ibd_industry_groups`.
- **Schedule** — routed to the market jobs queue; one Sunday 6 AM ET beat entry per supported market (after the Saturday classifier publish + Sunday universe refresh). No-ops for `live_only` deployments. Also manually invocable.

## Out of scope
- No change to the GitHub classifier job or the static-site build (CLI args unchanged).
- `csv`/`manual` provenance rows remain authoritative and untouched.

## Testing
- `pytest tests/unit/test_ibd_classification_sync_task.py` — 4 tests: service non-fatal (`live_only`), service success-import, task delegation + timestamp, beat/routing wiring guard (one entry per `SUPPORTED_MARKETS`).
- Regression: `test_ibd_classification_bundle`, `test_runtime_bootstrap_tasks`, `test_github_release_sync_service` — **30 passed** total.
- `py_compile` + `ruff check` clean on all changed files.

## Note for reviewers
The task's registered Celery name is `…sync_ibd_classification` (the service keeps the `_from_github` suffix) to avoid a symbol collision. This branch was never previously deployed, so no existing beat entry references an old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-market weekly sync job for IBD classification data from GitHub (Sundays at 6:00 ET).
  * Introduced a shared sync workflow that validates bundle status, enforces market matching, imports classifications, and reports import counts.

* **Bug Fixes**
  * Hard-fails on invalid sync outcomes while treating specific no-op statuses as non-fatal.
  * Ensures temporary downloaded bundle files are removed after successful processing.

* **Tests**
  * Expanded coverage for market mismatch handling, cleanup behavior, hard-failure vs non-fatal task outcomes, and scheduling/routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->