### PR TITLE
[codex] Require SPY for static US exposure

### DIFF
--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -89,8 +89,14 @@ def _upsert_feature_run_pointer(*, pointer_key: str, run_id: int) -> None:
 def _compute_static_market_exposure(*, as_of_date: date, market: str) -> dict[str, Any]:
     from app.services.market_exposure_service import refresh_market_exposure_for_date
 
+    normalized_market = market.upper()
     with SessionLocal() as db:
-        return refresh_market_exposure_for_date(db, market, as_of_date)
+        return refresh_market_exposure_for_date(
+            db,
+            normalized_market,
+            as_of_date,
+            allow_benchmark_fallback=normalized_market != STATIC_DEFAULT_MARKET,
+        )
 
 
 def _snapshot_publishable(snapshot: dict[str, Any]) -> bool:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -18,6 +18,7 @@ from app.scripts._runtime import prepare_runtime, repo_root
 from app.services.breadth_calculator_service import BreadthCalculatorService
 from app.services.bulk_data_fetcher import BulkDataFetcher
 from app.services.ibd_industry_service import IBDIndustryService
+from app.services.benchmark_cache_service import BenchmarkFallbackPolicy
 from app.services.static_daily_price_refresh_service import (
     StaticDailyPriceRefreshService,
     static_daily_price_refresh_batch_size as _static_daily_price_refresh_batch_size,
@@ -43,6 +44,7 @@ STATIC_BUILD_MODE_PRICE_DELTA = "price_delta"
 STATIC_BUILD_MODE_FULL = "full"
 STATIC_EXPORT_MARKETS = market_registry.supported_market_codes()
 STATIC_DEFAULT_MARKET = "US"
+STATIC_EXPOSURE_PRIMARY_ONLY_BENCHMARK_MARKETS = frozenset({"US"})
 STATIC_EXPORT_SKIPPED_EXIT_CODE = 78
 STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE = 79
 
@@ -86,6 +88,13 @@ def _upsert_feature_run_pointer(*, pointer_key: str, run_id: int) -> None:
         db.commit()
 
 
+def _static_exposure_benchmark_fallback_policy(market: str) -> BenchmarkFallbackPolicy:
+    normalized_market = market.upper()
+    if normalized_market in STATIC_EXPOSURE_PRIMARY_ONLY_BENCHMARK_MARKETS:
+        return BenchmarkFallbackPolicy.PRIMARY_ONLY
+    return BenchmarkFallbackPolicy.ALLOW
+
+
 def _compute_static_market_exposure(*, as_of_date: date, market: str) -> dict[str, Any]:
     from app.services.market_exposure_service import refresh_market_exposure_for_date
 
@@ -95,7 +104,7 @@ def _compute_static_market_exposure(*, as_of_date: date, market: str) -> dict[st
             db,
             normalized_market,
             as_of_date,
-            allow_benchmark_fallback=normalized_market != STATIC_DEFAULT_MARKET,
+            benchmark_fallback_policy=_static_exposure_benchmark_fallback_policy(normalized_market),
         )
 
 

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -8,6 +8,7 @@ import logging
 import pickle
 import time
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Optional, Callable
 from datetime import datetime, timedelta
 import pandas as pd
@@ -42,6 +43,13 @@ class BenchmarkDataBundle:
     benchmark_kind: str | None
     candidate_symbols: tuple[str, ...]
     data: pd.DataFrame
+
+
+class BenchmarkFallbackPolicy(str, Enum):
+    """Controls whether benchmark fallback symbols are eligible for a lookup."""
+
+    ALLOW = "allow"
+    PRIMARY_ONLY = "primary_only"
 
 
 class BenchmarkCacheService:
@@ -162,13 +170,18 @@ class BenchmarkCacheService:
         market: str = "US",
         period: str = "2y",
         force_refresh: bool = False,
-        allow_fallback: bool = True,
+        fallback_policy: BenchmarkFallbackPolicy = BenchmarkFallbackPolicy.ALLOW,
     ) -> Optional[BenchmarkDataBundle]:
         """Resolve benchmark data plus the selected candidate metadata."""
         normalized_market = self._normalize_market(market)
         all_candidates = self.get_benchmark_candidates(normalized_market)
-        candidates = all_candidates if allow_fallback else all_candidates[:1]
-        candidate_tuple = tuple(all_candidates)
+        normalized_policy = BenchmarkFallbackPolicy(fallback_policy)
+        candidates = (
+            all_candidates
+            if normalized_policy == BenchmarkFallbackPolicy.ALLOW
+            else all_candidates[:1]
+        )
+        candidate_tuple = tuple(candidates)
         registry_entry = self._benchmark_registry.get_entry(normalized_market)
 
         # Pass 1: Prefer any cached candidate before triggering network fetches.

--- a/backend/app/services/benchmark_cache_service.py
+++ b/backend/app/services/benchmark_cache_service.py
@@ -162,11 +162,13 @@ class BenchmarkCacheService:
         market: str = "US",
         period: str = "2y",
         force_refresh: bool = False,
+        allow_fallback: bool = True,
     ) -> Optional[BenchmarkDataBundle]:
         """Resolve benchmark data plus the selected candidate metadata."""
         normalized_market = self._normalize_market(market)
-        candidates = self.get_benchmark_candidates(normalized_market)
-        candidate_tuple = tuple(candidates)
+        all_candidates = self.get_benchmark_candidates(normalized_market)
+        candidates = all_candidates if allow_fallback else all_candidates[:1]
+        candidate_tuple = tuple(all_candidates)
         registry_entry = self._benchmark_registry.get_entry(normalized_market)
 
         # Pass 1: Prefer any cached candidate before triggering network fetches.

--- a/backend/app/services/market_exposure_service.py
+++ b/backend/app/services/market_exposure_service.py
@@ -80,6 +80,7 @@ FTD_FLOOR = 45.0                # recent FTD after a correction raises the floor
 # --- History seeding (one-time, so the timeline renders on launch) ----------
 EXPOSURE_HISTORY_MIN_ROWS = 60   # below this many stored rows -> seed history
 EXPOSURE_BACKFILL_DAYS = 220     # trailing calendar days to seed (~150 sessions)
