### PR TITLE
Fix bootstrap reference seeding and Finviz ticker parsing

### DIFF
--- a/backend/app/services/stock_universe_service.py
+++ b/backend/app/services/stock_universe_service.py
@@ -84,6 +84,8 @@ FINVIZ_EXCHANGE_FILTER_CODES = {
     "NASDAQ": "nasd",
     "NYSE": "nyse",
 }
+# Keep the universe path on our parser: finvizfinance==1.2.0 reads ticker-cell
+# text, which duplicates the leading ticker letter after Finviz's logo markup.
 FINVIZ_SCREENER_URL = "https://finviz.com/screener.ashx"
 FINVIZ_OVERVIEW_PAGE = 111
 FINVIZ_SCREENER_PAGE_SIZE = 20
@@ -650,8 +652,15 @@ class StockUniverseService:
             cells = row.find_all("td")[1:]
             if not cells:
                 continue
+            if len(cells) != len(headers):
+                logger.warning(
+                    "Skipping finviz row with %d cells (expected %d headers)",
+                    len(cells),
+                    len(headers),
+                )
+                continue
             payload: dict[str, Any] = {}
-            for header, cell in zip(headers, cells):
+            for header, cell in zip(headers, cells, strict=True):
                 if header == "Ticker":
                     payload[header] = self._extract_finviz_ticker(cell)
                 else:

--- a/backend/app/services/stock_universe_service.py
+++ b/backend/app/services/stock_universe_service.py
@@ -9,11 +9,13 @@ import hashlib
 import io
 import json
 import os
+from time import sleep
 from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 import pandas as pd
 from typing import Any, Dict, Iterable, List, Mapping, Optional
-from finvizfinance.screener.overview import Overview
+from finvizfinance.util import web_scrap
 from sqlalchemy.orm import Session
 from sqlalchemy import and_, func, or_
 from datetime import datetime, timedelta, timezone
@@ -77,6 +79,14 @@ CN_ACTIVE_UNIVERSE_MIN_COUNT = 5217
 # after ETF/fund/debt/derivative exclusions). Re-baseline against the first
 # successful TMX snapshot before treating as authoritative.
 CA_ACTIVE_UNIVERSE_MIN_COUNT = 2300
+FINVIZ_EXCHANGE_FILTER_CODES = {
+    "AMEX": "amex",
+    "NASDAQ": "nasd",
+    "NYSE": "nyse",
+}
+FINVIZ_SCREENER_URL = "https://finviz.com/screener.ashx"
+FINVIZ_OVERVIEW_PAGE = 111
+FINVIZ_SCREENER_PAGE_SIZE = 20
 
 
 class StockUniverseService:
