### PR TITLE
Fix Asia static-site publish blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,6 @@ jobs:
       - name: Install dependencies
         run: pip install -r backend/requirements.txt -r backend/requirements-test.txt
 
-      - name: Restore backend unit duration cache
-        uses: actions/cache/restore@v4
-        with:
-          path: backend/.test_durations
-          key: backend-unit-durations-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}-${{ matrix.shard }}
-          restore-keys: |
-            backend-unit-durations-${{ runner.os }}-${{ github.ref_name }}-
-            backend-unit-durations-${{ runner.os }}-
-
       - name: Comprehensive backend unit suite (shard ${{ matrix.shard }}/4)
         shell: bash
         run: |
@@ -109,16 +100,7 @@ jobs:
             --splits 4 \
             --group "${{ matrix.shard }}" \
             --splitting-algorithm least_duration \
-            --durations-path .test_durations \
-            --store-durations \
             -vv
-
-      - name: Save backend unit duration cache
-        if: always() && hashFiles('backend/.test_durations') != ''
-        uses: actions/cache/save@v4
-        with:
-          path: backend/.test_durations
-          key: backend-unit-durations-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}-${{ matrix.shard }}
 
   frontend:
     name: Frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
             ignore_args+=(--ignore "${path}")
           done < "${gate_unit_file}"
 
+          # Intentionally cache-free: without duration data, pytest-split gives each test equal weight and all shards compute the same partition.
           python -m pytest tests/unit \
             "${ignore_args[@]}" \
             -m "not live_service and not load" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-test.txt
 
       - name: Install dependencies
         run: pip install -r backend/requirements.txt -r backend/requirements-test.txt
@@ -72,34 +74,51 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-test.txt
 
       - name: Install dependencies
         run: pip install -r backend/requirements.txt -r backend/requirements-test.txt
 
+      - name: Restore backend unit duration cache
+        uses: actions/cache/restore@v4
+        with:
+          path: backend/.test_durations
+          key: backend-unit-durations-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}-${{ matrix.shard }}
+          restore-keys: |
+            backend-unit-durations-${{ runner.os }}-${{ github.ref_name }}-
+            backend-unit-durations-${{ runner.os }}-
+
       - name: Comprehensive backend unit suite (shard ${{ matrix.shard }}/4)
         shell: bash
         run: |
+          gate_unit_file="${RUNNER_TEMP}/backend-gate-unit-files.txt"
+          make gate-unit-files > "${gate_unit_file}"
+
           cd backend
-          collection_file="${RUNNER_TEMP}/backend-unit-nodeids.txt"
-          python -m pytest tests/unit --collect-only -qq -m "not live_service and not load" > "${collection_file}"
-          mapfile -t tests < <(awk '/^tests\/unit\/.*::/' "${collection_file}")
+          ignore_args=()
+          while IFS= read -r path; do
+            [[ -n "${path}" ]] || continue
+            ignore_args+=(--ignore "${path}")
+          done < "${gate_unit_file}"
 
-          target_shard=$((${{ matrix.shard }} - 1))
-          shard_tests=()
-          for index in "${!tests[@]}"; do
-            if ((index % 4 == target_shard)); then
-              shard_tests+=("${tests[$index]}")
-            fi
-          done
+          python -m pytest tests/unit \
+            "${ignore_args[@]}" \
+            -m "not live_service and not load" \
+            --splits 4 \
+            --group "${{ matrix.shard }}" \
+            --splitting-algorithm least_duration \
+            --durations-path .test_durations \
+            --store-durations \
+            -vv
 
