### PR TITLE
fix(celery): generate Beat schedules from enabled markets

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -334,7 +334,16 @@ celery_app.conf.result_expires = 86400  # Results expire after 24 hours
 
 # Celery Beat Schedule - Periodic Tasks
 if settings.cache_warmup_enabled:
-    _enabled_markets = list(SUPPORTED_MARKETS)
+
+    # Build the list of enabled markets from the runtime configuration.
+    # The setting is stored as a comma-separated string. Converting it
+    # to a list ensures the scheduler iterates over market codes
+    # (["US", "AU"]) rather than individual characters ("U", "S").
+    _enabled_markets = [
+        m.strip()
+        for m in settings.enabled_markets.split(",")
+        if m.strip()
+    ]
     beat_schedule: dict = {}
 
     for _market in _enabled_markets:

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -335,15 +335,10 @@ celery_app.conf.result_expires = 86400  # Results expire after 24 hours
 # Celery Beat Schedule - Periodic Tasks
 if settings.cache_warmup_enabled:
 
-    # Build the list of enabled markets from the runtime configuration.
-    # The setting is stored as a comma-separated string. Converting it
-    # to a list ensures the scheduler iterates over market codes
-    # (["US", "AU"]) rather than individual characters ("U", "S").
-    _enabled_markets = [
-        m.strip()
-        for m in settings.enabled_markets.split(",")
-        if m.strip()
-    ]
+    # Use the canonical list of enabled markets from the runtime configuration.
+    # The settings property handles parsing and validation.
+    _enabled_markets = settings.enabled_markets_list
+
     beat_schedule: dict = {}
 
     for _market in _enabled_markets:

--- a/backend/tests/unit/test_beat_schedule_fanout.py
+++ b/backend/tests/unit/test_beat_schedule_fanout.py
@@ -81,13 +81,21 @@ class TestBeatScheduleFanout:
 
     def test_weekly_universe_refresh_uses_market_appropriate_task(self):
         schedule = celery_app.conf.beat_schedule or {}
-        assert schedule["weekly-universe-refresh-us"]["task"] == (
-            "app.tasks.universe_tasks.refresh_stock_universe"
-        )
-        for market in (m.lower() for m in settings.enabled_markets_list if m != "US"):
+
+        if "US" in settings.enabled_markets_list:
+            assert schedule["weekly-universe-refresh-us"]["task"] == (
+                "app.tasks.universe_tasks.refresh_stock_universe"
+            )
+
+        for market in (
+            m.lower()
+            for m in settings.enabled_markets_list
+            if m != "US"
+        ):
             assert schedule[f"weekly-universe-refresh-{market}"]["task"] == (
                 "app.tasks.universe_tasks.refresh_official_market_universe"
             )
+        
 
     def test_independent_daily_refresh_compute_and_snapshot_entries_are_removed(self):
         schedule = celery_app.conf.beat_schedule or {}

--- a/backend/tests/unit/test_beat_schedule_fanout.py
+++ b/backend/tests/unit/test_beat_schedule_fanout.py
@@ -7,14 +7,12 @@ check it's easy for a new beat entry to silently land on the shared queue.
 from __future__ import annotations
 
 import pytest
-
 from app.celery_app import celery_app
+from app.config import settings
 from app.tasks.market_queues import (
-    SUPPORTED_MARKETS,
     data_fetch_queue_for_market,
     market_jobs_queue_for_market,
 )
-
 
 # Beat entry name prefixes that MUST be fanned out per market onto the
 # external-fetch lane.
@@ -65,7 +63,7 @@ class TestBeatScheduleFanout:
                 for name in schedule
                 if name.startswith(prefix)
             }
-            for m in SUPPORTED_MARKETS:
+            for m in settings.enabled_markets_list:
                 assert m in present, (
                     f"No beat entry for market {m!r} with prefix {prefix!r}. "
                     f"Fan-out gap: got {sorted(present)}"
@@ -86,14 +84,14 @@ class TestBeatScheduleFanout:
         assert schedule["weekly-universe-refresh-us"]["task"] == (
             "app.tasks.universe_tasks.refresh_stock_universe"
         )
-        for market in (m.lower() for m in SUPPORTED_MARKETS if m != "US"):
+        for market in (m.lower() for m in settings.enabled_markets_list if m != "US"):
             assert schedule[f"weekly-universe-refresh-{market}"]["task"] == (
                 "app.tasks.universe_tasks.refresh_official_market_universe"
             )
 
     def test_independent_daily_refresh_compute_and_snapshot_entries_are_removed(self):
         schedule = celery_app.conf.beat_schedule or {}
-        for market in SUPPORTED_MARKETS:
+        for market in settings.enabled_markets_list:
             m_lower = market.lower()
             assert f"daily-smart-refresh-{m_lower}" not in schedule
             assert f"daily-breadth-calculation-{m_lower}" not in schedule


### PR DESCRIPTION
## Summary

Update Celery Beat to generate market-specific schedules from the configured
`ENABLED_MARKETS` setting instead of all supported markets.

The scheduler now parses the comma-separated runtime configuration into a list
of market codes before constructing Beat schedules.

This ensures that only configured markets receive scheduled jobs.

#304 

## Problem

Previously, Beat generated schedules using `SUPPORTED_MARKETS`, which caused
scheduled jobs to be created for every supported market regardless of the
deployment configuration.

When switching to `settings.enabled_markets`, a second issue became apparent:
the setting is stored as a comma-separated string, so iterating over it treated
each character as a separate market (e.g. `"U"`, `"S"` instead of `"US"`).

## Solution

Parse `ENABLED_MARKETS` into a list of market codes before building Beat
schedules.

Example:

ENABLED_MARKETS=US

↓

["US"]

Example:

ENABLED_MARKETS=US,AU

↓

["US", "AU"]

Beat now generates schedules only for the configured markets.

## Validation

Validated using both single-market and multi-market configurations.

### ENABLED_MARKETS=US

- Runtime configuration correctly reports `US`
- Daily market schedule created only for `US`
- Weekly market-specific jobs created only for `US`
- No orphan market schedules generated

### ENABLED_MARKETS=US,AU

- Runtime configuration correctly reports `US,AU`
- Daily market schedules created for:
  - US
  - AU
- Weekly market-specific jobs created for:
  - US
  - AU
- Beat references only enabled markets
- Market workers correctly listen on:
  - `market_jobs_us`
  - `market_jobs_au`

## Result

- Beat now honors the runtime market configuration.
- No unnecessary schedules are created for disabled markets.
- Scheduler behavior is aligned with the deployed worker topology.
- Both single-market and multi-market deployments have been verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Market scheduled tasks (daily and weekly beat entries) now run only for markets explicitly enabled via runtime application configuration, rather than all supported markets.

* **Tests**
  * Updated beat schedule fan-out tests to validate expectations based on the enabled-market list from runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->