### PR TITLE
Use OS temporary directory for IBD classification sync

### DIFF
--- a/backend/app/services/ibd_classification_bundle.py
+++ b/backend/app/services/ibd_classification_bundle.py
@@ -221,9 +221,9 @@ def sync_ibd_classification_from_github(
             return {"market": normalized_market, "status": status, "imported": None, "reason": reason}
 
         # The downloaded bundle is transient: read it, import, then delete it so
-        # long-lived live workers don't accumulate one gzip per market per run.
-        # (DailyPriceBundleService uses a temp dir + rmtree; here output_dir is
-        # shared/default, so we unlink just this run's file.)
+        # long-lived workers don't accumulate one gzip per market per run.
+        # Auto-created temporary output directories are cleaned up in the outer
+        # finally block, matching the DailyPriceBundleService pattern.
         bundle_path = Path(result["bundle_path"])
         try:
             payload = read_bundle(bundle_path)

--- a/backend/app/services/ibd_classification_bundle.py
+++ b/backend/app/services/ibd_classification_bundle.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import gzip
 import hashlib
 import json
+import shutil
+import tempfile
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -191,44 +193,56 @@ def sync_ibd_classification_from_github(
     sync_service = github_sync_service or GitHubReleaseSyncService(
         api_base=settings.github_data_api_base
     )
-    result = sync_service.fetch_latest_bundle(
-        repository_full_name=settings.github_data_repository,
-        release_tag=RELEASE_TAG,
-        manifest_asset_name=latest_manifest_name(normalized_market),
-        source_mode=settings.market_data_source_mode,
-        expected_manifest_schema=IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION,
-        required_manifest_keys=("bundle_asset_name", "sha256"),
-        allow_stale=allow_stale,
-        github_token=settings.github_data_token,
-        request_timeout_seconds=settings.github_data_timeout_seconds,
-        output_dir=output_dir or str(Path(".tmp") / "ibd-classification"),
-    )
+    cleanup_download_dir = False
 
-    status = result.get("status")
-    if status != "success":
-        reason = result.get("reason") or result.get("stale_reason") or result.get("error")
-        return {"market": normalized_market, "status": status, "imported": None, "reason": reason}
+    if output_dir is None:
+        download_dir = Path(tempfile.mkdtemp(...))
+        cleanup_download_dir = True
+    else:
+        download_dir = Path(output_dir)
 
-    # The downloaded bundle is transient: read it, import, then delete it so
-    # long-lived live workers don't accumulate one gzip per market per run.
-    # (DailyPriceBundleService uses a temp dir + rmtree; here output_dir is
-    # shared/default, so we unlink just this run's file.)
-    bundle_path = Path(result["bundle_path"])
     try:
-        payload = read_bundle(bundle_path)
-        # Guard the download/trust boundary: the manifest asset is market-specific,
-        # so a market mismatch means a mispublished bundle. Mirror
-        # DailyPriceBundleService.sync_from_github, which rejects the same case.
-        payload_market = str(payload.get("market") or "").strip().upper()
-        if payload_market and payload_market != normalized_market:
-            return {
-                "market": normalized_market,
-                "status": "market_mismatch",
-                "imported": None,
-                "reason": f"bundle market {payload_market!r} does not match requested {normalized_market!r}",
-            }
+        result = sync_service.fetch_latest_bundle(
+            repository_full_name=settings.github_data_repository,
+            release_tag=RELEASE_TAG,
+            manifest_asset_name=latest_manifest_name(normalized_market),
+            source_mode=settings.market_data_source_mode,
+            expected_manifest_schema=IBD_CLASSIFICATION_MANIFEST_SCHEMA_VERSION,
+            required_manifest_keys=("bundle_asset_name", "sha256"),
+            allow_stale=allow_stale,
+            github_token=settings.github_data_token,
+            request_timeout_seconds=settings.github_data_timeout_seconds,
+            output_dir=download_dir,
+        )
 
-        stats = import_classifications(db, payload)
-        return {"market": normalized_market, "status": status, "imported": stats, "reason": None}
+        status = result.get("status")
+        if status != "success":
+            reason = result.get("reason") or result.get("stale_reason") or result.get("error")
+            return {"market": normalized_market, "status": status, "imported": None, "reason": reason}
+
+        # The downloaded bundle is transient: read it, import, then delete it so
+        # long-lived live workers don't accumulate one gzip per market per run.
+        # (DailyPriceBundleService uses a temp dir + rmtree; here output_dir is
+        # shared/default, so we unlink just this run's file.)
+        bundle_path = Path(result["bundle_path"])
+        try:
+            payload = read_bundle(bundle_path)
+            # Guard the download/trust boundary: the manifest asset is market-specific,
+            # so a market mismatch means a mispublished bundle. Mirror
+            # DailyPriceBundleService.sync_from_github, which rejects the same case.
+            payload_market = str(payload.get("market") or "").strip().upper()
+            if payload_market and payload_market != normalized_market:
+                return {
+                    "market": normalized_market,
+                    "status": "market_mismatch",
+                    "imported": None,
+                    "reason": f"bundle market {payload_market!r} does not match requested {normalized_market!r}",
+                }
+
+            stats = import_classifications(db, payload)
+            return {"market": normalized_market, "status": status, "imported": stats, "reason": None}
+        finally:
+            bundle_path.unlink(missing_ok=True)
     finally:
-        bundle_path.unlink(missing_ok=True)
+        if cleanup_download_dir:
+            shutil.rmtree(download_dir, ignore_errors=True)

--- a/backend/app/services/ibd_classification_bundle.py
+++ b/backend/app/services/ibd_classification_bundle.py
@@ -196,7 +196,9 @@ def sync_ibd_classification_from_github(
     cleanup_download_dir = False
 
     if output_dir is None:
-        download_dir = Path(tempfile.mkdtemp(...))
+        download_dir = Path(
+            tempfile.mkdtemp(prefix=f"ibd-classification-{normalized_market.lower()}-")
+        )
         cleanup_download_dir = True
     else:
         download_dir = Path(output_dir)

--- a/backend/tests/unit/test_ibd_classification_sync_task.py
+++ b/backend/tests/unit/test_ibd_classification_sync_task.py
@@ -7,7 +7,6 @@ boundary injected) and the Celery task that delegates to it.
 from __future__ import annotations
 
 import pytest
-
 from app.services import ibd_classification_bundle as bundle
 
 
@@ -131,7 +130,7 @@ def test_sync_preserves_caller_output_dir(tmp_path, monkeypatch):
     )
 
     assert out["status"] == "success"
-    assert fake.calls[0]["output_dir"] == str(output_dir)
+    assert fake.calls[0]["output_dir"] == output_dir
     assert output_dir.exists()
     assert not bundle_file.exists()
 

--- a/backend/tests/unit/test_ibd_classification_sync_task.py
+++ b/backend/tests/unit/test_ibd_classification_sync_task.py
@@ -16,8 +16,10 @@ class _FakeSyncService:
 
     def __init__(self, result: dict):
         self._result = result
+        self.calls = []
 
     def fetch_latest_bundle(self, **kwargs):
+        self.calls.append(kwargs)
         return self._result
 
 
@@ -83,6 +85,54 @@ def test_sync_unlinks_bundle_after_import(tmp_path, monkeypatch):
     )
 
     assert out["status"] == "success"
