### PR TITLE
[codex] Show scan group rank date in tooltip

### DIFF
--- a/backend/app/infra/db/repositories/feature_store_repo.py
+++ b/backend/app/infra/db/repositories/feature_store_repo.py
@@ -782,6 +782,7 @@ def _map_feature_to_scan_result(
         "eps_rating": d.get("eps_rating"),
         "ibd_industry_group": d.get("ibd_industry_group"),
         "ibd_group_rank": d.get("ibd_group_rank"),
+        "ibd_group_rank_date": d.get("ibd_group_rank_date"),
         "market_themes": normalize_string_list(d.get("market_themes")),
         "gics_sector": d.get("gics_sector"),
         "gics_industry": d.get("gics_industry"),

--- a/backend/app/infra/db/repositories/scan_result_repo.py
+++ b/backend/app/infra/db/repositories/scan_result_repo.py
@@ -382,7 +382,13 @@ class SqlScanResultRepository(ScanResultRepository):
         for symbol, d in enrichment.items():
             group_name = d.get("ibd_industry_group")
             if group_name:
-                d["ibd_group_rank"] = rank_by_group.get(group_name)
+                group_rank = rank_by_group.get(group_name)
+                d["ibd_group_rank"] = group_rank
+                d["ibd_group_rank_date"] = (
+                    latest_rank_date.isoformat()
+                    if group_rank is not None and latest_rank_date is not None
+                    else None
+                )
 
         requested_markets = {
             str(d.get("market") or "").strip().upper()
@@ -413,8 +419,14 @@ class SqlScanResultRepository(ScanResultRepository):
                 continue
 
             if entry.industry_group:
+                group_rank = non_us_rank_maps.get(market, {}).get(entry.industry_group)
                 d["ibd_industry_group"] = entry.industry_group
-                d["ibd_group_rank"] = non_us_rank_maps.get(market, {}).get(entry.industry_group)
+                d["ibd_group_rank"] = group_rank
+                d["ibd_group_rank_date"] = (
+                    ranking_date.isoformat()
+                    if group_rank is not None and ranking_date is not None
+                    else None
+                )
             if entry.sector:
                 d["sector"] = entry.sector
             if entry.industry:
@@ -457,17 +469,23 @@ class SqlScanResultRepository(ScanResultRepository):
             meta = enrichment.get(row.symbol, {})
             industry_group = meta.get("ibd_industry_group")
             group_rank = meta.get("ibd_group_rank")
+            group_rank_date = meta.get("ibd_group_rank_date")
             if industry_group is None:
                 missing_industry_rows += 1
             elif group_rank is None:
                 missing_rank_rows += 1
 
-            if row.ibd_industry_group != industry_group or row.ibd_group_rank != group_rank:
+            details = dict(row.details or {})
+            if (
+                row.ibd_industry_group != industry_group
+                or row.ibd_group_rank != group_rank
+                or details.get("ibd_group_rank_date") != group_rank_date
+            ):
                 row.ibd_industry_group = industry_group
                 row.ibd_group_rank = group_rank
-                details = dict(row.details or {})
                 details["ibd_industry_group"] = industry_group
                 details["ibd_group_rank"] = group_rank
+                details["ibd_group_rank_date"] = group_rank_date
                 row.details = details
                 updated_rows += 1
 
@@ -543,6 +561,13 @@ class SqlScanResultRepository(ScanResultRepository):
             and meta.get("ibd_group_rank") is not None
         ):
             enriched["ibd_group_rank"] = meta["ibd_group_rank"]
+        if (
+            enriched.get("ibd_group_rank") is not None
+            and enriched.get("ibd_group_rank") == meta.get("ibd_group_rank")
+            and not enriched.get("ibd_group_rank_date")
+            and meta.get("ibd_group_rank_date")
+        ):
+            enriched["ibd_group_rank_date"] = meta["ibd_group_rank_date"]
         if "market_themes" not in enriched:
             enriched["market_themes"] = normalize_string_list(meta.get("market_themes"))
 
@@ -805,6 +830,7 @@ def _map_row_to_domain(
         "eps_rating": result.eps_rating,
         "ibd_industry_group": result.ibd_industry_group,
         "ibd_group_rank": result.ibd_group_rank,
+        "ibd_group_rank_date": details.get("ibd_group_rank_date"),
         "market_themes": normalize_string_list(details.get("market_themes")),
         "gics_sector": result.gics_sector,
         "gics_industry": result.gics_industry,

--- a/backend/app/infra/db/repositories/scan_result_repo.py
+++ b/backend/app/infra/db/repositories/scan_result_repo.py
@@ -395,8 +395,8 @@ class SqlScanResultRepository(ScanResultRepository):
             for d in enrichment.values()
             if str(d.get("market") or "").strip().upper() not in {"", "US"}
         }
-        non_us_rank_maps = {
-            market: self._market_group_ranking_service.get_current_rank_map(
+        non_us_rank_snapshots = {
+            market: self._market_group_ranking_service.get_current_rank_snapshot(
                 self._session,
                 market=market,
                 calculation_date=ranking_date,
@@ -419,12 +419,17 @@ class SqlScanResultRepository(ScanResultRepository):
                 continue
 
             if entry.industry_group:
-                group_rank = non_us_rank_maps.get(market, {}).get(entry.industry_group)
+                rank_snapshot = non_us_rank_snapshots.get(market)
+                group_rank = (
+                    rank_snapshot.ranks_by_group.get(entry.industry_group)
+                    if rank_snapshot is not None
+                    else None
+                )
                 d["ibd_industry_group"] = entry.industry_group
                 d["ibd_group_rank"] = group_rank
                 d["ibd_group_rank_date"] = (
-                    ranking_date.isoformat()
-                    if group_rank is not None and ranking_date is not None
+                    rank_snapshot.date
+                    if group_rank is not None and rank_snapshot is not None
                     else None
                 )
             if entry.sector:

--- a/backend/app/interfaces/tasks/feature_store_tasks.py
+++ b/backend/app/interfaces/tasks/feature_store_tasks.py
@@ -374,6 +374,7 @@ def _enrich_feature_run_with_ibd_metadata(
                 details = dict(row.details_json or {})
                 industry_group = industries_by_symbol.get(row.symbol)
                 group_rank = ranks_by_group.get(industry_group) if industry_group else None
+                group_rank_date = ranking_date.isoformat() if group_rank is not None else None
                 market_themes = [] if market == "US" else list(market_themes_by_symbol.get(row.symbol) or [])
                 sector = sector_by_symbol.get(row.symbol)
                 industry = industry_by_symbol.get(row.symbol)
@@ -395,12 +396,14 @@ def _enrich_feature_run_with_ibd_metadata(
                 if (
                     details.get("ibd_industry_group") != industry_group
                     or details.get("ibd_group_rank") != group_rank
+                    or details.get("ibd_group_rank_date") != group_rank_date
                     or list(details.get("market_themes") or []) != market_themes
                     or sector_changed
                     or industry_changed
                 ):
                     details["ibd_industry_group"] = industry_group
                     details["ibd_group_rank"] = group_rank
+                    details["ibd_group_rank_date"] = group_rank_date
                     details["market_themes"] = market_themes
                     if sector_changed:
                         details["gics_sector"] = sector

--- a/backend/app/schemas/scanning.py
+++ b/backend/app/schemas/scanning.py
@@ -167,6 +167,7 @@ class ScanResultItem(BaseModel):
     # Industry classifications
     ibd_industry_group: Optional[str] = None
     ibd_group_rank: Optional[int] = None
+    ibd_group_rank_date: Optional[str] = None
     market_themes: List[str] = Field(default_factory=list)
     gics_sector: Optional[str] = None
     gics_industry: Optional[str] = None
@@ -311,6 +312,7 @@ class ScanResultItem(BaseModel):
             # Industry classifications
             ibd_industry_group=ef.get("ibd_industry_group"),
             ibd_group_rank=ef.get("ibd_group_rank"),
+            ibd_group_rank_date=ef.get("ibd_group_rank_date"),
             market_themes=normalize_string_list(ef.get("market_themes")),
             gics_sector=ef.get("gics_sector"),
             gics_industry=ef.get("gics_industry"),

--- a/backend/app/services/market_group_ranking_service.py
+++ b/backend/app/services/market_group_ranking_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import date, timedelta
 import json
 import logging
@@ -38,6 +39,12 @@ GroupRankingHistoryResult: TypeAlias = tuple[
 RRG_HISTORY_CACHE_TTL_SECONDS = 604800
 RRG_HISTORY_CACHE_SCHEMA_VERSION = 1
 _REDIS_CLIENT_UNSET = object()
+
+
+@dataclass(frozen=True)
+class GroupRankSnapshot:
+    date: str | None
+    ranks_by_group: dict[str, int]
 
 
 class MarketGroupRankingService:
@@ -212,6 +219,19 @@ class MarketGroupRankingService:
         market: str,
         calculation_date: date | None = None,
     ) -> dict[str, int]:
+        return self.get_current_rank_snapshot(
+            db,
+            market=market,
+            calculation_date=calculation_date,
+        ).ranks_by_group
+
+    def get_current_rank_snapshot(
+        self,
+        db: Session,
+        *,
+        market: str,
+        calculation_date: date | None = None,
+    ) -> GroupRankSnapshot:
         rankings = self.get_current_rankings(
             db,
             market=market,
@@ -219,11 +239,18 @@ class MarketGroupRankingService:
             calculation_date=calculation_date,
             include_rank_changes=False,
         )
-        return {
-            str(row["industry_group"]): int(row["rank"])
-            for row in rankings
-            if row.get("industry_group") and row.get("rank") is not None
-        }
+        ranking_date = next(
+            (str(row["date"]) for row in rankings if row.get("date")),
+            None,
+        )
+        return GroupRankSnapshot(
+            date=ranking_date,
+            ranks_by_group={
+                str(row["industry_group"]): int(row["rank"])
+                for row in rankings
+                if row.get("industry_group") and row.get("rank") is not None
+            },
+        )
 
     def get_rank_movers(
         self,

--- a/backend/tests/integration/test_scan_result_repo_enrichment.py
+++ b/backend/tests/integration/test_scan_result_repo_enrichment.py
@@ -9,11 +9,13 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from app.database import Base
+from app.domain.scanning.filter_spec import QuerySpec
 from app.infra.db.repositories.scan_result_repo import SqlScanResultRepository
 from app.models.industry import IBDGroupRank, IBDIndustryGroup
 from app.models.scan_result import Scan, ScanResult
 from app.models.stock import StockFundamental, StockIndustry
 from app.models.stock_universe import StockUniverse
+from app.schemas.scanning import ScanResultItem
 from app.services.market_taxonomy_service import MarketTaxonomyEntry
 
 
@@ -96,6 +98,11 @@ def test_persist_orchestrator_results_enriches_reference_fields(session: Session
     assert row.gics_industry == "Consumer Electronics"
     assert row.ibd_industry_group == "Computer-Hardware/Peripherals"
     assert row.ibd_group_rank == 5
+    assert row.details["ibd_group_rank_date"] == "2026-02-19"
+
+    page = repo.query("scan-1", QuerySpec())
+    assert page.items[0].extended_fields["ibd_group_rank_date"] == "2026-02-19"
+    assert ScanResultItem.from_domain(page.items[0]).ibd_group_rank_date == "2026-02-19"
 
 
 def test_persist_orchestrator_results_uses_ipo_screener_date_fallback(session: Session):
@@ -237,6 +244,7 @@ def test_non_us_rank_enrichment_honors_explicit_ranking_date(session: Session):
 
     assert stats["updated_rows"] == 1
     assert row.ibd_group_rank == 7
+    assert row.details["ibd_group_rank_date"] == "2026-02-19"
     assert seen_dates == [date(2026, 2, 19)]
 
 

--- a/backend/tests/integration/test_scan_result_repo_enrichment.py
+++ b/backend/tests/integration/test_scan_result_repo_enrichment.py
@@ -16,6 +16,7 @@ from app.models.scan_result import Scan, ScanResult
 from app.models.stock import StockFundamental, StockIndustry
 from app.models.stock_universe import StockUniverse
 from app.schemas.scanning import ScanResultItem
+from app.services.market_group_ranking_service import GroupRankSnapshot
 from app.services.market_taxonomy_service import MarketTaxonomyEntry
 
 
@@ -158,9 +159,13 @@ def test_persist_orchestrator_results_enriches_non_us_market_taxonomy(session: S
             return None
 
     class _FakeMarketGroupRankingService:
-        def get_current_rank_map(self, db, *, market, calculation_date=None):  # noqa: ARG002
+        def get_current_rank_snapshot(self, db, *, market, calculation_date=None):  # noqa: ARG002
             assert market == "HK"
-            return {"Internet Services": 4}
+            assert calculation_date is None
+            return GroupRankSnapshot(
+                date="2026-06-14",
+                ranks_by_group={"Internet Services": 4},
+            )
 
     repo = SqlScanResultRepository(
         session,
@@ -177,6 +182,7 @@ def test_persist_orchestrator_results_enriches_non_us_market_taxonomy(session: S
 
     assert row.ibd_industry_group == "Internet Services"
     assert row.ibd_group_rank == 4
+    assert row.details["ibd_group_rank_date"] == "2026-06-14"
     assert row.details["market_themes"] == ["AI Infrastructure", "Cloud"]
 
 
@@ -205,10 +211,13 @@ def test_non_us_rank_enrichment_honors_explicit_ranking_date(session: Session):
             return None
 
     class _FakeMarketGroupRankingService:
-        def get_current_rank_map(self, db, *, market, calculation_date=None):  # noqa: ARG002
+        def get_current_rank_snapshot(self, db, *, market, calculation_date=None):  # noqa: ARG002
             assert market == "HK"
             seen_dates.append(calculation_date)
-            return {"Internet Services": 7}
+            return GroupRankSnapshot(
+                date=calculation_date.isoformat() if calculation_date else None,
+                ranks_by_group={"Internet Services": 7},
+            )
 
     repo = SqlScanResultRepository(
         session,
@@ -280,9 +289,12 @@ def test_persist_orchestrator_results_overrides_non_us_sector_and_industry_with_
             return None
 
     class _FakeMarketGroupRankingService:
-        def get_current_rank_map(self, db, *, market, calculation_date=None):  # noqa: ARG002
+        def get_current_rank_snapshot(self, db, *, market, calculation_date=None):  # noqa: ARG002
             assert market == "JP"
-            return {"Transportation Equipment": 3}
+            return GroupRankSnapshot(
+                date=calculation_date.isoformat() if calculation_date else "2026-06-14",
+                ranks_by_group={"Transportation Equipment": 3},
+            )
 
     repo = SqlScanResultRepository(
         session,
@@ -397,9 +409,12 @@ def test_persist_orchestrator_results_strips_market_before_rank_map_lookup(sessi
             return None
 
     class _FakeMarketGroupRankingService:
-        def get_current_rank_map(self, db, *, market, calculation_date=None):  # noqa: ARG002
+        def get_current_rank_snapshot(self, db, *, market, calculation_date=None):  # noqa: ARG002
             assert market == "HK"
-            return {"Internet Services": 4}
+            return GroupRankSnapshot(
+                date=calculation_date.isoformat() if calculation_date else "2026-06-14",
+                ranks_by_group={"Internet Services": 4},
+            )
 
     repo = SqlScanResultRepository(
         session,

--- a/backend/tests/unit/test_feature_store_tasks.py
+++ b/backend/tests/unit/test_feature_store_tasks.py
@@ -1133,8 +1133,10 @@ def test_enrich_feature_run_with_ibd_metadata_updates_details_json():
     assert stats["missing_rank_rows"] == 1
     assert nvda.details_json["ibd_industry_group"] == "Semiconductors"
     assert nvda.details_json["ibd_group_rank"] == 1
+    assert nvda.details_json["ibd_group_rank_date"] == "2026-04-02"
     assert msft.details_json["ibd_industry_group"] == "Software"
     assert msft.details_json["ibd_group_rank"] is None
+    assert msft.details_json["ibd_group_rank_date"] is None
 
     engine.dispose()
 

--- a/backend/tests/unit/test_market_group_ranking_service.py
+++ b/backend/tests/unit/test_market_group_ranking_service.py
@@ -139,6 +139,43 @@ def test_get_current_rank_map_skips_historical_rank_change_work(monkeypatch):
     assert rank_map == {"Internet Services": 4, "Software": 7}
 
 
+def test_get_current_rank_snapshot_returns_rank_date_and_map(monkeypatch):
+    service = MarketGroupRankingService()
+    latest_run = SimpleNamespace(id=42, as_of_date=date(2026, 4, 4))
+
+    monkeypatch.setattr(
+        service,
+        "_get_latest_published_run",
+        lambda db, *, market, calculation_date=None: latest_run,  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        service,
+        "_load_run_rows",
+        lambda db, run_id: ["placeholder"],  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        service,
+        "compute_group_rankings_from_rows",
+        lambda rows, *, ranking_date: [  # noqa: ARG005
+            {
+                "industry_group": "Internet Services",
+                "date": ranking_date.isoformat(),
+                "rank": 4,
+            },
+            {
+                "industry_group": "Software",
+                "date": ranking_date.isoformat(),
+                "rank": 7,
+            },
+        ],
+    )
+
+    snapshot = service.get_current_rank_snapshot(Session(), market="HK")
+
+    assert snapshot.date == "2026-04-04"
+    assert snapshot.ranks_by_group == {"Internet Services": 4, "Software": 7}
+
+
 def test_market_group_ranking_service_loads_rrg_runs_once_and_returns_ascending_series(monkeypatch):
     fake_redis = _FakeRedis()
     service = MarketGroupRankingService(redis_client=fake_redis)

--- a/frontend/src/components/Scan/ResultsTable.jsx
+++ b/frontend/src/components/Scan/ResultsTable.jsx
@@ -52,6 +52,25 @@ const MCAP_DISPLAY = Object.freeze({
   LOCAL: 'local',
 });
 
+const formatGroupRankDate = (value) => {
+  if (!value) return null;
+  const [year, month, day] = String(value).split('-').map((part) => Number(part));
+  if (year && month && day) {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    }).format(new Date(Date.UTC(year, month - 1, day)));
+  }
+  return String(value);
+};
+
+const getGroupRankTooltip = (row) => {
+  if (row.ibd_group_rank == null || !row.ibd_group_rank_date) return undefined;
+  return `Group rank ${row.ibd_group_rank} as of ${formatGroupRankDate(row.ibd_group_rank_date)}`;
+};
+
 // Column definitions with explicit widths
 const columns = [
   { id: 'chart', label: '', sortable: false, width: 60 },
@@ -263,7 +282,7 @@ const VirtualTableRow = memo(function VirtualTableRow({
         <MarketThemesList themes={row.market_themes} variant="compact" />
       </TableCell>
 
-      <TableCell align="center" sx={{
+      <TableCell align="center" title={getGroupRankTooltip(row)} sx={{
         fontFamily: 'monospace',
         color: getGroupRankColor(row.ibd_group_rank),
         fontWeight: row.ibd_group_rank && row.ibd_group_rank <= 20 ? 600 : 400,
@@ -485,6 +504,7 @@ const VirtualTableRow = memo(function VirtualTableRow({
          prevProps.row.gics_sector === nextProps.row.gics_sector &&
          prevProps.row.ibd_industry_group === nextProps.row.ibd_industry_group &&
          prevProps.row.ibd_group_rank === nextProps.row.ibd_group_rank &&
+         prevProps.row.ibd_group_rank_date === nextProps.row.ibd_group_rank_date &&
          prevProps.row.scan_mode === nextProps.row.scan_mode &&
          prevProps.row.data_status === nextProps.row.data_status &&
          prevProps.row.is_scannable === nextProps.row.is_scannable &&

--- a/frontend/src/components/Scan/ResultsTable.test.jsx
+++ b/frontend/src/components/Scan/ResultsTable.test.jsx
@@ -201,6 +201,23 @@ describe('ResultsTable', () => {
       expect(screen.getByText('AI Infrastructure')).toBeInTheDocument();
       expect(screen.getByText('+1')).toBeInTheDocument();
     });
+
+    it('keeps group rank compact and exposes the rank date in a tooltip', () => {
+      renderWithProviders(
+        <ResultsTable
+          {...defaultProps}
+          results={[{
+            ...fullSeRow,
+            ibd_group_rank: 153,
+            ibd_group_rank_date: '2026-06-14',
+          }]}
+        />
+      );
+
+      const rankCell = screen.getByText('153').closest('td');
+      expect(rankCell).toHaveAttribute('title', 'Group rank 153 as of Jun 14, 2026');
+      expect(screen.queryByText(/Jun 14, 2026/)).not.toBeInTheDocument();
+    });
   });
 
   // ── structural ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #256.

This PR clarifies why the scan results `Grp` value can differ from the current group ranking table by preserving and surfacing the scan-date group rank date in the scan results tooltip.

Changes:
- Adds optional `ibd_group_rank_date` to scan result payloads.
- Persists the rank date for new live scan rows and feature-store scan rows going forward.
- Adds a `GroupRankSnapshot` boundary for non-US group rankings so rank and as-of date travel together.
- Keeps the scan table compact: the date appears only in the `Grp` cell tooltip.
- Covers both live API results and static scan serialization paths.

## Validation

- `cd backend && source venv/bin/activate && pytest tests/integration/test_scan_result_repo_enrichment.py tests/integration/test_feature_store_scan_results.py tests/unit/test_feature_store_tasks.py::test_enrich_feature_run_with_ibd_metadata_updates_details_json tests/unit/test_static_site_export_service.py::test_export_chart_bundle_writes_top_ranked_payloads_with_sidebar_metadata tests/unit/test_market_group_ranking_service.py -q` — 31 passed
- `cd frontend && npm run test:run -- src/components/Scan/ResultsTable.test.jsx src/static/pages/StaticScanPage.test.jsx` — 33 passed
- `cd frontend && npm run lint` — 0 errors, 4 pre-existing warnings
- `git diff --check origin/main...HEAD` — clean

## Notes

No database migration is required. Existing historical rows without `ibd_group_rank_date` will continue to load and simply omit the tooltip date until regenerated or re-enriched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Industry group rankings now include date information showing when the rank was determined. Hovering over the rank value in the scan results table displays the date via tooltip.

* **Tests**
  * Extended test coverage to validate ranking date tracking, persistence, enrichment, and display across backend data models and frontend components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->