### PR TITLE
Fix price refresh progress callback propagation

### DIFF
--- a/backend/app/services/bulk_data_fetcher.py
+++ b/backend/app/services/bulk_data_fetcher.py
@@ -10,13 +10,14 @@ docs/learning_loop/adr_ll2_e1_canonical_price_contract_v1.md
 """
 import logging
 import math
-from collections.abc import Callable
-from typing import TYPE_CHECKING, List, Dict, Optional, Any, NamedTuple
-from threading import RLock
-import yfinance as yf
-from datetime import datetime
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from threading import RLock
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional
+
+import yfinance as yf
 
 from ..config import settings
 from ..domain.providers.price_symbol_support import yahoo_price_no_data_error_for_symbol
@@ -646,9 +647,10 @@ class BulkDataFetcher:
     def fetch_prices_in_batches(
         self,
         symbols: List[str],
-        period: str = '2y',
+        period: str = "2y",
         start_batch_size: Optional[int] = None,
         market: Optional[str] = None,
+        progress_callback: Callable[[int], None] | None = None,
     ) -> Dict[str, Dict]:
         """Fetch prices for many symbols using market-aware batch routing.
 
@@ -670,6 +672,7 @@ class BulkDataFetcher:
             period=period,
             start_batch_size=start_batch_size,
             market=market,
+            progress_callback=progress_callback,
         )
 
     def _get_cn_price_service(self):
@@ -715,6 +718,7 @@ class BulkDataFetcher:
         period: str,
         start_batch_size: Optional[int] = None,
         market: Optional[str] = None,
+        progress_callback: Callable[[int], None] | None = None,
     ) -> Dict[str, Dict]:
         fetch_symbols, combined_results = self._split_fetchable_price_symbols(
             symbols
@@ -801,6 +805,17 @@ class BulkDataFetcher:
                         min_interval_s=settings.yfinance_batch_rate_limit_interval,
                     )
             batch_start += len(batch_symbols)
+
+            if progress_callback is not None:
+                try:
+                    progress_callback(len(batch_symbols))
+                except Exception as exc:
+                    logger.warning(
+                        "Ignoring price progress callback failure at %d/%d symbols: %s",
+                        batch_start,
+                        len(fetch_symbols),
+                        exc,
+                    )
 
         return combined_results
 

--- a/backend/app/services/price_refresh_execution.py
+++ b/backend/app/services/price_refresh_execution.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
-import logging
 from typing import Any
 
 from celery.exceptions import SoftTimeLimitExceeded
@@ -15,7 +15,6 @@ from .price_fetch_failures import (
     normalize_price_fetch_failure_kind,
 )
 from .price_refresh_planning import PriceRefreshJob
-
 
 logger = logging.getLogger(__name__)
 
@@ -273,6 +272,7 @@ def iter_price_refresh_batches(
     fetch_batch: Callable[..., MappingResult],
     market_for_symbol: Callable[[str], str],
     raise_if_transient_database_error: Callable[[Exception], None],
+    progress_callback: Callable[[int], None] | None = None,
 ) -> Iterator[PriceRefreshBatchOutcome]:
     total_batches = _total_batches(jobs, batch_size)
     batch_number = 0
