### PR TITLE
fix: hydrate static RRG startup price history

### DIFF
--- a/backend/app/services/static_daily_price_refresh_service.py
+++ b/backend/app/services/static_daily_price_refresh_service.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
+import math
 from typing import Any, Callable
-
-from sqlalchemy import func
 
 from app.domain.markets import get_market_catalog
 from app.domain.markets.key_markets import key_market_price_symbols
@@ -231,12 +230,12 @@ class StaticDailyPriceRefreshService:
             "rate_limited_retry": retry_stats,
         }
 
-    def _rrg_history_cutoff(
+    def _rrg_required_anchor_dates(
         self,
         *,
         as_of_date: date,
         market: str | None,
-    ) -> date | None:
+    ) -> frozenset[date] | None:
         if market is None:
             return None
         normalized_market = str(market or "").strip().upper()
@@ -257,16 +256,33 @@ class StaticDailyPriceRefreshService:
             )
             if not target_dates:
                 return None
-            oldest_target = target_dates[0]
-            oldest_offset = max(HORIZON_SESSIONS.values())
-            anchors = self._calendar_service.session_anchors(
-                normalized_market,
-                oldest_target,
-                offsets=(oldest_offset,),
+            anchor_dates: set[date] = set()
+            offsets = tuple(HORIZON_SESSIONS.values())
+            for target_date in target_dates:
+                anchors = self._calendar_service.session_anchors(
+                    normalized_market,
+                    target_date,
+                    offsets=offsets,
+                )
+                anchor_dates.update(anchors.values())
+        except Exception as exc:
+            print(
+                "[static-daily prices] Could not resolve RRG history anchors "
+                f"for market={normalized_market}: {exc}",
+                flush=True,
             )
-        except Exception:
             return None
-        return anchors[oldest_offset]
+        return frozenset(anchor_dates)
+
+    @staticmethod
+    def _valid_adjusted_close(value: object) -> bool:
+        if value is None:
+            return False
+        try:
+            price = float(value)
+        except (TypeError, ValueError):
+            return False
+        return math.isfinite(price) and price > 0
 
     def _symbols_with_short_rrg_history(
         self,
@@ -279,32 +295,41 @@ class StaticDailyPriceRefreshService:
     ) -> list[str]:
         if not enabled or not symbols:
             return []
-        cutoff = self._rrg_history_cutoff(as_of_date=as_of_date, market=market)
-        if cutoff is None:
+        anchor_dates = self._rrg_required_anchor_dates(
+            as_of_date=as_of_date,
+            market=market,
+        )
+        if not anchor_dates:
             return []
 
-        earliest_by_symbol: dict[str, date] = {}
+        anchor_count = len(anchor_dates)
+        available_anchor_counts: dict[str, int] = {}
         for chunk_start in range(0, len(symbols), 500):
             chunk_symbols = symbols[chunk_start:chunk_start + 500]
             rows = (
-                db.query(StockPrice.symbol, func.min(StockPrice.date))
-                .filter(StockPrice.symbol.in_(chunk_symbols))
-                .group_by(StockPrice.symbol)
+                db.query(StockPrice.symbol, StockPrice.date, StockPrice.adj_close)
+                .filter(
+                    StockPrice.symbol.in_(chunk_symbols),
+                    StockPrice.date.in_(anchor_dates),
+                )
                 .all()
             )
-            earliest_by_symbol.update(
+            available_by_symbol: dict[str, set[date]] = {}
+            for symbol, row_date, adj_close in rows:
+                if row_date is None or not self._valid_adjusted_close(adj_close):
+                    continue
+                available_by_symbol.setdefault(str(symbol).upper(), set()).add(row_date)
+            available_anchor_counts.update(
                 {
-                    str(symbol).upper(): earliest_date
-                    for symbol, earliest_date in rows
-                    if earliest_date is not None
+                    symbol: len(dates)
+                    for symbol, dates in available_by_symbol.items()
                 }
             )
 
         return [
             symbol
             for symbol in symbols
-            if earliest_by_symbol.get(symbol) is not None
-            and earliest_by_symbol[symbol] > cutoff
+            if available_anchor_counts.get(symbol, 0) < anchor_count
         ]
 
     def _fetch_and_store(

--- a/backend/tests/unit/test_static_daily_price_refresh_service.py
+++ b/backend/tests/unit/test_static_daily_price_refresh_service.py
@@ -35,6 +35,27 @@ US_KEY_MARKET_PRICE_SYMBOLS = [
 ]
 
 
+class _RRGStartupCalendar:
+    @staticmethod
+    def trading_days(market, start, end):
+        assert market == "IN"
+        assert start < end
+        return [date(2026, 3, 2), end]
+
+    @staticmethod
+    def session_anchors(market, as_of_date, *, offsets):
+        assert market == "IN"
+        assert tuple(offsets) == (21, 63, 126, 189, 252)
+        return {
+            0: as_of_date,
+            21: date(2026, 1, 30),
+            63: date(2025, 12, 1),
+            126: date(2025, 9, 1),
+            189: date(2025, 6, 2),
+            252: date(2025, 3, 3),
+        }
+
+
 def _sqlite_session_factory():
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(
@@ -440,6 +461,7 @@ def test_static_daily_price_refresh_hydrates_short_history_for_rrg_startup() -> 
         price_cache=SimpleNamespace(store_batch_in_cache=lambda *_args, **_kwargs: None),
         fetcher=_FakeFetcher(),
         batch_size_for_market=lambda _market: 25,
+        calendar_service=_RRGStartupCalendar(),
         sleep=lambda _seconds: None,
     )
 
@@ -462,6 +484,90 @@ def test_static_daily_price_refresh_hydrates_short_history_for_rrg_startup() -> 
     assert result["no_history_symbols"] == len(IN_KEY_MARKET_PRICE_SYMBOLS)
     assert result["history_incomplete_symbols"] == 1
     assert result["yahoo_fetched_symbols"] == 6
+
+
+def test_static_daily_price_refresh_hydrates_sparse_old_rows_for_rrg_startup() -> None:
+    session_factory = _sqlite_session_factory()
+
+    with session_factory() as db:
+        db.add(
+            StockUniverse(
+                symbol="SPARSE.NS",
+                market="IN",
+                is_active=True,
+                market_cap=100.0,
+            )
+        )
+        db.add_all(
+            [
+                StockPrice(
+                    symbol="SPARSE.NS",
+                    date=date(2025, 1, 2),
+                    open=1.0,
+                    high=1.0,
+                    low=1.0,
+                    close=1.0,
+                    adj_close=1.0,
+                    volume=1000,
+                ),
+                StockPrice(
+                    symbol="SPARSE.NS",
+                    date=date(2026, 6, 4),
+                    open=2.0,
+                    high=2.0,
+                    low=2.0,
+                    close=2.0,
+                    adj_close=2.0,
+                    volume=1000,
+                ),
+            ]
+        )
+        db.commit()
+
+    fetch_calls: list[dict] = []
+
+    class _FakeFetcher:
+        def fetch_prices_in_batches(
+            self, symbols, period="2y", start_batch_size=None, market=None
+        ):
+            fetch_calls.append(
+                {
+                    "symbols": list(symbols),
+                    "period": period,
+                    "start_batch_size": start_batch_size,
+                    "market": market,
+                }
+            )
+            return {
+                symbol: {"price_data": SimpleNamespace(empty=False), "has_error": False}
+                for symbol in symbols
+            }
+
+    service = StaticDailyPriceRefreshService(
+        session_factory=session_factory,
+        price_cache=SimpleNamespace(store_batch_in_cache=lambda *_args, **_kwargs: None),
+        fetcher=_FakeFetcher(),
+        batch_size_for_market=lambda _market: 25,
+        calendar_service=_RRGStartupCalendar(),
+        sleep=lambda _seconds: None,
+    )
+
+    result = service.refresh(
+        as_of_date=date(2026, 6, 4),
+        market="IN",
+        ensure_rrg_history=True,
+    )
+
+    assert fetch_calls == [
+        {
+            "symbols": ["SPARSE.NS", *IN_KEY_MARKET_PRICE_SYMBOLS],
+            "period": STATIC_DAILY_PRICE_BOOTSTRAP_PERIOD,
+            "start_batch_size": 25,
+            "market": "IN",
+        }
+    ]
+    assert result["db_fresh_symbols"] == 1
+    assert result["history_incomplete_symbols"] == 1
 
 
 def test_static_daily_price_refresh_uses_date_only_freshness_for_key_market_symbols() -> None:


### PR DESCRIPTION
## Summary
- Follow-up to the static RRG startup hydration fix already on `main`.
- Replace the earliest-price-date proxy with exact required RRG anchor-date coverage over valid adjusted closes.
- Log cutoff/anchor resolution failures while preserving fail-closed behavior.
- Add regression coverage for sparse old rows that previously suppressed the 2y bootstrap.

## Root Cause
The first pass classified RRG startup history completeness with `min(stock_prices.date)`. A symbol could have one old row before the cutoff plus a current row, while still missing the exact adjusted-close anchor dates that balanced Market RS requires. That could let backfill hit the same old-date failures or exclusions we were trying to prevent.

## Validation
- `pytest tests/unit/test_static_daily_price_refresh_service.py -q` — 13 passed.
- `pytest tests/unit/test_static_daily_price_refresh_service.py tests/unit/test_export_static_site_script.py tests/unit/test_static_rrg_history_bundle.py -q` — 63 passed.
- `python -m compileall app/services/static_daily_price_refresh_service.py tests/unit/test_static_daily_price_refresh_service.py` — passed.
- `git diff --check` — passed.
- Full backend `pytest` was previously attempted; unrelated existing failures remain in theme API integration tests returning 503 and load tests missing simulator profiles for AU/CA/CN/DE/IN/KR/MY/SG.
- `ruff` is not available in the backend venv (`No module named ruff`).
