### PR TITLE
Fix bootstrap reset after premature daily pipeline

### DIFF
--- a/backend/app/services/runtime_activity_presenter.py
+++ b/backend/app/services/runtime_activity_presenter.py
@@ -54,19 +54,22 @@ def build_runtime_activity_status(
     )
     summary_status = "warning" if has_warning else ("active" if active_markets else "idle")
 
+    bootstrap_records = [
+        record for record in activity_records if record.lifecycle == "bootstrap"
+    ]
     primary_record = next(
-        (record for record in activity_records if record.market == primary_market),
+        (record for record in bootstrap_records if record.market == primary_market),
         None,
     )
     secondary_active = [
         record.market
-        for record in activity_records
+        for record in bootstrap_records
         if record.market != primary_market and record.active_bootstrap
     ]
     secondary_active_record = next(
         (
             record
-            for record in activity_records
+            for record in bootstrap_records
             if record.market != primary_market and record.active_bootstrap
         ),
         None,
@@ -94,15 +97,15 @@ def build_runtime_activity_status(
             if not secondary_active
             else "Primary market is ready while additional market loading continues."
         )
-    elif any(record.progress_mode == "determinate" for record in activity_records):
+    elif any(record.progress_mode == "determinate" for record in bootstrap_records):
         focus_record = next(
-            (record for record in activity_records if record.status in ACTIVE_ACTIVITY_STATUSES),
+            (record for record in bootstrap_records if record.status in ACTIVE_ACTIVITY_STATUSES),
             primary_record,
         )
         bootstrap_progress_mode = "determinate"
         bootstrap_percent = round(
-            sum(_bootstrap_progress_percent(record) for record in activity_records)
-            / max(len(activity_records), 1),
+            sum(_bootstrap_progress_percent(record) for record in bootstrap_records)
+            / max(len(bootstrap_records), 1),
             2,
         )
         bootstrap_stage = focus_record.stage_label if focus_record else None

--- a/backend/app/tasks/daily_market_pipeline_tasks.py
+++ b/backend/app/tasks/daily_market_pipeline_tasks.py
@@ -336,6 +336,10 @@ def queue_daily_market_pipeline(self, market: str) -> dict:
     from app.services.runtime_preferences_service import is_market_enabled_now
 
     market_code = _normalize_pipeline_market(market)
+    bootstrap_blocker = _local_runtime_bootstrap_blocker(market_code)
+    if bootstrap_blocker is not None:
+        return bootstrap_blocker
+
     if not is_market_enabled_now(market_code):
         return {
             "status": "skipped",
@@ -343,10 +347,6 @@ def queue_daily_market_pipeline(self, market: str) -> dict:
             "market": market_code,
             "timestamp": datetime.now().isoformat(),
         }
-
-    bootstrap_blocker = _local_runtime_bootstrap_blocker(market_code)
-    if bootstrap_blocker is not None:
-        return bootstrap_blocker
 
     holder = _market_pipeline_active(market_code)
     if holder:

--- a/backend/app/tasks/daily_market_pipeline_tasks.py
+++ b/backend/app/tasks/daily_market_pipeline_tasks.py
@@ -305,6 +305,28 @@ def _market_pipeline_active(market: str) -> dict | None:
         return None
 
 
+def _local_runtime_bootstrap_blocker(market: str) -> dict | None:
+    from app.services.runtime_preferences_service import get_runtime_bootstrap_status
+
+    db = SessionLocal()
+    try:
+        bootstrap_status = get_runtime_bootstrap_status(db)
+    finally:
+        db.close()
+
+    if not bootstrap_status.bootstrap_required:
+        return None
+
+    return {
+        "status": "skipped",
+        "reason": "local_runtime_bootstrap_not_ready",
+        "market": market,
+        "bootstrap_state": bootstrap_status.bootstrap_state,
+        "bootstrap_required": bootstrap_status.bootstrap_required,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
 @celery_app.task(
     bind=True,
     name="app.tasks.daily_market_pipeline_tasks.queue_daily_market_pipeline",
@@ -321,6 +343,10 @@ def queue_daily_market_pipeline(self, market: str) -> dict:
             "market": market_code,
             "timestamp": datetime.now().isoformat(),
         }
+
+    bootstrap_blocker = _local_runtime_bootstrap_blocker(market_code)
+    if bootstrap_blocker is not None:
+        return bootstrap_blocker
 
     holder = _market_pipeline_active(market_code)
     if holder:

--- a/backend/tests/unit/test_daily_market_pipeline_tasks.py
+++ b/backend/tests/unit/test_daily_market_pipeline_tasks.py
@@ -105,11 +105,46 @@ def test_queue_daily_market_pipeline_skips_disabled_market(monkeypatch):
         "app.services.runtime_preferences_service.is_market_enabled_now",
         lambda _market: False,
     )
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.get_runtime_bootstrap_status",
+        lambda _db: SimpleNamespace(
+            bootstrap_required=False,
+            bootstrap_state="ready",
+            primary_market="US",
+            enabled_markets=["US"],
+        ),
+    )
+    monkeypatch.setattr(module, "SessionLocal", lambda: SimpleNamespace(close=lambda: None))
 
     result = module.queue_daily_market_pipeline.run("HK")
 
     assert result["status"] == "skipped"
     assert result["reason"] == "market HK is disabled in local runtime preferences"