+STRICT_BENCHMARK_HISTORY_INCOMPLETE = "strict_benchmark_history_incomplete"
 
 # Stance bands, highest lower-bound first.
 STANCE_BANDS = [
@@ -407,7 +408,16 @@ def refresh_market_exposure_for_date(
             benchmark_fallback_policy=benchmark_fallback_policy,
         )
     except Exception as exc:
-        return {**result, "history_seed": {"error": str(exc)}}
+        history_seed = {"error": str(exc)}
+        if benchmark_fallback_policy == BenchmarkFallbackPolicy.PRIMARY_ONLY:
+            return {**result, "error": history_seed["error"], "history_seed": history_seed}
+        return {**result, "history_seed": history_seed}
+    if (
+        benchmark_fallback_policy == BenchmarkFallbackPolicy.PRIMARY_ONLY
+        and isinstance(history_seed, dict)
+        and history_seed.get("error")
+    ):
+        return {**result, "error": history_seed["error"], "history_seed": history_seed}
     return {**result, "history_seed": history_seed}
 
 
@@ -511,6 +521,31 @@ def backfill_exposure(
     return {"seeded": seeded, "failed": failed}
 
 
+def _non_primary_benchmark_row_count(
+    db: Session,
+    *,
+    market: str,
+    primary_symbol: str,
+    start: date,
+    end: date,
+) -> int:
+    return (
+        db.query(MarketExposure)
+        .filter(
+            MarketExposure.market == market,
+            MarketExposure.date >= start,
+            MarketExposure.date <= end,
+        )
+        .filter(
+            or_(
+                MarketExposure.benchmark_symbol.is_(None),
+                MarketExposure.benchmark_symbol != primary_symbol,
+            )
+        )
+        .count()
+    )
+
+
 def ensure_exposure_history(
     db: Session,
     market: str,
@@ -535,30 +570,55 @@ def ensure_exposure_history(
 
     existing_query = db.query(MarketExposure).filter(MarketExposure.market == market)
     existing = existing_query.count()
+    primary_symbol = (
+        get_primary_benchmark_symbol(market)
+        if benchmark_fallback_policy == BenchmarkFallbackPolicy.PRIMARY_ONLY
+        else None
+    )
     if existing >= min_rows:
         if benchmark_fallback_policy != BenchmarkFallbackPolicy.PRIMARY_ONLY:
             return {"seeded": 0, "skipped": True}
 
-        primary_symbol = get_primary_benchmark_symbol(market)
-        primary_rows = existing_query.filter(MarketExposure.benchmark_symbol == primary_symbol).count()
-        non_primary_rows_in_seed_window = (
+        primary_rows = (
             existing_query
-            .filter(MarketExposure.date >= start, MarketExposure.date <= end)
-            .filter(
-                or_(
-                    MarketExposure.benchmark_symbol.is_(None),
-                    MarketExposure.benchmark_symbol != primary_symbol,
-                )
-            )
+            .filter(MarketExposure.benchmark_symbol == primary_symbol)
             .count()
+        )
+        non_primary_rows_in_seed_window = _non_primary_benchmark_row_count(
+            db,
+            market=market,
+            primary_symbol=primary_symbol,
+            start=start,
+            end=end,
         )
         if primary_rows >= min_rows and non_primary_rows_in_seed_window == 0:
             return {"seeded": 0, "skipped": True}
 
-    return backfill_exposure(
+    result = backfill_exposure(
         db,
         market,
         start,
         end,
         benchmark_fallback_policy=benchmark_fallback_policy,
     )
+    if benchmark_fallback_policy != BenchmarkFallbackPolicy.PRIMARY_ONLY:
+        return result
+
+    non_primary_rows_in_seed_window = _non_primary_benchmark_row_count(
+        db,
+        market=market,
+        primary_symbol=primary_symbol,
+        start=start,
+        end=end,
+    )
+    if non_primary_rows_in_seed_window:
+        return {
+            **result,
+            "error": STRICT_BENCHMARK_HISTORY_INCOMPLETE,
+            "market": market,
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "primary_benchmark_symbol": primary_symbol,
+            "non_primary_benchmark_rows": non_primary_rows_in_seed_window,
+        }
+    return result

--- a/backend/app/services/market_exposure_service.py
+++ b/backend/app/services/market_exposure_service.py
@@ -17,7 +17,7 @@ daily; the Daily Snapshot payloads (live + static) call ``build_exposure_payload
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Optional
+from typing import Any, Optional
 
 import pandas as pd
 from sqlalchemy.orm import Session
@@ -279,7 +279,13 @@ def _net_4pct_on_date(db: Session, market: str, as_of_date: date) -> Optional[in
     return int((row.stocks_up_4pct or 0) - (row.stocks_down_4pct or 0))
 
 
-def compute_exposure(market: str, as_of_date: date, db: Session) -> dict:
+def compute_exposure(
+    market: str,
+    as_of_date: date,
+    db: Session,
+    *,
+    allow_benchmark_fallback: bool = True,
+) -> dict:
     """Compute the exposure dict for one market as of ``as_of_date``.
 
     Returns ``{"error": ...}`` (no row written) when index OHLCV is unavailable,
@@ -291,7 +297,10 @@ def compute_exposure(market: str, as_of_date: date, db: Session) -> dict:
     # db (it closes the session in a finally block).
     from .benchmark_cache_service import BenchmarkCacheService
 
-    bundle = BenchmarkCacheService().get_benchmark_bundle(market=market, period="2y")
+    benchmark_kwargs: dict[str, Any] = {"market": market, "period": "2y"}
+    if not allow_benchmark_fallback:
+        benchmark_kwargs["allow_fallback"] = False
+    bundle = BenchmarkCacheService().get_benchmark_bundle(**benchmark_kwargs)
     if bundle is None or bundle.data is None or bundle.data.empty:
         return {"error": "no_benchmark_data", "market": market, "date": as_of_date.isoformat()}
 
@@ -332,14 +341,23 @@ def compute_exposure(market: str, as_of_date: date, db: Session) -> dict:
     }
 
 
-def compute_and_store(market: str, as_of_date: date, db: Session) -> dict:
+def compute_and_store(
+    market: str,
+    as_of_date: date,
+    db: Session,
+    *,
+    allow_benchmark_fallback: bool = True,
+) -> dict:
     """Compute and upsert one MarketExposure row by (date, market).
 
     ``compute_exposure`` returns a dict whose keys are exactly MarketExposure
     columns (including market/date), so it is applied directly — there is no
     separate field mapping to keep in sync as the model grows.
     """
-    result = compute_exposure(market, as_of_date, db)
+    compute_kwargs: dict[str, Any] = {}
+    if not allow_benchmark_fallback:
+        compute_kwargs["allow_benchmark_fallback"] = False
+    result = compute_exposure(market, as_of_date, db, **compute_kwargs)
     if result.get("error"):
         return result
 
@@ -363,10 +381,14 @@ def refresh_market_exposure_for_date(
     as_of_date: date,
     *,
     seed_history: bool = True,
+    allow_benchmark_fallback: bool = True,
 ) -> dict:
     """Compute/store exposure and run the canonical launch-history self-heal."""
     normalized_market = (market or "US").upper()
-    result = compute_and_store(normalized_market, as_of_date, db)
+    compute_kwargs: dict[str, Any] = {}
+    if not allow_benchmark_fallback:
+        compute_kwargs["allow_benchmark_fallback"] = False
+    result = compute_and_store(normalized_market, as_of_date, db, **compute_kwargs)
     if result.get("error") or not seed_history:
         return result
 

--- a/backend/app/services/market_exposure_service.py
+++ b/backend/app/services/market_exposure_service.py
@@ -399,7 +399,11 @@ def refresh_market_exposure_for_date(
         return result
 
     try:
-        history_seed = ensure_exposure_history(db, normalized_market)
+        history_seed = ensure_exposure_history(
+            db,
+            normalized_market,
+            benchmark_fallback_policy=benchmark_fallback_policy,
+        )
     except Exception as exc:
         return {**result, "history_seed": {"error": str(exc)}}
     return {**result, "history_seed": history_seed}
@@ -470,7 +474,14 @@ def build_exposure_payload(
     }
 
 
-def backfill_exposure(db: Session, market: str, start: date, end: date) -> dict:
+def backfill_exposure(
+    db: Session,
+    market: str,
+    start: date,
+    end: date,
+    *,
+    benchmark_fallback_policy: BenchmarkFallbackPolicy = BenchmarkFallbackPolicy.ALLOW,
+) -> dict:
     """Compute + store exposure for every trading day in [start, end].
 
     The single source of truth for range backfills (used by the Celery backfill
@@ -483,7 +494,12 @@ def backfill_exposure(db: Session, market: str, start: date, end: date) -> dict:
     seeded = failed = 0
     for day in MarketCalendarService().trading_days(market, start, end):
         try:
-            if compute_and_store(market, day, db).get("error"):
+            if compute_and_store(
+                market,
+                day,
+                db,
+                benchmark_fallback_policy=benchmark_fallback_policy,
+            ).get("error"):
                 failed += 1
             else:
                 seeded += 1
@@ -499,6 +515,7 @@ def ensure_exposure_history(
     *,
     min_rows: int = EXPOSURE_HISTORY_MIN_ROWS,
     days: int = EXPOSURE_BACKFILL_DAYS,
+    benchmark_fallback_policy: BenchmarkFallbackPolicy = BenchmarkFallbackPolicy.ALLOW,
 ) -> dict:
     """Seed history once so the timeline isn't empty on launch.
 
@@ -516,4 +533,10 @@ def ensure_exposure_history(
         return {"seeded": 0, "skipped": True}
 
     end = MarketCalendarService().last_completed_trading_day(market)
-    return backfill_exposure(db, market, end - timedelta(days=days), end)
+    return backfill_exposure(
+        db,
+        market,
+        end - timedelta(days=days),
+        end,
+        benchmark_fallback_policy=benchmark_fallback_policy,
+    )

--- a/backend/app/services/market_exposure_service.py
+++ b/backend/app/services/market_exposure_service.py
@@ -20,8 +20,10 @@ from datetime import date, timedelta
 from typing import Optional
 
 import pandas as pd
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from ..domain.common.benchmarks import get_primary_benchmark_symbol
 from ..models.market_breadth import MarketBreadth
 from ..models.market_exposure import MarketExposure
 from ..models.stock import StockPrice
@@ -528,15 +530,35 @@ def ensure_exposure_history(
     from .market_calendar_service import MarketCalendarService
 
     market = (market or "US").upper()
-    existing = db.query(MarketExposure).filter(MarketExposure.market == market).count()
-    if existing >= min_rows:
-        return {"seeded": 0, "skipped": True}
-
     end = MarketCalendarService().last_completed_trading_day(market)
+    start = end - timedelta(days=days)
+
+    existing_query = db.query(MarketExposure).filter(MarketExposure.market == market)
+    existing = existing_query.count()
+    if existing >= min_rows:
+        if benchmark_fallback_policy != BenchmarkFallbackPolicy.PRIMARY_ONLY:
+            return {"seeded": 0, "skipped": True}
+
+        primary_symbol = get_primary_benchmark_symbol(market)
+        primary_rows = existing_query.filter(MarketExposure.benchmark_symbol == primary_symbol).count()
+        non_primary_rows_in_seed_window = (
+            existing_query
+            .filter(MarketExposure.date >= start, MarketExposure.date <= end)
+            .filter(
+                or_(
+                    MarketExposure.benchmark_symbol.is_(None),
+                    MarketExposure.benchmark_symbol != primary_symbol,
+                )
+            )
+            .count()
+        )
+        if primary_rows >= min_rows and non_primary_rows_in_seed_window == 0:
+            return {"seeded": 0, "skipped": True}
+
     return backfill_exposure(
         db,
         market,
-        end - timedelta(days=days),
+        start,
         end,
         benchmark_fallback_policy=benchmark_fallback_policy,
     )

--- a/backend/app/services/market_exposure_service.py
+++ b/backend/app/services/market_exposure_service.py
@@ -17,7 +17,7 @@ daily; the Daily Snapshot payloads (live + static) call ``build_exposure_payload
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Any, Optional
+from typing import Optional
 
 import pandas as pd
 from sqlalchemy.orm import Session
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 from ..models.market_breadth import MarketBreadth
 from ..models.market_exposure import MarketExposure
 from ..models.stock import StockPrice
+from .benchmark_cache_service import BenchmarkFallbackPolicy
 
 # --- Distribution day detection -------------------------------------------
 DISTRIBUTION_LOOKBACK = 25       # rolling sessions
@@ -284,7 +285,7 @@ def compute_exposure(
     as_of_date: date,
     db: Session,
     *,
-    allow_benchmark_fallback: bool = True,
+    benchmark_fallback_policy: BenchmarkFallbackPolicy = BenchmarkFallbackPolicy.ALLOW,
 ) -> dict:
     """Compute the exposure dict for one market as of ``as_of_date``.
 
@@ -297,10 +298,11 @@ def compute_exposure(
     # db (it closes the session in a finally block).
     from .benchmark_cache_service import BenchmarkCacheService
 
-    benchmark_kwargs: dict[str, Any] = {"market": market, "period": "2y"}
-    if not allow_benchmark_fallback:
-        benchmark_kwargs["allow_fallback"] = False
-    bundle = BenchmarkCacheService().get_benchmark_bundle(**benchmark_kwargs)
+    bundle = BenchmarkCacheService().get_benchmark_bundle(
+        market=market,
+        period="2y",
+        fallback_policy=benchmark_fallback_policy,
+    )
     if bundle is None or bundle.data is None or bundle.data.empty:
         return {"error": "no_benchmark_data", "market": market, "date": as_of_date.isoformat()}
 
@@ -346,7 +348,7 @@ def compute_and_store(
     as_of_date: date,
     db: Session,
     *,
-    allow_benchmark_fallback: bool = True,
+    benchmark_fallback_policy: BenchmarkFallbackPolicy = BenchmarkFallbackPolicy.ALLOW,
 ) -> dict:
     """Compute and upsert one MarketExposure row by (date, market).
 
@@ -354,10 +356,12 @@ def compute_and_store(
     columns (including market/date), so it is applied directly — there is no
     separate field mapping to keep in sync as the model grows.
     """
-    compute_kwargs: dict[str, Any] = {}
-    if not allow_benchmark_fallback:
-        compute_kwargs["allow_benchmark_fallback"] = False
-    result = compute_exposure(market, as_of_date, db, **compute_kwargs)
+    result = compute_exposure(
+        market,
+        as_of_date,
+        db,
+        benchmark_fallback_policy=benchmark_fallback_policy,
+    )
     if result.get("error"):
         return result
 
@@ -381,14 +385,16 @@ def refresh_market_exposure_for_date(
     as_of_date: date,
     *,
     seed_history: bool = True,
-    allow_benchmark_fallback: bool = True,
+    benchmark_fallback_policy: BenchmarkFallbackPolicy = BenchmarkFallbackPolicy.ALLOW,
 ) -> dict:
     """Compute/store exposure and run the canonical launch-history self-heal."""
     normalized_market = (market or "US").upper()
-    compute_kwargs: dict[str, Any] = {}
-    if not allow_benchmark_fallback:
-        compute_kwargs["allow_benchmark_fallback"] = False
-    result = compute_and_store(normalized_market, as_of_date, db, **compute_kwargs)
+    result = compute_and_store(
+        normalized_market,
+        as_of_date,
+        db,
+        benchmark_fallback_policy=benchmark_fallback_policy,
+    )
     if result.get("error") or not seed_history:
         return result
 

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -167,6 +167,42 @@ def test_get_benchmark_data_prefers_cached_fallback_before_primary_network_fetch
     assert calls == []
 
 
+def test_get_benchmark_bundle_fetches_primary_when_fallback_disallowed():
+    service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
+    service._redis_client = None
+
+    cached_fallback_df = pd.DataFrame({"Close": [1.0]}, index=pd.to_datetime(["2026-04-10"]))
+    fetched_primary_df = pd.DataFrame({"Close": [2.0]}, index=pd.to_datetime(["2026-04-10"]))
+    fetch_calls = []
+
+    def fake_get_from_db(*, benchmark_symbol, period, market):
+        if benchmark_symbol == "IVV":
+            return cached_fallback_df
+        return None
+
+    def fake_fetch(*, benchmark_symbol, market, period):
+        fetch_calls.append(benchmark_symbol)
+        if benchmark_symbol == "SPY":
+            return fetched_primary_df
+        return pd.DataFrame()
+
+    service._get_from_database = fake_get_from_db  # type: ignore[assignment]
+    service._is_data_fresh = lambda data, market="US", max_age_hours=24: True  # type: ignore[assignment]
+    service._fetch_and_cache_benchmark = fake_fetch  # type: ignore[assignment]
+
+    bundle = service.get_benchmark_bundle(
+        market="US",
+        period="2y",
+        allow_fallback=False,
+    )
+
+    assert bundle is not None
+    assert bundle.benchmark_symbol == "SPY"
+    assert bundle.benchmark_role == "primary"
+    assert bundle.data is fetched_primary_df
+    assert fetch_calls == ["SPY"]
+
+
 def test_get_benchmark_data_skips_stale_redis_hit():
     service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
     service._redis_client = None

--- a/backend/tests/unit/test_benchmark_cache_service.py
+++ b/backend/tests/unit/test_benchmark_cache_service.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from datetime import datetime
 
-from app.services.benchmark_cache_service import BenchmarkCacheService
+from app.services.benchmark_cache_service import BenchmarkCacheService, BenchmarkFallbackPolicy
 import app.services.benchmark_cache_service as benchmark_cache_module
 
 
@@ -167,7 +167,7 @@ def test_get_benchmark_data_prefers_cached_fallback_before_primary_network_fetch
     assert calls == []
 
 
-def test_get_benchmark_bundle_fetches_primary_when_fallback_disallowed():
+def test_get_benchmark_bundle_primary_only_policy_fetches_primary():
     service = BenchmarkCacheService(redis_client=None, session_factory=lambda: None)
     service._redis_client = None
 
@@ -193,12 +193,13 @@ def test_get_benchmark_bundle_fetches_primary_when_fallback_disallowed():
     bundle = service.get_benchmark_bundle(
         market="US",
         period="2y",
-        allow_fallback=False,
+        fallback_policy=BenchmarkFallbackPolicy.PRIMARY_ONLY,
     )
 
     assert bundle is not None
     assert bundle.benchmark_symbol == "SPY"
     assert bundle.benchmark_role == "primary"
+    assert bundle.candidate_symbols == ("SPY",)
     assert bundle.data is fetched_primary_df
     assert fetch_calls == ["SPY"]
 

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -36,52 +36,6 @@ def _stub_static_market_exposure(monkeypatch):
     )
 
 
-def test_compute_static_market_exposure_disallows_us_benchmark_fallback(monkeypatch):
-    calls: list[dict[str, object]] = []
-    db = object()
-
-    @contextmanager
-    def fake_session():
-        yield db
-
-    def fake_refresh(db_arg, market, as_of_date, *, allow_benchmark_fallback=True):
-        calls.append(
-            {
-                "db": db_arg,
-                "market": market,
-                "as_of_date": as_of_date,
-                "allow_benchmark_fallback": allow_benchmark_fallback,
-            }
-        )
-        return {
-            "market": market,
-            "date": as_of_date,
-            "exposure_score": 70.0,
-            "benchmark_symbol": "SPY",
-        }
-
-    monkeypatch.setattr(export_script, "SessionLocal", fake_session)
-    monkeypatch.setattr(
-        "app.services.market_exposure_service.refresh_market_exposure_for_date",
-        fake_refresh,
-    )
-
-    result = export_script._compute_static_market_exposure(  # noqa: SLF001
-        as_of_date=date(2026, 7, 1),
-        market="US",
-    )
-
-    assert result["benchmark_symbol"] == "SPY"
-    assert calls == [
-        {
-            "db": db,
-            "market": "US",
-            "as_of_date": date(2026, 7, 1),
-            "allow_benchmark_fallback": False,
-        }
-    ]
-
-
 def test_ensure_group_rank_history_uses_market_calendar_for_non_us_market(monkeypatch):
     query = MagicMock()
     query.filter.return_value = query

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -36,6 +36,52 @@ def _stub_static_market_exposure(monkeypatch):
     )
 
 
+def test_compute_static_market_exposure_disallows_us_benchmark_fallback(monkeypatch):
+    calls: list[dict[str, object]] = []
+    db = object()
+
+    @contextmanager
+    def fake_session():
+        yield db
+
+    def fake_refresh(db_arg, market, as_of_date, *, allow_benchmark_fallback=True):
+        calls.append(
+            {
+                "db": db_arg,
+                "market": market,
+                "as_of_date": as_of_date,
+                "allow_benchmark_fallback": allow_benchmark_fallback,
+            }
+        )
+        return {
+            "market": market,
+            "date": as_of_date,
+            "exposure_score": 70.0,
+            "benchmark_symbol": "SPY",
+        }
+
+    monkeypatch.setattr(export_script, "SessionLocal", fake_session)
+    monkeypatch.setattr(
+        "app.services.market_exposure_service.refresh_market_exposure_for_date",
+        fake_refresh,
+    )
+
+    result = export_script._compute_static_market_exposure(  # noqa: SLF001
+        as_of_date=date(2026, 7, 1),
+        market="US",
+    )
+
+    assert result["benchmark_symbol"] == "SPY"
+    assert calls == [
+        {
+            "db": db,
+            "market": "US",
+            "as_of_date": date(2026, 7, 1),
+            "allow_benchmark_fallback": False,
+        }
+    ]
+
+
 def test_ensure_group_rank_history_uses_market_calendar_for_non_us_market(monkeypatch):
     query = MagicMock()
     query.filter.return_value = query

--- a/backend/tests/unit/test_market_exposure_service.py
+++ b/backend/tests/unit/test_market_exposure_service.py
@@ -105,6 +105,42 @@ def _fake_benchmark_factory(df, symbol="SPY"):
     return _FakeBenchmarkCacheService
 
 
+def test_refresh_market_exposure_for_date_can_disable_benchmark_fallback(monkeypatch):
+    from app.database import SessionLocal
+
+    calls = []
+    df = _df(list(range(100, 350)), [1000] * 250)
+
+    class _FakeBenchmarkCacheService:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_benchmark_bundle(self, **kwargs):
+            calls.append(kwargs)
+            return _FakeBundle(df, "SPY")
+
+    monkeypatch.setattr(
+        "app.services.benchmark_cache_service.BenchmarkCacheService",
+        _FakeBenchmarkCacheService,
+    )
+
+    as_of = df.index[-1].date()
+    db = SessionLocal()
+    try:
+        result = refresh_market_exposure_for_date(
+            db,
+            "us",
+            as_of,
+            seed_history=False,
+            allow_benchmark_fallback=False,
+        )
+        assert "error" not in result
+        assert result["benchmark_symbol"] == "SPY"
+        assert calls == [{"market": "US", "period": "2y", "allow_fallback": False}]
+    finally:
+        db.close()
+
+
 def test_compute_and_store_round_trip_validates_against_schema(monkeypatch):
     from app.database import SessionLocal
     from app.models.market_exposure import MarketExposure

--- a/backend/tests/unit/test_market_exposure_service.py
+++ b/backend/tests/unit/test_market_exposure_service.py
@@ -320,6 +320,9 @@ def test_ensure_exposure_history_rebuilds_non_primary_history_for_primary_only_p
         benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
     ):
         calls.append((db_arg, market, start, end_arg, benchmark_fallback_policy))
+        for row in db_arg.query(MarketExposure).filter(MarketExposure.market == market).all():
+            row.benchmark_symbol = "SPY"
+        db_arg.commit()
         return {"seeded": 2, "failed": 0}
 
     monkeypatch.setattr(svc, "backfill_exposure", fake_backfill)
@@ -366,6 +369,105 @@ def test_ensure_exposure_history_rebuilds_non_primary_history_for_primary_only_p
             BenchmarkFallbackPolicy.PRIMARY_ONLY,
         )
     ]
+
+
+def test_ensure_exposure_history_reports_error_when_strict_rebuild_leaves_non_primary_rows(monkeypatch):
+    from app.database import SessionLocal
+    from app.models.market_exposure import MarketExposure
+    from app.services.market_calendar_service import MarketCalendarService
+
+    end = date(2026, 6, 25)
+
+    monkeypatch.setattr(
+        MarketCalendarService,
+        "last_completed_trading_day",
+        lambda self, market: end,
+    )
+
+    def fake_backfill(
+        db_arg,
+        market,
+        start,
+        end_arg,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
+        return {"seeded": 0, "failed": 1}
+
+    monkeypatch.setattr(svc, "backfill_exposure", fake_backfill)
+
+    db = SessionLocal()
+    try:
+        db.add(
+            MarketExposure(
+                market="US",
+                date=date(2026, 6, 24),
+                exposure_score=71.0,
+                stance="Confirmed Uptrend",
+                benchmark_symbol="IVV",
+            )
+        )
+        db.commit()
+
+        result = svc.ensure_exposure_history(
+            db,
+            "US",
+            min_rows=1,
+            days=12,
+            benchmark_fallback_policy=BenchmarkFallbackPolicy.PRIMARY_ONLY,
+        )
+    finally:
+        db.close()
+
+    assert result["error"] == "strict_benchmark_history_incomplete"
+    assert result["failed"] == 1
+    assert result["non_primary_benchmark_rows"] == 1
+    assert result["primary_benchmark_symbol"] == "SPY"
+
+
+def test_refresh_market_exposure_for_date_promotes_strict_history_seed_error(monkeypatch):
+    db = object()
+    as_of = date(2026, 6, 25)
+    history_seed = {
+        "error": "strict_benchmark_history_incomplete",
+        "failed": 1,
+        "non_primary_benchmark_rows": 1,
+    }
+
+    def fake_compute(
+        market,
+        as_of_date,
+        db_arg,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
+        return {
+            "market": market,
+            "date": as_of_date,
+            "exposure_score": 78.0,
+            "stance": "Confirmed Uptrend",
+        }
+
+    def fake_seed(
+        db_arg,
+        market,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
+        return history_seed
+
+    monkeypatch.setattr(svc, "compute_and_store", fake_compute)
+    monkeypatch.setattr(svc, "ensure_exposure_history", fake_seed)
+
+    result = refresh_market_exposure_for_date(
+        db,
+        "us",
+        as_of,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.PRIMARY_ONLY,
+    )
+
+    assert result["error"] == "strict_benchmark_history_incomplete"
+    assert result["history_seed"] == history_seed
 
 
 def test_compute_and_store_round_trip_validates_against_schema(monkeypatch):

--- a/backend/tests/unit/test_market_exposure_service.py
+++ b/backend/tests/unit/test_market_exposure_service.py
@@ -8,6 +8,7 @@ from app.services.benchmark_cache_service import BenchmarkFallbackPolicy
 from app.services.market_exposure_service import (
     CAP_BELOW_200DMA,
     CAP_HEAVY_DISTRIBUTION,
+    backfill_exposure,
     build_exposure_payload,
     compute_and_store,
     count_distribution_days,
@@ -160,6 +161,142 @@ def test_refresh_market_exposure_for_date_can_use_primary_only_benchmark_policy(
         db.close()
 
 
+def test_refresh_market_exposure_for_date_seeds_history_with_same_benchmark_policy(monkeypatch):
+    db = object()
+    as_of = date(2026, 6, 25)
+    calls: list[tuple] = []
+
+    def fake_compute(
+        market,
+        as_of_date,
+        db_arg,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
+        calls.append(("compute", market, as_of_date, db_arg, benchmark_fallback_policy))
+        return {
+            "market": market,
+            "date": as_of_date,
+            "exposure_score": 78.0,
+            "stance": "Confirmed Uptrend",
+        }
+
+    def fake_seed(
+        db_arg,
+        market,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
+        calls.append(("seed", db_arg, market, benchmark_fallback_policy))
+        return {"seeded": 4, "failed": 0}
+
+    monkeypatch.setattr(svc, "compute_and_store", fake_compute)
+    monkeypatch.setattr(svc, "ensure_exposure_history", fake_seed)
+
+    result = refresh_market_exposure_for_date(
+        db,
+        "us",
+        as_of,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.PRIMARY_ONLY,
+    )
+
+    assert calls == [
+        ("compute", "US", as_of, db, BenchmarkFallbackPolicy.PRIMARY_ONLY),
+        ("seed", db, "US", BenchmarkFallbackPolicy.PRIMARY_ONLY),
+    ]
+    assert result["history_seed"] == {"seeded": 4, "failed": 0}
+
+
+def test_backfill_exposure_uses_requested_benchmark_policy_for_each_day(monkeypatch):
+    from app.services.market_calendar_service import MarketCalendarService
+
+    days = [date(2026, 6, 24), date(2026, 6, 25)]
+    calls: list[tuple] = []
+    db = object()
+
+    monkeypatch.setattr(
+        MarketCalendarService,
+        "trading_days",
+        lambda self, market, start, end: days,
+    )
+
+    def fake_compute(
+        market,
+        day,
+        db_arg,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
+        calls.append((market, day, db_arg, benchmark_fallback_policy))
+        return {"market": market, "date": day, "exposure_score": 70.0}
+
+    monkeypatch.setattr(svc, "compute_and_store", fake_compute)
+
+    result = backfill_exposure(
+        db,
+        "us",
+        days[0],
+        days[-1],
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.PRIMARY_ONLY,
+    )
+
+    assert result == {"seeded": 2, "failed": 0}
+    assert calls == [
+        ("US", days[0], db, BenchmarkFallbackPolicy.PRIMARY_ONLY),
+        ("US", days[1], db, BenchmarkFallbackPolicy.PRIMARY_ONLY),
+    ]
+
+
+def test_ensure_exposure_history_passes_benchmark_policy_to_backfill(monkeypatch):
+    from app.database import SessionLocal
+    from app.services.market_calendar_service import MarketCalendarService
+
+    end = date(2026, 6, 25)
+    calls: list[tuple] = []
+
+    monkeypatch.setattr(
+        MarketCalendarService,
+        "last_completed_trading_day",
+        lambda self, market: end,
+    )
+
+    def fake_backfill(
+        db_arg,
+        market,
+        start,
+        end_arg,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
+        calls.append((db_arg, market, start, end_arg, benchmark_fallback_policy))
+        return {"seeded": 2, "failed": 0}
+
+    monkeypatch.setattr(svc, "backfill_exposure", fake_backfill)
+
+    db = SessionLocal()
+    try:
+        result = svc.ensure_exposure_history(
+            db,
+            "us",
+            min_rows=2,
+            days=12,
+            benchmark_fallback_policy=BenchmarkFallbackPolicy.PRIMARY_ONLY,
+        )
+    finally:
+        db.close()
+
+    assert result == {"seeded": 2, "failed": 0}
+    assert calls == [
+        (
+            db,
+            "US",
+            date(2026, 6, 13),
+            end,
+            BenchmarkFallbackPolicy.PRIMARY_ONLY,
+        )
+    ]
+
+
 def test_compute_and_store_round_trip_validates_against_schema(monkeypatch):
     from app.database import SessionLocal
     from app.models.market_exposure import MarketExposure
@@ -244,7 +381,12 @@ def test_refresh_market_exposure_for_date_computes_and_seeds_history(monkeypatch
             "stance": "Confirmed Uptrend",
         }
 
-    def fake_seed(db_arg, market):
+    def fake_seed(
+        db_arg,
+        market,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
         calls.append(("seed", db_arg, market))
         return {"seeded": 4, "failed": 0}
 

--- a/backend/tests/unit/test_market_exposure_service.py
+++ b/backend/tests/unit/test_market_exposure_service.py
@@ -297,6 +297,77 @@ def test_ensure_exposure_history_passes_benchmark_policy_to_backfill(monkeypatch
     ]
 
 
+def test_ensure_exposure_history_rebuilds_non_primary_history_for_primary_only_policy(monkeypatch):
+    from app.database import SessionLocal
+    from app.models.market_exposure import MarketExposure
+    from app.services.market_calendar_service import MarketCalendarService
+
+    end = date(2026, 6, 25)
+    calls: list[tuple] = []
+
+    monkeypatch.setattr(
+        MarketCalendarService,
+        "last_completed_trading_day",
+        lambda self, market: end,
+    )
+
+    def fake_backfill(
+        db_arg,
+        market,
+        start,
+        end_arg,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
+        calls.append((db_arg, market, start, end_arg, benchmark_fallback_policy))
+        return {"seeded": 2, "failed": 0}
+
+    monkeypatch.setattr(svc, "backfill_exposure", fake_backfill)
+
+    db = SessionLocal()
+    try:
+        db.add_all(
+            [
+                MarketExposure(
+                    market="US",
+                    date=date(2026, 6, 23),
+                    exposure_score=70.0,
+                    stance="Confirmed Uptrend",
+                    benchmark_symbol="IVV",
+                ),
+                MarketExposure(
+                    market="US",
+                    date=date(2026, 6, 24),
+                    exposure_score=71.0,
+                    stance="Confirmed Uptrend",
+                    benchmark_symbol="IVV",
+                ),
+            ]
+        )
+        db.commit()
+
+        result = svc.ensure_exposure_history(
+            db,
+            "US",
+            min_rows=2,
+            days=12,
+            benchmark_fallback_policy=BenchmarkFallbackPolicy.PRIMARY_ONLY,
+        )
+    finally:
+        db.close()
+
+    assert result == {"seeded": 2, "failed": 0}
+    assert calls == [
+        (
+            db,
+            "US",
+            date(2026, 6, 13),
+            end,
+            BenchmarkFallbackPolicy.PRIMARY_ONLY,
+        )
+    ]
+
+
 def test_compute_and_store_round_trip_validates_against_schema(monkeypatch):
     from app.database import SessionLocal
     from app.models.market_exposure import MarketExposure

--- a/backend/tests/unit/test_market_exposure_service.py
+++ b/backend/tests/unit/test_market_exposure_service.py
@@ -4,6 +4,7 @@ from datetime import date
 import pandas as pd
 
 import app.services.market_exposure_service as svc
+from app.services.benchmark_cache_service import BenchmarkFallbackPolicy
 from app.services.market_exposure_service import (
     CAP_BELOW_200DMA,
     CAP_HEAVY_DISTRIBUTION,
@@ -99,13 +100,19 @@ def _fake_benchmark_factory(df, symbol="SPY"):
         def __init__(self, *a, **k):
             pass
 
-        def get_benchmark_bundle(self, market="US", period="2y", force_refresh=False):
+        def get_benchmark_bundle(
+            self,
+            market="US",
+            period="2y",
+            force_refresh=False,
+            fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+        ):
             return _FakeBundle(df, symbol)
 
     return _FakeBenchmarkCacheService
 
 
-def test_refresh_market_exposure_for_date_can_disable_benchmark_fallback(monkeypatch):
+def test_refresh_market_exposure_for_date_can_use_primary_only_benchmark_policy(monkeypatch):
     from app.database import SessionLocal
 
     calls = []
@@ -115,8 +122,14 @@ def test_refresh_market_exposure_for_date_can_disable_benchmark_fallback(monkeyp
         def __init__(self, *a, **k):
             pass
 
-        def get_benchmark_bundle(self, **kwargs):
-            calls.append(kwargs)
+        def get_benchmark_bundle(self, *, market, period, fallback_policy):
+            calls.append(
+                {
+                    "market": market,
+                    "period": period,
+                    "fallback_policy": fallback_policy,
+                }
+            )
             return _FakeBundle(df, "SPY")
 
     monkeypatch.setattr(
@@ -132,11 +145,17 @@ def test_refresh_market_exposure_for_date_can_disable_benchmark_fallback(monkeyp
             "us",
             as_of,
             seed_history=False,
-            allow_benchmark_fallback=False,
+            benchmark_fallback_policy=BenchmarkFallbackPolicy.PRIMARY_ONLY,
         )
         assert "error" not in result
         assert result["benchmark_symbol"] == "SPY"
-        assert calls == [{"market": "US", "period": "2y", "allow_fallback": False}]
+        assert calls == [
+            {
+                "market": "US",
+                "period": "2y",
+                "fallback_policy": BenchmarkFallbackPolicy.PRIMARY_ONLY,
+            }
+        ]
     finally:
         db.close()
 
@@ -210,7 +229,13 @@ def test_refresh_market_exposure_for_date_computes_and_seeds_history(monkeypatch
     as_of = date(2026, 6, 25)
     calls: list[tuple] = []
 
-    def fake_compute(market, as_of_date, db_arg):
+    def fake_compute(
+        market,
+        as_of_date,
+        db_arg,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
         calls.append(("compute", market, as_of_date, db_arg))
         return {
             "market": market,
@@ -246,7 +271,13 @@ def test_refresh_market_exposure_for_date_does_not_seed_after_compute_error(monk
     as_of = date(2026, 6, 25)
     calls: list[tuple] = []
 
-    def fake_compute(market, as_of_date, db_arg):
+    def fake_compute(
+        market,
+        as_of_date,
+        db_arg,
+        *,
+        benchmark_fallback_policy=BenchmarkFallbackPolicy.ALLOW,
+    ):
         calls.append(("compute", market, as_of_date, db_arg))
         return {"market": market, "date": as_of_date.isoformat(), "error": "no_benchmark_data"}
 

--- a/backend/tests/unit/test_static_export_market_exposure.py
+++ b/backend/tests/unit/test_static_export_market_exposure.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import date
+
+import app.scripts.export_static_site as export_script
+from app.services.benchmark_cache_service import BenchmarkFallbackPolicy
+
+
+def test_compute_static_market_exposure_uses_primary_only_policy_for_us(monkeypatch):
+    calls: list[dict[str, object]] = []
+    db = object()
+
+    @contextmanager
+    def fake_session():
+        yield db
+
+    def fake_refresh(db_arg, market, as_of_date, *, benchmark_fallback_policy):
+        calls.append(
+            {
+                "db": db_arg,
+                "market": market,
+                "as_of_date": as_of_date,
+                "benchmark_fallback_policy": benchmark_fallback_policy,
+            }
+        )
+        return {
+            "market": market,
+            "date": as_of_date,
+            "exposure_score": 70.0,
+            "benchmark_symbol": "SPY",
+        }
+
+    monkeypatch.setattr(export_script, "SessionLocal", fake_session)
+    monkeypatch.setattr(
+        "app.services.market_exposure_service.refresh_market_exposure_for_date",
+        fake_refresh,
+    )
+
+    result = export_script._compute_static_market_exposure(  # noqa: SLF001
+        as_of_date=date(2026, 7, 1),
+        market="us",
+    )
+
+    assert result["benchmark_symbol"] == "SPY"
+    assert calls == [
+        {
+            "db": db,
+            "market": "US",
+            "as_of_date": date(2026, 7, 1),
+            "benchmark_fallback_policy": BenchmarkFallbackPolicy.PRIMARY_ONLY,
+        }
+    ]
+
+
+def test_compute_static_market_exposure_allows_fallback_policy_for_non_us(monkeypatch):
+    calls: list[dict[str, object]] = []
+    db = object()
+
+    @contextmanager
+    def fake_session():
+        yield db
+
+    def fake_refresh(db_arg, market, as_of_date, *, benchmark_fallback_policy):
+        calls.append(
+            {
+                "db": db_arg,
+                "market": market,
+                "as_of_date": as_of_date,
+                "benchmark_fallback_policy": benchmark_fallback_policy,
+            }
+        )
+        return {
+            "market": market,
+            "date": as_of_date,
+            "exposure_score": 70.0,
+            "benchmark_symbol": "^HSI",
+        }
+
+    monkeypatch.setattr(export_script, "SessionLocal", fake_session)
+    monkeypatch.setattr(
+        "app.services.market_exposure_service.refresh_market_exposure_for_date",
+        fake_refresh,
+    )
+
+    result = export_script._compute_static_market_exposure(  # noqa: SLF001
+        as_of_date=date(2026, 7, 1),
+        market="hk",
+    )
+
+    assert result["benchmark_symbol"] == "^HSI"
+    assert calls == [
+        {
+            "db": db,
+            "market": "HK",
+            "as_of_date": date(2026, 7, 1),
+            "benchmark_fallback_policy": BenchmarkFallbackPolicy.ALLOW,
+        }
+    ]


### PR DESCRIPTION
## Summary

- Require static US market health/exposure to use the primary SPY benchmark only.
- Add an explicit `BenchmarkFallbackPolicy` so strict benchmark selection is a named contract instead of a boolean or ad-hoc kwargs path.
- Keep default/live and non-US benchmark fallback behavior unchanged.
- Split static exposure policy tests into a focused unit test module.

## Root Cause

Static US exposure reused the general benchmark cache behavior, which could accept a fresh cached IVV fallback before retrying or fetching missing SPY data. That allowed static market health/exposure to diverge from paths that depended on SPY for RS calculations.

## Validation

- `backend/venv/bin/python -m pytest backend/tests/unit/test_benchmark_cache_service.py backend/tests/unit/test_market_exposure_service.py backend/tests/unit/test_export_static_site_script.py backend/tests/unit/test_static_export_market_exposure.py -q`
- Result: `59 passed, 19 warnings`

## Notes

`bd dolt push` could not run because the local Dolt issue DB has no `origin` remote configured. Git branch `codex/static-spy-exposure` is pushed and up to date on origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable benchmark fallback handling via a new benchmark fallback policy (default: allow) across market exposure computation and static export.
  * US uses a primary-only benchmark fallback; other markets retain allow-fallback behavior.

* **Bug Fixes**
  * Improved market normalization to ensure the correct fallback policy is applied consistently.

* **Tests**
  * Added unit tests verifying primary-only candidate selection and end-to-end policy propagation through refresh, backfill, and static export flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->