@@ -294,6 +294,7 @@ def iter_price_refresh_batches(
                     batch_symbols,
                     period=job.period,
                     market=market,
+                    progress_callback=progress_callback,
                 )
                 yield classify_price_refresh_batch(
                     batch_number=batch_number,

--- a/backend/app/services/price_refresh_live_runner.py
+++ b/backend/app/services/price_refresh_live_runner.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from .price_fetch_failures import is_retryable_price_failure_kind
-from .price_refresh_activity import CeleryTaskLike, PriceRefreshActivityReporter, task_id
+from .price_refresh_activity import (
+    CeleryTaskLike,
+    PriceRefreshActivityReporter,
+    task_id,
+)
 from .price_refresh_execution import (
     PriceRefreshExecutionAccumulator,
     PriceRefreshExecutionSummary,
@@ -63,12 +67,43 @@ class LivePriceRefreshRunner:
         def market_for_symbol(symbol: str) -> str:
             return symbol_markets.get(str(symbol).upper(), effective_market)
 
-        def fetch_batch(symbols: Sequence[str], *, period: str, market: str | None):
+        processed = 0
+
+        def progress_callback(batch_processed: int) -> None:
+            nonlocal processed
+
+            processed += batch_processed
+
+            percent = (processed / total) * 100 if total else 100.0
+
+            activity_reporter.publish_progress(
+                db,
+                price_cache,
+                task=task,
+                market=market,
+                effective_market=effective_market,
+                lifecycle=activity_lifecycle,
+                current=processed,
+                total=total,
+                percent=percent,
+                message="Refreshing market prices",
+                refreshed=processed,  # adjust if you want true refreshed count
+                failed=0,
+            )
+
+        def fetch_batch(
+            symbols: Sequence[str],
+            *,
+            period: str,
+            market: str | None,
+            progress_callback: Callable[[int], None] | None = None,
+        ):
             return self._deps.fetch_with_backoff(
                 bulk_fetcher,
                 list(symbols),
                 period=period,
                 market=market,
+                progress_callback=progress_callback,
             )
 
         try:
@@ -79,6 +114,7 @@ class LivePriceRefreshRunner:
                 fetch_batch=fetch_batch,
                 market_for_symbol=market_for_symbol,
                 raise_if_transient_database_error=self._deps.raise_if_transient_database_error,
+                progress_callback=progress_callback,
             ):
                 if batch.price_data_by_symbol:
                     price_cache.store_batch_in_cache(

--- a/backend/app/services/provider_adapters/price_plan_executor.py
+++ b/backend/app/services/provider_adapters/price_plan_executor.py
@@ -34,8 +34,8 @@ class PriceFetcher(Protocol):
         period: str,
         start_batch_size: int | None = None,
         market: str | None = None,
-    ) -> dict[str, dict[str, Any]]:
-        ...
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> dict[str, dict[str, Any]]: ...
 
     def _fetch_cn_price_batch(
         self,
@@ -80,6 +80,7 @@ class PriceProviderPlanExecutor:
         period: str = "2y",
         start_batch_size: int | None = None,
         market: str | None = None,
+        progress_callback: Callable[[int], None] | None = None,
     ) -> dict[str, dict[str, Any]]:
         if not symbols:
             return {}
@@ -122,6 +123,7 @@ class PriceProviderPlanExecutor:
                     market=market,
                     plan=plan,
                     step=step,
+                    progress_callback=progress_callback,
                 )
 
             logger.warning(
@@ -152,12 +154,14 @@ class PriceProviderPlanExecutor:
         market: str | None,
         plan: ProviderDataPlan,
         step: ProviderPlanStep,
+        progress_callback: Callable[[int], None] | None = None,
     ) -> dict[str, dict[str, Any]]:
         results = self._fetcher._fetch_yfinance_prices_in_batches(
             symbols,
             period=period,
             start_batch_size=start_batch_size if start_batch_size is not None else step.batch_size,
             market=market,
+            progress_callback=progress_callback,
         )
         return self._with_plan_metadata(results, plan)
 
@@ -169,6 +173,7 @@ class PriceProviderPlanExecutor:
         start_batch_size: int | None,
         market: str | None,
         plan: ProviderDataPlan,
+        progress_callback: Callable[[int], None] | None = None,
     ) -> dict[str, dict[str, Any]]:
         native_results = self._fetcher._fetch_cn_price_batch(symbols, period=period)
         fallback_symbols = [
@@ -185,6 +190,7 @@ class PriceProviderPlanExecutor:
             period=period,
             start_batch_size=start_batch_size if start_batch_size is not None else plan.step_for(PROVIDER_YFINANCE).batch_size,
             market=market,
+            progress_callback=progress_callback,
         )
         merged = dict(native_results)
         for symbol, fallback_payload in fallback_results.items():
@@ -207,6 +213,7 @@ class PriceProviderPlanExecutor:
         start_batch_size: int | None,
         market: str | None,
         plan: ProviderDataPlan,
+        progress_callback: Callable[[int], None] | None = None,
     ) -> dict[str, dict[str, Any]]:
         krx_results = self._fetcher._fetch_kr_price_batch(symbols, period=period)
         fallback_symbols = [
@@ -222,6 +229,7 @@ class PriceProviderPlanExecutor:
             period=period,
             start_batch_size=start_batch_size if start_batch_size is not None else plan.step_for(PROVIDER_YFINANCE).batch_size,
             market=market,
+            progress_callback=progress_callback,
         )
         merged = dict(krx_results)
         for symbol, fallback_payload in fallback_results.items():