@@ -550,7 +560,7 @@ class StockUniverseService:
 
     def fetch_from_finviz(self, exchange_filter: Optional[str] = None) -> List[Dict]:
         """
-        Fetch all US stocks from finviz using finvizfinance library.
+        Fetch all US stocks from the Finviz screener.
 
         Args:
             exchange_filter: Optional filter: 'nyse', 'nasdaq', 'amex', or None for all
@@ -569,15 +579,10 @@ class StockUniverseService:
                     try:
                         logger.info(f"Fetching stocks from {exchange}...")
 
-                        # Create new screener instance for each exchange
-                        fviz = Overview()
-                        fviz.set_filter(filters_dict={'Exchange': exchange})
-                        df = fviz.screener_view(verbose=0)
-
-                        if df is not None and not df.empty:
-                            stocks = self._parse_finviz_dataframe(df, exchange)
+                        stocks = self._fetch_finviz_exchange_rows(exchange)
+                        if stocks:
                             all_stocks.extend(stocks)
-                            logger.info(f"Fetched {len(stocks)} stocks from {exchange}")
+                        logger.info(f"Fetched {len(stocks)} stocks from {exchange}")
                     except Exception as e:
                         logger.warning(f"Error fetching from {exchange}: {e}")
                         continue
@@ -591,21 +596,88 @@ class StockUniverseService:
                     logger.warning(f"Invalid exchange filter: {exchange_filter}")
                     return []
 
-                fviz = Overview()
-                fviz.set_filter(filters_dict={'Exchange': exchange_name})
-                df = fviz.screener_view(verbose=0)
-
-                if df is None or df.empty:
+                stocks = self._fetch_finviz_exchange_rows(exchange_name)
+                if not stocks:
                     logger.warning(f"No data returned from finviz for exchange {exchange_filter}")
                     return []
 
-                stocks = self._parse_finviz_dataframe(df, exchange_name)
                 logger.info(f"Successfully fetched {len(stocks)} stocks from {exchange_name}")
                 return stocks
 
         except Exception as e:
             logger.error(f"Error fetching stocks from finviz: {e}", exc_info=True)
             return []
+
+    def _fetch_finviz_exchange_rows(self, exchange: str) -> List[Dict[str, Any]]:
+        params: dict[str, Any] = {
+            "v": FINVIZ_OVERVIEW_PAGE,
+            "f": f"exch_{FINVIZ_EXCHANGE_FILTER_CODES[exchange]}",
+            "o": "ticker",
+        }
+        stocks: list[dict[str, Any]] = []
+
+        soup = web_scrap(FINVIZ_SCREENER_URL, params)
+        page_count = self._finviz_page_count(soup)
+        stocks.extend(self._parse_finviz_screener_soup(soup, exchange))
+
+        for page_index in range(1, page_count):
+            sleep(1)
+            params["r"] = page_index * FINVIZ_SCREENER_PAGE_SIZE + 1
+            soup = web_scrap(FINVIZ_SCREENER_URL, params)
+            stocks.extend(self._parse_finviz_screener_soup(soup, exchange))
+
+        return stocks
+
+    @staticmethod
+    def _finviz_page_count(soup: Any) -> int:
+        page_select = soup.find(id="pageSelect")
+        if page_select is None:
+            return 0
+        return len(page_select.find_all("option"))
+
+    def _parse_finviz_screener_soup(self, soup: Any, exchange: str) -> list[dict[str, Any]]:
+        table = soup.find("table", class_="screener_table")
+        if table is None:
+            return []
+
+        rows = table.find_all("tr")
+        if not rows:
+            return []
+
+        headers = [header.get_text(strip=True) for header in rows[0].find_all("th")][1:]
+        parsed_rows: list[dict[str, Any]] = []
+        for row in rows[1:]:
+            cells = row.find_all("td")[1:]
+            if not cells:
+                continue
+            payload: dict[str, Any] = {}
+            for header, cell in zip(headers, cells):
+                if header == "Ticker":
+                    payload[header] = self._extract_finviz_ticker(cell)
+                else:
+                    payload[header] = cell.get_text(strip=True)
+            parsed_rows.append(payload)
+
+        return self._parse_finviz_dataframe(pd.DataFrame(parsed_rows), exchange)
+
+    @staticmethod
+    def _extract_finviz_ticker(cell: Any) -> str:
+        data_ticker = str(cell.get("data-boxover-ticker") or "").strip()
+        if data_ticker:
+            return data_ticker
+
+        tab_link = cell.find("a", class_=lambda value: value and "tab-link" in value)
+        if tab_link is not None:
+            tab_text = tab_link.get_text(strip=True)
+            if tab_text:
+                return tab_text
+
+        for link in cell.find_all("a", href=True):
+            ticker_values = parse_qs(urlparse(link["href"]).query).get("t")
+            if ticker_values and ticker_values[0]:
+                return ticker_values[0]
+
+        return cell.get_text(strip=True)
 
     def _parse_finviz_dataframe(self, df, exchange: str) -> List[Dict]:
         """

--- a/backend/app/tasks/universe_tasks.py
+++ b/backend/app/tasks/universe_tasks.py
@@ -125,8 +125,15 @@ def _official_lock_retry_delay(retry_count: int) -> int:
     )
 
 
