### PR TITLE
Reduce memory usage during daily snapshot builds

### DIFF
--- a/backend/app/use_cases/feature_store/build_daily_snapshot.py
+++ b/backend/app/use_cases/feature_store/build_daily_snapshot.py
@@ -37,7 +37,7 @@ from app.domain.feature_store.models import (
     RunStatus,
     RunType,
 )
-from app.domain.feature_store.quality import DQInputs, DQThresholds
+from app.domain.feature_store.quality import DQThresholds
 from app.domain.scanning.signature import (
     build_scan_signature_payload,
     hash_scan_signature,
@@ -577,7 +577,6 @@ class BuildDailyFeatureSnapshotUseCase:
         uow.commit()
 
         # ── 3. Scan symbols in chunks ───────────────────────────
-        all_rows: list[FeatureRowWrite] = []
         merged_requirements = None
         bulk_prefetch_enabled = self._data_provider is not None
 
@@ -808,7 +807,6 @@ class BuildDailyFeatureSnapshotUseCase:
             # 3c — Persist chunk (checkpoint)
             if chunk_rows:
                 uow.feature_store.upsert_snapshot_rows(run_id, chunk_rows)
-                all_rows.extend(chunk_rows)
             uow.commit()
 
             # 3d — Progress reporting
@@ -831,6 +829,9 @@ class BuildDailyFeatureSnapshotUseCase:
                     eta_seconds=round(eta) if eta is not None else None,
                 )
             )
+            chunk_rows.clear()
+            outcomes_by_symbol.clear()
+            pre_fetched_data.clear()
 
         # ── 4. Mark completed ───────────────────────────────────
         duration = time.monotonic() - start_time
@@ -855,29 +856,8 @@ class BuildDailyFeatureSnapshotUseCase:
 
         # ── 5. Delegate DQ + publish to PublishFeatureRunUseCase ──
         actual_count = uow.feature_store.count_by_run_id(run_id)
-        nulls = sum(1 for r in all_rows if r.composite_score is None)
-        scores = tuple(
-            r.composite_score for r in all_rows if r.composite_score is not None
-        )
-        ratings = tuple(
-            r.overall_rating for r in all_rows if r.overall_rating is not None
-        )
-        result_syms = tuple(r.symbol for r in all_rows)
-
-        dq_inputs = DQInputs(
-            expected_row_count=total,
-            actual_row_count=actual_count,
-            null_score_count=nulls,
-            total_row_count=len(all_rows),
-            scores=scores,
-            ratings=ratings,
-            universe_symbols=tuple(symbols),
-            result_symbols=result_syms,
-        )
-
         publish_cmd = PublishRunCommand(
             run_id=run_id,
-            dq_inputs=dq_inputs,
             pointer_key=cmd.publish_pointer_key,
             dq_thresholds=cmd.dq_thresholds,
         )

--- a/backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
+++ b/backend/tests/unit/use_cases/feature_store/test_build_daily_snapshot.py
@@ -251,6 +251,37 @@ class TestHappyPath:
         assert count == 3
 
     @_PATCH_TRADING_DAY
+    def test_publish_dq_inputs_are_loaded_from_persisted_rows(self, _mock_td):
+        class RecordingFeatureStore(FakeFeatureStoreRepository):
+            def __init__(self) -> None:
+                super().__init__()
+                self.dq_input_run_ids: list[int] = []
+
+            def get_run_dq_inputs(self, run_id: int):
+                self.dq_input_run_ids.append(run_id)
+                return super().get_run_dq_inputs(run_id)
+
+        universe = FakeUniverseRepository(["AAPL", "MSFT", "GOOGL"])
+        feature_runs = FakeFeatureRunRepository()
+        feature_store = RecordingFeatureStore()
+        uow = FakeUnitOfWork(
+            universe=universe,
+            feature_runs=feature_runs,
+            feature_store=feature_store,
+        )
+        use_case = BuildDailyFeatureSnapshotUseCase(scanner=FakeScanner())
+
+        result = use_case.execute(
+            uow,
+            _make_cmd(chunk_size=2),
+            FakeProgressSink(),
+            FakeCancellationToken(),
+        )
+
+        assert result.status == RunStatus.PUBLISHED.value
+        assert feature_store.dq_input_run_ids == [result.run_id]
+
+    @_PATCH_TRADING_DAY
     def test_universe_symbols_saved(self, _mock_td):
         uow, scanner = _make_uow(symbols=["AAPL", "TSLA"])
         use_case = BuildDailyFeatureSnapshotUseCase(scanner=scanner)


### PR DESCRIPTION
## Summary
- Stop retaining all feature rows in memory during snapshot builds
- Clear per-chunk scan data after persistence
- Load data-quality inputs from persisted rows before publishing
- Add unit coverage for persisted DQ input loading

## Testing
- Unit tests added for the daily snapshot use case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily snapshot publishing by using persisted feature-store data for row counts and data-quality inputs.
  * Added cleanup during chunk processing to support more efficient memory usage.
  * Ensured publish-time data-quality checks use the correct snapshot run.

* **Tests**
  * Added regression coverage verifying persisted data is queried correctly during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->