+
+
+def test_queue_daily_market_pipeline_prefers_bootstrap_blocker_over_disabled_market(monkeypatch):
+    from app.tasks import daily_market_pipeline_tasks as module
+
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.is_market_enabled_now",
+        lambda _market: False,
+    )
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.get_runtime_bootstrap_status",
+        lambda _db: SimpleNamespace(
+            bootstrap_required=True,
+            bootstrap_state="not_started",
+            primary_market="US",
+            enabled_markets=["US"],
+        ),
+    )
+    monkeypatch.setattr(module, "SessionLocal", lambda: SimpleNamespace(close=lambda: None))
+
+    result = module.queue_daily_market_pipeline.run("HK")
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "local_runtime_bootstrap_not_ready"
+    assert result["market"] == "HK"
 
 
 def test_queue_daily_market_pipeline_skips_until_local_bootstrap_ready(monkeypatch):

--- a/backend/tests/unit/test_daily_market_pipeline_tasks.py
+++ b/backend/tests/unit/test_daily_market_pipeline_tasks.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from datetime import date
+from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -108,6 +110,55 @@ def test_queue_daily_market_pipeline_skips_disabled_market(monkeypatch):
 
     assert result["status"] == "skipped"
     assert result["reason"] == "market HK is disabled in local runtime preferences"
+
+
+def test_queue_daily_market_pipeline_skips_until_local_bootstrap_ready(monkeypatch):
+    from app.tasks import daily_market_pipeline_tasks as module
+
+    class _FakeCalendar:
+        def market_now(self, _market):
+            return datetime(2026, 3, 16, 10, 0)
+
+        def is_trading_day(self, _market, _today):
+            return True
+
+        def last_completed_trading_day(self, _market):
+            return date(2026, 3, 16)
+
+    chain_called = False
+
+    class _FakeChain:
+        def apply_async(self):
+            nonlocal chain_called
+            chain_called = True
+            return SimpleNamespace(id="queued-task")
+
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.is_market_enabled_now",
+        lambda _market: True,
+    )
+    monkeypatch.setattr(
+        "app.services.runtime_preferences_service.get_runtime_bootstrap_status",
+        lambda _db: SimpleNamespace(
+            bootstrap_required=True,
+            bootstrap_state="not_started",
+            primary_market="US",
+            enabled_markets=["US"],
+        ),
+    )
+    monkeypatch.setattr(module, "SessionLocal", lambda: SimpleNamespace(close=lambda: None))
+    monkeypatch.setattr(module, "_market_pipeline_active", lambda _market: None)
+    monkeypatch.setattr(module, "MarketCalendarService", lambda: _FakeCalendar())
+    monkeypatch.setattr(module, "_build_daily_market_pipeline_signatures", lambda *_args: [])
+    monkeypatch.setattr(module, "chain", lambda *_signatures: _FakeChain())
+
+    result = module.queue_daily_market_pipeline.run("US")
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "local_runtime_bootstrap_not_ready"
+    assert result["bootstrap_state"] == "not_started"
+    assert result["bootstrap_required"] is True
+    assert chain_called is False
 
 
 def test_guard_price_refresh_fails_lock_contention_skip_result():