-def _allow_stale_weekly_reference_for_lifecycle(activity_lifecycle: str | None) -> bool:
-    return str(activity_lifecycle or "").strip().lower() == "bootstrap"
+def _allow_stale_weekly_reference_for_lifecycle(
+    activity_lifecycle: str | None,
+    *,
+    active_universe_count: int | None,
+) -> bool:
+    return (
+        str(activity_lifecycle or "").strip().lower() == "bootstrap"
+        and active_universe_count == 0
+    )
 
 
 def _ingest_official_snapshot(snapshot: Any) -> dict[str, Any]:
@@ -225,7 +232,10 @@ def refresh_stock_universe(
             market=effective_market,
             hydrate_cache=True,
             hydrate_mode="static",
-            allow_stale=_allow_stale_weekly_reference_for_lifecycle(activity_lifecycle),
+            allow_stale=_allow_stale_weekly_reference_for_lifecycle(
+                activity_lifecycle,
+                active_universe_count=prior_size,
+            ),
         )
         if github_sync.get("status") in _GITHUB_SYNC_SUCCESS_STATUSES:
             _emit_universe_drift(effective_market, prior_size)
@@ -397,7 +407,10 @@ def refresh_official_market_universe(
                 market=_market,
                 hydrate_cache=True,
                 hydrate_mode="static",
-                allow_stale=_allow_stale_weekly_reference_for_lifecycle(activity_lifecycle),
+                allow_stale=_allow_stale_weekly_reference_for_lifecycle(
+                    activity_lifecycle,
+                    active_universe_count=prior_size,
+                ),
             )
         finally:
             sync_db.close()

--- a/backend/app/tasks/universe_tasks.py
+++ b/backend/app/tasks/universe_tasks.py
@@ -125,6 +125,10 @@ def _official_lock_retry_delay(retry_count: int) -> int:
     )
 
 
+def _allow_stale_weekly_reference_for_lifecycle(activity_lifecycle: str | None) -> bool:
+    return str(activity_lifecycle or "").strip().lower() == "bootstrap"
+
+
 def _ingest_official_snapshot(snapshot: Any) -> dict[str, Any]:
     """Dispatch an official-source snapshot into the market-specific ingest path."""
     db = SessionLocal()
@@ -221,6 +225,7 @@ def refresh_stock_universe(
             market=effective_market,
             hydrate_cache=True,
             hydrate_mode="static",
+            allow_stale=_allow_stale_weekly_reference_for_lifecycle(activity_lifecycle),
         )
         if github_sync.get("status") in _GITHUB_SYNC_SUCCESS_STATUSES:
             _emit_universe_drift(effective_market, prior_size)
@@ -392,6 +397,7 @@ def refresh_official_market_universe(
                 market=_market,
                 hydrate_cache=True,
                 hydrate_mode="static",
+                allow_stale=_allow_stale_weekly_reference_for_lifecycle(activity_lifecycle),
             )
         finally:
             sync_db.close()

--- a/backend/tests/unit/test_stock_universe_service.py
+++ b/backend/tests/unit/test_stock_universe_service.py
@@ -1195,6 +1195,32 @@ def test_fetch_from_finviz_prefers_ticker_metadata_over_logo_text(monkeypatch):
     assert requests_seen == [{"v": 111, "f": "exch_nyse", "o": "ticker"}]
 
 
+def test_parse_finviz_screener_soup_skips_rows_with_mismatched_columns(caplog):
+    service = StockUniverseService()
+    html = """
+    <html><body>
+      <table class="screener_table">
+        <tr>
+          <th>No.</th><th>Ticker</th><th>Company</th><th>Sector</th>
+          <th>Industry</th><th>Country</th><th>Market Cap</th>
+        </tr>
+        <tr>
+          <td>1</td><td data-boxover-ticker="A">AA</td><td>Agilent</td>
+          <td>Healthcare</td><td>Diagnostics</td><td>USA</td><td>38.00B</td>
+        </tr>
+        <tr>
+          <td>2</td><td data-boxover-ticker="BAD">BADBAD</td><td>Malformed</td>
+        </tr>
+      </table>
+    </body></html>
+    """
+
+    stocks = service._parse_finviz_screener_soup(BeautifulSoup(html, "lxml"), "NYSE")
+
+    assert [stock["symbol"] for stock in stocks] == ["A"]
+    assert "Skipping finviz row with 2 cells (expected 6 headers)" in caplog.text
+
+
 def test_populate_universe_reconciliation_baseline_is_source_scoped(monkeypatch):
     TestingSessionLocal = _make_session()
     db = TestingSessionLocal()

