### PR TITLE
docs: clarify Celery Beat timezone configuration

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -135,8 +135,47 @@ REDIS_PORT=6379
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
 
-# Celery Beat timezone for scheduled tasks (IANA format)
-# All schedule hours (cache_warm_hour, etc.) are written in this timezone
+# ---------------------------------------------------------------------------
+# Celery Beat Scheduling Timezone
+# ---------------------------------------------------------------------------
+#
+# IMPORTANT:
+# This is the timezone used by Celery Beat when evaluating ALL `crontab(...)`
+# schedules. It is NOT the operating system timezone.
+#
+# Example:
+#
+#     timezone = "America/New_York"
+#     crontab(hour=16, minute=30)
+#
+# means:
+#
+#     Run at 4:30 PM New York time
+#
+# regardless of where this server is physically located. Celery automatically
+# converts between the configured timezone and the server's local clock,
+# including Daylight Saving Time (DST) transitions.
+#
+# This application schedules most business events relative to the U.S. stock
+# market (market close, weekly fundamentals, universe refreshes, etc.), which
+# are defined in Eastern Time.
+#
+# Therefore this setting should normally remain:
+#
+#     CELERY_TIMEZONE=America/New_York
+#
+# Do NOT change this to match the server's physical location (for example
+# Europe/Luxembourg) unless the entire scheduling model of the application is
+# intentionally being redesigned. Changing this value changes when every
+# scheduled task executes.
+#
+# Celery documentation:
+#   - Configuration → Time and Date Settings
+#     https://docs.celeryq.dev/en/stable/userguide/configuration.html
+#
+#   - Periodic Tasks → Time Zones
+#     https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html
+# ---------------------------------------------------------------------------
 CELERY_TIMEZONE=America/New_York
 
 # Server binding (internal, nginx handles external)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -108,8 +108,47 @@ REDIS_PORT=6379
 CELERY_BROKER_URL=redis://localhost:6379/0
 CELERY_RESULT_BACKEND=redis://localhost:6379/1
 
-# Celery Beat timezone for scheduled tasks (IANA format)
-# All schedule hours (cache_warm_hour, etc.) are written in this timezone
+# ---------------------------------------------------------------------------
+# Celery Beat Scheduling Timezone
+# ---------------------------------------------------------------------------
+#
+# IMPORTANT:
+# This is the timezone used by Celery Beat when evaluating ALL `crontab(...)`
+# schedules. It is NOT the operating system timezone.
+#
+# Example:
+#
+#     timezone = "America/New_York"
+#     crontab(hour=16, minute=30)
+#
+# means:
+#
+#     Run at 4:30 PM New York time
+#
+# regardless of where this server is physically located. Celery automatically
+# converts between the configured timezone and the server's local clock,
+# including Daylight Saving Time (DST) transitions.
+#
+# This application schedules most business events relative to the U.S. stock
+# market (market close, weekly fundamentals, universe refreshes, etc.), which
+# are defined in Eastern Time.
+#
+# Therefore this setting should normally remain:
+#
+#     CELERY_TIMEZONE=America/New_York
+#
+# Do NOT change this to match the server's physical location (for example
+# Europe/Luxembourg) unless the entire scheduling model of the application is
+# intentionally being redesigned. Changing this value changes when every
+# scheduled task executes.
+#
+# Celery documentation:
+#   - Configuration → Time and Date Settings
+#     https://docs.celeryq.dev/en/stable/userguide/configuration.html
+#
+#   - Periodic Tasks → Time Zones
+#     https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html
+# ---------------------------------------------------------------------------
 CELERY_TIMEZONE=America/New_York
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Clarify how `CELERY_TIMEZONE` affects Celery Beat scheduling and document why this project intentionally uses `America/New_York`.

This change adds documentation explaining that Celery Beat evaluates all `crontab(...)` schedules using the configured Celery timezone, **not** the operating system timezone. The comments also include links to the relevant Celery documentation.

## Background

While investigating scheduling behavior, it became clear that the purpose of CELERY_TIMEZONE could easily be misunderstood.

Celery Beat evaluates crontab(...) schedules using the configured Celery timezone rather than the host operating system timezone. Because this project schedules most business events relative to U.S. market hours, America/New_York is the intended configuration.

For this project, the majority of scheduled jobs are intentionally aligned with U.S. market hours (market close, weekly fundamentals refresh, cache refreshes, etc.), so the scheduler should remain configured for Eastern Time.

## What changed

- Added explanatory comments describing how Celery Beat interprets scheduled tasks.
- Clarified that `CELERY_TIMEZONE` is a business scheduling timezone, **not** the server timezone.
- Documented why the project intentionally uses `America/New_York`.
- Added links to the relevant Celery documentation.

## Validation

Verified by changing the scheduler timezone to `America/New_York` and confirming:

- Weekly Fundamental Refresh scheduled for **Friday 8:00 PM ET** executed at **02:00 Saturday** in Central Europe Timezone (during daylight saving time).
- Celery Beat correctly evaluated `crontab(...)` schedules relative to Eastern Time.
- Docker Compose, container environment, and Celery Beat all reported the expected timezone.

## References

Celery documentation:

- https://docs.celeryq.dev/en/latest/userguide/periodic-tasks.html
- https://docs.celeryq.dev/en/stable/userguide/configuration.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded environment configuration guidance for scheduled task timezones.
  * Clarified how `CELERY_TIMEZONE` affects recurring schedules, daylight saving time, and execution times.
  * Documented the application’s Eastern Time scheduling convention and advised against changing the setting based on server location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->