### PR TITLE
Fix/ibd classification updates

### DIFF
--- a/data/IBD_industry_group.csv
+++ b/data/IBD_industry_group.csv
@@ -10041,7 +10041,7 @@ YYY,Finance-ETF / ETN
 Z,Internet-Content
 ZALT,Finance-ETF / ETN
 ZAPP,Auto Manufacturers
-ZBAO,Group not available
+ZBAO,Insurance-Brokers
 ZBH,Medical-Products
 ZBRA,Elec-Misc Products
 ZCAR,Leisure-Services

--- a/data/IBD_industry_group.csv
+++ b/data/IBD_industry_group.csv
@@ -1065,7 +1065,7 @@ BITI,Finance-ETF / ETN
 BITO,Finance-ETF / ETN
 BITQ,Finance-ETF / ETN
 BITS,Finance-ETF / ETN
-BITU,Group not available
+BITU,Finance-ETF / ETN
 BITW,Finance-Publ Inv Fd-Glbl
 BITX,Finance-ETF / ETN
 BIV,Finance-ETF / ETN
@@ -5239,7 +5239,7 @@ KOKU,Finance-ETF / ETN
 KOLD,Finance-ETF / ETN
 KOMP,Finance-ETF / ETN
 KONG,Finance-ETF / ETN
-KOOL,Group not available
+KOOL,Finance-ETF / ETN
 KOP,Chemicals-Specialty
 KOPN,Elec-Semiconductor Equip
 KORE,Computer Sftwr-Enterprse
@@ -7863,7 +7863,7 @@ SBH,Retail-Specialty
 SBI,Finance-Publ Inv Fd-Bond
 SBIG,Consumer Prod-Specialty
 SBIO,Finance-ETF / ETN
-SBIT,Group not available
+SBIT,Finance-ETF / ETN
 SBLK,Transportation-Ship
 SBND,Finance-ETF / ETN
 SBNY,Banks-Northeast


### PR DESCRIPTION
## Summary

Updates several `Group not available` entries in `IBD_industry_group.csv` where the classification could be determined from the existing taxonomy used by the project.

### Changes

* BITU → `Finance-ETF / ETN`
* KOOL → `Finance-ETF / ETN`
* SBIT → `Finance-ETF / ETN`
* ZBAO → `Insurance-Brokers`

### Investigation

While looking into the `Group not available` classifications I found:

* 61 total `Group not available` entries in the authoritative CSV.
* 55 of those symbols are no longer present in the active universe.
* 6 symbols remain active.
* Of those 6, three are ETFs and one is an insurance broker with clear existing peer classifications.

For the ETF symbols, the existing taxonomy already classifies approximately **2,425** ETFs as `Finance-ETF / ETN`, making these three the only obvious active ETF exceptions.

### Rationale

While investigating the `Group not available` classifications, I noticed these symbols were active companies with well-established peers already classified in the dataset.

For the ETF symbols, the existing taxonomy consistently classifies comparable ETFs (for example SPY, QQQ, GLD, SLV, IBIT, BITO, XLE, XLF, XLK and XTN) as `Finance-ETF / ETN`.

For ZBAO, the provider industry is `Insurance Brokers`, which is consistent with the existing `Insurance-Brokers` classification already used for comparable companies such as AJG, AON, BRO, EHTH, ERIE, GOCO, SLQT and WTW.

I intentionally left symbols with less obvious mappings (for example GEV and MAMO) unchanged, as they span multiple existing IBD industry groups and would benefit from additional review rather than a subjective assignment.