--- a/backend/app/tasks/cache_tasks.py
+++ b/backend/app/tasks/cache_tasks.py
@@ -9,18 +9,19 @@ Provides background tasks for:
 All data-fetching tasks use the @serialized_data_fetch decorator
 to ensure only one task fetches external data at a time.
 """
+import logging
 from contextlib import contextmanager
 from contextvars import ContextVar
-import logging
-from typing import List, Optional
 from datetime import datetime, timezone
+from typing import Callable, List, Optional
 
 from celery.exceptions import SoftTimeLimitExceeded
 
 from ..celery_app import celery_app
+from ..config import settings
 from ..database import SessionLocal, is_corruption_error, safe_rollback
-from ..services.cache_manager import CacheManager
 from ..services.benchmark_registry_service import benchmark_registry
+from ..services.cache_manager import CacheManager
 from ..services.market_activity_service import (
     mark_market_activity_completed,
     mark_market_activity_failed,
@@ -30,35 +31,43 @@ from ..services.market_activity_service import (
 from ..services.price_fetch_failures import (
     classify_price_fetch_error,
     is_no_data_price_failure,
+)
+from ..services.price_fetch_failures import (
     is_rate_limit_error as is_price_rate_limit_error,
+)
+from ..services.price_fetch_failures import (
     is_retryable_price_failure,
 )
-from ..services.price_refresh_execution import classify_price_refresh_batch
-from ..services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
-from ..services.price_refresh_plan_builder import build_market_price_refresh_plan
 from ..services.price_refresh_activity import (
     PriceRefreshActivityDependencies,
     PriceRefreshActivityReporter,
 )
+from ..services.price_refresh_execution import classify_price_refresh_batch
 from ..services.price_refresh_live_runner import (
     LivePriceRefreshRunner,
     LivePriceRefreshRunnerDependencies,
     PriceRefreshRetryScheduler,
 )
+from ..services.price_refresh_plan_builder import build_market_price_refresh_plan
+from ..services.price_refresh_planning import PriceRefreshJob, PriceRefreshJobKind
 from ..services.price_refresh_workflow import (
     PriceRefreshMarketGateway,
     PriceRefreshWorkflow,
     PriceRefreshWorkflowDependencies,
 )
-from ..config import settings
-from ..utils.market_hours import is_market_open, is_trading_day, get_eastern_now, format_market_status
+from ..services.security_master_service import security_master_resolver
+from ..utils.market_hours import (
+    format_market_status,
+    get_eastern_now,
+    is_market_open,
+    is_trading_day,
+)
 from ..wiring.bootstrap import (
     get_daily_price_bundle_service,
     get_market_calendar_service,
     get_rate_limiter,
     get_stock_universe_service,
 )
-from ..services.security_master_service import security_master_resolver
 from .data_fetch_lock import serialized_data_fetch
 from .runtime_activity_failure_hooks import RuntimeActivityTrackedTask
 from .transient_database import raise_if_transient_database_error
@@ -192,6 +201,7 @@ def run_orphaned_scan_cleanup(
     than only queueing work for a background worker.
     """
     from datetime import timedelta
+
     from ..models.scan_result import Scan, ScanResult
 
     if now_utc is None:
@@ -366,8 +376,8 @@ def warm_spy_cache(market: Optional[str] = None):
         # Per-market telemetry (bead asia.10.1): record successful warms only
         # so a fully failed warm doesn't reset the "age" gauge to zero.
         try:
-            from ..services.telemetry import get_telemetry
             from ..services.benchmark_registry_service import benchmark_registry
+            from ..services.telemetry import get_telemetry
             telemetry = get_telemetry()
             for warmed_market, periods in by_market.items():
                 if any(periods.values()):
@@ -516,10 +526,11 @@ def weekly_full_refresh(self, market: str | None = None):
         Dict with refresh results
     """
     import time
-    from ..wiring.bootstrap import get_price_cache
+
     from ..services.bulk_data_fetcher import BulkDataFetcher
-    from .market_queues import market_tag, log_extra, normalize_market
     from ..services.runtime_preferences_service import is_market_enabled_now
+    from ..wiring.bootstrap import get_price_cache
+    from .market_queues import log_extra, market_tag, normalize_market
 
     _log_extra = log_extra(market)
     price_cache = get_price_cache()
@@ -1049,6 +1060,7 @@ def _fetch_with_backoff(
     period: str = "2y",
     max_retries: int = 3,
     market: str | None = None,
+    progress_callback: Callable[[int], None] | None = None,
 ):
     """
     Fetch batch data with exponential backoff on rate limit errors.