--- a/backend/tests/unit/test_stock_universe_service.py
+++ b/backend/tests/unit/test_stock_universe_service.py
@@ -4,10 +4,12 @@ import json
 from datetime import datetime, timedelta
 
 import pytest
+from bs4 import BeautifulSoup
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.database import Base
+import app.services.stock_universe_service as stock_universe_module
 from app.models.stock_universe import (
     StockUniverse,
     StockUniverseReconciliationRun,
@@ -1141,6 +1143,56 @@ def test_populate_universe_keeps_snapshot_when_finviz_has_bad_rows(monkeypatch):
     assert stats["rejected_rows"][0]["reason"] == "Missing symbol/ticker"
     assert db.query(StockUniverse).filter(StockUniverse.symbol == "AAPL").one()
     db.close()
+
+
+def test_fetch_from_finviz_prefers_ticker_metadata_over_logo_text(monkeypatch):
+    service = StockUniverseService()
+    html = """
+    <html><body>
+      <select id="pageSelect"><option value="1">1</option></select>
+      <table class="screener_table">
+        <tr>
+          <th>No.</th><th>Ticker</th><th>Company</th><th>Sector</th>
+          <th>Industry</th><th>Country</th><th>Market Cap</th><th>P/E</th>
+          <th>Price</th><th>Change</th><th>Volume</th>
+        </tr>
+        <tr>
+          <td><a href="stock?t=A&amp;ty=c&amp;p=d&amp;b=1">1</a></td>
+          <td data-boxover-ticker="A">
+            <span>
+              <a class="company-ticker" href="stock?t=A&amp;ty=c&amp;p=d&amp;b=1">
+                <span>A</span>
+              </a>
+              <a class="tab-link" href="stock?t=A&amp;ty=c&amp;p=d&amp;b=1">A</a>
+            </span>
+          </td>
+          <td>Agilent Technologies Inc</td>
+          <td>Healthcare</td>
+          <td>Diagnostics &amp; Research</td>
+          <td>USA</td>
+          <td>38.00B</td>
+          <td>27.02</td>
+          <td>133.00</td>
+          <td>1.00%</td>
+          <td>2,000,000</td>
+        </tr>
+      </table>
+    </body></html>
+    """
+    requests_seen = []
+
+    def fake_web_scrap(url, params=None):
+        requests_seen.append(dict(params or {}))
+        return BeautifulSoup(html, "lxml")
+
+    monkeypatch.setattr(stock_universe_module, "web_scrap", fake_web_scrap, raising=False)
+
+    stocks = service.fetch_from_finviz(exchange_filter="NYSE")
+
+    assert stocks[0]["symbol"] == "A"
+    assert stocks[0]["name"] == "Agilent Technologies Inc"
+    assert stocks[0]["market_cap"] == 38_000_000_000.0
+    assert requests_seen == [{"v": 111, "f": "exch_nyse", "o": "ticker"}]
 
 
 def test_populate_universe_reconciliation_baseline_is_source_scoped(monkeypatch):

--- a/backend/tests/unit/test_universe_tasks.py
+++ b/backend/tests/unit/test_universe_tasks.py
@@ -196,7 +196,7 @@ def test_refresh_stock_universe_allows_stale_github_bundle_for_bootstrap(monkeyp
     sync_calls: list[dict] = []
     _patch_data_fetch_lock(monkeypatch)
     monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
-    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
+    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 0)
     monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
@@ -228,6 +228,47 @@ def test_refresh_stock_universe_allows_stale_github_bundle_for_bootstrap(monkeyp
     assert result["status"] == "success"
     assert result["source"] == "github"
     assert sync_calls[0]["allow_stale"] is True
+
+
+def test_refresh_stock_universe_does_not_allow_stale_github_bundle_for_populated_bootstrap(monkeypatch):
+    import app.tasks.universe_tasks as module
+
+    fake_db = MagicMock()
+    sync_calls: list[dict] = []
+    _patch_data_fetch_lock(monkeypatch)
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 42)
+    monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
+    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "get_provider_snapshot_service",
+        lambda: SimpleNamespace(
+            sync_weekly_reference_from_github=lambda db, **kwargs: sync_calls.append(kwargs)
+            or {
+                "status": "success",
+                "source": "github",
+                "market": kwargs["market"],
+                "source_revision": "fundamentals_v1_us:20260711143920-seeded-fallback",
+                "import": {"universe_rows": 100},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "get_stock_universe_service",
+        lambda: SimpleNamespace(populate_universe=MagicMock()),
+    )
+
+    result = module.refresh_stock_universe.run(
+        market="US",
+        activity_lifecycle="bootstrap",
+    )
+
+    assert result["status"] == "success"
+    assert result["source"] == "github"
+    assert sync_calls[0]["allow_stale"] is False
 
 
 def test_refresh_official_market_universe_falls_back_when_github_sync_is_unsupported(monkeypatch):
@@ -289,7 +330,7 @@ def test_refresh_official_market_universe_allows_stale_github_bundle_for_bootstr
     sync_calls: list[dict] = []
     activity_sessions = [MagicMock(), MagicMock(), MagicMock()]
     monkeypatch.setattr(module, "SessionLocal", lambda: activity_sessions.pop(0))
-    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
+    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 0)
     monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
     monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "_mark_market_activity_progress_safely", lambda **kwargs: None)
