### PR TITLE
fix(scanner): prevent NaN avg dollar volume failures

### DIFF
--- a/backend/app/scanners/scan_orchestrator.py
+++ b/backend/app/scanners/scan_orchestrator.py
@@ -63,7 +63,18 @@ def _series_last_float(series) -> float | None:
     return float(value)
 
 
-def _build_precomputed_scan_context(stock_data: StockData) -> PrecomputedScanContext | None:
+def _finite_float(value: object) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return numeric if math.isfinite(numeric) else None
+
+
     """Build shared derived scan metrics once per symbol."""
     price_data = stock_data.price_data
     if price_data is None or price_data.empty or "Close" not in price_data.columns:
@@ -884,13 +895,11 @@ class ScanOrchestrator:
                     avg_volume = int(vol_series.mean())
 
         # Calculate dollar volume if we have both avg_volume and price
-        if (
-            avg_volume is not None
-            and current_price is not None
-            and not math.isnan(float(avg_volume))
-            and not math.isnan(float(current_price))
-        ):
-            result["avg_dollar_volume"] = int(avg_volume * current_price)
+        avg_volume_value = _finite_float(avg_volume)
+        current_price_value = _finite_float(current_price)
+
+        if avg_volume_value is not None and current_price_value is not None:
+            result["avg_dollar_volume"] = int(avg_volume_value * current_price_value)
         else:
             logger.debug(
                 "Skipping avg_dollar_volume for %s avg_volume=%s current_price=%s",

--- a/backend/app/scanners/scan_orchestrator.py
+++ b/backend/app/scanners/scan_orchestrator.py
@@ -75,6 +75,9 @@ def _finite_float(value: object) -> float | None:
     return numeric if math.isfinite(numeric) else None
 
 
+def _build_precomputed_scan_context(
+    stock_data: StockData,
+) -> PrecomputedScanContext | None:
     """Build shared derived scan metrics once per symbol."""
     price_data = stock_data.price_data
     if price_data is None or price_data.empty or "Close" not in price_data.columns:

--- a/backend/app/scanners/scan_orchestrator.py
+++ b/backend/app/scanners/scan_orchestrator.py
@@ -6,8 +6,9 @@ fetched once and shared across all screeners. Combines results and
 calculates composite scores.
 """
 import logging
-from typing import Dict, List, Optional
+import math
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, List, Optional
 
 from .base_screener import (
     BaseStockScreener,
@@ -883,8 +884,20 @@ class ScanOrchestrator:
                     avg_volume = int(vol_series.mean())
 
         # Calculate dollar volume if we have both avg_volume and price
-        if avg_volume and current_price:
+        if (
+            avg_volume is not None
+            and current_price is not None
+            and not math.isnan(float(avg_volume))
+            and not math.isnan(float(current_price))
+        ):
             result["avg_dollar_volume"] = int(avg_volume * current_price)
+        else:
+            logger.debug(
+                "Skipping avg_dollar_volume for %s avg_volume=%s current_price=%s",
+                symbol,
+                avg_volume,
+                current_price,
+            )
 
         return result
 


### PR DESCRIPTION
## Summary

Prevent snapshot scan failures when `avg_dollar_volume` cannot be calculated due to NaN values.

## Problem

Daily snapshot generation was quarantining with:

* 9,979 symbols processed
* 6,741 `scanner_error_result` failures
* 3,238 rows produced

Investigation traced the failures to:

```python
result["avg_dollar_volume"] = int(avg_volume * current_price)
```

where either `avg_volume` or `current_price` could contain NaN values.

This resulted in:

```text
ValueError: cannot convert float NaN to integer
```

and caused the entire symbol scan result to be marked as an error.

## Fix

Handle invalid values during `avg_dollar_volume` calculation instead of allowing the exception to propagate and fail the scan.  #257 

## Impact

Prevents valid symbol scans from being discarded due to NaN values encountered while calculating the derived `avg_dollar_volume` field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the robustness of average dollar volume calculations by only computing the value when both required inputs are valid finite numbers; non-finite values no longer lead to incorrect results.
  * Added debug logging to clearly indicate when average dollar volume is skipped due to invalid or missing input data, helping diagnose edge cases faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->