-          if ((${#shard_tests[@]} == 0)); then
-            echo "No tests selected for shard ${{ matrix.shard }}/4" >&2
-            exit 1
-          fi
-
-          echo "Running shard ${{ matrix.shard }}/4 with ${#shard_tests[@]} of ${#tests[@]} unit tests"
-          python -m pytest -vv "${shard_tests[@]}"
+      - name: Save backend unit duration cache
+        if: always() && hashFiles('backend/.test_durations') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: backend/.test_durations
+          key: backend-unit-durations-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}-${{ matrix.shard }}
 
   frontend:
     name: Frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
           python-version: "3.11"
           cache: pip
           cache-dependency-path: |
-            backend/requirements.txt
+            backend/requirements-runtime.txt
             backend/requirements-test.txt
 
       - name: Install dependencies
-        run: pip install -r backend/requirements.txt -r backend/requirements-test.txt
+        run: pip install -r backend/requirements-runtime.txt -r backend/requirements-test.txt
 
       - name: Check generated scan-field contracts
         run: python scripts/generate_scan_filter_contract.py --check
@@ -75,11 +75,11 @@ jobs:
           python-version: "3.11"
           cache: pip
           cache-dependency-path: |
-            backend/requirements.txt
+            backend/requirements-runtime.txt
             backend/requirements-test.txt
 
       - name: Install dependencies
-        run: pip install -r backend/requirements.txt -r backend/requirements-test.txt
+        run: pip install -r backend/requirements-runtime.txt -r backend/requirements-test.txt
 
       - name: Comprehensive backend unit suite (shard ${{ matrix.shard }}/4)
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@
 
 .PHONY: help gate-identity gate-1 gate-2 gate-3 gate-4 gate-5 gate-6-load gate-7-chaos \
         gate-market-parity gates gate-check frontend-lint frontend-test frontend \
-        phase2-type-gate phase2-reliability golden-update load-baseline-update all
+        phase2-type-gate phase2-reliability golden-update load-baseline-update \
+        gate-unit-files all
 
 # ── Tooling ─────────────────────────────────────────────────────────
 
@@ -87,6 +88,8 @@ GATE_MARKET_PARITY = \
 # All gate files (used by gate-check)
 ALL_GATE_FILES = $(GATE_1) $(GATE_2) $(GATE_3) $(GATE_4) $(GATE_5) $(GATE_MARKET_PARITY)
 
+GATE_UNIT_FILES = $(filter tests/unit/%,$(GATE_IDENTITY) $(ALL_GATE_FILES))
+
 
 # ═══════════════════════════════════════════════════════════════════
 # Targets
@@ -102,6 +105,9 @@ help: ## Show available targets
 
 gate-1: ## Detector correctness
 	$(PYTEST) $(GATE_1) -v --tb=short
+
+gate-unit-files: ## Print unit test files already covered by backend gates
+	@printf '%s\n' $(GATE_UNIT_FILES) | sort -u
 
 gate-identity: ## Theme identity invariants
 	$(PYTEST) $(GATE_IDENTITY) -v --tb=short

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -533,6 +533,15 @@ class Settings(BaseSettings):
     # Yahoo does not price consistently. This gate applies to every canonical
     # Market RS calculation path, including static publish, backfill, and rollout.
     market_rs_min_current_price_coverage_ca: float = 0.70
+    # Asia static-site actuals from the 2026-07-22 scheduled run landed well
+    # below the global 90% bar for several Yahoo-covered broad universes. Keep
+    # market-specific floors close to observed coverage instead of weakening
+    # JP/AU/KR or the global default.
+    market_rs_min_current_price_coverage_hk: float = 0.75
+    market_rs_min_current_price_coverage_in: float = 0.45
+    market_rs_min_current_price_coverage_my: float = 0.85
+    market_rs_min_current_price_coverage_sg: float = 0.55
+    market_rs_min_current_price_coverage_tw: float = 0.50
     market_data_source_mode: str = "github_first"  # github_first | live_only
     github_data_repository: str = "xang1234/stock-screener"
     github_data_api_base: str = "https://api.github.com"
@@ -685,6 +694,11 @@ class Settings(BaseSettings):
     @field_validator(
         'market_rs_min_current_price_coverage',
         'market_rs_min_current_price_coverage_ca',
+        'market_rs_min_current_price_coverage_hk',
+        'market_rs_min_current_price_coverage_in',
+        'market_rs_min_current_price_coverage_my',
+        'market_rs_min_current_price_coverage_sg',
+        'market_rs_min_current_price_coverage_tw',
     )
     @classmethod
     def validate_market_rs_current_price_coverage(cls, v: float) -> float:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -40,6 +40,7 @@ from app.services.static_groups_rrg_export import (
     StaticGroupsRRGRollingHistoryExportSession,
 )
 from app.services.static_rrg_history_contract import StaticRRGHistoryBundleError
+from app.services.static_market_publish_policy import OPTIONAL_STATIC_MARKETS
 from app.tasks.data_fetch_lock import disable_serialized_data_fetch_lock
 from app.tasks.workload_coordination import disable_serialized_market_workload
 from app.wiring.bootstrap import (
@@ -784,6 +785,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             # Last-good artifacts can predate the balanced rollout. Only an
             # explicit operator override constrains a fallback publication.
             fallback_rs_formula_version_overrides=args.rs_formula_overrides_json,
+            optional_markets=OPTIONAL_STATIC_MARKETS,
         )
     else:
         prepare_runtime()

--- a/backend/app/scripts/validate_static_market_artifacts.py
+++ b/backend/app/scripts/validate_static_market_artifacts.py
@@ -14,6 +14,7 @@ from app.services.static_market_artifact_contract import (
     expected_market_from_static_market_manifest_path,
     read_static_market_manifest,
 )
+from app.services.static_market_publish_policy import OPTIONAL_STATIC_MARKETS
 
 
 class StaticMarketArtifactValidationError(RuntimeError):
@@ -28,7 +29,7 @@ _VALID_REASON_VALUES = frozenset(
         "export_failed",
     }
 )
-_ALLOWED_MISSING_MARKETS = frozenset({"CN"})
+_ALLOWED_MISSING_MARKETS = OPTIONAL_STATIC_MARKETS
 
 
 @dataclass(frozen=True)

--- a/backend/app/scripts/validate_static_market_artifacts.py
+++ b/backend/app/scripts/validate_static_market_artifacts.py
@@ -28,6 +28,7 @@ _VALID_REASON_VALUES = frozenset(
         "export_failed",
     }
 )
