### PR TITLE
Fix Finviz provider snapshot ticker parsing

### DIFF
--- a/backend/app/services/provider_snapshot_service.py
+++ b/backend/app/services/provider_snapshot_service.py
@@ -12,9 +12,13 @@ import shutil
 import tempfile
 from datetime import date, datetime
 from pathlib import Path
+from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Literal, Optional
+from urllib.parse import parse_qs, urlparse
 
 import pandas as pd
+from finvizfinance.constants import NUMBER_COL
+from finvizfinance.util import number_covert, progress_bar, web_scrap
 from sqlalchemy.orm import Session
 
 from ..config import settings
@@ -223,8 +227,84 @@ class ProviderSnapshotService:
         screener_cls = self._load_screener_class(category)
         screener = screener_cls()
         screener.set_filter(filters_dict={"Exchange": exchange})
-        df = screener.screener_view(verbose=1 if show_progress else 0)
-        return df if df is not None else pd.DataFrame()
+        screener.request_params["o"] = "ticker"
+
+        soup = web_scrap(screener.url, screener.request_params)
+        page_count = self._finviz_page_count(soup)
+        if page_count == 0:
+            return pd.DataFrame()
+
+        df = self._parse_finviz_screener_table(soup)
+        for page_index in range(1, page_count):
+            sleep(1)
+            if show_progress:
+                progress_bar(page_index, page_count)
+            screener.request_params["r"] = page_index * screener.size + 1
+            soup = web_scrap(screener.url, screener.request_params)
+            page_df = self._parse_finviz_screener_table(soup)
+            df = pd.concat([df, page_df], ignore_index=True)
+        return df
+
+    @staticmethod
+    def _finviz_page_count(soup: Any) -> int:
+        page_select = soup.find(id="pageSelect")
+        if page_select is None:
+            return 0
+        return len(page_select.find_all("option"))
+
+    @staticmethod
+    def _extract_finviz_ticker(cell: Any) -> str:
+        data_ticker = str(cell.get("data-boxover-ticker") or "").strip()
+        if data_ticker:
+            return data_ticker
+
+        tab_link = cell.find("a", class_=lambda value: value and "tab-link" in value)
+        if tab_link is not None:
+            tab_text = tab_link.get_text(strip=True)
+            if tab_text:
+                return tab_text
+
+        for link in cell.find_all("a", href=True):
+            ticker_values = parse_qs(urlparse(link["href"]).query).get("t")
+            if ticker_values and ticker_values[0]:
+                return ticker_values[0]
+
+        return cell.get_text(strip=True)
+
+    @classmethod
+    def _parse_finviz_screener_table(cls, soup: Any) -> pd.DataFrame:
+        table = soup.find("table", class_="screener_table")
+        if table is None:
+            return pd.DataFrame()
+
+        rows = table.find_all("tr")
+        if not rows:
+            return pd.DataFrame()
+
+        headers = [header.get_text(strip=True) for header in rows[0].find_all("th")][1:]
+        frame: list[dict[str, Any]] = []
+        for row in rows[1:]:
+            cells = row.find_all("td")[1:]
+            if not cells:
+                continue
+            if len(cells) != len(headers):
+                logger.warning(
+                    "Skipping finviz snapshot row with %d cells (expected %d headers)",
+                    len(cells),
+                    len(headers),
+                )
+                continue
+
+            payload: dict[str, Any] = {}
+            for header, cell in zip(headers, cells, strict=True):
+                if header == "Ticker":
+                    payload[header] = cls._extract_finviz_ticker(cell)
+                elif header in NUMBER_COL:
+                    payload[header] = number_covert(cell.get_text(strip=True))
+                else:
+                    payload[header] = cell.get_text(strip=True)
+            frame.append(payload)
+        return pd.DataFrame(frame)
 
     def _normalize_row(self, raw_row: Dict[str, Any], exchange: str) -> Dict[str, Any]:
         normalized = self.parser.normalize_fundamentals(raw_row)