+    assert not bundle_file.exists()
+
+
+def test_sync_uses_and_cleans_auto_temp_download_dir(tmp_path, monkeypatch):
+    """The default runtime path is an OS temp dir, not .tmp under the app root."""
+    download_dir = tmp_path / "ibd-download"
+    bundle_file = download_dir / "ibd-classification-us.json.gz"
+
+    def _mkdtemp(prefix):
+        assert prefix == "ibd-classification-us-"
+        download_dir.mkdir()
+        bundle_file.write_bytes(b"gz")
+        return str(download_dir)
+
+    fake = _FakeSyncService({"status": "success", "bundle_path": str(bundle_file)})
+    monkeypatch.setattr(bundle.tempfile, "mkdtemp", _mkdtemp)
+    monkeypatch.setattr(bundle, "read_bundle", lambda _path: {"classifications": []})
+    monkeypatch.setattr(bundle, "import_classifications", lambda _db, _payload: {"inserted": 0})
+
+    out = bundle.sync_ibd_classification_from_github(
+        db=object(), market="US", github_sync_service=fake
+    )
+
+    assert out["status"] == "success"
+    assert fake.calls[0]["output_dir"] == download_dir
+    assert not download_dir.exists()
+
+
+def test_sync_preserves_caller_output_dir(tmp_path, monkeypatch):
+    """Explicit output_dir remains caller-owned and is not removed."""
+    output_dir = tmp_path / "caller-owned"
+    output_dir.mkdir()
+    bundle_file = output_dir / "ibd-classification-us.json.gz"
+    bundle_file.write_bytes(b"gz")
+    fake = _FakeSyncService({"status": "success", "bundle_path": str(bundle_file)})
+    monkeypatch.setattr(bundle, "read_bundle", lambda _path: {"classifications": []})
+    monkeypatch.setattr(bundle, "import_classifications", lambda _db, _payload: {"inserted": 0})
+
+    out = bundle.sync_ibd_classification_from_github(
+        db=object(),
+        market="US",
+        output_dir=str(output_dir),
+        github_sync_service=fake,
+    )
+
+    assert out["status"] == "success"
+    assert fake.calls[0]["output_dir"] == str(output_dir)
+    assert output_dir.exists()
     assert not bundle_file.exists()
 
 


### PR DESCRIPTION
## Summary

Update the IBD classification runtime sync to use an OS temporary directory when no `output_dir` is provided, matching the existing pattern used by the Daily Price and Weekly Reference bundle synchronization services.

Fix #290 

## Changes

* Use `tempfile.mkdtemp()` to create a temporary working directory when `output_dir` is not supplied.
* Pass the temporary directory to `GitHubReleaseSyncService.fetch_latest_bundle()`.
* Clean up the auto-created temporary directory in a `finally` block using `shutil.rmtree(..., ignore_errors=True)`.
* Preserve the existing behavior when `output_dir` is explicitly provided by the caller.

## Motivation

The previous implementation defaulted to:

```text
.tmp/ibd-classification
```

When running inside the Dockerized Stock Screener, this resolves to `/app/.tmp/ibd-classification`. Since the application runs as the non-root `stockscanner` user and `/app` is not writable, the Celery task failed with:

```text
PermissionError: [Errno 13] Permission denied: '.tmp'
```

This change brings the IBD classification sync in line with the existing runtime bundle synchronization pattern already used elsewhere in the project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IBD classification bundle syncing to manage temporary download folders automatically when no download directory is provided.
  * Preserves caller-specified download directories after syncing, while still removing the downloaded bundle file itself.
* **Tests**
  * Updated unit tests to verify the exact download directory passed during bundle fetches.
  * Added coverage to confirm auto temp directory cleanup vs. caller directory preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->