--- a/backend/tests/unit/test_runtime_activity_presenter.py
+++ b/backend/tests/unit/test_runtime_activity_presenter.py
@@ -1,0 +1,45 @@
+"""Unit tests for runtime activity presentation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _bootstrap_status(
+    *,
+    bootstrap_state: str = "not_started",
+    bootstrap_required: bool = True,
+    primary_market: str = "US",
+    enabled_markets: list[str] | None = None,
+):
+    return SimpleNamespace(
+        bootstrap_state=bootstrap_state,
+        bootstrap_required=bootstrap_required,
+        primary_market=primary_market,
+        enabled_markets=enabled_markets or [primary_market],
+    )
+
+
+def test_bootstrap_summary_ignores_daily_refresh_activity_when_not_started():
+    from app.services.runtime_activity_contract import RuntimeActivityRecord
+    from app.services.runtime_activity_presenter import build_runtime_activity_status
+
+    daily_failure = RuntimeActivityRecord.create(
+        market="US",
+        lifecycle="daily_refresh",
+        stage_key="breadth",
+        status="failed",
+        message="Daily breadth calculation failed: no usable stocks",
+    ).to_payload()
+
+    status = build_runtime_activity_status(
+        bootstrap_status=_bootstrap_status(),
+        bootstrap_run={},
+        market_payloads=[daily_failure],
+    )
+
+    assert status["bootstrap"]["state"] == "not_started"
+    assert status["bootstrap"]["current_stage"] is None
+    assert status["bootstrap"]["message"] == "Bootstrap queued."
+    assert status["summary"]["status"] == "warning"
+    assert status["markets"] == [daily_failure]


### PR DESCRIPTION
## Summary
- Skip scheduled daily market pipelines while local runtime bootstrap is still required, preventing empty first-run databases from recording misleading daily-refresh failures.
- Make bootstrap activity presentation use only `lifecycle=bootstrap` records for bootstrap progress while preserving daily warnings in market activity.
- Add regression coverage for both the scheduler guard and bootstrap presenter behavior.

## Verification
- `backend/venv/bin/python -m pytest backend/tests/unit/test_daily_market_pipeline_tasks.py backend/tests/unit/test_runtime_activity_presenter.py backend/tests/unit/test_runtime_preferences_service.py backend/tests/unit/test_runtime_activity_staleness.py -q` -> 28 passed.
- `venv/bin/python -m pytest` from `backend/` -> 5428 passed, 7 failed, 3 skipped. Failures are existing unrelated theme/load baseline issues: theme pipeline API 503s and missing yfinance simulator profiles for AU/CA/CN/DE/IN/KR/MY/SG.
- `git diff --check` -> clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime activity summaries now correctly distinguish bootstrap activity from daily refresh activity.
  * Bootstrap progress percentages and status messages now reflect only relevant bootstrap-scoped records.
  * Daily market pipelines are skipped until required local runtime bootstrap is ready.
  * Skipped pipeline results now include bootstrap state and timestamp, preventing downstream chaining.
* **Tests**
  * Added unit coverage for bootstrap-aware activity summaries and local runtime bootstrap gating behavior in pipeline queuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->