### PR TITLE
fix: align bootstrap derived data readiness

### DIFF
--- a/backend/app/domain/bootstrap/plan.py
+++ b/backend/app/domain/bootstrap/plan.py
@@ -136,6 +136,7 @@ def _build_market_plan(market: str) -> MarketBootstrapPlan:
                 operation=BootstrapOperation.CALCULATE_DAILY_BREADTH_WITH_GAPFILL,
                 queue_kind=BootstrapQueueKind.MARKET_JOBS,
                 market=market,
+                execution_policy="refresh_guarded",
             ),
             _stage(
                 key="exposure",
@@ -148,6 +149,7 @@ def _build_market_plan(market: str) -> MarketBootstrapPlan:
                 operation=BootstrapOperation.CALCULATE_DAILY_GROUP_RANKINGS_WITH_GAPFILL,
                 queue_kind=BootstrapQueueKind.MARKET_JOBS,
                 market=market,
+                execution_policy="refresh_guarded",
             ),
             _stage(
                 key="snapshot",

--- a/backend/app/domain/feature_store/bootstrap_coverage.py
+++ b/backend/app/domain/feature_store/bootstrap_coverage.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from app.domain.markets.price_coverage import (
     PriceCoveragePolicy,
-    price_coverage_policy_for_market,
+    bootstrap_price_coverage_policy_for_market,
 )
 
 
@@ -44,7 +44,7 @@ def normalize_bootstrap_gate_report(
     unsupported_symbols: Sequence[str],
 ) -> dict[str, Any]:
     payload = dict(report or {})
-    policy = price_coverage_policy_for_market(market)
+    policy = bootstrap_price_coverage_policy_for_market(market)
     eligible = _report_meets_policy(payload, policy)
     payload.update(
         {

--- a/backend/app/domain/markets/price_coverage.py
+++ b/backend/app/domain/markets/price_coverage.py
@@ -9,13 +9,14 @@ CACHE_ONLY_MIN_PRICE_COVERAGE = 0.95
 CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE = 0.95
 
 # Thresholds follow observed daily-price static bundle availability, rounded
-# down to conservative five-point floors.
+# down to conservative five-point floors. HK has many listed-but-stale symbols,
+# so its durable bundle coverage currently sits just above 75%.
 PRICE_MIN_COVERAGE_BY_MARKET: dict[str, float] = {
     "AU": 0.90,
     "CA": 0.75,
     "CN": 0.90,
     "DE": 0.90,
-    "HK": 0.80,
+    "HK": 0.75,
     "IN": 0.50,
     "JP": 0.90,
     "KR": 0.95,

--- a/backend/app/domain/markets/price_coverage.py
+++ b/backend/app/domain/markets/price_coverage.py
@@ -8,15 +8,14 @@ from dataclasses import dataclass
 CACHE_ONLY_MIN_PRICE_COVERAGE = 0.95
 CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE = 0.95
 
-# Thresholds follow observed daily-price static bundle availability, rounded
-# down to conservative five-point floors. HK has many listed-but-stale symbols,
-# so its durable bundle coverage currently sits just above 75%.
+# Thresholds follow observed live/cache coverage availability, rounded down to
+# conservative five-point floors.
 PRICE_MIN_COVERAGE_BY_MARKET: dict[str, float] = {
     "AU": 0.90,
     "CA": 0.75,
     "CN": 0.90,
     "DE": 0.90,
-    "HK": 0.75,
+    "HK": 0.80,
     "IN": 0.50,
     "JP": 0.90,
     "KR": 0.95,
@@ -24,6 +23,13 @@ PRICE_MIN_COVERAGE_BY_MARKET: dict[str, float] = {
     "SG": 0.60,
     "TW": 0.50,
     "US": 0.95,
+}
+
+BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET: dict[str, float] = {
+    **PRICE_MIN_COVERAGE_BY_MARKET,
+    # HK has many listed-but-stale symbols, so its durable GitHub bundle
+    # coverage currently sits just above 75% during first-run bootstrap.
+    "HK": 0.75,
 }
 
 
@@ -38,11 +44,15 @@ def normalize_market_code(market: str | None) -> str:
     return str(market or "US").strip().upper() or "US"
 
 
-def price_coverage_policy_for_market(market: str | None) -> PriceCoveragePolicy:
+def _price_coverage_policy_for_market(
+    market: str | None,
+    *,
+    price_thresholds: dict[str, float],
+) -> PriceCoveragePolicy:
     normalized_market = normalize_market_code(market)
     return PriceCoveragePolicy(
         market=normalized_market,
-        price_min_coverage=PRICE_MIN_COVERAGE_BY_MARKET.get(
+        price_min_coverage=price_thresholds.get(
             normalized_market,
             CACHE_ONLY_MIN_PRICE_COVERAGE,
         ),
@@ -50,11 +60,29 @@ def price_coverage_policy_for_market(market: str | None) -> PriceCoveragePolicy:
     )
 
 
+def price_coverage_policy_for_market(market: str | None) -> PriceCoveragePolicy:
+    return _price_coverage_policy_for_market(
+        market,
+        price_thresholds=PRICE_MIN_COVERAGE_BY_MARKET,
+    )
+
+
+def bootstrap_price_coverage_policy_for_market(
+    market: str | None,
+) -> PriceCoveragePolicy:
+    return _price_coverage_policy_for_market(
+        market,
+        price_thresholds=BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET,
+    )
+
+
 __all__ = [
+    "BOOTSTRAP_PRICE_MIN_COVERAGE_BY_MARKET",
     "CACHE_ONLY_MIN_FUNDAMENTALS_COVERAGE",
     "CACHE_ONLY_MIN_PRICE_COVERAGE",
     "PRICE_MIN_COVERAGE_BY_MARKET",
     "PriceCoveragePolicy",
+    "bootstrap_price_coverage_policy_for_market",
     "normalize_market_code",
     "price_coverage_policy_for_market",
 ]

--- a/backend/app/services/bootstrap_cache_coverage.py
+++ b/backend/app/services/bootstrap_cache_coverage.py
@@ -16,8 +16,8 @@ from app.domain.feature_store.bootstrap_coverage import (
 )
 from app.domain.markets.price_coverage import (
     PriceCoveragePolicy,
+    bootstrap_price_coverage_policy_for_market,
     normalize_market_code,
-    price_coverage_policy_for_market,
 )
 from app.models.provider_snapshot import (
     ProviderSnapshotPointer,
@@ -215,7 +215,7 @@ def evaluate_bootstrap_price_cache_coverage(
         if latest_price_by_symbol.get(symbol) is None
         or latest_price_by_symbol[symbol] < as_of_date
     )
-    policy = price_coverage_policy_for_market(normalized_market)
+    policy = bootstrap_price_coverage_policy_for_market(normalized_market)
     return BootstrapPriceCoverageReport(
         policy=policy,
         price_coverage_date=as_of_date,

--- a/backend/app/tasks/date_resolution.py
+++ b/backend/app/tasks/date_resolution.py
@@ -8,7 +8,7 @@ from typing import Protocol
 
 
 class MarketCalendarLike(Protocol):
-    def market_now(self, market: str) -> datetime:
+    def last_completed_trading_day(self, market: str) -> date:
         ...
 
 
@@ -27,13 +27,13 @@ def resolve_task_target_date(
     market: str,
     calendar_service: MarketCalendarLike,
 ) -> ResolvedTaskDate:
-    """Resolve a task target date without changing nested task semantics."""
+    """Resolve implicit daily work to the latest completed market session."""
     if calculation_date:
         return ResolvedTaskDate(
             target_date=datetime.strptime(calculation_date, "%Y-%m-%d").date(),
             was_explicit=True,
         )
     return ResolvedTaskDate(
-        target_date=calendar_service.market_now(market).date(),
+        target_date=calendar_service.last_completed_trading_day(market),
         was_explicit=False,
     )

--- a/backend/app/tasks/date_resolution.py
+++ b/backend/app/tasks/date_resolution.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date
 from typing import Protocol
 
 
@@ -30,7 +30,7 @@ def resolve_task_target_date(
     """Resolve implicit daily work to the latest completed market session."""
     if calculation_date:
         return ResolvedTaskDate(
-            target_date=datetime.strptime(calculation_date, "%Y-%m-%d").date(),
+            target_date=date.fromisoformat(calculation_date),
             was_explicit=True,
         )
     return ResolvedTaskDate(

--- a/backend/tests/unit/domain/test_bootstrap_plan.py
+++ b/backend/tests/unit/domain/test_bootstrap_plan.py
@@ -49,6 +49,11 @@ def test_non_us_bootstrap_plan_uses_official_universe_without_industry_seed() ->
         "activity_lifecycle": "bootstrap",
         "bootstrap_cache_only_if_covered": True,
     }
+    breadth_stage = next(stage for stage in hk_plan.stages if stage.key == "breadth")
+    groups_stage = next(stage for stage in hk_plan.stages if stage.key == "groups")
+
+    assert breadth_stage.kwargs["execution_policy"] == "refresh_guarded"
+    assert groups_stage.kwargs["execution_policy"] == "refresh_guarded"
 
 
 def test_au_bootstrap_plan_refreshes_universe_before_prices_and_fundamentals() -> None:

--- a/backend/tests/unit/test_bootstrap_cache_coverage.py
+++ b/backend/tests/unit/test_bootstrap_cache_coverage.py
@@ -331,6 +331,23 @@ def test_normalize_bootstrap_gate_report_owns_threshold_and_unsupported_metadata
     assert report["unsupported_symbols_preview"] == ["1234.BAD", "5678.BAD"]
 
 
+def test_normalize_bootstrap_gate_report_uses_bootstrap_specific_hk_price_floor():
+    report = normalize_bootstrap_gate_report(
+        market="HK",
+        report={
+            "eligible": False,
+            "price_coverage_ratio": 0.77,
+            "fundamentals_coverage_ratio": 1.0,
+        },
+        unsupported_symbols=["1234.BAD"],
+    )
+
+    assert report["threshold"] == report["price_threshold"] == 0.75
+    assert report["eligible"] is True
+    assert report["mode"] == "cache_only"
+    assert report["unsupported_skipped_count"] == 1
+
+
 def test_normalize_bootstrap_gate_report_derives_eligibility_from_ratios_not_claim():
     report = normalize_bootstrap_gate_report(
         market="TW",
@@ -384,7 +401,7 @@ def test_bootstrap_price_thresholds_cover_every_supported_market():
         "CA": 0.75,
         "CN": 0.90,
         "DE": 0.90,
-        "HK": 0.75,
+        "HK": 0.80,
         "IN": 0.50,
         "JP": 0.90,
         "KR": 0.95,

--- a/backend/tests/unit/test_bootstrap_cache_coverage.py
+++ b/backend/tests/unit/test_bootstrap_cache_coverage.py
@@ -229,6 +229,25 @@ def test_bootstrap_price_cache_coverage_uses_market_specific_threshold():
     assert report["eligible"] is True
 
 
+def test_hk_bootstrap_price_policy_accepts_current_github_bundle_floor():
+    db = _session()
+    symbols = [f"SYM{i}" for i in range(100)]
+    as_of = date(2026, 7, 20)
+    db.add_all([_price(symbol, as_of) for symbol in symbols[:77]])
+    db.commit()
+
+    report = evaluate_bootstrap_price_cache_coverage(
+        db,
+        market="HK",
+        symbols=symbols,
+        as_of_date=as_of,
+    )
+
+    assert report["threshold"] == 0.75
+    assert report["price_coverage_ratio"] == 0.77
+    assert report["eligible"] is True
+
+
 def test_bootstrap_cache_coverage_keeps_fundamentals_threshold_strict_for_partial_price_markets():
     db = _session()
     symbols = [f"SYM{i}" for i in range(20)]
@@ -365,7 +384,7 @@ def test_bootstrap_price_thresholds_cover_every_supported_market():
         "CA": 0.75,
         "CN": 0.90,
         "DE": 0.90,
-        "HK": 0.80,
+        "HK": 0.75,
         "IN": 0.50,
         "JP": 0.90,
         "KR": 0.95,

--- a/backend/tests/unit/test_group_rank_warmup_policy.py
+++ b/backend/tests/unit/test_group_rank_warmup_policy.py
@@ -25,6 +25,21 @@ def test_group_rank_warmup_policy_allows_partial_cache_above_market_threshold() 
     )
 
 
+def test_group_rank_warmup_policy_keeps_hk_same_day_threshold_stricter_than_bootstrap() -> None:
+    price_cache = MagicMock()
+    price_cache.get_warmup_metadata.return_value = {
+        "status": "partial",
+        "count": 77,
+        "total": 100,
+        "completed_at": datetime.now().isoformat(),
+    }
+
+    decision = evaluate_same_day_group_rank_warmup(price_cache, market="HK")
+
+    assert decision.error is not None
+    assert decision.cache_requirement == GroupRankCacheRequirement.disabled()
+
+
 def test_group_rank_warmup_policy_uses_strict_requirement_after_completed_warmup() -> None:
     price_cache = MagicMock()
     price_cache.get_warmup_metadata.return_value = {

--- a/backend/tests/unit/test_runtime_bootstrap_tasks.py
+++ b/backend/tests/unit/test_runtime_bootstrap_tasks.py
@@ -103,6 +103,19 @@ def test_non_us_bootstrap_uses_market_feature_snapshot(monkeypatch):
         "app.tasks.group_rank_tasks.calculate_daily_group_rankings_with_gapfill"
         in task_names
     )
+    breadth = next(
+        signature
+        for signature in signatures
+        if signature.task == "app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill"
+    )
+    groups = next(
+        signature
+        for signature in signatures
+        if signature.task
+        == "app.tasks.group_rank_tasks.calculate_daily_group_rankings_with_gapfill"
+    )
+    assert breadth.kwargs["execution_policy"] == "refresh_guarded"
+    assert groups.kwargs["execution_policy"] == "refresh_guarded"
     snapshot = signatures[-1]
     assert snapshot.kwargs["market"] == "HK"
     assert snapshot.kwargs["universe_name"] == "market:HK"

--- a/backend/tests/unit/test_task_date_resolution.py
+++ b/backend/tests/unit/test_task_date_resolution.py
@@ -6,13 +6,19 @@ from app.tasks.date_resolution import resolve_task_target_date
 
 
 class FakeCalendar:
-    def __init__(self, now: datetime):
+    def __init__(self, now: datetime, last_completed: str = "2026-03-16"):
         self.now = now
         self.market_calls: list[str] = []
+        self.last_completed = last_completed
+        self.last_completed_calls: list[str] = []
 
     def market_now(self, market: str) -> datetime:
         self.market_calls.append(market)
         return self.now
+
+    def last_completed_trading_day(self, market: str):
+        self.last_completed_calls.append(market)
+        return datetime.strptime(self.last_completed, "%Y-%m-%d").date()
 
 
 def test_resolve_task_target_date_uses_explicit_date_without_calendar_lookup():
@@ -28,10 +34,14 @@ def test_resolve_task_target_date_uses_explicit_date_without_calendar_lookup():
     assert resolved.was_explicit is True
     assert resolved.nested_daily_kwargs() == {"calculation_date": "2026-03-16"}
     assert calendar.market_calls == []
+    assert calendar.last_completed_calls == []
 
 
-def test_resolve_task_target_date_uses_market_local_today_for_scheduled_runs():
-    calendar = FakeCalendar(datetime(2026, 3, 17, 9, 30, 0))
+def test_resolve_task_target_date_uses_last_completed_session_for_scheduled_runs():
+    calendar = FakeCalendar(
+        datetime(2026, 3, 17, 9, 30, 0),
+        last_completed="2026-03-16",
+    )
 
     resolved = resolve_task_target_date(
         None,
@@ -39,7 +49,8 @@ def test_resolve_task_target_date_uses_market_local_today_for_scheduled_runs():
         calendar_service=calendar,
     )
 
-    assert resolved.target_date.isoformat() == "2026-03-17"
+    assert resolved.target_date.isoformat() == "2026-03-16"
     assert resolved.was_explicit is False
-    assert resolved.nested_daily_kwargs() == {"calculation_date": "2026-03-17"}
-    assert calendar.market_calls == ["JP"]
+    assert resolved.nested_daily_kwargs() == {"calculation_date": "2026-03-16"}
+    assert calendar.market_calls == []
+    assert calendar.last_completed_calls == ["JP"]

--- a/backend/tests/unit/test_task_date_resolution.py
+++ b/backend/tests/unit/test_task_date_resolution.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pytest
+
 from app.tasks.date_resolution import resolve_task_target_date
 
 
@@ -35,6 +37,17 @@ def test_resolve_task_target_date_uses_explicit_date_without_calendar_lookup():
     assert resolved.nested_daily_kwargs() == {"calculation_date": "2026-03-16"}
     assert calendar.market_calls == []
     assert calendar.last_completed_calls == []
+
+
+def test_resolve_task_target_date_rejects_non_iso_explicit_date():
+    calendar = FakeCalendar(datetime(2026, 3, 17, 12, 0, 0))
+
+    with pytest.raises(ValueError):
+        resolve_task_target_date(
+            "2026-3-7",
+            market="HK",
+            calendar_service=calendar,
+        )
 
 
 def test_resolve_task_target_date_uses_last_completed_session_for_scheduled_runs():


### PR DESCRIPTION
## Summary

Fix the Asia bootstrap failures caused by bootstrap-derived data tasks drifting out of sync with the refresh-guarded cache workflow.

## Root Cause

After the refresh-guarded breadth/group ranking changes, bootstrap still invoked breadth and group ranking without `execution_policy="refresh_guarded"`. That allowed same-day runs to enforce strict warmup completeness and fail on partial cache metadata.

Implicit daily task dates also resolved to market-local `today`, while the initial GitHub price bundles are anchored to the latest completed trading session. For Asia markets, bootstrap can run before same-day bars exist, producing false cache-miss failures.

HK had an additional gate mismatch: the durable daily-price GitHub bundle currently sits around 76-77% current-session coverage because many listed symbols are stale, while the HK gate was 80%.

## Changes

- Resolve implicit daily task dates to `last_completed_trading_day`.
- Make bootstrap breadth and group ranking stages pass `execution_policy="refresh_guarded"`.
- Lower HK bootstrap price coverage floor from 80% to 75%.
- Add regression tests for date resolution, bootstrap plan wiring, runtime signature propagation, and HK bundle coverage.

## Validation

- `cd backend && /Users/admin/StockScreenClaude/backend/venv/bin/python -m pytest tests/unit -q`
  - `5221 passed, 21 warnings`
- `git diff --check`
- `cd backend && /Users/admin/StockScreenClaude/backend/venv/bin/python -m compileall app/tasks/date_resolution.py app/domain/bootstrap/plan.py app/domain/markets/price_coverage.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled daily tasks now target the latest completed trading session when no date is provided.
  * Market bootstrap breadth and group-ranking stages now use guarded refresh execution.
* **Bug Fixes**
  * Updated bootstrap price-coverage rules to apply an HK minimum floor of 75%, improving acceptance of valid bootstrap cache coverage.
* **Tests**
  * Added coverage for date-resolution behavior and bootstrap HK price-floor/eligibility logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->