### PR TITLE
Add provider-aware market calendars and session invariants

### DIFF
--- a/backend/app/domain/markets/__init__.py
+++ b/backend/app/domain/markets/__init__.py
@@ -14,6 +14,11 @@ from .catalog import (
     MarketCatalogError,
     get_market_catalog,
 )
+from .calendar_policy import (
+    CalendarProvider,
+    CalendarSessionOverride,
+    calendar_session_probe_expectations,
+)
 from .market import (
     SUPPORTED_MARKET_CODE_ORDER,
     SUPPORTED_MARKET_CODES,
@@ -67,6 +72,8 @@ __all__ = [
     "MarketProfile",
     "MarketRegistry",
     "BenchmarkFacts",
+    "CalendarProvider",
+    "CalendarSessionOverride",
     "MicFacts",
     "MicAliasDefinition",
     "MicAliasRegistry",
@@ -76,6 +83,7 @@ __all__ = [
     "SUPPORTED_MARKET_CODE_ORDER",
     "SUPPORTED_MARKET_CODES",
     "UnsupportedMarketError",
+    "calendar_session_probe_expectations",
     "get_market_catalog",
     "market_registry",
     "mic_alias_registry",

--- a/backend/app/domain/markets/calendar_policy.py
+++ b/backend/app/domain/markets/calendar_policy.py
@@ -1,0 +1,49 @@
+"""Canonical market calendar provider and session-override policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+
+
+class CalendarProvider(Enum):
+    """Supported third-party calendar engines."""
+
+    EXCHANGE_CALENDARS = "exchange_calendars"
+    PANDAS_MARKET_CALENDARS = "pandas_market_calendars"
+
+    @property
+    def package_name(self) -> str:
+        return self.value.replace("_", "-")
+
+
+@dataclass(frozen=True, slots=True)
+class CalendarSessionOverride:
+    """Authoritative override for a provider-reported market session date."""
+
+    market: str
+    day: date
+    is_trading_day: bool
+
+    def normalized_market(self) -> str:
+        return self.market.strip().upper()
+
+
+DEFAULT_CALENDAR_SESSION_OVERRIDES: tuple[CalendarSessionOverride, ...] = (
+    CalendarSessionOverride("JP", date(2026, 3, 20), False),
+    CalendarSessionOverride("JP", date(2026, 9, 22), False),
+    CalendarSessionOverride("JP", date(2026, 9, 23), False),
+)
+
+
+def calendar_session_probe_expectations(
+    overrides: tuple[CalendarSessionOverride, ...] = DEFAULT_CALENDAR_SESSION_OVERRIDES,
+) -> dict[str, dict[date, bool]]:
+    """Return market/date expectations used by health checks and gates."""
+    expectations: dict[str, dict[date, bool]] = {}
+    for override in overrides:
+        expectations.setdefault(override.normalized_market(), {})[
+            override.day
+        ] = override.is_trading_day
+    return expectations

--- a/backend/app/domain/markets/catalog.py
+++ b/backend/app/domain/markets/catalog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, fields, replace
 from typing import Iterable
 
+from .calendar_policy import CalendarProvider
 from .mic import MicFacts
 
 CATALOG_VERSION = "2026-05-17.v1"
@@ -138,7 +139,7 @@ class MarketCatalogEntry:
             "mics": list(self.mics),
             "supported_currencies": list(self.supported_currencies),
             "default_currency": self.default_currency,
-            "mic_facts": [asdict(facts) for facts in self.mic_facts],
+            "mic_facts": [facts.as_runtime_payload() for facts in self.mic_facts],
             # Compatibility fields for existing frontend/runtime consumers.
             "currency": self.currency,
             "timezone": self.timezone,
@@ -238,6 +239,7 @@ def _mic_facts(
     default_currency: str,
     calendar_id: str | None = None,
     provider_calendar_id: str | None = None,
+    calendar_provider: CalendarProvider = CalendarProvider.EXCHANGE_CALENDARS,
 ) -> MicFacts:
     return MicFacts(
         mic=mic,
@@ -245,6 +247,7 @@ def _mic_facts(
         timezone=timezone,
         default_currency=default_currency,
         provider_calendar_id=provider_calendar_id,
+        calendar_provider=calendar_provider,
     )
 
 
@@ -341,11 +344,13 @@ MARKET_CATALOG = MarketCatalog(
                     timezone="Asia/Kolkata",
                     default_currency="INR",
                     provider_calendar_id="NSE",
+                    calendar_provider=CalendarProvider.PANDAS_MARKET_CALENDARS,
                 ),
                 _mic_facts(
                     "XBOM",
                     timezone="Asia/Kolkata",
                     default_currency="INR",
+                    calendar_provider=CalendarProvider.PANDAS_MARKET_CALENDARS,
                 ),
             ),
             exchanges=("NSE", "XNSE", "BSE", "XBOM"),
@@ -360,6 +365,8 @@ MARKET_CATALOG = MarketCatalog(
                     "XTKS",
                     timezone="Asia/Tokyo",
                     default_currency="JPY",
+                    provider_calendar_id="JPX",
+                    calendar_provider=CalendarProvider.PANDAS_MARKET_CALENDARS,
                 ),
             ),
             exchanges=("TSE", "JPX", "XTKS"),

--- a/backend/app/domain/markets/catalog.py
+++ b/backend/app/domain/markets/catalog.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, fields, replace
-from typing import Iterable
 
 from .calendar_policy import CalendarProvider
 from .mic import MicFacts
@@ -350,6 +350,7 @@ MARKET_CATALOG = MarketCatalog(
                     "XBOM",
                     timezone="Asia/Kolkata",
                     default_currency="INR",
+                    provider_calendar_id="BSE",
                     calendar_provider=CalendarProvider.PANDAS_MARKET_CALENDARS,
                 ),
             ),

--- a/backend/app/domain/markets/mic.py
+++ b/backend/app/domain/markets/mic.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .calendar_policy import CalendarProvider
+
 
 @dataclass(frozen=True, slots=True)
 class MicFacts:
@@ -14,3 +16,14 @@ class MicFacts:
     timezone: str
     default_currency: str
     provider_calendar_id: str | None = None
+    calendar_provider: CalendarProvider = CalendarProvider.EXCHANGE_CALENDARS
+
+    def as_runtime_payload(self) -> dict[str, str | None]:
+        return {
+            "mic": self.mic,
+            "calendar_id": self.calendar_id,
+            "timezone": self.timezone,
+            "default_currency": self.default_currency,
+            "provider_calendar_id": self.provider_calendar_id,
+            "calendar_provider": self.calendar_provider.value,
+        }

--- a/backend/app/schemas/app_runtime.py
+++ b/backend/app/schemas/app_runtime.py
@@ -55,6 +55,7 @@ class MicFactsResponse(BaseModel):
     timezone: str
     default_currency: str
     provider_calendar_id: str | None = None
+    calendar_provider: str | None = None
 
 
 class MarketCatalogEntryResponse(BaseModel):

--- a/backend/app/services/governance/calendar_benchmark_invariants.py
+++ b/backend/app/services/governance/calendar_benchmark_invariants.py
@@ -127,19 +127,33 @@ def collect_calendar_benchmark_invariants(
     calendar_metadata: dict[str, dict[str, str | None]] = {}
     session_probe_expectations = calendar_session_probe_expectations()
 
-    for market in markets:
+    for raw_market in markets:
+        try:
+            market = service.normalize_market(raw_market)
+        except ValueError as exc:
+            market = str(raw_market)
+            benchmark_mismatches[market] = f"unsupported market: {exc}"
+            continue
         try:
             got = registry.get_primary_symbol(market)
         except (KeyError, ValueError) as exc:
             benchmark_mismatches[market] = f"lookup failed: {exc}"
             continue
-        expected_benchmark = EXPECTED_BENCHMARK_SYMBOLS[market]
-        if got != expected_benchmark:
+        expected_benchmark = EXPECTED_BENCHMARK_SYMBOLS.get(market)
+        if expected_benchmark is None:
+            benchmark_mismatches[market] = (
+                f"no expected benchmark symbol configured for {market}"
+            )
+        elif got != expected_benchmark:
             benchmark_mismatches[market] = f"expected {expected_benchmark}, got {got}"
 
         calendar_id = service.calendar_id(market)
-        expected_calendar_id = EXPECTED_CALENDAR_IDS[market]
-        if calendar_id != expected_calendar_id:
+        expected_calendar_id = EXPECTED_CALENDAR_IDS.get(market)
+        if expected_calendar_id is None:
+            calendar_id_mismatches[market] = (
+                f"no expected calendar ID configured for {market}"
+            )
+        elif calendar_id != expected_calendar_id:
             calendar_id_mismatches[market] = (
                 f"expected {expected_calendar_id}, got {calendar_id}"
             )

--- a/backend/app/services/governance/calendar_benchmark_invariants.py
+++ b/backend/app/services/governance/calendar_benchmark_invariants.py
@@ -1,0 +1,182 @@
+"""Benchmark and calendar invariants for launch-gate evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any
+
+from ...domain.markets.calendar_policy import calendar_session_probe_expectations
+from ..benchmark_registry_service import BenchmarkRegistryService, benchmark_registry
+from ..market_calendar_service import MarketCalendarService
+
+EXPECTED_BENCHMARK_SYMBOLS = {
+    "US": "SPY",
+    "HK": "^HSI",
+    "IN": "^NSEI",
+    "JP": "^N225",
+    "KR": "^KS11",
+    "TW": "^TWII",
+    "CN": "000300.SS",
+    "SG": "^STI",
+    "MY": "^KLSE",
+    "CA": "^GSPTSE",
+    "DE": "^GDAXI",
+    "AU": "^AXJO",
+}
+
+EXPECTED_CALENDAR_IDS = {
+    "US": "XNYS",
+    "HK": "XHKG",
+    "IN": "XNSE",
+    "JP": "XTKS",
+    "KR": "XKRX",
+    "TW": "XTAI",
+    "CN": "XSHG",
+    "SG": "XSES",
+    "MY": "XKLS",
+    "CA": "XTSE",
+    "DE": "XETR",
+    "AU": "XASX",
+}
+
+SATURDAY_PROBE = date(2026, 4, 11)
+SUNDAY_ROLLOVER_PROBE = datetime(2026, 4, 12, 12, 0, 0, tzinfo=timezone.utc)
+EXPECTED_SUNDAY_LAST_COMPLETED = date(2026, 4, 10)
+
+
+@dataclass(frozen=True, slots=True)
+class CalendarBenchmarkInvariantResult:
+    benchmark_mismatches: dict[str, str]
+    calendar_id_mismatches: dict[str, str]
+    weekend_regressions: list[str]
+    sunday_rollover_regressions: dict[str, str]
+    weekday_holiday_probes: dict[str, dict[str, bool]]
+    weekday_holiday_regressions: dict[str, dict[str, dict[str, bool]]]
+    calendar_metadata: dict[str, dict[str, str | None]]
+
+    @property
+    def has_regressions(self) -> bool:
+        return any(
+            (
+                self.benchmark_mismatches,
+                self.calendar_id_mismatches,
+                self.weekend_regressions,
+                self.sunday_rollover_regressions,
+                self.weekday_holiday_regressions,
+            )
+        )
+
+    def failure_detail(self) -> str:
+        return (
+            "Benchmark/calendar regressions detected: "
+            f"benchmark={self.benchmark_mismatches}, "
+            f"calendar_ids={self.calendar_id_mismatches}, "
+            f"weekend_sessions={self.weekend_regressions}, "
+            f"sunday_rollover={self.sunday_rollover_regressions}, "
+            f"weekday_holidays={self.weekday_holiday_regressions}"
+        )
+
+    def failure_metrics(
+        self,
+        *,
+        markets: tuple[str, ...],
+        calendar_dependency_versions: dict[str, str | None],
+    ) -> dict[str, Any]:
+        return {
+            "enabled_markets": list(markets),
+            "benchmark_mismatches": self.benchmark_mismatches,
+            "calendar_id_mismatches": self.calendar_id_mismatches,
+            "weekend_session_regressions": self.weekend_regressions,
+            "sunday_rollover_regressions": self.sunday_rollover_regressions,
+            "weekday_holiday_probes": self.weekday_holiday_probes,
+            "weekday_holiday_regressions": self.weekday_holiday_regressions,
+            "calendar_metadata": self.calendar_metadata,
+            "calendar_dependency_versions": calendar_dependency_versions,
+        }
+
+    def pass_metrics(
+        self,
+        *,
+        markets: tuple[str, ...],
+        calendar_dependency_versions: dict[str, str | None],
+    ) -> dict[str, Any]:
+        return {
+            "checked_markets": list(markets),
+            "saturday_probe": str(SATURDAY_PROBE),
+            "sunday_rollover_probe": str(SUNDAY_ROLLOVER_PROBE.date()),
+            "weekday_holiday_probes": self.weekday_holiday_probes,
+            "calendar_metadata": self.calendar_metadata,
+            "calendar_dependency_versions": calendar_dependency_versions,
+        }
+
+
+def collect_calendar_benchmark_invariants(
+    markets: tuple[str, ...],
+    *,
+    registry: BenchmarkRegistryService = benchmark_registry,
+    calendar_service: MarketCalendarService | None = None,
+) -> CalendarBenchmarkInvariantResult:
+    service = calendar_service or MarketCalendarService()
+    benchmark_mismatches: dict[str, str] = {}
+    calendar_id_mismatches: dict[str, str] = {}
+    weekend_regressions: list[str] = []
+    sunday_rollover_regressions: dict[str, str] = {}
+    weekday_holiday_probes: dict[str, dict[str, bool]] = {}
+    weekday_holiday_regressions: dict[str, dict[str, dict[str, bool]]] = {}
+    calendar_metadata: dict[str, dict[str, str | None]] = {}
+    session_probe_expectations = calendar_session_probe_expectations()
+
+    for market in markets:
+        try:
+            got = registry.get_primary_symbol(market)
+        except (KeyError, ValueError) as exc:
+            benchmark_mismatches[market] = f"lookup failed: {exc}"
+            continue
+        expected_benchmark = EXPECTED_BENCHMARK_SYMBOLS[market]
+        if got != expected_benchmark:
+            benchmark_mismatches[market] = f"expected {expected_benchmark}, got {got}"
+
+        calendar_id = service.calendar_id(market)
+        expected_calendar_id = EXPECTED_CALENDAR_IDS[market]
+        if calendar_id != expected_calendar_id:
+            calendar_id_mismatches[market] = (
+                f"expected {expected_calendar_id}, got {calendar_id}"
+            )
+        calendar_metadata[market] = service.calendar_metadata(market)
+
+        if service.is_trading_day(market, SATURDAY_PROBE):
+            weekend_regressions.append(market)
+
+        last_completed = service.last_completed_trading_day(
+            market,
+            now=SUNDAY_ROLLOVER_PROBE,
+        )
+        if last_completed != EXPECTED_SUNDAY_LAST_COMPLETED:
+            sunday_rollover_regressions[market] = str(last_completed)
+
+        for probe_day, expected_is_trading_day in session_probe_expectations.get(
+            market,
+            {},
+        ).items():
+            actual_is_trading_day = service.is_trading_day(market, probe_day)
+            weekday_holiday_probes.setdefault(market, {})[probe_day.isoformat()] = (
+                actual_is_trading_day
+            )
+            if actual_is_trading_day != expected_is_trading_day:
+                weekday_holiday_regressions.setdefault(market, {})[
+                    probe_day.isoformat()
+                ] = {
+                    "expected": expected_is_trading_day,
+                    "actual": actual_is_trading_day,
+                }
+
+    return CalendarBenchmarkInvariantResult(
+        benchmark_mismatches=benchmark_mismatches,
+        calendar_id_mismatches=calendar_id_mismatches,
+        weekend_regressions=weekend_regressions,
+        sunday_rollover_regressions=sunday_rollover_regressions,
+        weekday_holiday_probes=weekday_holiday_probes,
+        weekday_holiday_regressions=weekday_holiday_regressions,
+        calendar_metadata=calendar_metadata,
+    )

--- a/backend/app/services/governance/launch_gates.py
+++ b/backend/app/services/governance/launch_gates.py
@@ -25,7 +25,8 @@ import inspect
 import json
 import re
 from dataclasses import asdict, dataclass, field
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
+from importlib import metadata
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -35,7 +36,7 @@ from .signed_artifact import compute_content_hash
 
 REPORT_SCHEMA_VERSION = 2
 CHARTER_VERSION = "1.0"  # ties to docs/asia/asia_v2_launch_gate_charter.md
-GATE_RUNNER_VERSION = "1.2"
+GATE_RUNNER_VERSION = "1.3"
 
 
 class GateStatus:
@@ -137,6 +138,16 @@ def _normalize_markets(markets: Optional[List[str]] = None) -> tuple[str, ...]:
     if not normalized:
         raise ValueError("enabled_markets must not be empty.")
     return tuple(normalized)
+
+
+def _dependency_versions(package_names: tuple[str, ...]) -> dict[str, str | None]:
+    versions: dict[str, str | None] = {}
+    for package_name in package_names:
+        try:
+            versions[package_name] = metadata.version(package_name)
+        except metadata.PackageNotFoundError:
+            versions[package_name] = None
+    return versions
 
 
 def _latest_rows_by_market(rows: List[object], markets: tuple[str, ...]) -> Dict[str, object]:
@@ -453,8 +464,9 @@ def _check_g3_benchmark(ctx: GateContext) -> GateResult:
     by unit tests; the gate runner re-asserts it at evidence-capture time.
     """
     try:
-        from ...services.benchmark_registry_service import benchmark_registry
-        from ...services.market_calendar_service import MarketCalendarService
+        from .calendar_benchmark_invariants import (
+            collect_calendar_benchmark_invariants,
+        )
     except Exception as exc:
         return GateResult(
             gate_id="G3", name="Benchmark/Calendar Correctness", severity="hard",
@@ -462,90 +474,32 @@ def _check_g3_benchmark(ctx: GateContext) -> GateResult:
             detail=f"Benchmark/calendar dependency import failed: {exc}",
         )
 
-    expected = {
-        "US": "SPY",
-        "HK": "^HSI",
-        "IN": "^NSEI",
-        "JP": "^N225",
-        "KR": "^KS11",
-        "TW": "^TWII",
-        "CN": "000300.SS",
-        "SG": "^STI",
-        "MY": "^KLSE",
-        "CA": "^GSPTSE",
-        "DE": "^GDAXI",
-        "AU": "^AXJO",
-    }
-    expected_calendar_ids = {
-        "US": "XNYS",
-        "HK": "XHKG",
-        "IN": "XNSE",
-        "JP": "XTKS",
-        "KR": "XKRX",
-        "TW": "XTAI",
-        "CN": "XSHG",
-        "SG": "XSES",
-        "MY": "XKLS",
-        "CA": "XTSE",
-        "DE": "XETR",
-        "AU": "XASX",
-    }
     markets = ctx.enabled_markets
-    benchmark_mismatches = {}
-    calendar_id_mismatches = {}
-    weekend_regressions = []
-    sunday_regressions = {}
+    calendar_dependency_versions = _dependency_versions(
+        ("pandas-market-calendars", "exchange-calendars")
+    )
+    try:
+        invariants = collect_calendar_benchmark_invariants(markets)
+    except Exception as exc:
+        return GateResult(
+            gate_id="G3", name="Benchmark/Calendar Correctness", severity="hard",
+            status=GateStatus.MISSING_EVIDENCE,
+            detail=f"Calendar invariant check failed to execute: {exc}",
+            metrics={
+                "enabled_markets": list(markets),
+                "calendar_dependency_versions": calendar_dependency_versions,
+            },
+        )
 
-    service = MarketCalendarService()
-    saturday = date(2026, 4, 11)
-    sunday_utc = datetime(2026, 4, 12, 12, 0, 0, tzinfo=timezone.utc)
-    expected_last_completed = date(2026, 4, 10)
-
-    for market in markets:
-        try:
-            got = benchmark_registry.get_primary_symbol(market)
-        except Exception as exc:
-            benchmark_mismatches[market] = f"lookup failed: {exc}"
-            continue
-        if got != expected[market]:
-            benchmark_mismatches[market] = f"expected {expected[market]}, got {got}"
-        try:
-            calendar_id = service.calendar_id(market)
-            if calendar_id != expected_calendar_ids[market]:
-                calendar_id_mismatches[market] = (
-                    f"expected {expected_calendar_ids[market]}, got {calendar_id}"
-                )
-            if service.is_trading_day(market, saturday):
-                weekend_regressions.append(market)
-            last_completed = service.last_completed_trading_day(market, now=sunday_utc)
-            if last_completed != expected_last_completed:
-                sunday_regressions[market] = str(last_completed)
-        except Exception as exc:
-            return GateResult(
-                gate_id="G3", name="Benchmark/Calendar Correctness", severity="hard",
-                status=GateStatus.MISSING_EVIDENCE,
-                detail=f"Calendar invariant check failed to execute: {exc}",
-                metrics={"enabled_markets": list(markets)},
-            )
-
-    if benchmark_mismatches or calendar_id_mismatches or weekend_regressions or sunday_regressions:
+    if invariants.has_regressions:
         return GateResult(
             gate_id="G3", name="Benchmark/Calendar Correctness", severity="hard",
             status=GateStatus.FAIL,
-            detail=(
-                "Benchmark/calendar regressions detected: "
-                f"benchmark={benchmark_mismatches}, "
-                f"calendar_ids={calendar_id_mismatches}, "
-                f"weekend_sessions={weekend_regressions}, "
-                f"sunday_rollover={sunday_regressions}"
+            detail=invariants.failure_detail(),
+            metrics=invariants.failure_metrics(
+                markets=markets,
+                calendar_dependency_versions=calendar_dependency_versions,
             ),
-            metrics={
-                "enabled_markets": list(markets),
-                "benchmark_mismatches": benchmark_mismatches,
-                "calendar_id_mismatches": calendar_id_mismatches,
-                "weekend_session_regressions": weekend_regressions,
-                "sunday_rollover_regressions": sunday_regressions,
-            },
         )
     return GateResult(
         gate_id="G3", name="Benchmark/Calendar Correctness", severity="hard",
@@ -554,11 +508,10 @@ def _check_g3_benchmark(ctx: GateContext) -> GateResult:
             "Benchmark registry and calendar invariants passed for "
             f"{list(markets)}."
         ),
-        metrics={
-            "checked_markets": list(markets),
-            "saturday_probe": str(saturday),
-            "sunday_rollover_probe": str(sunday_utc.date()),
-        },
+        metrics=invariants.pass_metrics(
+            markets=markets,
+            calendar_dependency_versions=calendar_dependency_versions,
+        ),
     )
 
 

--- a/backend/app/services/market_calendar_adapters.py
+++ b/backend/app/services/market_calendar_adapters.py
@@ -1,0 +1,109 @@
+"""Adapters that normalize third-party market calendar APIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Protocol
+
+import pandas as pd
+
+
+class CalendarScheduleUnavailable(RuntimeError):
+    """Raised when a calendar object cannot expose a session schedule."""
+
+
+class MarketCalendarAdapter(Protocol):
+    """Provider-neutral calendar operations used by MarketCalendarService."""
+
+    def is_session(self, session: pd.Timestamp) -> bool: ...
+
+    def session_close(self, day: date) -> pd.Timestamp | None: ...
+
+    def session_open_close(
+        self, day: date
+    ) -> tuple[pd.Timestamp, pd.Timestamp] | None: ...
+
+    def is_open_on_minute(self, minute_utc: pd.Timestamp) -> bool | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RawMarketCalendarAdapter:
+    """Normalize exchange_calendars and pandas_market_calendars objects."""
+
+    raw_calendar: object
+
+    def is_session(self, session: pd.Timestamp) -> bool:
+        is_session = getattr(self.raw_calendar, "is_session", None)
+        if callable(is_session):
+            return bool(is_session(session))
+        return not self._schedule_for_range(
+            start_day=session.date(),
+            end_day=session.date(),
+        ).empty
+
+    def session_close(self, day: date) -> pd.Timestamp | None:
+        schedule = self._schedule_for_range(start_day=day, end_day=day)
+        if schedule.empty:
+            return None
+        session_row = schedule.iloc[0]
+        return self._timestamp_field(
+            session_row,
+            ("close", "market_close"),
+            day=day,
+        )
+
+    def session_open_close(self, day: date) -> tuple[pd.Timestamp, pd.Timestamp] | None:
+        schedule = self._schedule_for_range(start_day=day, end_day=day)
+        if schedule.empty:
+            return None
+        session_row = schedule.iloc[0]
+        return (
+            self._timestamp_field(session_row, ("open", "market_open"), day=day),
+            self._timestamp_field(session_row, ("close", "market_close"), day=day),
+        )
+
+    def is_open_on_minute(self, minute_utc: pd.Timestamp) -> bool | None:
+        is_open_on_minute = getattr(self.raw_calendar, "is_open_on_minute", None)
+        if not callable(is_open_on_minute):
+            return None
+        return bool(is_open_on_minute(minute_utc, ignore_breaks=False))
+
+    def _schedule_for_range(
+        self,
+        *,
+        start_day: date,
+        end_day: date,
+    ) -> pd.DataFrame:
+        schedule_attr = getattr(self.raw_calendar, "schedule", None)
+        start_ts = pd.Timestamp(start_day)
+        end_ts = pd.Timestamp(end_day)
+        if callable(schedule_attr):
+            return schedule_attr(start_date=start_ts, end_date=end_ts)
+        if hasattr(schedule_attr, "loc"):
+            return schedule_attr.loc[start_ts:end_ts]
+        raise CalendarScheduleUnavailable(
+            "Calendar object does not expose a usable schedule"
+        )
+
+    @classmethod
+    def _timestamp_field(
+        cls,
+        session_row: pd.Series,
+        field_names: tuple[str, ...],
+        *,
+        day: date,
+    ) -> pd.Timestamp:
+        for field_name in field_names:
+            if field_name in session_row.index:
+                return cls._utc_timestamp(session_row[field_name])
+        raise CalendarScheduleUnavailable(
+            f"Calendar schedule for {day.isoformat()} is missing all of {field_names}"
+        )
+
+    @staticmethod
+    def _utc_timestamp(value: object) -> pd.Timestamp:
+        timestamp = pd.Timestamp(value)
+        if timestamp.tzinfo is None:
+            return timestamp.tz_localize("UTC")
+        return timestamp.tz_convert("UTC")

--- a/backend/app/services/market_calendar_adapters.py
+++ b/backend/app/services/market_calendar_adapters.py
@@ -2,11 +2,29 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import json
+import logging
+from dataclasses import dataclass
 from datetime import date
+from time import monotonic
 from typing import Protocol
 
 import pandas as pd
+
+from .redis_pool import get_redis_client
+
+try:
+    from redis.exceptions import RedisError
+except ModuleNotFoundError:  # pragma: no cover - runtime guard mirrors redis_pool
+    _REDIS_CACHE_EXCEPTIONS: tuple[type[BaseException], ...] = (RuntimeError, OSError)
+else:
+    _REDIS_CACHE_EXCEPTIONS = (RedisError, RuntimeError, OSError)
+
+logger = logging.getLogger(__name__)
+
+SESSION_RANGE_CACHE_TTL_SECONDS = 60 * 60 * 24
+_SESSION_RANGE_CACHE_RETRY_INTERVAL_SECONDS = 30.0
+_session_range_cache_retry_after = 0.0
 
 
 class CalendarScheduleUnavailable(RuntimeError):
@@ -19,6 +37,8 @@ class MarketCalendarAdapter(Protocol):
     def is_session(self, session: pd.Timestamp) -> bool: ...
 
     def sessions_in_range(self, start_day: date, end_day: date) -> tuple[date, ...]: ...
+
+    def last_session_date(self) -> date | None: ...
 
     def session_close(self, day: date) -> pd.Timestamp | None: ...
 
@@ -34,10 +54,7 @@ class RawMarketCalendarAdapter:
     """Normalize exchange_calendars and pandas_market_calendars objects."""
 
     raw_calendar: object
-    _session_range_cache: dict[tuple[date, date], tuple[date, ...]] = field(
-        default_factory=dict,
-        init=False,
-    )
+    cache_namespace: str = "default"
 
     def is_session(self, session: pd.Timestamp) -> bool:
         is_session = getattr(self.raw_calendar, "is_session", None)
@@ -51,25 +68,35 @@ class RawMarketCalendarAdapter:
     def sessions_in_range(self, start_day: date, end_day: date) -> tuple[date, ...]:
         if start_day > end_day:
             return ()
-        cache_key = (start_day, end_day)
-        if cache_key not in self._session_range_cache:
-            sessions_attr = getattr(self.raw_calendar, "sessions", None)
-            if sessions_attr is not None:
-                sessions = tuple(
-                    pd.Timestamp(session).date()
-                    for session in sessions_attr
-                    if start_day <= pd.Timestamp(session).date() <= end_day
-                )
-            else:
-                schedule = self._schedule_for_range(
-                    start_day=start_day,
-                    end_day=end_day,
-                )
-                sessions = tuple(
-                    pd.Timestamp(session).date() for session in schedule.index
-                )
-            self._session_range_cache[cache_key] = sessions
-        return self._session_range_cache[cache_key]
+        cache_key = self._session_range_cache_key(start_day, end_day)
+        cached_sessions = self._read_session_range_cache(cache_key)
+        if cached_sessions is not None:
+            return cached_sessions
+        sessions = self._compute_sessions_in_range(start_day, end_day)
+        self._write_session_range_cache(cache_key, sessions)
+        return sessions
+
+    def last_session_date(self) -> date | None:
+        for attr_name in ("last_session", "last_session_date"):
+            attr_value = getattr(self.raw_calendar, attr_name, None)
+            if attr_value is None:
+                continue
+            if callable(attr_value):
+                attr_value = attr_value()
+            return pd.Timestamp(attr_value).date()
+
+        sessions_attr = getattr(self.raw_calendar, "sessions", None)
+        if sessions_attr is None:
+            return None
+        try:
+            if len(sessions_attr) == 0:
+                return None
+            return pd.Timestamp(sessions_attr[-1]).date()
+        except (IndexError, KeyError, TypeError):
+            sessions = tuple(sessions_attr)
+            if not sessions:
+                return None
+            return pd.Timestamp(sessions[-1]).date()
 
     def session_close(self, day: date) -> pd.Timestamp | None:
         schedule = self._schedule_for_range(start_day=day, end_day=day)
@@ -142,6 +169,84 @@ class RawMarketCalendarAdapter:
             "Calendar object does not expose a usable schedule"
         )
 
+    def _compute_sessions_in_range(
+        self,
+        start_day: date,
+        end_day: date,
+    ) -> tuple[date, ...]:
+        sessions_in_range = getattr(self.raw_calendar, "sessions_in_range", None)
+        if callable(sessions_in_range):
+            return tuple(
+                pd.Timestamp(session).date()
+                for session in sessions_in_range(
+                    pd.Timestamp(start_day),
+                    pd.Timestamp(end_day),
+                )
+            )
+
+        sessions_attr = getattr(self.raw_calendar, "sessions", None)
+        if sessions_attr is not None:
+            return tuple(
+                session_day
+                for session_day in (
+                    pd.Timestamp(session).date() for session in sessions_attr
+                )
+                if start_day <= session_day <= end_day
+            )
+
+        schedule = self._schedule_for_range(
+            start_day=start_day,
+            end_day=end_day,
+        )
+        return tuple(pd.Timestamp(session).date() for session in schedule.index)
+
+    def _session_range_cache_key(self, start_day: date, end_day: date) -> str:
+        return (
+            "calendar:sessions:v1:"
+            f"{self.cache_namespace}:{start_day.isoformat()}:{end_day.isoformat()}"
+        )
+
+    def _read_session_range_cache(self, cache_key: str) -> tuple[date, ...] | None:
+        client = self._session_range_cache_client()
+        if client is None:
+            return None
+        try:
+            raw = client.get(cache_key)
+        except _REDIS_CACHE_EXCEPTIONS as exc:
+            logger.debug("Calendar session-range cache read failed: %s", exc)
+            return None
+        if raw is None:
+            return None
+        try:
+            payload = json.loads(raw)
+            return tuple(date.fromisoformat(value) for value in payload)
+        except (TypeError, ValueError) as exc:
+            logger.debug("Calendar session-range cache decode failed: %s", exc)
+            return None
+
+    def _write_session_range_cache(
+        self,
+        cache_key: str,
+        sessions: tuple[date, ...],
+    ) -> None:
+        client = self._session_range_cache_client()
+        if client is None:
+            return
+        try:
+            client.setex(
+                cache_key,
+                SESSION_RANGE_CACHE_TTL_SECONDS,
+                json.dumps(
+                    [session.isoformat() for session in sessions],
+                    separators=(",", ":"),
+                ),
+            )
+        except _REDIS_CACHE_EXCEPTIONS as exc:
+            logger.debug("Calendar session-range cache write failed: %s", exc)
+
+    def _session_range_cache_client(self):
+        return _get_session_range_cache_client()
+
     @classmethod
     def _timestamp_field(
         cls,
@@ -177,3 +282,17 @@ class RawMarketCalendarAdapter:
         if timestamp.tzinfo is None:
             return timestamp.tz_localize("UTC")
         return timestamp.tz_convert("UTC")
+
+
+def _get_session_range_cache_client():
+    global _session_range_cache_retry_after
+
+    now = monotonic()
+    if now < _session_range_cache_retry_after:
+        return None
+    client = get_redis_client()
+    if client is None:
+        _session_range_cache_retry_after = (
+            now + _SESSION_RANGE_CACHE_RETRY_INTERVAL_SECONDS
+        )
+    return client

--- a/backend/app/services/market_calendar_adapters.py
+++ b/backend/app/services/market_calendar_adapters.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from typing import Protocol
 
@@ -18,29 +18,58 @@ class MarketCalendarAdapter(Protocol):
 
     def is_session(self, session: pd.Timestamp) -> bool: ...
 
+    def sessions_in_range(self, start_day: date, end_day: date) -> tuple[date, ...]: ...
+
     def session_close(self, day: date) -> pd.Timestamp | None: ...
 
-    def session_open_close(
+    def session_open_ranges(
         self, day: date
-    ) -> tuple[pd.Timestamp, pd.Timestamp] | None: ...
+    ) -> tuple[tuple[pd.Timestamp, pd.Timestamp], ...] | None: ...
 
     def is_open_on_minute(self, minute_utc: pd.Timestamp) -> bool | None: ...
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class RawMarketCalendarAdapter:
     """Normalize exchange_calendars and pandas_market_calendars objects."""
 
     raw_calendar: object
+    _session_range_cache: dict[tuple[date, date], tuple[date, ...]] = field(
+        default_factory=dict,
+        init=False,
+    )
 
     def is_session(self, session: pd.Timestamp) -> bool:
         is_session = getattr(self.raw_calendar, "is_session", None)
         if callable(is_session):
             return bool(is_session(session))
-        return not self._schedule_for_range(
-            start_day=session.date(),
-            end_day=session.date(),
-        ).empty
+        return session.date() in self.sessions_in_range(
+            session.date(),
+            session.date(),
+        )
+
+    def sessions_in_range(self, start_day: date, end_day: date) -> tuple[date, ...]:
+        if start_day > end_day:
+            return ()
+        cache_key = (start_day, end_day)
+        if cache_key not in self._session_range_cache:
+            sessions_attr = getattr(self.raw_calendar, "sessions", None)
+            if sessions_attr is not None:
+                sessions = tuple(
+                    pd.Timestamp(session).date()
+                    for session in sessions_attr
+                    if start_day <= pd.Timestamp(session).date() <= end_day
+                )
+            else:
+                schedule = self._schedule_for_range(
+                    start_day=start_day,
+                    end_day=end_day,
+                )
+                sessions = tuple(
+                    pd.Timestamp(session).date() for session in schedule.index
+                )
+            self._session_range_cache[cache_key] = sessions
+        return self._session_range_cache[cache_key]
 
     def session_close(self, day: date) -> pd.Timestamp | None:
         schedule = self._schedule_for_range(start_day=day, end_day=day)
@@ -53,15 +82,42 @@ class RawMarketCalendarAdapter:
             day=day,
         )
 
-    def session_open_close(self, day: date) -> tuple[pd.Timestamp, pd.Timestamp] | None:
+    def session_open_ranges(
+        self,
+        day: date,
+    ) -> tuple[tuple[pd.Timestamp, pd.Timestamp], ...] | None:
         schedule = self._schedule_for_range(start_day=day, end_day=day)
         if schedule.empty:
             return None
         session_row = schedule.iloc[0]
-        return (
-            self._timestamp_field(session_row, ("open", "market_open"), day=day),
-            self._timestamp_field(session_row, ("close", "market_close"), day=day),
+        market_open = self._timestamp_field(
+            session_row,
+            ("open", "market_open"),
+            day=day,
         )
+        market_close = self._timestamp_field(
+            session_row,
+            ("close", "market_close"),
+            day=day,
+        )
+        break_start = self._optional_timestamp_field(
+            session_row,
+            ("break_start", "market_break_start"),
+        )
+        break_end = self._optional_timestamp_field(
+            session_row,
+            ("break_end", "market_break_end"),
+        )
+        if (
+            break_start is not None
+            and break_end is not None
+            and market_open < break_start < break_end < market_close
+        ):
+            return (
+                (market_open, break_start),
+                (break_end, market_close),
+            )
+        return ((market_open, market_close),)
 
     def is_open_on_minute(self, minute_utc: pd.Timestamp) -> bool | None:
         is_open_on_minute = getattr(self.raw_calendar, "is_open_on_minute", None)
@@ -100,6 +156,20 @@ class RawMarketCalendarAdapter:
         raise CalendarScheduleUnavailable(
             f"Calendar schedule for {day.isoformat()} is missing all of {field_names}"
         )
+
+    @classmethod
+    def _optional_timestamp_field(
+        cls,
+        session_row: pd.Series,
+        field_names: tuple[str, ...],
+    ) -> pd.Timestamp | None:
+        for field_name in field_names:
+            if field_name in session_row.index:
+                value = session_row[field_name]
+                if pd.isna(value):
+                    return None
+                return cls._utc_timestamp(value)
+        return None
 
     @staticmethod
     def _utc_timestamp(value: object) -> pd.Timestamp:

--- a/backend/app/services/market_calendar_adapters.py
+++ b/backend/app/services/market_calendar_adapters.py
@@ -83,7 +83,12 @@ class RawMarketCalendarAdapter:
                 continue
             if callable(attr_value):
                 attr_value = attr_value()
-            return pd.Timestamp(attr_value).date()
+            if attr_value is None:
+                continue
+            timestamp = pd.Timestamp(attr_value)
+            if pd.isna(timestamp):
+                continue
+            return timestamp.date()
 
         sessions_attr = getattr(self.raw_calendar, "sessions", None)
         if sessions_attr is None:

--- a/backend/app/services/market_calendar_adapters.py
+++ b/backend/app/services/market_calendar_adapters.py
@@ -38,6 +38,8 @@ class MarketCalendarAdapter(Protocol):
 
     def sessions_in_range(self, start_day: date, end_day: date) -> tuple[date, ...]: ...
 
+    def first_session_date(self) -> date | None: ...
+
     def last_session_date(self) -> date | None: ...
 
     def session_close(self, day: date) -> pd.Timestamp | None: ...
@@ -76,8 +78,25 @@ class RawMarketCalendarAdapter:
         self._write_session_range_cache(cache_key, sessions)
         return sessions
 
+    def first_session_date(self) -> date | None:
+        return self._session_bound_date(
+            ("first_session", "first_session_date"),
+            fallback_index=0,
+        )
+
     def last_session_date(self) -> date | None:
-        for attr_name in ("last_session", "last_session_date"):
+        return self._session_bound_date(
+            ("last_session", "last_session_date"),
+            fallback_index=-1,
+        )
+
+    def _session_bound_date(
+        self,
+        attr_names: tuple[str, ...],
+        *,
+        fallback_index: int,
+    ) -> date | None:
+        for attr_name in attr_names:
             attr_value = getattr(self.raw_calendar, attr_name, None)
             if attr_value is None:
                 continue
@@ -96,12 +115,12 @@ class RawMarketCalendarAdapter:
         try:
             if len(sessions_attr) == 0:
                 return None
-            return pd.Timestamp(sessions_attr[-1]).date()
+            return pd.Timestamp(sessions_attr[fallback_index]).date()
         except (IndexError, KeyError, TypeError):
             sessions = tuple(sessions_attr)
             if not sessions:
                 return None
-            return pd.Timestamp(sessions[-1]).date()
+            return pd.Timestamp(sessions[fallback_index]).date()
 
     def session_close(self, day: date) -> pd.Timestamp | None:
         schedule = self._schedule_for_range(start_day=day, end_day=day)

--- a/backend/app/services/market_calendar_service.py
+++ b/backend/app/services/market_calendar_service.py
@@ -250,23 +250,17 @@ class MarketCalendarService:
         *,
         start: date,
         end: date,
+        first_provider_session: date | None,
         last_provider_session: date | None,
     ) -> list[date]:
         session_days = set(sessions)
-        if (
-            market in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
-            and last_provider_session is not None
-        ):
-            if session_days:
-                last_returned_session = max(session_days)
-                fallback_start = last_returned_session + timedelta(days=1)
-                if (
-                    last_returned_session >= last_provider_session
-                    and fallback_start <= end
-                ):
-                    session_days.update(self._weekday_trading_days(fallback_start, end))
-            elif last_provider_session < start:
-                session_days.update(self._weekday_trading_days(start, end))
+        if market in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS:
+            if first_provider_session is not None and start < first_provider_session:
+                prefix_end = min(end, first_provider_session - timedelta(days=1))
+                session_days.update(self._weekday_trading_days(start, prefix_end))
+            if last_provider_session is not None and last_provider_session < end:
+                suffix_start = max(start, last_provider_session + timedelta(days=1))
+                session_days.update(self._weekday_trading_days(suffix_start, end))
         return sorted(session_days)
 
     def _previous_effective_session_date(
@@ -369,27 +363,25 @@ class MarketCalendarService:
         normalized = self.normalize_market(market)
         try:
             calendar = self._get_calendar(normalized, mic=mic)
+            first_provider_session = calendar.first_session_date()
             last_provider_session = calendar.last_session_date()
-            if (
-                normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
-                and last_provider_session is not None
-                and last_provider_session < start
-            ):
-                raw_sessions = ()
-            else:
-                provider_lookup_end = end
-                if (
-                    normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
-                    and last_provider_session is not None
-                    and start <= last_provider_session < end
-                ):
-                    provider_lookup_end = last_provider_session
-                raw_sessions = calendar.sessions_in_range(start, provider_lookup_end)
+            provider_lookup_start = start
+            provider_lookup_end = end
+            if normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS:
+                if first_provider_session is not None:
+                    provider_lookup_start = max(start, first_provider_session)
+                if last_provider_session is not None:
+                    provider_lookup_end = min(end, last_provider_session)
+            raw_sessions = calendar.sessions_in_range(
+                provider_lookup_start,
+                provider_lookup_end,
+            )
             provider_sessions = self._extend_with_weekday_bounds_fallback(
                 normalized,
                 raw_sessions,
                 start=start,
                 end=end,
+                first_provider_session=first_provider_session,
                 last_provider_session=last_provider_session,
             )
             return self._apply_session_overrides(

--- a/backend/app/services/market_calendar_service.py
+++ b/backend/app/services/market_calendar_service.py
@@ -2,17 +2,29 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable, Mapping
 from datetime import date, datetime, timedelta
+from importlib import metadata
 from zoneinfo import ZoneInfo
 
 import pandas as pd
 
+from ..domain.markets.calendar_policy import (
+    DEFAULT_CALENDAR_SESSION_OVERRIDES,
+    CalendarProvider,
+    CalendarSessionOverride,
+)
 from ..domain.markets.catalog import (
     MarketCatalog,
     MarketCatalogError,
     get_market_catalog,
 )
 from ..domain.markets.mic import MicFacts
+from .market_calendar_adapters import (
+    CalendarScheduleUnavailable,
+    MarketCalendarAdapter,
+    RawMarketCalendarAdapter,
+)
 
 try:
     import exchange_calendars as xcals  # type: ignore
@@ -26,20 +38,40 @@ except ModuleNotFoundError:  # pragma: no cover - runtime guard
 
 
 class MarketCalendarService:
-    """Unified market calendar contract backed by exchange_calendars."""
+    """Unified market calendar contract backed by provider-specific calendars."""
 
     WEEKDAY_BOUNDS_FALLBACK_MARKETS = frozenset({"CN", "SG"})
 
     def __init__(
         self,
-        calendar_provider=None,
+        calendar_providers: Mapping[CalendarProvider, Callable[[str], object]]
+        | None = None,
         market_catalog: MarketCatalog | None = None,
+        session_overrides: Iterable[CalendarSessionOverride] | None = None,
     ):
         self._market_catalog = market_catalog or get_market_catalog()
-        self._calendar_provider = calendar_provider
-        self._xcals_provider = xcals.get_calendar if xcals is not None else None
-        self._pmc_provider = pmc.get_calendar if pmc is not None else None
-        self._calendar_cache: dict[str, object] = {}
+        self._calendar_providers: dict[
+            CalendarProvider,
+            Callable[[str], object] | None,
+        ] = {
+            CalendarProvider.EXCHANGE_CALENDARS: (
+                xcals.get_calendar if xcals is not None else None
+            ),
+            CalendarProvider.PANDAS_MARKET_CALENDARS: (
+                pmc.get_calendar if pmc is not None else None
+            ),
+        }
+        self._calendar_providers.update(calendar_providers or {})
+        self._session_overrides = self._normalize_session_overrides(
+            (
+                *DEFAULT_CALENDAR_SESSION_OVERRIDES,
+                *(session_overrides or ()),
+            )
+        )
+        self._calendar_cache: dict[
+            tuple[CalendarProvider, str, str],
+            MarketCalendarAdapter,
+        ] = {}
 
     def normalize_market(self, market: str | None) -> str:
         try:
@@ -82,62 +114,92 @@ class MarketCalendarService:
     ) -> str | None:
         return self._mic_facts(market, mic=mic).provider_calendar_id
 
+    def calendar_provider(
+        self,
+        market: str,
+        *,
+        mic: str | None = None,
+    ) -> CalendarProvider:
+        return self._calendar_provider_for_facts(self._mic_facts(market, mic=mic))
+
+    def calendar_metadata(
+        self,
+        market: str,
+        *,
+        mic: str | None = None,
+    ) -> dict[str, str | None]:
+        facts = self._mic_facts(market, mic=mic)
+        provider = self._calendar_provider_for_facts(facts)
+        return {
+            "market": self.normalize_market(market),
+            "calendar_id": facts.calendar_id,
+            "provider_calendar_id": facts.provider_calendar_id or facts.calendar_id,
+            "calendar_provider": provider.value,
+            "provider_package_version": self._provider_version(provider),
+        }
+
     def default_currency(self, market: str, *, mic: str | None = None) -> str:
         return self._mic_facts(market, mic=mic).default_currency
 
-    def _get_calendar(self, market: str, *, mic: str | None = None):
+    def _get_calendar(self, market: str, *, mic: str | None = None) -> MarketCalendarAdapter:
         normalized = self.normalize_market(market)
         facts = self._mic_facts(normalized, mic=mic)
         calendar_id = facts.calendar_id
         provider_calendar_id = facts.provider_calendar_id or calendar_id
-        provider = self._calendar_provider
-        uses_pmc_provider = False
+        provider_engine = self._calendar_provider_for_facts(facts)
+        provider = self._calendar_providers.get(provider_engine)
         if provider is None:
-            uses_pmc_provider = normalized == "IN"
-            provider = self._pmc_provider if uses_pmc_provider else self._xcals_provider
-        if provider is None:
-            required_package = (
-                "pandas_market_calendars" if uses_pmc_provider else "exchange_calendars"
+            raise RuntimeError(
+                f"{provider_engine.value} is required for MarketCalendarService"
             )
-            raise RuntimeError(f"{required_package} is required for MarketCalendarService")
-        if calendar_id not in self._calendar_cache:
-            self._calendar_cache[calendar_id] = provider(provider_calendar_id)
-        return self._calendar_cache[calendar_id]
+        cache_key = (provider_engine, calendar_id, provider_calendar_id)
+        if cache_key not in self._calendar_cache:
+            self._calendar_cache[cache_key] = RawMarketCalendarAdapter(
+                provider(provider_calendar_id)
+            )
+        return self._calendar_cache[cache_key]
 
     @staticmethod
-    def _schedule_for_range(calendar: object, *, start_day: date, end_day: date) -> pd.DataFrame:
-        schedule_attr = getattr(calendar, "schedule", None)
-        start_ts = pd.Timestamp(start_day)
-        end_ts = pd.Timestamp(end_day)
-        if callable(schedule_attr):
-            return schedule_attr(start_date=start_ts, end_date=end_ts)
-        if hasattr(schedule_attr, "loc"):
-            return schedule_attr.loc[start_ts:end_ts]
-        raise TypeError("Calendar object does not expose a usable schedule")
+    def _normalize_session_overrides(
+        overrides: Iterable[CalendarSessionOverride],
+    ) -> dict[str, dict[date, bool]]:
+        normalized: dict[str, dict[date, bool]] = {}
+        for override in overrides:
+            normalized.setdefault(override.normalized_market(), {})[
+                override.day
+            ] = override.is_trading_day
+        return normalized
 
-    def _is_session(self, calendar: object, session: pd.Timestamp) -> bool:
-        is_session = getattr(calendar, "is_session", None)
-        if callable(is_session):
-            return bool(is_session(session))
-        return not self._schedule_for_range(
-            calendar,
-            start_day=session.date(),
-            end_day=session.date(),
-        ).empty
+    @staticmethod
+    def _calendar_provider_for_facts(facts: MicFacts) -> CalendarProvider:
+        return facts.calendar_provider
 
-    def _previous_session(self, calendar: object, session: pd.Timestamp) -> pd.Timestamp:
-        previous_session = getattr(calendar, "previous_session", None)
-        if callable(previous_session):
-            return previous_session(session)
+    @staticmethod
+    def _provider_version(provider_engine: CalendarProvider) -> str | None:
+        try:
+            return metadata.version(provider_engine.package_name)
+        except metadata.PackageNotFoundError:
+            return None
 
-        schedule = self._schedule_for_range(
-            calendar,
-            start_day=(session - pd.Timedelta(days=31)).date(),
-            end_day=(session - pd.Timedelta(days=1)).date(),
+    def _override_for_day(self, market: str, day: date) -> bool | None:
+        normalized = self.normalize_market(market)
+        return self._session_overrides.get(normalized, {}).get(day)
+
+    def _previous_effective_session_date(
+        self,
+        market: str,
+        day: date,
+        *,
+        mic: str | None = None,
+    ) -> date:
+        candidate = day - timedelta(days=1)
+        for _ in range(370):
+            if self.is_trading_day(market, candidate, mic=mic):
+                return candidate
+            candidate -= timedelta(days=1)
+        raise ValueError(
+            f"No previous effective trading session available before {day.isoformat()}"
         )
-        if schedule.empty:
-            raise ValueError(f"No previous session available before {session.date().isoformat()}")
-        return pd.Timestamp(schedule.index[-1])
 
     @staticmethod
     def _is_calendar_bounds_error(exc: Exception) -> bool:
@@ -161,6 +223,24 @@ class MarketCalendarService:
             candidate -= timedelta(days=1)
         return candidate
 
+    def _last_completed_from_weekday_bounds_fallback(
+        self,
+        market: str,
+        current_day: date,
+        market_now: datetime,
+        exc: Exception,
+    ) -> date | None:
+        if market not in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS:
+            return None
+        if not (
+            self._is_calendar_bounds_error(exc)
+            or isinstance(exc, CalendarScheduleUnavailable)
+        ):
+            return None
+        if self._is_weekday(current_day) and market_now.time().hour >= 16:
+            return current_day
+        return self._previous_weekday(current_day)
+
     def is_trading_day(
         self,
         market: str,
@@ -170,9 +250,12 @@ class MarketCalendarService:
     ) -> bool:
         normalized = self.normalize_market(market)
         candidate_day = day or self.market_now(normalized, mic=mic).date()
+        override = self._override_for_day(normalized, candidate_day)
+        if override is not None:
+            return override
         try:
             calendar = self._get_calendar(normalized, mic=mic)
-            return self._is_session(calendar, pd.Timestamp(candidate_day))
+            return calendar.is_session(pd.Timestamp(candidate_day))
         except Exception as exc:
             if (
                 normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
@@ -240,34 +323,20 @@ class MarketCalendarService:
         *,
         mic: str | None = None,
     ) -> bool:
-        calendar = self._get_calendar(market, mic=mic)
         market_now = self.market_now(market, now=now, mic=mic)
+        if not self.is_trading_day(market, market_now.date(), mic=mic):
+            return False
+        calendar = self._get_calendar(market, mic=mic)
         current_session = pd.Timestamp(market_now.date())
-        if not self._is_session(calendar, current_session):
-            return False
         minute_utc = pd.Timestamp(market_now).tz_convert("UTC").floor("min")
-        is_open_on_minute = getattr(calendar, "is_open_on_minute", None)
-        if callable(is_open_on_minute):
-            return bool(is_open_on_minute(minute_utc, ignore_breaks=False))
+        open_on_minute = calendar.is_open_on_minute(minute_utc)
+        if open_on_minute is not None:
+            return open_on_minute
 
-        schedule = self._schedule_for_range(
-            calendar,
-            start_day=current_session.date(),
-            end_day=current_session.date(),
-        )
-        if schedule.empty:
+        session_bounds = calendar.session_open_close(current_session.date())
+        if session_bounds is None:
             return False
-        session_row = schedule.iloc[0]
-        market_open = (
-            session_row["market_open"] if "market_open" in session_row.index else session_row["open"]
-        )
-        market_close = (
-            session_row["market_close"] if "market_close" in session_row.index else session_row["close"]
-        )
-        if market_open.tzinfo is None:
-            market_open = market_open.tz_localize("UTC")
-        if market_close.tzinfo is None:
-            market_close = market_close.tz_localize("UTC")
+        market_open, market_close = session_bounds
         return bool(market_open.floor("min") <= minute_utc < market_close.floor("min"))
 
     def last_completed_trading_day(
@@ -280,31 +349,35 @@ class MarketCalendarService:
         """Return the latest trading day that should already have end-of-day bars."""
         normalized = self.normalize_market(market)
         market_now = self.market_now(normalized, now=now, mic=mic)
-        current_session = pd.Timestamp(market_now.date())
+        current_day = market_now.date()
 
         try:
+            if not self.is_trading_day(normalized, current_day, mic=mic):
+                return self._previous_effective_session_date(
+                    normalized,
+                    current_day,
+                    mic=mic,
+                )
             calendar = self._get_calendar(normalized, mic=mic)
 
-            if not self._is_session(calendar, current_session):
-                date_to_session = getattr(calendar, "date_to_session", None)
-                if callable(date_to_session):
-                    return date_to_session(current_session, direction="previous").date()
-                return self._previous_session(calendar, current_session).date()
-
-            schedule = self._schedule_for_range(
-                calendar,
-                start_day=current_session.date(),
-                end_day=current_session.date(),
-            )
-            if schedule.empty:
-                date_to_session = getattr(calendar, "date_to_session", None)
-                if callable(date_to_session):
-                    return date_to_session(current_session, direction="previous").date()
-                return self._previous_session(calendar, current_session).date()
-
-            market_close = schedule.iloc[0]["close"] if "close" in schedule.columns else schedule.iloc[0]["market_close"]
-            if market_close.tzinfo is None:
-                market_close = market_close.tz_localize("UTC")
+            try:
+                market_close = calendar.session_close(current_day)
+            except Exception as schedule_exc:
+                fallback_day = self._last_completed_from_weekday_bounds_fallback(
+                    normalized,
+                    current_day,
+                    market_now,
+                    schedule_exc,
+                )
+                if fallback_day is not None:
+                    return fallback_day
+                raise
+            if market_close is None:
+                return self._previous_effective_session_date(
+                    normalized,
+                    current_day,
+                    mic=mic,
+                )
             close_with_buffer = (
                 market_close.tz_convert(
                     self.market_timezone(normalized, mic=mic)
@@ -312,14 +385,19 @@ class MarketCalendarService:
                 + timedelta(minutes=30)
             )
             if market_now >= close_with_buffer:
-                return current_session.date()
-            return self._previous_session(calendar, current_session).date()
+                return current_day
+            return self._previous_effective_session_date(
+                normalized,
+                current_day,
+                mic=mic,
+            )
         except Exception as exc:
-            if (
-                normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
-                and self._is_calendar_bounds_error(exc)
-            ):
-                if self._is_weekday(current_session.date()) and market_now.time().hour >= 16:
-                    return current_session.date()
-                return self._previous_weekday(current_session.date())
+            fallback_day = self._last_completed_from_weekday_bounds_fallback(
+                normalized,
+                current_day,
+                market_now,
+                exc,
+            )
+            if fallback_day is not None:
+                return fallback_day
             raise

--- a/backend/app/services/market_calendar_service.py
+++ b/backend/app/services/market_calendar_service.py
@@ -141,7 +141,9 @@ class MarketCalendarService:
     def default_currency(self, market: str, *, mic: str | None = None) -> str:
         return self._mic_facts(market, mic=mic).default_currency
 
-    def _get_calendar(self, market: str, *, mic: str | None = None) -> MarketCalendarAdapter:
+    def _get_calendar(
+        self, market: str, *, mic: str | None = None
+    ) -> MarketCalendarAdapter:
         normalized = self.normalize_market(market)
         facts = self._mic_facts(normalized, mic=mic)
         calendar_id = facts.calendar_id
@@ -165,9 +167,14 @@ class MarketCalendarService:
     ) -> dict[str, dict[date, bool]]:
         normalized: dict[str, dict[date, bool]] = {}
         for override in overrides:
-            normalized.setdefault(override.normalized_market(), {})[
-                override.day
-            ] = override.is_trading_day
+            if override.is_trading_day:
+                raise ValueError(
+                    "positive trading-day overrides are not supported without "
+                    "effective session bounds"
+                )
+            normalized.setdefault(override.normalized_market(), {})[override.day] = (
+                override.is_trading_day
+            )
         return normalized
 
     @staticmethod
@@ -185,6 +192,72 @@ class MarketCalendarService:
         normalized = self.normalize_market(market)
         return self._session_overrides.get(normalized, {}).get(day)
 
+    def _apply_session_overrides(
+        self,
+        market: str,
+        sessions: Iterable[date],
+        *,
+        start: date,
+        end: date,
+    ) -> list[date]:
+        normalized = self.normalize_market(market)
+        effective_sessions = set(sessions)
+        for override_day, is_trading_day in self._session_overrides.get(
+            normalized,
+            {},
+        ).items():
+            if start <= override_day <= end and not is_trading_day:
+                effective_sessions.discard(override_day)
+        return sorted(effective_sessions)
+
+    def _weekday_trading_days(self, start: date, end: date) -> list[date]:
+        days: list[date] = []
+        candidate = start
+        while candidate <= end:
+            if self._is_weekday(candidate):
+                days.append(candidate)
+            candidate += timedelta(days=1)
+        return days
+
+    def _trading_days_from_weekday_bounds_fallback(
+        self,
+        market: str,
+        start: date,
+        end: date,
+        exc: Exception,
+    ) -> list[date] | None:
+        if market not in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS:
+            return None
+        if not (
+            self._is_calendar_bounds_error(exc)
+            or isinstance(exc, CalendarScheduleUnavailable)
+        ):
+            return None
+        return self._apply_session_overrides(
+            market,
+            self._weekday_trading_days(start, end),
+            start=start,
+            end=end,
+        )
+
+    def _extend_with_weekday_bounds_fallback(
+        self,
+        market: str,
+        sessions: Iterable[date],
+        *,
+        start: date,
+        end: date,
+    ) -> list[date]:
+        session_days = set(sessions)
+        if market in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS:
+            if session_days:
+                fallback_start = max(session_days) + timedelta(days=1)
+                if fallback_start <= end:
+                    session_days.update(self._weekday_trading_days(fallback_start, end))
+            else:
+                session_days.update(self._weekday_trading_days(start, end))
+        return sorted(session_days)
+
     def _previous_effective_session_date(
         self,
         market: str,
@@ -192,11 +265,11 @@ class MarketCalendarService:
         *,
         mic: str | None = None,
     ) -> date:
-        candidate = day - timedelta(days=1)
-        for _ in range(370):
-            if self.is_trading_day(market, candidate, mic=mic):
-                return candidate
-            candidate -= timedelta(days=1)
+        start = day - timedelta(days=370)
+        end = day - timedelta(days=1)
+        sessions = self.trading_days(market, start, end, mic=mic)
+        if sessions:
+            return sessions[-1]
         raise ValueError(
             f"No previous effective trading session available before {day.isoformat()}"
         )
@@ -279,13 +352,30 @@ class MarketCalendarService:
         ``is_trading_day``.
         """
         normalized = self.normalize_market(market)
-        days: list[date] = []
-        day = start
-        while day <= end:
-            if self.is_trading_day(normalized, day, mic=mic):
-                days.append(day)
-            day += timedelta(days=1)
-        return days
+        try:
+            calendar = self._get_calendar(normalized, mic=mic)
+            provider_sessions = self._extend_with_weekday_bounds_fallback(
+                normalized,
+                calendar.sessions_in_range(start, end),
+                start=start,
+                end=end,
+            )
+            return self._apply_session_overrides(
+                normalized,
+                provider_sessions,
+                start=start,
+                end=end,
+            )
+        except Exception as exc:
+            fallback_days = self._trading_days_from_weekday_bounds_fallback(
+                normalized,
+                start,
+                end,
+                exc,
+            )
+            if fallback_days is not None:
+                return fallback_days
+            raise
 
     def session_anchors(
         self,
@@ -333,11 +423,13 @@ class MarketCalendarService:
         if open_on_minute is not None:
             return open_on_minute
 
-        session_bounds = calendar.session_open_close(current_session.date())
-        if session_bounds is None:
+        session_ranges = calendar.session_open_ranges(current_session.date())
+        if session_ranges is None:
             return False
-        market_open, market_close = session_bounds
-        return bool(market_open.floor("min") <= minute_utc < market_close.floor("min"))
+        return any(
+            market_open.floor("min") <= minute_utc < market_close.floor("min")
+            for market_open, market_close in session_ranges
+        )
 
     def last_completed_trading_day(
         self,
@@ -360,30 +452,16 @@ class MarketCalendarService:
                 )
             calendar = self._get_calendar(normalized, mic=mic)
 
-            try:
-                market_close = calendar.session_close(current_day)
-            except Exception as schedule_exc:
-                fallback_day = self._last_completed_from_weekday_bounds_fallback(
-                    normalized,
-                    current_day,
-                    market_now,
-                    schedule_exc,
-                )
-                if fallback_day is not None:
-                    return fallback_day
-                raise
+            market_close = calendar.session_close(current_day)
             if market_close is None:
                 return self._previous_effective_session_date(
                     normalized,
                     current_day,
                     mic=mic,
                 )
-            close_with_buffer = (
-                market_close.tz_convert(
-                    self.market_timezone(normalized, mic=mic)
-                ).to_pydatetime()
-                + timedelta(minutes=30)
-            )
+            close_with_buffer = market_close.tz_convert(
+                self.market_timezone(normalized, mic=mic)
+            ).to_pydatetime() + timedelta(minutes=30)
             if market_now >= close_with_buffer:
                 return current_day
             return self._previous_effective_session_date(

--- a/backend/app/services/market_calendar_service.py
+++ b/backend/app/services/market_calendar_service.py
@@ -369,12 +369,28 @@ class MarketCalendarService:
         normalized = self.normalize_market(market)
         try:
             calendar = self._get_calendar(normalized, mic=mic)
+            last_provider_session = calendar.last_session_date()
+            if (
+                normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
+                and last_provider_session is not None
+                and last_provider_session < start
+            ):
+                raw_sessions = ()
+            else:
+                provider_lookup_end = end
+                if (
+                    normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
+                    and last_provider_session is not None
+                    and start <= last_provider_session < end
+                ):
+                    provider_lookup_end = last_provider_session
+                raw_sessions = calendar.sessions_in_range(start, provider_lookup_end)
             provider_sessions = self._extend_with_weekday_bounds_fallback(
                 normalized,
-                calendar.sessions_in_range(start, end),
+                raw_sessions,
                 start=start,
                 end=end,
-                last_provider_session=calendar.last_session_date(),
+                last_provider_session=last_provider_session,
             )
             return self._apply_session_overrides(
                 normalized,

--- a/backend/app/services/market_calendar_service.py
+++ b/backend/app/services/market_calendar_service.py
@@ -157,7 +157,10 @@ class MarketCalendarService:
         cache_key = (provider_engine, calendar_id, provider_calendar_id)
         if cache_key not in self._calendar_cache:
             self._calendar_cache[cache_key] = RawMarketCalendarAdapter(
-                provider(provider_calendar_id)
+                provider(provider_calendar_id),
+                cache_namespace=(
+                    f"{provider_engine.value}:{calendar_id}:{provider_calendar_id}"
+                ),
             )
         return self._calendar_cache[cache_key]
 
@@ -247,14 +250,22 @@ class MarketCalendarService:
         *,
         start: date,
         end: date,
+        last_provider_session: date | None,
     ) -> list[date]:
         session_days = set(sessions)
-        if market in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS:
+        if (
+            market in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
+            and last_provider_session is not None
+        ):
             if session_days:
-                fallback_start = max(session_days) + timedelta(days=1)
-                if fallback_start <= end:
+                last_returned_session = max(session_days)
+                fallback_start = last_returned_session + timedelta(days=1)
+                if (
+                    last_returned_session >= last_provider_session
+                    and fallback_start <= end
+                ):
                     session_days.update(self._weekday_trading_days(fallback_start, end))
-            else:
+            elif last_provider_session < start:
                 session_days.update(self._weekday_trading_days(start, end))
         return sorted(session_days)
 
@@ -283,6 +294,10 @@ class MarketCalendarService:
             or "out of bounds" in message
             or "last session" in message
             or "first session" in message
+            or "latest date" in message
+            or "earliest date" in message
+            or "last date" in message
+            or "first date" in message
         )
 
     @staticmethod
@@ -330,9 +345,9 @@ class MarketCalendarService:
             calendar = self._get_calendar(normalized, mic=mic)
             return calendar.is_session(pd.Timestamp(candidate_day))
         except Exception as exc:
-            if (
-                normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS
-                and self._is_calendar_bounds_error(exc)
+            if normalized in self.WEEKDAY_BOUNDS_FALLBACK_MARKETS and (
+                self._is_calendar_bounds_error(exc)
+                or isinstance(exc, CalendarScheduleUnavailable)
             ):
                 return self._is_weekday(candidate_day)
             raise
@@ -359,6 +374,7 @@ class MarketCalendarService:
                 calendar.sessions_in_range(start, end),
                 start=start,
                 end=end,
+                last_provider_session=calendar.last_session_date(),
             )
             return self._apply_session_overrides(
                 normalized,

--- a/backend/app/services/market_rs_inputs.py
+++ b/backend/app/services/market_rs_inputs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass
 from datetime import date
+from typing import Protocol
 
 from sqlalchemy.orm import Session
 
@@ -61,12 +62,26 @@ class MarketRsInputUnavailable(RuntimeError):
         self.expected_symbol_count = expected_symbol_count
 
 
+class MarketCalendarForRsInputs(Protocol):
+    def session_anchors(
+        self,
+        market: str,
+        as_of_date: date,
+        *,
+        offsets: tuple[int, ...],
+    ) -> dict[int, date]:
+        ...
+
+    def calendar_metadata(self, market: str) -> dict[str, str | None]:
+        ...
+
+
 class MarketRsInputLoader:
     def __init__(
         self,
         *,
         point_in_time_universe: PointInTimeUniverseService | None = None,
-        market_calendar: MarketCalendarService | None = None,
+        market_calendar: MarketCalendarForRsInputs | None = None,
         benchmark_registry: BenchmarkRegistryService = benchmark_registry,
     ) -> None:
         self._point_in_time_universe = (
@@ -162,6 +177,7 @@ class MarketRsInputLoader:
             None,
         )
         if benchmark_symbol is None:
+            anchor_count = len(anchor_dates)
             missing_by_candidate = {
                 candidate: sorted(
                     anchor.isoformat()
@@ -170,10 +186,25 @@ class MarketRsInputLoader:
                 )
                 for candidate in benchmark_candidates
             }
+            price_coverage_by_candidate = {
+                candidate: (
+                    (anchor_count - len(missing_dates)) / anchor_count
+                    if anchor_count
+                    else 0.0
+                )
+                for candidate, missing_dates in missing_by_candidate.items()
+            }
+            diagnostics: dict[str, object] = {
+                "missing_anchor_dates": missing_by_candidate,
+                "benchmark_anchor_price_coverage": price_coverage_by_candidate,
+                "calendar_metadata": self._market_calendar.calendar_metadata(
+                    normalized
+                ),
+            }
             raise MarketRsInputUnavailable(
                 f"No {normalized} benchmark has every exact RS session anchor",
                 reason_code=MARKET_RS_REASON_BENCHMARK_ADJUSTED_ANCHOR_MISSING,
-                diagnostics={"missing_anchor_dates": missing_by_candidate},
+                diagnostics=diagnostics,
                 **context,
             )
 

--- a/backend/requirements-runtime.txt
+++ b/backend/requirements-runtime.txt
@@ -15,7 +15,8 @@ baostock>=0.8.9
 defusedxml>=0.7.1
 curl_cffi>=0.7.0
 pandas==2.2.0
-pandas-market-calendars>=4.5.0
+pandas-market-calendars==5.3.0
+exchange-calendars==4.11.1
 numpy==1.26.3
 requests==2.31.0
 openpyxl>=3.1.0

--- a/backend/requirements-runtime.txt
+++ b/backend/requirements-runtime.txt
@@ -17,7 +17,7 @@ curl_cffi>=0.7.0
 pandas==2.2.0
 pandas-market-calendars==5.3.0
 exchange-calendars==4.11.1
-numpy==1.26.3
+numpy==1.26.4
 requests==2.31.0
 openpyxl>=3.1.0
 xlrd>=2.0.1

--- a/backend/requirements-server.txt
+++ b/backend/requirements-server.txt
@@ -15,7 +15,8 @@ baostock>=0.8.9
 defusedxml>=0.7.1
 curl_cffi>=0.7.0
 pandas==2.2.0
-pandas-market-calendars>=4.5.0
+pandas-market-calendars==5.3.0
+exchange-calendars==4.11.1
 numpy==1.26.3
 requests==2.31.0
 openpyxl>=3.1.0

--- a/backend/requirements-server.txt
+++ b/backend/requirements-server.txt
@@ -17,7 +17,7 @@ curl_cffi>=0.7.0
 pandas==2.2.0
 pandas-market-calendars==5.3.0
 exchange-calendars==4.11.1
-numpy==1.26.3
+numpy==1.26.4
 requests==2.31.0
 openpyxl>=3.1.0
 xlrd>=2.0.1

--- a/backend/tests/unit/domain/test_market_catalog.py
+++ b/backend/tests/unit/domain/test_market_catalog.py
@@ -8,6 +8,7 @@ from app.domain.markets import (
     MicFacts,
     market_registry,
 )
+from app.domain.markets.calendar_policy import CalendarProvider
 from app.domain.markets.catalog import MarketCatalogError, get_market_catalog
 from app.domain.universe.indexes import index_registry
 
@@ -137,7 +138,20 @@ def test_market_catalog_entry_exposes_canonical_mic_and_currency_facts() -> None
     assert india.mics == ("XNSE", "XBOM")
     assert india.supported_currencies == ("INR",)
     assert india.primary_mic_facts.provider_calendar_id == "NSE"
+    assert (
+        india.primary_mic_facts.calendar_provider
+        is CalendarProvider.PANDAS_MARKET_CALENDARS
+    )
     assert india.mic_facts_for("XBOM").calendar_id == "XBOM"
+    assert (
+        india.mic_facts_for("XBOM").calendar_provider
+        is CalendarProvider.PANDAS_MARKET_CALENDARS
+    )
+
+    jp = catalog.get("JP")
+    assert jp.primary_mic_facts.calendar_id == "XTKS"
+    assert jp.primary_mic_facts.provider_calendar_id == "JPX"
+    assert jp.primary_mic_facts.calendar_provider is CalendarProvider.PANDAS_MARKET_CALENDARS
 
 
 def test_market_catalog_entry_rejects_mic_facts_outside_declared_mics() -> None:
@@ -242,6 +256,7 @@ def test_market_catalog_runtime_payload_is_frontend_ready() -> None:
                 "timezone": "America/New_York",
                 "default_currency": "USD",
                 "provider_calendar_id": None,
+                "calendar_provider": "exchange_calendars",
             },
             {
                 "mic": "XNAS",
@@ -249,6 +264,7 @@ def test_market_catalog_runtime_payload_is_frontend_ready() -> None:
                 "timezone": "America/New_York",
                 "default_currency": "USD",
                 "provider_calendar_id": None,
+                "calendar_provider": "exchange_calendars",
             },
             {
                 "mic": "XASE",
@@ -256,6 +272,7 @@ def test_market_catalog_runtime_payload_is_frontend_ready() -> None:
                 "timezone": "America/New_York",
                 "default_currency": "USD",
                 "provider_calendar_id": None,
+                "calendar_provider": "exchange_calendars",
             },
         ],
         "currency": "USD",

--- a/backend/tests/unit/domain/test_market_catalog.py
+++ b/backend/tests/unit/domain/test_market_catalog.py
@@ -16,7 +16,9 @@ from app.domain.universe.indexes import index_registry
 def test_market_catalog_lists_supported_markets_in_runtime_order() -> None:
     catalog = get_market_catalog()
 
-    assert catalog.supported_market_codes() == list(market_registry.supported_market_codes())
+    assert catalog.supported_market_codes() == list(
+        market_registry.supported_market_codes()
+    )
 
 
 def test_market_catalog_entry_contains_stable_market_facts() -> None:
@@ -143,6 +145,7 @@ def test_market_catalog_entry_exposes_canonical_mic_and_currency_facts() -> None
         is CalendarProvider.PANDAS_MARKET_CALENDARS
     )
     assert india.mic_facts_for("XBOM").calendar_id == "XBOM"
+    assert india.mic_facts_for("XBOM").provider_calendar_id == "BSE"
     assert (
         india.mic_facts_for("XBOM").calendar_provider
         is CalendarProvider.PANDAS_MARKET_CALENDARS
@@ -151,7 +154,10 @@ def test_market_catalog_entry_exposes_canonical_mic_and_currency_facts() -> None
     jp = catalog.get("JP")
     assert jp.primary_mic_facts.calendar_id == "XTKS"
     assert jp.primary_mic_facts.provider_calendar_id == "JPX"
-    assert jp.primary_mic_facts.calendar_provider is CalendarProvider.PANDAS_MARKET_CALENDARS
+    assert (
+        jp.primary_mic_facts.calendar_provider
+        is CalendarProvider.PANDAS_MARKET_CALENDARS
+    )
 
 
 def test_market_catalog_entry_rejects_mic_facts_outside_declared_mics() -> None:
@@ -191,7 +197,9 @@ def test_market_catalog_entry_rejects_mic_facts_outside_declared_mics() -> None:
         )
 
 
-def test_market_catalog_entry_rejects_mic_fact_currency_outside_supported_currencies() -> None:
+def test_market_catalog_entry_rejects_mic_fact_currency_outside_supported_currencies() -> (
+    None
+):
     with pytest.raises(ValueError, match="MIC default currencies"):
         MarketCatalogEntry(
             code="XX",

--- a/backend/tests/unit/test_calendar_benchmark_invariants.py
+++ b/backend/tests/unit/test_calendar_benchmark_invariants.py
@@ -1,0 +1,93 @@
+from datetime import date
+
+from app.services.governance import calendar_benchmark_invariants as invariants
+from app.services.governance.calendar_benchmark_invariants import (
+    EXPECTED_SUNDAY_LAST_COMPLETED,
+    SATURDAY_PROBE,
+    SUNDAY_ROLLOVER_PROBE,
+    collect_calendar_benchmark_invariants,
+)
+
+
+class _RegistryStub:
+    @staticmethod
+    def get_primary_symbol(market):
+        if str(market).strip().upper() == "JP":
+            return "^N225"
+        raise KeyError(market)
+
+
+class _CalendarStub:
+    @staticmethod
+    def normalize_market(market):
+        return str(market).strip().upper()
+
+    @staticmethod
+    def calendar_id(market):
+        assert market == "JP"
+        return "XTKS"
+
+    @staticmethod
+    def calendar_metadata(market):
+        assert market == "JP"
+        return {
+            "market": "JP",
+            "calendar_id": "XTKS",
+            "provider_calendar_id": "JPX",
+            "calendar_provider": "pandas_market_calendars",
+        }
+
+    @staticmethod
+    def is_trading_day(market, day):
+        assert market == "JP"
+        if day == SATURDAY_PROBE:
+            return False
+        return day not in {
+            date(2026, 3, 20),
+            date(2026, 9, 22),
+            date(2026, 9, 23),
+        }
+
+    @staticmethod
+    def last_completed_trading_day(market, *, now):
+        assert market == "JP"
+        assert now == SUNDAY_ROLLOVER_PROBE
+        return EXPECTED_SUNDAY_LAST_COMPLETED
+
+
+def test_collect_calendar_benchmark_invariants_normalizes_market_keys():
+    result = collect_calendar_benchmark_invariants(
+        (" jp ",),
+        registry=_RegistryStub(),
+        calendar_service=_CalendarStub(),
+    )
+
+    assert result.has_regressions is False
+    assert result.weekday_holiday_probes == {
+        "JP": {
+            "2026-03-20": False,
+            "2026-09-22": False,
+            "2026-09-23": False,
+        }
+    }
+    assert set(result.calendar_metadata) == {"JP"}
+
+
+def test_collect_calendar_benchmark_invariants_reports_missing_expected_config(
+    monkeypatch,
+):
+    monkeypatch.delitem(invariants.EXPECTED_BENCHMARK_SYMBOLS, "JP")
+    monkeypatch.delitem(invariants.EXPECTED_CALENDAR_IDS, "JP")
+
+    result = collect_calendar_benchmark_invariants(
+        ("JP",),
+        registry=_RegistryStub(),
+        calendar_service=_CalendarStub(),
+    )
+
+    assert result.benchmark_mismatches == {
+        "JP": "no expected benchmark symbol configured for JP"
+    }
+    assert result.calendar_id_mismatches == {
+        "JP": "no expected calendar ID configured for JP"
+    }

--- a/backend/tests/unit/test_launch_gates.py
+++ b/backend/tests/unit/test_launch_gates.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import pytest
 
+from app.domain.markets.calendar_policy import calendar_session_probe_expectations
 from app.services.governance.launch_gates import (
     GateContext,
     GateStatus,
@@ -126,6 +127,15 @@ class TestSelfCheckGates:
             "AU",
             "MY",
         ]
+        expected_probes = calendar_session_probe_expectations()
+        assert g3.metrics["weekday_holiday_probes"] == {
+            market: {
+                probe_day.isoformat(): expected
+                for probe_day, expected in probes.items()
+            }
+            for market, probes in expected_probes.items()
+        }
+        assert "pandas-market-calendars" in g3.metrics["calendar_dependency_versions"]
 
     def test_g8_observability_passes_with_recent_drill(self, tmp_path):
         root = _make_docs_root(tmp_path)

--- a/backend/tests/unit/test_market_calendar_adapters.py
+++ b/backend/tests/unit/test_market_calendar_adapters.py
@@ -1,0 +1,59 @@
+from datetime import date
+
+import pandas as pd
+
+from app.services import market_calendar_adapters as module
+from app.services.market_calendar_adapters import RawMarketCalendarAdapter
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.values = {}
+        self.setex_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def setex(self, key, ttl, value):
+        self.setex_calls.append((key, ttl, value))
+        self.values[key] = value
+
+
+class _ScheduleCalendar:
+    def __init__(self):
+        self.calls = []
+
+    def schedule(self, *, start_date: pd.Timestamp, end_date: pd.Timestamp):
+        start = start_date.date()
+        end = end_date.date()
+        self.calls.append((start, end))
+        sessions = [
+            pd.Timestamp(session_day)
+            for session_day in (date(2026, 1, 2), date(2026, 1, 5))
+            if start <= session_day <= end
+        ]
+        return pd.DataFrame(index=sessions)
+
+
+def test_sessions_in_range_uses_redis_cache(monkeypatch):
+    redis = _FakeRedis()
+    calendar = _ScheduleCalendar()
+    monkeypatch.setattr(module, "get_redis_client", lambda: redis)
+    adapter = RawMarketCalendarAdapter(
+        calendar,
+        cache_namespace="exchange_calendars:XSES:XSES",
+    )
+
+    first = adapter.sessions_in_range(date(2026, 1, 1), date(2026, 1, 7))
+    second = adapter.sessions_in_range(date(2026, 1, 1), date(2026, 1, 7))
+
+    assert first == (date(2026, 1, 2), date(2026, 1, 5))
+    assert second == first
+    assert calendar.calls == [(date(2026, 1, 1), date(2026, 1, 7))]
+    assert redis.setex_calls == [
+        (
+            "calendar:sessions:v1:exchange_calendars:XSES:XSES:2026-01-01:2026-01-07",
+            module.SESSION_RANGE_CACHE_TTL_SECONDS,
+            '["2026-01-02","2026-01-05"]',
+        )
+    ]

--- a/backend/tests/unit/test_market_calendar_adapters.py
+++ b/backend/tests/unit/test_market_calendar_adapters.py
@@ -35,10 +35,19 @@ class _ScheduleCalendar:
         return pd.DataFrame(index=sessions)
 
 
+class _CallableLastSessionCalendar:
+    def __init__(self):
+        self.sessions = [pd.Timestamp("2026-01-07")]
+
+    def last_session(self):
+        return None
+
+
 def test_sessions_in_range_uses_redis_cache(monkeypatch):
     redis = _FakeRedis()
     calendar = _ScheduleCalendar()
     monkeypatch.setattr(module, "get_redis_client", lambda: redis)
+    monkeypatch.setattr(module, "_session_range_cache_retry_after", 0.0)
     adapter = RawMarketCalendarAdapter(
         calendar,
         cache_namespace="exchange_calendars:XSES:XSES",
@@ -57,3 +66,9 @@ def test_sessions_in_range_uses_redis_cache(monkeypatch):
             '["2026-01-02","2026-01-05"]',
         )
     ]
+
+
+def test_last_session_date_falls_back_when_callable_returns_none():
+    adapter = RawMarketCalendarAdapter(_CallableLastSessionCalendar())
+
+    assert adapter.last_session_date() == date(2026, 1, 7)

--- a/backend/tests/unit/test_market_calendar_adapters.py
+++ b/backend/tests/unit/test_market_calendar_adapters.py
@@ -43,6 +43,14 @@ class _CallableLastSessionCalendar:
         return None
 
 
+class _CallableFirstSessionCalendar:
+    def __init__(self):
+        self.sessions = [pd.Timestamp("2026-01-07")]
+
+    def first_session(self):
+        return None
+
+
 def test_sessions_in_range_uses_redis_cache(monkeypatch):
     redis = _FakeRedis()
     calendar = _ScheduleCalendar()
@@ -72,3 +80,9 @@ def test_last_session_date_falls_back_when_callable_returns_none():
     adapter = RawMarketCalendarAdapter(_CallableLastSessionCalendar())
 
     assert adapter.last_session_date() == date(2026, 1, 7)
+
+
+def test_first_session_date_falls_back_when_callable_returns_none():
+    adapter = RawMarketCalendarAdapter(_CallableFirstSessionCalendar())
+
+    assert adapter.first_session_date() == date(2026, 1, 7)

--- a/backend/tests/unit/test_market_calendar_service.py
+++ b/backend/tests/unit/test_market_calendar_service.py
@@ -55,8 +55,64 @@ class _FallbackCalendar:
         return any(s.date() == session.date() for s in self.sessions)
 
 
+class _BreakCalendar:
+    def __init__(self):
+        self.sessions = [pd.Timestamp("2026-04-10")]
+        self.schedule = pd.DataFrame(
+            {
+                "market_open": [pd.Timestamp("2026-04-10 00:00:00+00:00")],
+                "break_start": [pd.Timestamp("2026-04-10 02:30:00+00:00")],
+                "break_end": [pd.Timestamp("2026-04-10 03:30:00+00:00")],
+                "market_close": [pd.Timestamp("2026-04-10 06:00:00+00:00")],
+            },
+            index=self.sessions,
+        )
+
+    def is_session(self, session: pd.Timestamp) -> bool:
+        return any(s.date() == session.date() for s in self.sessions)
+
+
 class _ProviderCalendar:
     pass
+
+
+class _RangeScheduleCalendar:
+    def __init__(self):
+        self.calls = []
+        self.session_dates = {
+            date(2026, 3, 18),
+            date(2026, 3, 19),
+            date(2026, 3, 20),
+            date(2026, 3, 23),
+        }
+
+    def schedule(self, *, start_date: pd.Timestamp, end_date: pd.Timestamp):
+        start = start_date.date()
+        end = end_date.date()
+        self.calls.append((start, end))
+        sessions = [
+            pd.Timestamp(session_date)
+            for session_date in sorted(self.session_dates)
+            if start <= session_date <= end
+        ]
+        return pd.DataFrame(
+            {
+                "market_open": [
+                    pd.Timestamp.combine(
+                        session.date(), datetime.min.time()
+                    ).tz_localize("UTC")
+                    for session in sessions
+                ],
+                "market_close": [
+                    pd.Timestamp.combine(
+                        session.date(), datetime.min.time()
+                    ).tz_localize("UTC")
+                    + pd.Timedelta(hours=6)
+                    for session in sessions
+                ],
+            },
+            index=sessions,
+        )
 
 
 class _BoundsCalendar:
@@ -184,6 +240,17 @@ def test_is_market_open_schedule_fallback_treats_close_minute_as_closed():
     assert service.is_market_open("IN", now=close_minute_ist) is False
 
 
+def test_is_market_open_schedule_fallback_excludes_intraday_break():
+    service = _service_with_provider(lambda _: _BreakCalendar())
+    morning_tokyo = datetime.fromisoformat("2026-04-10T10:00:00+09:00")
+    lunch_tokyo = datetime.fromisoformat("2026-04-10T12:00:00+09:00")
+    afternoon_tokyo = datetime.fromisoformat("2026-04-10T13:00:00+09:00")
+
+    assert service.is_market_open("JP", now=morning_tokyo) is True
+    assert service.is_market_open("JP", now=lunch_tokyo) is False
+    assert service.is_market_open("JP", now=afternoon_tokyo) is True
+
+
 def test_india_pmc_lookup_uses_provider_specific_calendar_id():
     calls = []
     service = MarketCalendarService(
@@ -207,19 +274,21 @@ def test_india_secondary_mic_lookup_uses_pmc_provider():
     service = MarketCalendarService(
         calendar_providers={
             CalendarProvider.PANDAS_MARKET_CALENDARS: (
-                lambda calendar_id: calls.append(("pmc", calendar_id))
-                or _ProviderCalendar()
+                lambda calendar_id: (
+                    calls.append(("pmc", calendar_id)) or _ProviderCalendar()
+                )
             ),
             CalendarProvider.EXCHANGE_CALENDARS: (
-                lambda calendar_id: calls.append(("xcals", calendar_id))
-                or _ProviderCalendar()
+                lambda calendar_id: (
+                    calls.append(("xcals", calendar_id)) or _ProviderCalendar()
+                )
             ),
         }
     )
 
     service._get_calendar("IN", mic="XBOM")
 
-    assert calls == [("pmc", "XBOM")]
+    assert calls == [("pmc", "BSE")]
 
 
 def test_japan_lookup_uses_jpx_pmc_calendar_provider():
@@ -227,12 +296,14 @@ def test_japan_lookup_uses_jpx_pmc_calendar_provider():
     service = MarketCalendarService(
         calendar_providers={
             CalendarProvider.PANDAS_MARKET_CALENDARS: (
-                lambda calendar_id: calls.append(("pmc", calendar_id))
-                or _ProviderCalendar()
+                lambda calendar_id: (
+                    calls.append(("pmc", calendar_id)) or _ProviderCalendar()
+                )
             ),
             CalendarProvider.EXCHANGE_CALENDARS: (
-                lambda calendar_id: calls.append(("xcals", calendar_id))
-                or _ProviderCalendar()
+                lambda calendar_id: (
+                    calls.append(("xcals", calendar_id)) or _ProviderCalendar()
+                )
             ),
         }
     )
@@ -247,12 +318,14 @@ def test_singapore_lookup_uses_exchange_calendars_calendar_id():
     service = MarketCalendarService(
         calendar_providers={
             CalendarProvider.PANDAS_MARKET_CALENDARS: (
-                lambda calendar_id: calls.append(("pmc", calendar_id))
-                or _ProviderCalendar()
+                lambda calendar_id: (
+                    calls.append(("pmc", calendar_id)) or _ProviderCalendar()
+                )
             ),
             CalendarProvider.EXCHANGE_CALENDARS: (
-                lambda calendar_id: calls.append(("xcals", calendar_id))
-                or _ProviderCalendar()
+                lambda calendar_id: (
+                    calls.append(("xcals", calendar_id)) or _ProviderCalendar()
+                )
             ),
         }
     )
@@ -298,7 +371,7 @@ def test_injected_calendar_provider_uses_mic_specific_provider_calendar_id():
 
     service._get_calendar("IN", mic="XBOM")
 
-    assert calls == ["XBOM"]
+    assert calls == ["BSE"]
 
 
 def test_trading_day_lookup_uses_mic_specific_calendar_id():
@@ -308,7 +381,7 @@ def test_trading_day_lookup_uses_mic_specific_calendar_id():
     )
 
     assert service.is_trading_day("IN", date(2026, 4, 10), mic="XBOM") is True
-    assert calls == ["XBOM"]
+    assert calls == ["BSE"]
 
 
 def test_closed_date_overrides_hide_provider_sessions_from_anchors():
@@ -320,9 +393,7 @@ def test_closed_date_overrides_hide_provider_sessions_from_anchors():
     ]
     service = _service_with_provider(
         lambda _name: _SessionCalendar(sessions),
-        session_overrides=(
-            CalendarSessionOverride("JP", date(2026, 3, 20), False),
-        ),
+        session_overrides=(CalendarSessionOverride("JP", date(2026, 3, 20), False),),
     )
 
     assert service.is_trading_day("JP", date(2026, 3, 20)) is False
@@ -337,6 +408,14 @@ def test_closed_date_overrides_hide_provider_sessions_from_anchors():
     }
 
 
+def test_positive_session_overrides_are_rejected():
+    with pytest.raises(ValueError, match="positive trading-day overrides"):
+        _service_with_provider(
+            lambda _name: _FakeCalendar(),
+            session_overrides=(CalendarSessionOverride("JP", date(2026, 3, 20), True),),
+        )
+
+
 def test_last_completed_trading_day_respects_closed_date_overrides():
     sessions = [
         pd.Timestamp("2026-03-19"),
@@ -344,9 +423,7 @@ def test_last_completed_trading_day_respects_closed_date_overrides():
     ]
     service = _service_with_provider(
         lambda _name: _SessionCalendar(sessions),
-        session_overrides=(
-            CalendarSessionOverride("JP", date(2026, 3, 20), False),
-        ),
+        session_overrides=(CalendarSessionOverride("JP", date(2026, 3, 20), False),),
     )
     noon_tokyo = datetime.fromisoformat("2026-03-20T12:00:00+09:00")
 
@@ -368,8 +445,12 @@ def test_last_completed_trading_day_bounds_fallback(market):
     before_close = datetime.fromisoformat("2026-04-10T15:00:00+08:00")
     after_close = datetime.fromisoformat("2026-04-10T16:00:00+08:00")
 
-    assert service.last_completed_trading_day(market, now=before_close) == date(2026, 4, 9)
-    assert service.last_completed_trading_day(market, now=after_close) == date(2026, 4, 10)
+    assert service.last_completed_trading_day(market, now=before_close) == date(
+        2026, 4, 9
+    )
+    assert service.last_completed_trading_day(market, now=after_close) == date(
+        2026, 4, 10
+    )
 
 
 @pytest.mark.parametrize("market", ["CN", "SG"])
@@ -382,14 +463,24 @@ def test_last_completed_trading_day_does_not_mask_provider_type_errors(market):
         service.last_completed_trading_day(market, now=after_close)
 
 
+def test_trading_days_uses_range_schedule_and_applies_overrides():
+    calendar = _RangeScheduleCalendar()
+    service = _service_with_provider(lambda _: calendar)
+
+    assert service.trading_days("JP", date(2026, 3, 18), date(2026, 3, 23)) == [
+        date(2026, 3, 18),
+        date(2026, 3, 19),
+        date(2026, 3, 23),
+    ]
+    assert calendar.calls == [(date(2026, 3, 18), date(2026, 3, 23))]
+
+
 def test_session_anchors_return_exact_market_session_offsets():
     sessions = pd.date_range("2025-01-01", periods=260, freq="B")
     service = _service_with_provider(lambda _name: _SessionCalendar(sessions))
     as_of = sessions[-1].date()
 
-    anchors = service.session_anchors(
-        "US", as_of, offsets=(21, 63, 126, 189, 252)
-    )
+    anchors = service.session_anchors("US", as_of, offsets=(21, 63, 126, 189, 252))
 
     assert anchors[0] == as_of
     assert anchors[21] == sessions[-22].date()

--- a/backend/tests/unit/test_market_calendar_service.py
+++ b/backend/tests/unit/test_market_calendar_service.py
@@ -120,6 +120,18 @@ class _BoundsCalendar:
         raise ValueError("Requested date is later than the last session available")
 
 
+class _EarliestLatestBoundsCalendar:
+    def __init__(self, message: str):
+        self.message = message
+
+    def is_session(self, session: pd.Timestamp) -> bool:
+        raise ValueError(self.message)
+
+
+class _ScheduleUnavailableCalendar:
+    pass
+
+
 class _BrokenScheduleCalendar:
     def is_session(self, session: pd.Timestamp) -> bool:
         return True
@@ -135,6 +147,12 @@ class _SessionCalendar:
 
     def is_session(self, session: pd.Timestamp) -> bool:
         return session.date() in self._session_dates
+
+
+class _BoundedSessionCalendar(_SessionCalendar):
+    def __init__(self, sessions, last_session):
+        super().__init__(sessions)
+        self.last_session = pd.Timestamp(last_session)
 
 
 def _service_with_provider(provider_factory, **kwargs):
@@ -436,6 +454,57 @@ def test_calendar_bounds_fallback_uses_weekdays(market):
 
     assert service.is_trading_day(market, date(2026, 4, 10)) is True
     assert service.is_trading_day(market, date(2026, 4, 11)) is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "The requested date is before the earliest date supported by the calendar",
+        "The requested date is after the latest date supported by the calendar",
+    ],
+)
+def test_calendar_bounds_fallback_recognizes_earliest_latest_messages(message):
+    service = _service_with_provider(
+        lambda _: _EarliestLatestBoundsCalendar(message),
+    )
+
+    assert service.is_trading_day("CN", date(2026, 4, 10)) is True
+
+
+@pytest.mark.parametrize("market", ["CN", "SG"])
+def test_calendar_schedule_unavailable_fallback_uses_weekdays(market):
+    service = _service_with_provider(lambda _: _ScheduleUnavailableCalendar())
+
+    assert service.is_trading_day(market, date(2026, 4, 10)) is True
+    assert service.is_trading_day(market, date(2026, 4, 11)) is False
+
+
+def test_weekday_bounds_fallback_does_not_readd_provider_known_holidays():
+    service = _service_with_provider(
+        lambda _: _BoundedSessionCalendar(
+            sessions=[date(2026, 4, 10), date(2026, 12, 31)],
+            last_session=date(2026, 12, 31),
+        ),
+    )
+
+    assert service.trading_days("CN", date(2026, 4, 10), date(2026, 4, 13)) == [
+        date(2026, 4, 10),
+    ]
+
+
+def test_weekday_bounds_fallback_extends_after_provider_last_session():
+    service = _service_with_provider(
+        lambda _: _BoundedSessionCalendar(
+            sessions=[date(2025, 12, 31)],
+            last_session=date(2025, 12, 31),
+        ),
+    )
+
+    assert service.trading_days("CN", date(2026, 1, 1), date(2026, 1, 5)) == [
+        date(2026, 1, 1),
+        date(2026, 1, 2),
+        date(2026, 1, 5),
+    ]
 
 
 @pytest.mark.parametrize("market", ["CN", "SG"])

--- a/backend/tests/unit/test_market_calendar_service.py
+++ b/backend/tests/unit/test_market_calendar_service.py
@@ -155,6 +155,17 @@ class _BoundedSessionCalendar(_SessionCalendar):
         self.last_session = pd.Timestamp(last_session)
 
 
+class _RangeBoundedSessionCalendar(_BoundedSessionCalendar):
+    def sessions_in_range(self, start_session: pd.Timestamp, end_session: pd.Timestamp):
+        if end_session.date() > self.last_session.date():
+            raise ValueError("Requested end is later than the last session available")
+        return tuple(
+            session
+            for session in self.sessions
+            if start_session.date() <= session.date() <= end_session.date()
+        )
+
+
 def _service_with_provider(provider_factory, **kwargs):
     return MarketCalendarService(
         calendar_providers={
@@ -501,6 +512,23 @@ def test_weekday_bounds_fallback_extends_after_provider_last_session():
     )
 
     assert service.trading_days("CN", date(2026, 1, 1), date(2026, 1, 5)) == [
+        date(2026, 1, 1),
+        date(2026, 1, 2),
+        date(2026, 1, 5),
+    ]
+
+
+def test_weekday_bounds_fallback_preserves_provider_prefix_when_range_exceeds_bounds():
+    service = _service_with_provider(
+        lambda _: _RangeBoundedSessionCalendar(
+            sessions=[date(2025, 12, 29), date(2025, 12, 31)],
+            last_session=date(2025, 12, 31),
+        ),
+    )
+
+    assert service.trading_days("CN", date(2025, 12, 29), date(2026, 1, 5)) == [
+        date(2025, 12, 29),
+        date(2025, 12, 31),
         date(2026, 1, 1),
         date(2026, 1, 2),
         date(2026, 1, 5),

--- a/backend/tests/unit/test_market_calendar_service.py
+++ b/backend/tests/unit/test_market_calendar_service.py
@@ -150,13 +150,18 @@ class _SessionCalendar:
 
 
 class _BoundedSessionCalendar(_SessionCalendar):
-    def __init__(self, sessions, last_session):
+    def __init__(self, sessions, last_session, first_session=None):
         super().__init__(sessions)
         self.last_session = pd.Timestamp(last_session)
+        self.first_session = pd.Timestamp(first_session or sessions[0])
 
 
 class _RangeBoundedSessionCalendar(_BoundedSessionCalendar):
     def sessions_in_range(self, start_session: pd.Timestamp, end_session: pd.Timestamp):
+        if start_session.date() < self.first_session.date():
+            raise ValueError(
+                "Requested start is earlier than the first session available"
+            )
         if end_session.date() > self.last_session.date():
             raise ValueError("Requested end is later than the last session available")
         return tuple(
@@ -532,6 +537,25 @@ def test_weekday_bounds_fallback_preserves_provider_prefix_when_range_exceeds_bo
         date(2026, 1, 1),
         date(2026, 1, 2),
         date(2026, 1, 5),
+    ]
+
+
+def test_weekday_bounds_fallback_preserves_provider_suffix_when_range_starts_before_bounds():
+    service = _service_with_provider(
+        lambda _: _RangeBoundedSessionCalendar(
+            sessions=[date(2026, 1, 2), date(2026, 1, 6)],
+            first_session=date(2026, 1, 2),
+            last_session=date(2026, 12, 31),
+        ),
+    )
+
+    assert service.trading_days("CN", date(2025, 12, 29), date(2026, 1, 6)) == [
+        date(2025, 12, 29),
+        date(2025, 12, 30),
+        date(2025, 12, 31),
+        date(2026, 1, 1),
+        date(2026, 1, 2),
+        date(2026, 1, 6),
     ]
 
 

--- a/backend/tests/unit/test_market_calendar_service.py
+++ b/backend/tests/unit/test_market_calendar_service.py
@@ -3,7 +3,12 @@ from datetime import date, datetime
 import pandas as pd
 import pytest
 
+from app.domain.markets.calendar_policy import (
+    CalendarProvider,
+    CalendarSessionOverride,
+)
 from app.domain.markets.catalog import get_market_catalog
+from app.services import market_calendar_service as calendar_module
 from app.services.market_calendar_service import MarketCalendarService
 
 
@@ -59,6 +64,14 @@ class _BoundsCalendar:
         raise ValueError("Requested date is later than the last session available")
 
 
+class _BrokenScheduleCalendar:
+    def is_session(self, session: pd.Timestamp) -> bool:
+        return True
+
+    def schedule(self, *, start_date: pd.Timestamp, end_date: pd.Timestamp):
+        raise TypeError("provider schedule bug")
+
+
 class _SessionCalendar:
     def __init__(self, sessions):
         self.sessions = tuple(pd.Timestamp(session) for session in sessions)
@@ -68,8 +81,18 @@ class _SessionCalendar:
         return session.date() in self._session_dates
 
 
+def _service_with_provider(provider_factory, **kwargs):
+    return MarketCalendarService(
+        calendar_providers={
+            CalendarProvider.EXCHANGE_CALENDARS: provider_factory,
+            CalendarProvider.PANDAS_MARKET_CALENDARS: provider_factory,
+        },
+        **kwargs,
+    )
+
+
 def test_market_calendar_service_uses_canonical_calendar_ids():
-    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    service = _service_with_provider(lambda _: _FakeCalendar())
 
     assert service.calendar_id("US") == "XNYS"
     assert service.calendar_id("HK") == "XHKG"
@@ -82,7 +105,7 @@ def test_market_calendar_service_uses_canonical_calendar_ids():
 
 
 def test_market_calendar_service_matches_catalog_primary_mic_facts():
-    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    service = _service_with_provider(lambda _: _FakeCalendar())
 
     catalog = get_market_catalog()
     for market in catalog.supported_market_codes():
@@ -93,7 +116,7 @@ def test_market_calendar_service_matches_catalog_primary_mic_facts():
 
 
 def test_market_calendar_service_uses_primary_mic_facts_for_market_level_calls():
-    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    service = _service_with_provider(lambda _: _FakeCalendar())
     india = get_market_catalog().get("IN")
     primary_facts = india.primary_mic_facts
 
@@ -104,7 +127,7 @@ def test_market_calendar_service_uses_primary_mic_facts_for_market_level_calls()
 
 
 def test_market_calendar_service_supports_mic_specific_fact_lookup():
-    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    service = _service_with_provider(lambda _: _FakeCalendar())
     bombay_facts = get_market_catalog().get("IN").mic_facts_for("XBOM")
 
     assert service.calendar_id("IN", mic="XBOM") == bombay_facts.calendar_id
@@ -117,7 +140,7 @@ def test_market_calendar_service_supports_mic_specific_fact_lookup():
 
 
 def test_last_completed_trading_day_before_close_returns_previous_session():
-    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    service = _service_with_provider(lambda _: _FakeCalendar())
     now_hkt = datetime.fromisoformat("2026-04-10T15:30:00+08:00")
 
     expected = service.last_completed_trading_day("HK", now=now_hkt)
@@ -126,7 +149,7 @@ def test_last_completed_trading_day_before_close_returns_previous_session():
 
 
 def test_last_completed_trading_day_after_close_returns_current_session():
-    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    service = _service_with_provider(lambda _: _FakeCalendar())
     now_hkt = datetime.fromisoformat("2026-04-10T16:30:00+08:00")
 
     expected = service.last_completed_trading_day("HK", now=now_hkt)
@@ -135,7 +158,7 @@ def test_last_completed_trading_day_after_close_returns_current_session():
 
 
 def test_last_completed_trading_day_before_post_close_buffer_returns_previous_session():
-    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    service = _service_with_provider(lambda _: _FakeCalendar())
     now_hkt = datetime.fromisoformat("2026-04-10T16:29:00+08:00")
 
     expected = service.last_completed_trading_day("HK", now=now_hkt)
@@ -144,7 +167,7 @@ def test_last_completed_trading_day_before_post_close_buffer_returns_previous_se
 
 
 def test_is_market_open_uses_calendar_open_minute():
-    service = MarketCalendarService(calendar_provider=lambda _: _FakeCalendar())
+    service = _service_with_provider(lambda _: _FakeCalendar())
     open_minute_hkt = datetime.fromisoformat("2026-04-10T09:30:00+08:00")
     closed_minute_hkt = datetime.fromisoformat("2026-04-10T09:31:00+08:00")
 
@@ -153,7 +176,7 @@ def test_is_market_open_uses_calendar_open_minute():
 
 
 def test_is_market_open_schedule_fallback_treats_close_minute_as_closed():
-    service = MarketCalendarService(calendar_provider=lambda _: _FallbackCalendar())
+    service = _service_with_provider(lambda _: _FallbackCalendar())
     pre_close_ist = datetime.fromisoformat("2026-04-10T15:29:00+05:30")
     close_minute_ist = datetime.fromisoformat("2026-04-10T15:30:00+05:30")
 
@@ -163,23 +186,75 @@ def test_is_market_open_schedule_fallback_treats_close_minute_as_closed():
 
 def test_india_pmc_lookup_uses_provider_specific_calendar_id():
     calls = []
-    service = MarketCalendarService()
-    service._pmc_provider = lambda calendar_id: calls.append(calendar_id) or _ProviderCalendar()
-    service._xcals_provider = lambda calendar_id: calls.append(calendar_id) or _ProviderCalendar()
+    service = MarketCalendarService(
+        calendar_providers={
+            CalendarProvider.PANDAS_MARKET_CALENDARS: (
+                lambda calendar_id: calls.append(calendar_id) or _ProviderCalendar()
+            ),
+            CalendarProvider.EXCHANGE_CALENDARS: (
+                lambda calendar_id: calls.append(calendar_id) or _ProviderCalendar()
+            ),
+        }
+    )
 
     service._get_calendar("IN")
 
     assert calls == ["NSE"]
 
 
+def test_india_secondary_mic_lookup_uses_pmc_provider():
+    calls = []
+    service = MarketCalendarService(
+        calendar_providers={
+            CalendarProvider.PANDAS_MARKET_CALENDARS: (
+                lambda calendar_id: calls.append(("pmc", calendar_id))
+                or _ProviderCalendar()
+            ),
+            CalendarProvider.EXCHANGE_CALENDARS: (
+                lambda calendar_id: calls.append(("xcals", calendar_id))
+                or _ProviderCalendar()
+            ),
+        }
+    )
+
+    service._get_calendar("IN", mic="XBOM")
+
+    assert calls == [("pmc", "XBOM")]
+
+
+def test_japan_lookup_uses_jpx_pmc_calendar_provider():
+    calls = []
+    service = MarketCalendarService(
+        calendar_providers={
+            CalendarProvider.PANDAS_MARKET_CALENDARS: (
+                lambda calendar_id: calls.append(("pmc", calendar_id))
+                or _ProviderCalendar()
+            ),
+            CalendarProvider.EXCHANGE_CALENDARS: (
+                lambda calendar_id: calls.append(("xcals", calendar_id))
+                or _ProviderCalendar()
+            ),
+        }
+    )
+
+    service._get_calendar("JP")
+
+    assert calls == [("pmc", "JPX")]
+
+
 def test_singapore_lookup_uses_exchange_calendars_calendar_id():
     calls = []
-    service = MarketCalendarService()
-    service._pmc_provider = (
-        lambda calendar_id: calls.append(("pmc", calendar_id)) or _ProviderCalendar()
-    )
-    service._xcals_provider = (
-        lambda calendar_id: calls.append(("xcals", calendar_id)) or _ProviderCalendar()
+    service = MarketCalendarService(
+        calendar_providers={
+            CalendarProvider.PANDAS_MARKET_CALENDARS: (
+                lambda calendar_id: calls.append(("pmc", calendar_id))
+                or _ProviderCalendar()
+            ),
+            CalendarProvider.EXCHANGE_CALENDARS: (
+                lambda calendar_id: calls.append(("xcals", calendar_id))
+                or _ProviderCalendar()
+            ),
+        }
     )
 
     service._get_calendar("SG")
@@ -187,11 +262,27 @@ def test_singapore_lookup_uses_exchange_calendars_calendar_id():
     assert calls == [("xcals", "XSES")]
 
 
+@pytest.mark.skipif(
+    calendar_module.pmc is None,
+    reason="pandas_market_calendars is required for JP holiday checks",
+)
+def test_japan_known_2026_weekday_holidays_are_closed():
+    service = MarketCalendarService()
+
+    assert service.is_trading_day("JP", date(2026, 3, 20)) is False
+    assert service.is_trading_day("JP", date(2026, 9, 22)) is False
+    assert service.is_trading_day("JP", date(2026, 9, 23)) is False
+    assert service.trading_days("JP", date(2026, 3, 18), date(2026, 3, 23)) == [
+        date(2026, 3, 18),
+        date(2026, 3, 19),
+        date(2026, 3, 23),
+    ]
+
+
 def test_india_injected_calendar_provider_uses_provider_specific_calendar_id():
     calls = []
-    service = MarketCalendarService(
-        calendar_provider=lambda calendar_id: calls.append(calendar_id)
-        or _ProviderCalendar()
+    service = _service_with_provider(
+        lambda calendar_id: calls.append(calendar_id) or _ProviderCalendar()
     )
 
     service._get_calendar("IN")
@@ -201,9 +292,8 @@ def test_india_injected_calendar_provider_uses_provider_specific_calendar_id():
 
 def test_injected_calendar_provider_uses_mic_specific_provider_calendar_id():
     calls = []
-    service = MarketCalendarService(
-        calendar_provider=lambda calendar_id: calls.append(calendar_id)
-        or _ProviderCalendar()
+    service = _service_with_provider(
+        lambda calendar_id: calls.append(calendar_id) or _ProviderCalendar()
     )
 
     service._get_calendar("IN", mic="XBOM")
@@ -213,18 +303,59 @@ def test_injected_calendar_provider_uses_mic_specific_provider_calendar_id():
 
 def test_trading_day_lookup_uses_mic_specific_calendar_id():
     calls = []
-    service = MarketCalendarService(
-        calendar_provider=lambda calendar_id: calls.append(calendar_id)
-        or _FakeCalendar()
+    service = _service_with_provider(
+        lambda calendar_id: calls.append(calendar_id) or _FakeCalendar()
     )
 
     assert service.is_trading_day("IN", date(2026, 4, 10), mic="XBOM") is True
     assert calls == ["XBOM"]
 
 
+def test_closed_date_overrides_hide_provider_sessions_from_anchors():
+    sessions = [
+        pd.Timestamp("2026-03-18"),
+        pd.Timestamp("2026-03-19"),
+        pd.Timestamp("2026-03-20"),
+        pd.Timestamp("2026-03-23"),
+    ]
+    service = _service_with_provider(
+        lambda _name: _SessionCalendar(sessions),
+        session_overrides=(
+            CalendarSessionOverride("JP", date(2026, 3, 20), False),
+        ),
+    )
+
+    assert service.is_trading_day("JP", date(2026, 3, 20)) is False
+    assert service.trading_days("JP", date(2026, 3, 18), date(2026, 3, 23)) == [
+        date(2026, 3, 18),
+        date(2026, 3, 19),
+        date(2026, 3, 23),
+    ]
+    assert service.session_anchors("JP", date(2026, 3, 23), offsets=(1,)) == {
+        0: date(2026, 3, 23),
+        1: date(2026, 3, 19),
+    }
+
+
+def test_last_completed_trading_day_respects_closed_date_overrides():
+    sessions = [
+        pd.Timestamp("2026-03-19"),
+        pd.Timestamp("2026-03-20"),
+    ]
+    service = _service_with_provider(
+        lambda _name: _SessionCalendar(sessions),
+        session_overrides=(
+            CalendarSessionOverride("JP", date(2026, 3, 20), False),
+        ),
+    )
+    noon_tokyo = datetime.fromisoformat("2026-03-20T12:00:00+09:00")
+
+    assert service.last_completed_trading_day("JP", now=noon_tokyo) == date(2026, 3, 19)
+
+
 @pytest.mark.parametrize("market", ["CN", "SG"])
 def test_calendar_bounds_fallback_uses_weekdays(market):
-    service = MarketCalendarService(calendar_provider=lambda _: _BoundsCalendar())
+    service = _service_with_provider(lambda _: _BoundsCalendar())
 
     assert service.is_trading_day(market, date(2026, 4, 10)) is True
     assert service.is_trading_day(market, date(2026, 4, 11)) is False
@@ -232,7 +363,7 @@ def test_calendar_bounds_fallback_uses_weekdays(market):
 
 @pytest.mark.parametrize("market", ["CN", "SG"])
 def test_last_completed_trading_day_bounds_fallback(market):
-    service = MarketCalendarService(calendar_provider=lambda _: _BoundsCalendar())
+    service = _service_with_provider(lambda _: _BoundsCalendar())
 
     before_close = datetime.fromisoformat("2026-04-10T15:00:00+08:00")
     after_close = datetime.fromisoformat("2026-04-10T16:00:00+08:00")
@@ -241,11 +372,19 @@ def test_last_completed_trading_day_bounds_fallback(market):
     assert service.last_completed_trading_day(market, now=after_close) == date(2026, 4, 10)
 
 
+@pytest.mark.parametrize("market", ["CN", "SG"])
+def test_last_completed_trading_day_does_not_mask_provider_type_errors(market):
+    service = _service_with_provider(lambda _: _BrokenScheduleCalendar())
+
+    after_close = datetime.fromisoformat("2026-04-10T16:30:00+08:00")
+
+    with pytest.raises(TypeError, match="provider schedule bug"):
+        service.last_completed_trading_day(market, now=after_close)
+
+
 def test_session_anchors_return_exact_market_session_offsets():
     sessions = pd.date_range("2025-01-01", periods=260, freq="B")
-    service = MarketCalendarService(
-        calendar_provider=lambda _name: _SessionCalendar(sessions)
-    )
+    service = _service_with_provider(lambda _name: _SessionCalendar(sessions))
     as_of = sessions[-1].date()
 
     anchors = service.session_anchors(
@@ -259,9 +398,7 @@ def test_session_anchors_return_exact_market_session_offsets():
 
 def test_session_anchors_reject_a_non_session_as_of_date():
     sessions = pd.date_range("2025-01-01", periods=260, freq="B")
-    service = MarketCalendarService(
-        calendar_provider=lambda _name: _SessionCalendar(sessions)
-    )
+    service = _service_with_provider(lambda _name: _SessionCalendar(sessions))
     non_session = sessions[-1].date()
     while non_session.weekday() < 5:
         non_session += pd.Timedelta(days=1)
@@ -272,9 +409,7 @@ def test_session_anchors_reject_a_non_session_as_of_date():
 
 def test_session_anchors_require_enough_history():
     sessions = pd.date_range("2026-01-01", periods=100, freq="B")
-    service = MarketCalendarService(
-        calendar_provider=lambda _name: _SessionCalendar(sessions)
-    )
+    service = _service_with_provider(lambda _name: _SessionCalendar(sessions))
 
     with pytest.raises(ValueError, match="253 required"):
         service.session_anchors("US", sessions[-1].date(), offsets=(252,))

--- a/backend/tests/unit/test_market_rs_inputs.py
+++ b/backend/tests/unit/test_market_rs_inputs.py
@@ -13,7 +13,6 @@ from app.services.point_in_time_universe_service import (
     PointInTimeUniverseUnavailable,
 )
 
-
 ANCHORS = {
     0: date(2026, 4, 10),
     21: date(2026, 3, 10),
@@ -42,6 +41,26 @@ class _CalendarStub:
     def session_anchors(_market, _as_of_date, *, offsets):
         assert set(offsets) == {21, 63, 126, 189, 252}
         return dict(ANCHORS)
+
+    @staticmethod
+    def calendar_metadata(market):
+        return {
+            "market": market,
+            "calendar_id": "XNYS",
+            "provider_calendar_id": "XNYS",
+            "calendar_provider": "exchange_calendars",
+        }
+
+
+class _CalendarWithMetadata(_CalendarStub):
+    @staticmethod
+    def calendar_metadata(market):
+        return {
+            "market": market,
+            "calendar_id": "XTKS",
+            "provider_calendar_id": "JPX",
+            "calendar_provider": "pandas_market_calendars",
+        }
 
 
 class _BenchmarkRegistryStub:
@@ -171,6 +190,50 @@ def test_load_fails_when_no_benchmark_has_every_exact_anchor(db_session):
     assert exc_info.value.reason_code == "benchmark_adjusted_anchor_missing"
     assert exc_info.value.benchmark_symbol == "SPY"
     assert exc_info.value.expected_symbol_count == 1
+    assert exc_info.value.diagnostics["calendar_metadata"] == {
+        "market": "US",
+        "calendar_id": "XNYS",
+        "provider_calendar_id": "XNYS",
+        "calendar_provider": "exchange_calendars",
+    }
+
+
+def test_missing_benchmark_anchor_reports_price_backed_calendar_diagnostics(
+    db_session,
+):
+    db_session.add_all(
+        [
+            *_complete_rows("AAA", {offset: 100.0 for offset in ANCHORS}),
+            *[
+                _price("^N225", offset, adjusted=100.0)
+                for offset in ANCHORS
+                if offset != 21
+            ],
+        ]
+    )
+    db_session.commit()
+    loader = MarketRsInputLoader(
+        point_in_time_universe=_UniverseStub(("AAA",)),
+        market_calendar=_CalendarWithMetadata(),
+        benchmark_registry=_BenchmarkRegistryStub(candidates=("^N225",)),
+    )
+
+    with pytest.raises(MarketRsInputUnavailable) as exc_info:
+        loader.load(db_session, market="JP", as_of_date=ANCHORS[0])
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["missing_anchor_dates"] == {
+        "^N225": [ANCHORS[21].isoformat()]
+    }
+    assert diagnostics["benchmark_anchor_price_coverage"]["^N225"] == pytest.approx(
+        5 / 6
+    )
+    assert diagnostics["calendar_metadata"] == {
+        "market": "JP",
+        "calendar_id": "XTKS",
+        "provider_calendar_id": "JPX",
+        "calendar_provider": "pandas_market_calendars",
+    }
 
 
 def test_load_fails_when_current_price_coverage_is_below_ninety_percent(db_session):

--- a/backend/tests/unit/test_python_dependency_pins.py
+++ b/backend/tests/unit/test_python_dependency_pins.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+REQUIREMENT_FILES = (
+    Path(__file__).parents[2] / "requirements-runtime.txt",
+    Path(__file__).parents[2] / "requirements-server.txt",
+)
+
+
+def _exact_pin(path: Path, package_name: str) -> Version:
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("#", "-r")):
+            continue
+        requirement = Requirement(line)
+        if requirement.name.lower() != package_name.lower():
+            continue
+        pins = [
+            specifier.version
+            for specifier in requirement.specifier
+            if specifier.operator == "=="
+        ]
+        if len(pins) == 1:
+            return Version(pins[0])
+    raise AssertionError(f"{path} does not exactly pin {package_name}")
+
+
+def test_numpy_pin_satisfies_provider_calendar_policy():
+    for requirement_file in REQUIREMENT_FILES:
+        assert _exact_pin(requirement_file, "exchange-calendars") == Version("4.11.1")
+        assert _exact_pin(requirement_file, "numpy") >= Version("1.26.4")


### PR DESCRIPTION
## Summary
- Add provider-specific calendar policies and adapters for exchange calendars and pandas market calendars
- Configure India and Japan calendar mappings with runtime provider metadata
- Improve trading-day fallbacks, session overrides, dependency diagnostics, and RS benchmark coverage reporting
- Centralize benchmark/calendar launch-gate invariants and pin calendar dependencies

## Testing
- Expanded unit coverage for market catalog payloads, calendar providers, session behavior, launch-gate metrics, and diagnostics
- Tests not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple market-calendar providers with market-specific identifiers and metadata.
  * Improved trading-session detection, market-hours checks, holiday overrides, intraday breaks, and completed-session handling.
  * Added caching for session-range lookups.
  * Added calendar and benchmark validation to launch checks.

* **Bug Fixes**
  * Improved fallback handling for unavailable schedules and provider-specific boundary conditions.
  * Added support for Japanese holidays, weekend behavior, and Sunday rollover scenarios.
  * Enhanced benchmark diagnostics with calendar and price-coverage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->