--- a/backend/tests/unit/test_provider_snapshot_service.py
+++ b/backend/tests/unit/test_provider_snapshot_service.py
@@ -7,7 +7,9 @@ from datetime import date, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
+from bs4 import BeautifulSoup
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -20,6 +22,7 @@ from app.models.provider_snapshot import (
 from app.models.stock import StockFundamental
 from app.models.stock_universe import StockUniverse, UNIVERSE_STATUS_ACTIVE
 import app.services.fundamentals_cache_service as fundamentals_cache_module
+import app.services.provider_snapshot_service as provider_snapshot_module
 from app.services.fundamentals_cache_service import FundamentalsCacheService
 from app.services.provider_snapshot_service import ProviderSnapshotService, settings
 
@@ -93,6 +96,77 @@ def _make_provider_snapshot_service(
         fundamentals_cache=fundamentals_cache or _StubFundamentalsCache(),
         rate_limiter=MagicMock(),
     )
+
+
+def test_build_snapshot_rows_extracts_canonical_ticker_from_finviz_markup(monkeypatch):
+    service = _make_provider_snapshot_service()
+    html = """
+    <html><body>
+      <select id="pageSelect"><option value="1">1</option></select>
+      <table class="screener_table">
+        <tr>
+          <th>No.</th><th>Ticker</th><th>Company</th><th>Sector</th>
+          <th>Industry</th><th>Country</th><th>Market Cap</th>
+        </tr>
+        <tr>
+          <td>1</td>
+          <td data-boxover-ticker="A">
+            <span>
+              <a class="company-ticker" href="stock?t=A&amp;ty=c&amp;p=d&amp;b=1">
+                <span>A</span>
+              </a>
+              <a class="tab-link" href="stock?t=A&amp;ty=c&amp;p=d&amp;b=1">A</a>
+            </span>
+          </td>
+          <td>Agilent Technologies Inc</td>
+          <td>Healthcare</td>
+          <td>Diagnostics &amp; Research</td>
+          <td>USA</td>
+          <td>38.00B</td>
+        </tr>
+      </table>
+    </body></html>
+    """
+
+    class BrokenOverview:
+        url = "https://finviz.com/screener.ashx"
+        size = 20
+
+        def __init__(self):
+            self.request_params = {"v": 111}
+
+        def set_filter(self, filters_dict):
+            self.request_params["f"] = "exch_nyse"
+
+        def screener_view(self, verbose=0):
+            return pd.DataFrame(
+                [
+                    {
+                        "Ticker": "AA",
+                        "Company": "Agilent Technologies Inc",
+                        "Sector": "Healthcare",
+                        "Industry": "Diagnostics & Research",
+                        "Country": "USA",
+                        "Market Cap": "38.00B",
+                    }
+                ]
+            )
+
+    monkeypatch.setattr(service, "CATEGORY_LOADERS", {"overview": ("fake", "BrokenOverview")})
+    monkeypatch.setattr(service, "EXCHANGES", ("NYSE",))
+    monkeypatch.setattr(service, "_load_screener_class", lambda category: BrokenOverview)
+    monkeypatch.setattr(
+        provider_snapshot_module,
+        "web_scrap",
+        lambda url, params=None: BeautifulSoup(html, "lxml"),
+        raising=False,
+    )
+
+    rows = service._build_snapshot_rows()
+
+    assert sorted(rows) == ["A"]
+    assert rows["A"]["normalized_payload"]["symbol"] == "A"
+    assert rows["A"]["raw_payload"]["overview"]["Ticker"] == "A"
 
 
 def test_create_snapshot_run_blocks_publish_when_coverage_below_threshold(monkeypatch):


### PR DESCRIPTION
## Summary
- Fix the provider snapshot Finviz path to extract tickers from Finviz markup metadata/links instead of duplicated ticker-cell text.
- Preserve category pagination and numeric conversion while avoiding finvizfinance's broken Ticker text extraction.
- Add regression coverage proving snapshot rows are keyed as A, not AA, when Finviz renders logo plus ticker text.

## Root Cause
PR #311 fixed the universe refresh path, but the weekly reference fundamentals snapshot still called finvizfinance.screener_view() directly. With Finviz's July 2026 markup change, that path produced duplicated-leading-letter symbols, so corrected active universe symbols did not match snapshot symbols and the US coverage gate failed.

## Verification
- cd backend && source venv/bin/activate && pytest tests/unit/test_provider_snapshot_service.py tests/unit/test_weekly_reference_scripts.py tests/unit/test_stock_universe_service.py -q
- git diff --check

Result: 123 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved provider snapshot collection across multiple pages.
  * Added progress updates during snapshot retrieval.
  * Enhanced ticker recognition from different page formats.

* **Bug Fixes**
  * Improved handling of missing or incomplete table data.
  * Added safer numeric value conversion and row validation.
  * Fixed extraction of canonical ticker symbols from provider markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->