@@ -323,6 +364,50 @@ def test_refresh_official_market_universe_allows_stale_github_bundle_for_bootstr
     assert result["status"] == "success"
     assert result["source"] == "github"
     assert sync_calls[0]["allow_stale"] is True
+    fake_lock.release.assert_called_once_with("task-123", market="HK")
+
+
+def test_refresh_official_market_universe_does_not_allow_stale_github_bundle_for_populated_bootstrap(monkeypatch):
+    import app.tasks.universe_tasks as module
+
+    fake_lock = _patch_data_fetch_lock(monkeypatch)
+    sync_calls: list[dict] = []
+    activity_sessions = [MagicMock(), MagicMock(), MagicMock()]
+    monkeypatch.setattr(module, "SessionLocal", lambda: activity_sessions.pop(0))
+    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 42)
+    monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
+    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_mark_market_activity_progress_safely", lambda **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "get_provider_snapshot_service",
+        lambda: SimpleNamespace(
+            sync_weekly_reference_from_github=lambda db, **kwargs: sync_calls.append(kwargs)
+            or {
+                "status": "success",
+                "source": "github",
+                "market": kwargs["market"],
+                "source_revision": "fundamentals_v1_hk:20260711143920-seeded-fallback",
+                "import": {"universe_rows": 100},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.official_market_universe_source_service.OfficialMarketUniverseSourceService.fetch_market_snapshot",
+        MagicMock(side_effect=AssertionError("live provider should not be used")),
+    )
+
+    module.refresh_official_market_universe.request.id = "task-123"
+    module.refresh_official_market_universe.request.retries = 0
+    result = module.refresh_official_market_universe.run(
+        market="HK",
+        activity_lifecycle="bootstrap",
+    )
+
+    assert result["status"] == "success"
+    assert result["source"] == "github"
+    assert sync_calls[0]["allow_stale"] is False
     fake_lock.release.assert_called_once_with("task-123", market="HK")
 
 

--- a/backend/tests/unit/test_universe_tasks.py
+++ b/backend/tests/unit/test_universe_tasks.py
@@ -163,7 +163,7 @@ def test_refresh_stock_universe_prefers_github_weekly_bundle(monkeypatch):
         module,
         "get_provider_snapshot_service",
         lambda: SimpleNamespace(
-            sync_weekly_reference_from_github=lambda db, market, hydrate_cache, hydrate_mode: {
+            sync_weekly_reference_from_github=lambda db, market, hydrate_cache, hydrate_mode, allow_stale=False: {
                 "status": "success",
                 "source": "github",
                 "market": market,
@@ -189,6 +189,47 @@ def test_refresh_stock_universe_prefers_github_weekly_bundle(monkeypatch):
     assert not populate_calls
 
 
+def test_refresh_stock_universe_allows_stale_github_bundle_for_bootstrap(monkeypatch):
+    import app.tasks.universe_tasks as module
+
+    fake_db = MagicMock()
+    sync_calls: list[dict] = []
+    _patch_data_fetch_lock(monkeypatch)
+    monkeypatch.setattr(module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
+    monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
+    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "get_provider_snapshot_service",
+        lambda: SimpleNamespace(
+            sync_weekly_reference_from_github=lambda db, **kwargs: sync_calls.append(kwargs)
+            or {
+                "status": "success",
+                "source": "github",
+                "market": kwargs["market"],
+                "source_revision": "fundamentals_v1_us:20260711143920-seeded-fallback",
+                "import": {"universe_rows": 100},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "get_stock_universe_service",
+        lambda: SimpleNamespace(populate_universe=MagicMock()),
+    )
+
+    result = module.refresh_stock_universe.run(
+        market="US",
+        activity_lifecycle="bootstrap",
+    )
+
+    assert result["status"] == "success"
+    assert result["source"] == "github"
+    assert sync_calls[0]["allow_stale"] is True
+
+
 def test_refresh_official_market_universe_falls_back_when_github_sync_is_unsupported(monkeypatch):
     import app.tasks.universe_tasks as module
 
@@ -204,7 +245,7 @@ def test_refresh_official_market_universe_falls_back_when_github_sync_is_unsuppo
         module,
         "get_provider_snapshot_service",
         lambda: SimpleNamespace(
-            sync_weekly_reference_from_github=lambda db, market, hydrate_cache, hydrate_mode: {
+            sync_weekly_reference_from_github=lambda db, market, hydrate_cache, hydrate_mode, allow_stale=False: {
                 "status": "unsupported_market",
                 "market": market,
             }
@@ -241,6 +282,50 @@ def test_refresh_official_market_universe_falls_back_when_github_sync_is_unsuppo
     fake_lock.release.assert_called_once_with("task-123", market="IN")
 
 
+def test_refresh_official_market_universe_allows_stale_github_bundle_for_bootstrap(monkeypatch):
+    import app.tasks.universe_tasks as module
+
+    fake_lock = _patch_data_fetch_lock(monkeypatch)
+    sync_calls: list[dict] = []
+    activity_sessions = [MagicMock(), MagicMock(), MagicMock()]
+    monkeypatch.setattr(module, "SessionLocal", lambda: activity_sessions.pop(0))
+    monkeypatch.setattr(module, "_count_active_universe", lambda _market: 10)
+    monkeypatch.setattr("app.services.runtime_preferences_service.is_market_enabled_now", lambda _market: True)
+    monkeypatch.setattr(module, "mark_market_activity_started", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_mark_market_activity_progress_safely", lambda **kwargs: None)
+    monkeypatch.setattr(module, "mark_market_activity_completed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "get_provider_snapshot_service",
+        lambda: SimpleNamespace(
+            sync_weekly_reference_from_github=lambda db, **kwargs: sync_calls.append(kwargs)
+            or {
+                "status": "success",
+                "source": "github",
+                "market": kwargs["market"],
+                "source_revision": "fundamentals_v1_hk:20260711143920-seeded-fallback",
+                "import": {"universe_rows": 100},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.official_market_universe_source_service.OfficialMarketUniverseSourceService.fetch_market_snapshot",
+        MagicMock(side_effect=AssertionError("live provider should not be used")),
+    )
+
+    module.refresh_official_market_universe.request.id = "task-123"
+    module.refresh_official_market_universe.request.retries = 0
+    result = module.refresh_official_market_universe.run(
+        market="HK",
+        activity_lifecycle="bootstrap",
+    )
+
+    assert result["status"] == "success"
+    assert result["source"] == "github"
+    assert sync_calls[0]["allow_stale"] is True
+    fake_lock.release.assert_called_once_with("task-123", market="HK")
+
+
 def test_refresh_official_market_universe_retries_transient_provider_failure(monkeypatch):
     import app.tasks.universe_tasks as module
 
@@ -257,7 +342,7 @@ def test_refresh_official_market_universe_retries_transient_provider_failure(mon
         module,
         "get_provider_snapshot_service",
         lambda: SimpleNamespace(
-            sync_weekly_reference_from_github=lambda db, market, hydrate_cache, hydrate_mode: {
+            sync_weekly_reference_from_github=lambda db, market, hydrate_cache, hydrate_mode, allow_stale=False: {
                 "status": "missing",
                 "market": market,
             }


### PR DESCRIPTION
## Summary
- Allow bootstrap universe tasks to import stale weekly-reference GitHub bundles instead of falling back to slow live universe providers during initial setup.
- Fix US Finviz universe ingestion after Finviz changed ticker-cell markup and `finvizfinance==1.2.0` began returning duplicated-leading-letter symbols (`A` -> `AA`, `AA` -> `AAA`, `AAAC` -> `AAAAC`).
- Parse Finviz screener tickers from stable metadata/link targets (`data-boxover-ticker`, `.tab-link`, `stock?t=...`) instead of full cell text.
- Add regression coverage for bootstrap stale handling and the July 2026 Finviz ticker-cell markup.

## Root Cause
Bootstrap was failing in two layers:

1. The initial-run GitHub weekly-reference sync rejected the latest available bundle as stale, so bootstrap fell back to live provider paths even though a GitHub seed existed.
2. The US live Finviz fallback then ingested malformed symbols because Finviz added logo/ticker markup inside the ticker cell. `finvizfinance` reads `col.text`, which concatenates the logo text with the ticker text and produces symbols like `AACII`, `AACKY`, `AACLC`, and `AACLO`.

The upstream `finvizfinance` issue is tracked as lit26/finvizfinance#158, and PR #157 validates the same diagnosis.

## Verification
- `cd backend && source venv/bin/activate && pytest tests/unit/test_universe_tasks.py -q`
- `cd backend && source venv/bin/activate && pytest tests/unit/test_runtime_bootstrap_tasks.py tests/unit/test_weekly_reference_github_sync.py tests/unit/test_provider_snapshot_service.py -q`
- `cd backend && source venv/bin/activate && pytest tests/unit/test_stock_universe_service.py -q`
- `cd backend && source venv/bin/activate && pytest tests/unit/test_weekly_reference_scripts.py -q`
- `git diff --check`
- Live Finviz smoke parsed first NYSE symbols as `A, AA, AAA, AAAC...` instead of `AA, AAA, AAAA, AAAAC...`.

## Notes
- The branch is ready for review and targets `main`.
- A previous full backend pytest attempt was interrupted after 1m55s because it had unrelated existing failures: 3 theme pipeline API integration 503s and 4 load simulator profile failures for AU/CA/CN/DE/IN/KR/MY/SG.
- Local `bd sync` could not run because this `bd` binary reports: unknown command `sync`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Finviz stock data retrieval across NYSE, NASDAQ, and AMEX exchanges.
  * Added support for paginated results and more reliable ticker identification.

* **Bug Fixes**
  * During initial universe setup, stale weekly GitHub reference data can be used when no active universe exists.
  * Prevents stale data use once the universe is populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->