@@ -1085,6 +1097,7 @@ def _fetch_with_backoff(
                     symbols,
                     period=period,
                     market=market,
+                    progress_callback=progress_callback,
                 )
             else:
                 results = bulk_fetcher.fetch_prices_in_batches(
@@ -1094,6 +1107,7 @@ def _fetch_with_backoff(
                         len(symbols),
                         getattr(bulk_fetcher, "DEFAULT_PRICE_BATCH_SIZE", 100),
                     ),
+                    progress_callback=progress_callback,
                 )
 
             return results
@@ -1243,7 +1257,9 @@ def _record_market_refresh_success_safely(
     if market is None:
         return
     try:
-        from ..services.market_refresh_state_service import record_market_refresh_success
+        from ..services.market_refresh_state_service import (
+            record_market_refresh_success,
+        )
 
         record_market_refresh_success(
             db,
@@ -1443,8 +1459,9 @@ def _force_refresh_stale_intraday_impl(task, symbols: Optional[List[str]] = None
         Dict with refresh statistics
     """
     import time
-    from ..wiring.bootstrap import get_price_cache
+
     from ..services.bulk_data_fetcher import BulkDataFetcher
+    from ..wiring.bootstrap import get_price_cache
 
     logger.info("=" * 80)
     logger.info("TASK: Force Refresh Stale Intraday Data (Batch Mode)")
@@ -1651,7 +1668,7 @@ def run_smart_price_refresh(
     from ..services.bulk_data_fetcher import BulkDataFetcher
     from ..services.runtime_preferences_service import is_market_enabled_now
     from ..wiring.bootstrap import get_data_fetch_lock, get_price_cache
-    from .market_queues import market_tag, log_extra, normalize_market
+    from .market_queues import log_extra, market_tag, normalize_market
 
     def build_refresh_plan(db, *, mode, market, effective_market, recently_refreshed_filter):
         return build_market_price_refresh_plan(
@@ -1760,9 +1777,11 @@ def cleanup_old_price_data(self, keep_years: int = 5):
         Dict with cleanup statistics
     """
     from datetime import date, timedelta
-    from ..models.stock import StockPrice
-    from ..models.stock_universe import StockUniverse, UNIVERSE_STATUS_ACTIVE
+
     from sqlalchemy import func
+
+    from ..models.stock import StockPrice
+    from ..models.stock_universe import UNIVERSE_STATUS_ACTIVE, StockUniverse
 
     logger.info("=" * 80)
     logger.info(f"TASK: Cleanup Old Price Data (keeping {keep_years} years)")


### PR DESCRIPTION
## Summary

Fixes smart price refresh progress reporting during live Yahoo Finance batch downloads.
Fixes: #264 

## Problem

The smart refresh workflow reported 0% progress until the entire refresh completed because progress callbacks were not propagated through the bulk fetch pipeline.

The callback chain stopped before reaching the internal yfinance batch loop.

## Changes

- Propagate `progress_callback` through:
  - `_fetch_with_backoff()`
  - `BulkDataFetcher.fetch_prices_in_batches()`
  - `PriceProviderPlanExecutor.fetch()`
  - Provider execution methods
  - `_fetch_yfinance_prices_in_batches()`

- Invoke the callback after each successful internal Yahoo Finance batch.

## Result

Operations now receives incremental progress updates during long-running price refreshes instead of remaining at 0% until completion.

<img width="1262" height="684" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/ee9f41d4-d92a-4442-9091-049107fc3a0a" />

<img width="1266" height="735" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/cc867c44-212f-46e7-9bc4-778ec33db3d1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress updates during bulk price refreshes and cache warmups, so long-running price fetches can now report completion as batches finish.
  * Improved progress visibility across multiple refresh paths, including live runs and retry-based fetches.

* **Bug Fixes**
  * Progress reporting errors are safely handled and won’t interrupt ongoing price fetching.

* **Refactor**
  * Updated internal flow wiring to pass progress information consistently through batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->