+_ALLOWED_MISSING_MARKETS = frozenset({"CN"})
 
 
 @dataclass(frozen=True)
@@ -100,6 +101,7 @@ class StaticMarketArtifactValidationResult:
     current_markets: set[str]
     fallback_markets: set[str]
     statuses: dict[str, MarketArtifactStatus]
+    allowed_missing_markets: set[str]
 
     @property
     def present_markets(self) -> set[str]:
@@ -192,19 +194,23 @@ def validate_market_artifacts(
         if expected_markets is not None
         else {code.upper() for code in market_registry.supported_market_codes()}
     )
+    current_markets = collect_markets(current_dir)
+    fallback_markets = collect_markets(fallback_dir)
+    missing_set = expected - (current_markets | fallback_markets)
+    allowed_missing = missing_set & _ALLOWED_MISSING_MARKETS
+    disallowed_missing = sorted(missing_set - _ALLOWED_MISSING_MARKETS)
     result = StaticMarketArtifactValidationResult(
         expected_markets=expected,
         selected_markets=_normalize_markets(selected_markets),
-        current_markets=collect_markets(current_dir),
-        fallback_markets=collect_markets(fallback_dir),
+        current_markets=current_markets,
+        fallback_markets=fallback_markets,
         statuses=collect_statuses(current_dir),
+        allowed_missing_markets=allowed_missing,
     )
-
-    missing = sorted(result.expected_markets - result.present_markets)
-    if missing:
+    if disallowed_missing:
         raise StaticMarketArtifactValidationError(
             "Refusing to publish an incomplete static site. No current build "
-            f"and no fallback artifact for: {', '.join(missing)}."
+            f"and no fallback artifact for: {', '.join(disallowed_missing)}."
         )
 
     return result
@@ -247,7 +253,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"{_format_market_list(result.selected_fallback_markets)}. Details: {details}.",
             flush=True,
         )
-    print("All supported markets present; static site is complete.")
+    if result.allowed_missing_markets:
+        print(
+            "::warning::Publishing without optional market artifacts for: "
+            f"{_format_market_list(result.allowed_missing_markets)}.",
+            flush=True,
+        )
+        print("Required market artifacts present; static site is publishable.")
+    else:
+        print("All supported markets present; static site is complete.")
     return 0
 
 

--- a/backend/app/scripts/validate_static_market_artifacts.py
+++ b/backend/app/scripts/validate_static_market_artifacts.py
@@ -197,15 +197,20 @@ def validate_market_artifacts(
     )
     current_markets = collect_markets(current_dir)
     fallback_markets = collect_markets(fallback_dir)
+    statuses = collect_statuses(current_dir)
     missing_set = expected - (current_markets | fallback_markets)
-    allowed_missing = missing_set & _ALLOWED_MISSING_MARKETS
-    disallowed_missing = sorted(missing_set - _ALLOWED_MISSING_MARKETS)
+    allowed_missing = {
+        market
+        for market in missing_set & _ALLOWED_MISSING_MARKETS
+        if (status := statuses.get(market)) is None or not status.has_current_artifact
+    }
+    disallowed_missing = sorted(missing_set - allowed_missing)
     result = StaticMarketArtifactValidationResult(
         expected_markets=expected,
         selected_markets=_normalize_markets(selected_markets),
         current_markets=current_markets,
         fallback_markets=fallback_markets,
-        statuses=collect_statuses(current_dir),
+        statuses=statuses,
         allowed_missing_markets=allowed_missing,
     )
     if disallowed_missing:

--- a/backend/app/services/static_artifact_combiner.py
+++ b/backend/app/services/static_artifact_combiner.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 import shutil
 import tempfile
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from app.services.static_market_artifact_contract import (
     STATIC_MARKET_METADATA_FILENAME,
@@ -51,11 +51,17 @@ class StaticArtifactCombiner:
         output_dir: Path,
         required_formula_by_market: Mapping[str, str],
         fallback_required_formula_by_market: Mapping[str, str] | None = None,
+        optional_markets: Iterable[str] = (),
         clean: bool,
     ) -> StaticArtifactCombineResult:
         required = {
             str(market).strip().upper(): str(formula).strip()
             for market, formula in required_formula_by_market.items()
+        }
+        optional = {
+            str(market).strip().upper()
+            for market in optional_markets
+            if str(market).strip()
         }
         fallback_required = (
             required
@@ -84,7 +90,11 @@ class StaticArtifactCombiner:
             selected.setdefault(market, artifact)
 
         if required:
-            missing = sorted(market for market in required if market not in selected)
+            missing = sorted(
+                market
+                for market in required
+                if market not in selected and market not in optional
+            )
             if missing:
                 raise NoPublishedStaticMarketArtifact(
                     "No published compatible static artifact is available for required "
@@ -107,6 +117,12 @@ class StaticArtifactCombiner:
                     f"{market} reused from a previous static-site market artifact "
                     "because the current run produced no artifact."
                 )
+        optional_missing = sorted(market for market in optional if market not in entries)
+        warnings.extend(
+            f"Static export market {market} was omitted from the combined bundle "
+            "because no current or fallback artifact was available."
+            for market in optional_missing
+        )
         if not required:
             warnings.extend(
                 f"Static export market {market} was omitted from the combined bundle "

--- a/backend/app/services/static_artifact_combiner.py
+++ b/backend/app/services/static_artifact_combiner.py
@@ -137,6 +137,7 @@ class StaticArtifactCombiner:
         )
         self._publish(
             selected=selected,
+            omitted_markets=optional_missing,
             output_dir=Path(output_dir),
             manifest=manifest,
             clean=clean,
@@ -334,6 +335,7 @@ class StaticArtifactCombiner:
     def _publish(
         *,
         selected: dict[str, dict[str, Any]],
+        omitted_markets: Iterable[str],
         output_dir: Path,
         manifest: dict[str, Any],
         clean: bool,
@@ -346,6 +348,8 @@ class StaticArtifactCombiner:
         try:
             if not clean and output_dir.exists():
                 shutil.copytree(output_dir, stage, dirs_exist_ok=True)
+            for market in omitted_markets:
+                shutil.rmtree(stage / "markets" / market.lower(), ignore_errors=True)
             for market, artifact in selected.items():
                 shutil.copytree(
                     artifact["market_dir"],

--- a/backend/app/services/static_artifact_combiner.py
+++ b/backend/app/services/static_artifact_combiner.py
@@ -349,7 +349,9 @@ class StaticArtifactCombiner:
             if not clean and output_dir.exists():
                 shutil.copytree(output_dir, stage, dirs_exist_ok=True)
             for market in omitted_markets:
-                shutil.rmtree(stage / "markets" / market.lower(), ignore_errors=True)
+                omitted_dir = stage / "markets" / market.lower()
+                if omitted_dir.exists() or omitted_dir.is_symlink():
+                    shutil.rmtree(omitted_dir)
             for market, artifact in selected.items():
                 shutil.copytree(
                     artifact["market_dir"],

--- a/backend/app/services/static_market_publish_policy.py
+++ b/backend/app/services/static_market_publish_policy.py
@@ -1,0 +1,4 @@
+"""Shared policy for publishing multi-market static site artifacts."""
+from __future__ import annotations
+
+OPTIONAL_STATIC_MARKETS = frozenset({"CN"})

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -8,7 +8,7 @@ import json
 import logging
 from pathlib import Path
 import shutil
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -259,6 +259,7 @@ class StaticSiteExportService:
         clean: bool = True,
         rs_formula_version_overrides: Mapping[str, str] | None = None,
         fallback_rs_formula_version_overrides: Mapping[str, str] | None = None,
+        optional_markets: Iterable[str] = (),
     ) -> StaticSiteExportResult:
         combined = StaticArtifactCombiner(
             schema_version=STATIC_SITE_SCHEMA_VERSION,
@@ -279,6 +280,7 @@ class StaticSiteExportService:
                 if fallback_rs_formula_version_overrides is not None
                 else None
             ),
+            optional_markets=optional_markets,
             clean=clean,
         )
         return StaticSiteExportResult(

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -12,3 +12,4 @@ markers =
     slow: marks tests as slow running tests
     performance: marks tests as query performance benchmarks
     load: marks tests as per-market load/soak benchmarks (require Redis; opt-in via gate-6-load)
+    allow_real_celery_dispatch: allows a unit test to exercise Celery's real apply_async path

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -1,4 +1,5 @@
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
+pytest-split>=0.11.0,<0.12.0
 akshare>=1.18.59
 baostock>=0.8.9

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2,6 +2,8 @@ import pytest
 import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -16,6 +18,29 @@ import app.models.stock_universe  # noqa: F401
 
 from app.scanners.base_screener import StockData
 from app.scanners.data_preparation import DataPreparationLayer
+
+
+@pytest.fixture(autouse=True)
+def stub_celery_task_dispatch(monkeypatch, request):
+    """Prevent unit tests from opening real Celery broker connections."""
+    if request.node.get_closest_marker("allow_real_celery_dispatch"):
+        yield
+        return
+
+    from celery.app.task import Task
+
+    def apply_async_stub(self, args=None, kwargs=None, task_id=None, **_options):
+        resolved_task_id = task_id or f"unit-test-{self.name or 'celery-task'}-{uuid4().hex}"
+        return SimpleNamespace(
+            id=resolved_task_id,
+            task_id=resolved_task_id,
+            state="PENDING",
+            status="PENDING",
+        )
+
+    apply_async_stub._stockscreener_unit_stub = True
+    monkeypatch.setattr(Task, "apply_async", apply_async_stub)
+    yield
 
 
 @pytest.fixture

--- a/backend/tests/unit/services/test_static_artifact_combiner.py
+++ b/backend/tests/unit/services/test_static_artifact_combiner.py
@@ -233,6 +233,36 @@ def test_combiner_omits_optional_market_without_current_or_fallback_artifact(tmp
     assert any("CN was omitted" in warning for warning in result.manifest["warnings"])
 
 
+def test_combiner_removes_stale_optional_market_directory_on_incremental_publish(
+    tmp_path,
+):
+    current = write_market_artifact(
+        tmp_path / "current",
+        market="US",
+        formula=BALANCED_RS_FORMULA_VERSION,
+    )
+    output_dir = tmp_path / "out"
+    stale_cn_scan_dir = output_dir / "markets" / "cn" / "scan"
+    stale_cn_scan_dir.mkdir(parents=True)
+    (stale_cn_scan_dir / "manifest.json").write_text("{}", encoding="utf-8")
+
+    result = combiner().combine(
+        artifacts_dir=current,
+        fallback_artifacts_dir=tmp_path / "empty-fallback",
+        output_dir=output_dir,
+        required_formula_by_market={
+            "US": BALANCED_RS_FORMULA_VERSION,
+            "CN": BALANCED_RS_FORMULA_VERSION,
+        },
+        optional_markets={"CN"},
+        clean=False,
+    )
+
+    assert result.manifest["supported_markets"] == ["US"]
+    assert (output_dir / "markets" / "us").is_dir()
+    assert not (output_dir / "markets" / "cn").exists()
+
+
 def test_combiner_validates_optional_market_formula_when_artifact_exists(tmp_path):
     current = write_market_artifact(
         tmp_path / "current",

--- a/backend/tests/unit/services/test_static_artifact_combiner.py
+++ b/backend/tests/unit/services/test_static_artifact_combiner.py
@@ -263,6 +263,34 @@ def test_combiner_removes_stale_optional_market_directory_on_incremental_publish
     assert not (output_dir / "markets" / "cn").exists()
 
 
+def test_combiner_surfaces_stale_optional_market_cleanup_errors(tmp_path):
+    current = write_market_artifact(
+        tmp_path / "current",
+        market="US",
+        formula=BALANCED_RS_FORMULA_VERSION,
+    )
+    output_dir = tmp_path / "out"
+    stale_cn_path = output_dir / "markets" / "cn"
+    stale_cn_path.parent.mkdir(parents=True)
+    stale_cn_path.write_text("stale", encoding="utf-8")
+
+    with pytest.raises(NotADirectoryError):
+        combiner().combine(
+            artifacts_dir=current,
+            fallback_artifacts_dir=tmp_path / "empty-fallback",
+            output_dir=output_dir,
+            required_formula_by_market={
+                "US": BALANCED_RS_FORMULA_VERSION,
+                "CN": BALANCED_RS_FORMULA_VERSION,
+            },
+            optional_markets={"CN"},
+            clean=False,
+        )
+
+    assert stale_cn_path.is_file()
+    assert not (output_dir / "markets" / "us").exists()
+
+
 def test_combiner_validates_optional_market_formula_when_artifact_exists(tmp_path):
     current = write_market_artifact(
         tmp_path / "current",

--- a/backend/tests/unit/services/test_static_artifact_combiner.py
+++ b/backend/tests/unit/services/test_static_artifact_combiner.py
@@ -208,6 +208,49 @@ def test_combiner_allows_legacy_fallback_outside_explicit_formula_policy(tmp_pat
     )
 
 
+def test_combiner_omits_optional_market_without_current_or_fallback_artifact(tmp_path):
+    current = write_market_artifact(
+        tmp_path / "current",
+        market="US",
+        formula=BALANCED_RS_FORMULA_VERSION,
+    )
+
+    result = combiner().combine(
+        artifacts_dir=current,
+        fallback_artifacts_dir=tmp_path / "empty-fallback",
+        output_dir=tmp_path / "out",
+        required_formula_by_market={
+            "US": BALANCED_RS_FORMULA_VERSION,
+            "CN": BALANCED_RS_FORMULA_VERSION,
+        },
+        optional_markets={"CN"},
+        clean=True,
+    )
+
+    assert result.manifest["supported_markets"] == ["US"]
+    assert "CN" not in result.manifest["markets"]
+    assert not (tmp_path / "out" / "markets" / "cn").exists()
+    assert any("CN was omitted" in warning for warning in result.manifest["warnings"])
+
+
+def test_combiner_validates_optional_market_formula_when_artifact_exists(tmp_path):
+    current = write_market_artifact(
+        tmp_path / "current",
+        market="CN",
+        formula=LEGACY_RS_FORMULA_VERSION,
+    )
+
+    with pytest.raises(StaticArtifactFormulaError, match="CN current"):
+        combiner().combine(
+            artifacts_dir=current,
+            fallback_artifacts_dir=None,
+            output_dir=tmp_path / "out",
+            required_formula_by_market={"CN": BALANCED_RS_FORMULA_VERSION},
+            optional_markets={"CN"},
+            clean=True,
+        )
+
+
 def test_combiner_rejects_wrong_scan_manifest_formula(tmp_path):
     current = write_market_artifact(
         tmp_path / "current",

--- a/backend/tests/unit/test_ci_workflow.py
+++ b/backend/tests/unit/test_ci_workflow.py
@@ -6,7 +6,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def test_backend_unit_shards_exclude_opt_in_markers_during_collection():
+def test_backend_unit_shards_are_duration_split_and_exclude_opt_in_markers():
     workflow = yaml.safe_load(
         (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     )
@@ -21,7 +21,14 @@ def test_backend_unit_shards_exclude_opt_in_markers_during_collection():
             "Comprehensive backend unit suite"
         )
     )
-    assert (
-        'python -m pytest tests/unit --collect-only -qq '
-        '-m "not live_service and not load"'
-    ) in shard_script
+    assert 'make gate-unit-files > "${gate_unit_file}"' in shard_script
+    assert 'ignore_args+=(--ignore "${path}")' in shard_script
+    assert "python -m pytest tests/unit \\" in shard_script
+    assert '-m "not live_service and not load" \\' in shard_script
+    assert "--splits 4 \\" in shard_script
+    assert '--group "${{ matrix.shard }}" \\' in shard_script
+    assert "--splitting-algorithm least_duration \\" in shard_script
+    assert "--durations-path .test_durations \\" in shard_script
+    assert "--store-durations \\" in shard_script
+    assert "--collect-only" not in shard_script
+    assert "index % 4" not in shard_script

--- a/backend/tests/unit/test_ci_workflow.py
+++ b/backend/tests/unit/test_ci_workflow.py
@@ -34,7 +34,5 @@ def test_backend_unit_shards_use_cache_free_equal_weight_split_and_exclude_opt_i
     assert "--splits 4 \\" in shard_script
     assert '--group "${{ matrix.shard }}" \\' in shard_script
     assert "--splitting-algorithm least_duration \\" in shard_script
-    assert "--durations-path" not in shard_script
-    assert "--store-durations" not in shard_script
     assert "--collect-only" not in shard_script
     assert "index % 4" not in shard_script

--- a/backend/tests/unit/test_ci_workflow.py
+++ b/backend/tests/unit/test_ci_workflow.py
@@ -6,7 +6,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def test_backend_unit_shards_are_duration_split_and_exclude_opt_in_markers():
+def test_backend_unit_shards_use_cache_free_equal_weight_split_and_exclude_opt_in_markers():
     workflow = yaml.safe_load(
         (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     )
@@ -27,6 +27,10 @@ def test_backend_unit_shards_are_duration_split_and_exclude_opt_in_markers():
     assert 'ignore_args+=(--ignore "${path}")' in shard_script
     assert "python -m pytest tests/unit \\" in shard_script
     assert '-m "not live_service and not load" \\' in shard_script
+    assert (
+        "Intentionally cache-free: without duration data, pytest-split gives "
+        "each test equal weight and all shards compute the same partition."
+    ) in shard_script
     assert "--splits 4 \\" in shard_script
     assert '--group "${{ matrix.shard }}" \\' in shard_script
     assert "--splitting-algorithm least_duration \\" in shard_script

--- a/backend/tests/unit/test_ci_workflow.py
+++ b/backend/tests/unit/test_ci_workflow.py
@@ -6,6 +6,30 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
+def test_backend_ci_uses_runtime_requirements_without_optional_theme_ml_stack():
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    )
+
+    for job_name in ("backend", "backend-unit"):
+        steps = workflow["jobs"][job_name]["steps"]
+        setup_python_step = next(
+            step for step in steps if step.get("uses") == "actions/setup-python@v5"
+        )
+        cache_dependency_path = setup_python_step["with"]["cache-dependency-path"]
+        assert "backend/requirements-runtime.txt" in cache_dependency_path
+        assert "backend/requirements-test.txt" in cache_dependency_path
+        assert "backend/requirements.txt" not in cache_dependency_path
+
+        install_step = next(
+            step for step in steps if step.get("name") == "Install dependencies"
+        )
+        assert install_step["run"] == (
+            "pip install -r backend/requirements-runtime.txt "
+            "-r backend/requirements-test.txt"
+        )
+
+
 def test_backend_unit_shards_use_cache_free_equal_weight_split_and_exclude_opt_in_markers():
     workflow = yaml.safe_load(
         (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()

--- a/backend/tests/unit/test_ci_workflow.py
+++ b/backend/tests/unit/test_ci_workflow.py
@@ -14,6 +14,8 @@ def test_backend_unit_shards_are_duration_split_and_exclude_opt_in_markers():
     names = [step.get("name") for step in steps]
 
     assert "Safe test collection" not in names
+    assert "Restore backend unit duration cache" not in names
+    assert "Save backend unit duration cache" not in names
     shard_script = next(
         step["run"]
         for step in steps
@@ -28,7 +30,7 @@ def test_backend_unit_shards_are_duration_split_and_exclude_opt_in_markers():
     assert "--splits 4 \\" in shard_script
     assert '--group "${{ matrix.shard }}" \\' in shard_script
     assert "--splitting-algorithm least_duration \\" in shard_script
-    assert "--durations-path .test_durations \\" in shard_script
-    assert "--store-durations \\" in shard_script
+    assert "--durations-path" not in shard_script
+    assert "--store-durations" not in shard_script
     assert "--collect-only" not in shard_script
     assert "index % 4" not in shard_script

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -1376,7 +1376,7 @@ def test_main_rejects_fallback_artifacts_without_combine_mode(monkeypatch, tmp_p
 
 
 def test_main_passes_fallback_artifacts_dir_to_combine(monkeypatch, tmp_path):
-    combine_calls: list[tuple[object, object, object, bool, object, object]] = []
+    combine_calls: list[tuple[object, object, object, bool, object, object, object]] = []
     output_dir = tmp_path / "out"
     artifacts_dir = tmp_path / "artifacts"
     fallback_dir = tmp_path / "fallback"
@@ -1386,7 +1386,8 @@ def test_main_passes_fallback_artifacts_dir_to_combine(monkeypatch, tmp_path):
         "combine_market_artifacts",
         lambda artifacts_dir, output_dir, *, fallback_artifacts_dir=None, clean=True,
         rs_formula_version_overrides=None,
-        fallback_rs_formula_version_overrides=None: combine_calls.append(
+        fallback_rs_formula_version_overrides=None,
+        optional_markets=(): combine_calls.append(
             (
                 artifacts_dir,
                 output_dir,
@@ -1394,6 +1395,7 @@ def test_main_passes_fallback_artifacts_dir_to_combine(monkeypatch, tmp_path):
                 clean,
                 rs_formula_version_overrides,
                 fallback_rs_formula_version_overrides,
+                optional_markets,
             )
         )
         or SimpleNamespace(
@@ -1431,6 +1433,7 @@ def test_main_passes_fallback_artifacts_dir_to_combine(monkeypatch, tmp_path):
             for market in export_script.STATIC_EXPORT_MARKETS
         },
         {},
+        export_script.OPTIONAL_STATIC_MARKETS,
     )]
 
 

--- a/backend/tests/unit/test_market_rs_inputs.py
+++ b/backend/tests/unit/test_market_rs_inputs.py
@@ -223,6 +223,44 @@ def test_load_allows_ca_current_price_coverage_matching_configured_policy(
     assert set(inputs.exclusions) == set(symbols)
 
 
+@pytest.mark.parametrize(
+    ("market", "benchmark", "covered_count", "symbol_count", "expected_coverage"),
+    [
+        ("HK", "^HSI", 76, 100, 0.76),
+        ("IN", "^NSEI", 49, 100, 0.49),
+        ("MY", "^KLSE", 87, 100, 0.87),
+        ("SG", "^STI", 58, 100, 0.58),
+        ("TW", "^TWII", 55, 100, 0.55),
+    ],
+)
+def test_load_allows_static_asia_current_price_coverage_actuals(
+    db_session,
+    market,
+    benchmark,
+    covered_count,
+    symbol_count,
+    expected_coverage,
+):
+    symbols = tuple(f"S{index}" for index in range(symbol_count))
+    db_session.add_all(
+        [
+            *[
+                _price(symbol, 0, adjusted=100.0)
+                for symbol in symbols[:covered_count]
+            ],
+            *_complete_rows(benchmark, {offset: 100.0 for offset in ANCHORS}),
+        ]
+    )
+    db_session.commit()
+
+    inputs = _loader(symbols, candidates=(benchmark,)).load(
+        db_session, market=market, as_of_date=ANCHORS[0]
+    )
+
+    assert inputs.current_price_coverage == pytest.approx(expected_coverage)
+    assert set(inputs.exclusions) == set(symbols)
+
+
 def test_load_uses_configured_market_specific_current_price_threshold(
     db_session,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/unit/test_static_market_artifact_validation.py
+++ b/backend/tests/unit/test_static_market_artifact_validation.py
@@ -130,6 +130,40 @@ def test_static_market_validator_allows_selected_market_fallback_without_status(
     assert result.selected_fallback_diagnostics == {"CN": "missing status artifact"}
 
 
+def test_static_market_validator_allows_missing_cn_without_fallback(tmp_path: Path) -> None:
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    _write_market_manifest(current_dir, "static-market-US", "US")
+
+    result = validate_market_artifacts(
+        current_dir=current_dir,
+        fallback_dir=fallback_dir,
+        selected_markets={"CN"},
+        expected_markets={"US", "CN"},
+    )
+
+    assert result.present_markets == {"US"}
+    assert result.allowed_missing_markets == {"CN"}
+
+
+def test_static_market_validator_still_rejects_missing_non_cn_market(tmp_path: Path) -> None:
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    _write_market_manifest(current_dir, "static-market-US", "US")
+
+    with pytest.raises(StaticMarketArtifactValidationError) as exc_info:
+        validate_market_artifacts(
+            current_dir=current_dir,
+            fallback_dir=fallback_dir,
+            selected_markets={"HK"},
+            expected_markets={"US", "HK", "CN"},
+        )
+
+    message = str(exc_info.value)
+    assert "HK" in message
+    assert "CN" not in message
+
+
 def test_static_market_validator_warns_when_selected_market_uses_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -167,6 +201,36 @@ def test_static_market_validator_warns_when_selected_market_uses_fallback(
         "::warning::Publishing last-known-good fallback artifacts for selected markets: CN. "
         "Details: CN: status failed/no_current_artifact."
     ) in capsys.readouterr().out
+
+
+def test_static_market_validator_warns_when_cn_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    _write_market_manifest(current_dir, "static-market-US", "US")
+    monkeypatch.setattr(
+        "app.scripts.validate_static_market_artifacts.market_registry.supported_market_codes",
+        lambda: ("US", "CN"),
+    )
+
+    exit_code = main(
+        [
+            "--current-dir",
+            str(current_dir),
+            "--fallback-dir",
+            str(fallback_dir),
+            "--selected-markets",
+            '["CN"]',
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "::warning::Publishing without optional market artifacts for: CN." in output
+    assert "Required market artifacts present; static site is publishable." in output
 
 
 def test_static_market_validator_rejects_string_boolean_status_contract(tmp_path: Path) -> None:

--- a/backend/tests/unit/test_static_market_artifact_validation.py
+++ b/backend/tests/unit/test_static_market_artifact_validation.py
@@ -146,6 +146,31 @@ def test_static_market_validator_allows_missing_cn_without_fallback(tmp_path: Pa
     assert result.allowed_missing_markets == {"CN"}
 
 
+def test_static_market_validator_rejects_missing_cn_when_status_says_artifact_exists(
+    tmp_path: Path,
+) -> None:
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    _write_market_manifest(current_dir, "static-market-US", "US")
+    _write_market_status(
+        current_dir,
+        "CN",
+        has_current_artifact=True,
+        status="published",
+        reason=None,
+    )
+
+    with pytest.raises(StaticMarketArtifactValidationError) as exc_info:
+        validate_market_artifacts(
+            current_dir=current_dir,
+            fallback_dir=fallback_dir,
+            selected_markets={"CN"},
+            expected_markets={"US", "CN"},
+        )
+
+    assert "CN" in str(exc_info.value)
+
+
 def test_static_market_validator_still_rejects_missing_non_cn_market(tmp_path: Path) -> None:
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"

--- a/backend/tests/unit/test_unit_celery_dispatch_guard.py
+++ b/backend/tests/unit/test_unit_celery_dispatch_guard.py
@@ -1,0 +1,23 @@
+"""Guards that keep unit tests from dispatching real Celery broker messages."""
+from __future__ import annotations
+
+from celery.app.task import Task
+import pytest
+
+
+def test_unit_suite_replaces_celery_apply_async() -> None:
+    assert getattr(Task.apply_async, "_stockscreener_unit_stub", False) is True
+
+
+def test_unmocked_celery_delay_does_not_run_task_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.tasks.scan_tasks import finalize_scan_artifacts
+
+    def fail_if_executed(*_args, **_kwargs):
+        pytest.fail("unit Celery dispatch should not execute task bodies")
+
+    monkeypatch.setattr(finalize_scan_artifacts, "run", fail_if_executed)
+
+    result = finalize_scan_artifacts.delay("scan-001")
+
+    assert result.id.startswith("unit-test-app.tasks.scan_tasks.finalize_scan_artifacts-")
+    assert result.state == "PENDING"


### PR DESCRIPTION
## Summary

- Tune Asia Market RS current-price coverage floors for HK, IN, MY, SG, and TW based on the July 22 scheduled static-site actuals.
- Allow the static-site artifact validator to publish without CN when no current or compatible fallback artifact exists, while still requiring all non-CN markets.
- Add regression coverage for the Asia threshold actuals and the CN-optional combine policy.
- Track CN runtime instability as Beads follow-up stockscreenclaude-srh.

## Root Cause

The Asia scheduled run reached post-close data selection correctly, but several Yahoo-backed broad universes consistently landed below the global 90% Balanced RS coverage gate. CN separately stalls in static daily price refresh and has no v3 fallback artifact yet, causing combine validation to reject otherwise publishable runs.

## Validation

```bash
cd backend && source venv/bin/activate && pytest tests/unit/test_market_rs_inputs.py -q
cd backend && source venv/bin/activate && pytest tests/unit/test_settings_llm_keys.py -q
cd backend && source venv/bin/activate && pytest tests/unit/test_market_rs_inputs.py tests/unit/test_static_market_artifact_validation.py -q
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added market-specific minimum Yahoo current-price coverage thresholds for Hong Kong, India, Malaysia, Singapore, and Taiwan.
  - Static-site publishing now supports configurable “optional” markets (currently China), with clear warnings when those artifacts are omitted.

- **Bug Fixes**
  - Publishing no longer fails when optional China artifacts are missing; warning output only names truly disallowed missing markets.

- **Tests / CI**
  - Expanded unit coverage for market coverage inputs and optional artifact publish behavior, plus updated static export/combiner checks.
  - Improved CI unit-test sharding/caching; added a unit Celery dispatch stub and a new pytest marker for real dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->