### PR TITLE
Fix static exposure breadth parity

### DIFF
--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -617,14 +617,14 @@ def _ensure_breadth_history(
             db,
             market=normalized_market,
         )
+        minimum_validated_stocks = (
+            _static_breadth_minimum_validated_scan_count(
+                supported_symbol_count
+            )
+        )
         if supported_symbol_count <= 0:
             incomplete_existing_dates = list(target_dates)
         else:
-            minimum_validated_stocks = (
-                _static_breadth_minimum_validated_scan_count(
-                    supported_symbol_count
-                )
-            )
             incomplete_existing_dates = [
                 calc_date
                 for calc_date in target_dates
@@ -683,6 +683,19 @@ def _ensure_breadth_history(
             exclude_unsupported_price_symbols=True,
             required_as_of_date=as_of_date,
         )
+        undercovered_dates = _static_breadth_undercovered_backfill_dates(
+            db,
+            market=normalized_market,
+            dates=recompute_dates,
+            minimum_validated_stocks=minimum_validated_stocks,
+            stats=stats,
+        )
+        if undercovered_dates:
+            stats["undercovered_dates"] = [
+                calc_date.isoformat()
+                for calc_date in undercovered_dates
+            ]
+            stats["minimum_stocks_scanned"] = minimum_validated_stocks
         error = _static_breadth_backfill_error(stats)
         stats.update(
             {
@@ -713,6 +726,42 @@ def _static_breadth_supported_symbol_count(db, *, market: str) -> int:
     ]
     supported_symbols, _unsupported_symbols = split_supported_price_symbols(symbols)
     return len(supported_symbols)
+
+
+def _static_breadth_undercovered_backfill_dates(
+    db,
+    *,
+    market: str,
+    dates: Sequence[date],
+    minimum_validated_stocks: int,
+    stats: Mapping[str, Any],
+) -> list[date]:
+    insufficient_observations = int(
+        stats.get("insufficient_history_observations") or 0
+    )
+    if insufficient_observations <= 0 or minimum_validated_stocks <= 0:
+        return []
+
+    rows = (
+        db.query(MarketBreadth)
+        .filter(
+            MarketBreadth.date.in_(dates),
+            MarketBreadth.market == market,
+        )
+        .all()
+    )
+    rows_by_date = {row.date: row for row in rows}
+    return [
+        calc_date
+        for calc_date in dates
+        if (
+            calc_date not in rows_by_date
+            or not _static_breadth_row_has_accepted_coverage(
+                rows_by_date[calc_date],
+                minimum_validated_stocks=minimum_validated_stocks,
+            )
+        )
+    ]
 
 
 def _static_breadth_recompute_dates(
@@ -777,6 +826,16 @@ def _static_breadth_backfill_error(stats: Mapping[str, Any]) -> str | None:
     processed = int(stats.get("processed") or 0)
     if total_dates > 0 and processed == 0:
         return "Cache-only breadth backfill processed no dates"
+
+    undercovered_dates = stats.get("undercovered_dates")
+    if undercovered_dates:
+        date_sample = ",".join(str(calc_date) for calc_date in undercovered_dates)
+        minimum_stocks_scanned = int(stats.get("minimum_stocks_scanned") or 0)
+        return (
+            "Cache-only breadth backfill has insufficient usable coverage "
+            f"(dates={date_sample}, "
+            f"minimum_scanned={minimum_stocks_scanned})"
+        )
 
     target_symbols = stats.get("target_symbols")
     if target_symbols is None:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Any, Literal, Mapping, Sequence
@@ -618,13 +619,20 @@ def _ensure_breadth_history(
         if supported_symbol_count <= 0:
             incomplete_existing_dates = list(target_dates)
         else:
+            minimum_validated_stocks = (
+                _static_breadth_minimum_validated_scan_count(
+                    supported_symbol_count
+                )
+            )
             incomplete_existing_dates = [
                 calc_date
                 for calc_date in target_dates
                 if (
                     calc_date in existing_by_date
-                    and int(existing_by_date[calc_date].total_stocks_scanned or 0)
-                    < supported_symbol_count
+                    and not _static_breadth_row_has_accepted_coverage(
+                        existing_by_date[calc_date],
+                        minimum_validated_stocks=minimum_validated_stocks,
+                    )
                 )
             ]
         recompute_dates = sorted(set(missing_dates + incomplete_existing_dates + [as_of_date]))
@@ -699,6 +707,27 @@ def _static_breadth_supported_symbol_count(db, *, market: str) -> int:
     ]
     supported_symbols, _unsupported_symbols = split_supported_price_symbols(symbols)
     return len(supported_symbols)
+
+
+def _static_breadth_minimum_validated_scan_count(
+    supported_symbol_count: int,
+) -> int:
+    if supported_symbol_count <= 0:
+        return 0
+    return max(
+        1,
+        math.ceil(
+            supported_symbol_count * (1.0 - CACHE_MISS_TOLERANCE_RATIO)
+        ),
+    )
+
+
+def _static_breadth_row_has_accepted_coverage(
+    row: MarketBreadth,
+    *,
+    minimum_validated_stocks: int,
+) -> bool:
+    return int(row.total_stocks_scanned or 0) >= minimum_validated_stocks
 
 
 def _static_breadth_backfill_error(stats: Mapping[str, Any]) -> str | None:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -883,12 +883,26 @@ def _run_daily_refresh(
                     "as_of_date": as_of_by_market[selected_market].isoformat(),
                 }
                 continue
-            breadth_history[selected_market] = _ensure_breadth_history(
-                as_of_date=as_of_by_market[selected_market],
-                market=selected_market,
-                min_trading_days=0,
-                lookback_days=EXPOSURE_BACKFILL_DAYS,
-            )
+            market_as_of = as_of_by_market[selected_market]
+            try:
+                breadth_history[selected_market] = _ensure_breadth_history(
+                    as_of_date=market_as_of,
+                    market=selected_market,
+                    min_trading_days=0,
+                    lookback_days=EXPOSURE_BACKFILL_DAYS,
+                )
+            except Exception as exc:
+                breadth_history[selected_market] = {
+                    "status": "errored",
+                    "market": selected_market,
+                    "as_of_date": market_as_of.isoformat(),
+                    "error": str(exc),
+                    "exception_type": exc.__class__.__name__,
+                }
+                warnings.append(
+                    f"Static export market {selected_market} breadth history "
+                    f"failed for {market_as_of.isoformat()}: {exc}"
+                )
         results["breadth_history"] = breadth_history
 
         market_exposure: dict[str, Any] = {}

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -641,6 +641,7 @@ def _ensure_breadth_history(
             end_date=recompute_dates[-1],
             trading_dates=recompute_dates,
             cache_only=True,
+            exclude_unsupported_price_symbols=True,
         )
         error = _static_breadth_backfill_error(stats)
         stats.update(

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -10,14 +10,16 @@ from typing import Any, Literal, Mapping, Sequence
 
 from app.config import settings
 from app.database import SessionLocal
+from app.domain.markets import market_registry
+from app.domain.providers.price_symbol_support import split_supported_price_symbols
 from app.domain.relative_strength import (
     BALANCED_RS_FORMULA_VERSION,
     LEGACY_RS_FORMULA_VERSION,
 )
-from app.infra.db.repositories.market_rs_repo import MarketRsRunRepository
 from app.infra.db.models.feature_store import FeatureRunPointer
+from app.infra.db.repositories.market_rs_repo import MarketRsRunRepository
 from app.models.market_breadth import MarketBreadth
-from app.domain.markets import market_registry
+from app.models.stock_universe import StockUniverse
 from app.scripts._runtime import prepare_runtime, repo_root
 from app.services.breadth_calculator_service import BreadthCalculatorService
 from app.services.bulk_data_fetcher import BulkDataFetcher
@@ -597,20 +599,41 @@ def _ensure_breadth_history(
         }
 
     with SessionLocal() as db:
-        existing_dates = {
-            record_date
-            for record_date, in db.query(MarketBreadth.date)
+        existing_rows = (
+            db.query(MarketBreadth)
             .filter(
                 MarketBreadth.date >= target_dates[0],
                 MarketBreadth.date <= as_of_date,
                 MarketBreadth.market == normalized_market,
             )
             .all()
-        }
+        )
+        existing_by_date = {row.date: row for row in existing_rows}
+        existing_dates = set(existing_by_date)
         missing_dates = [calc_date for calc_date in target_dates if calc_date not in existing_dates]
-        recompute_dates = sorted(set(missing_dates + [as_of_date]))
+        supported_symbol_count = _static_breadth_supported_symbol_count(
+            db,
+            market=normalized_market,
+        )
+        if supported_symbol_count <= 0:
+            incomplete_existing_dates = list(target_dates)
+        else:
+            incomplete_existing_dates = [
+                calc_date
+                for calc_date in target_dates
+                if (
+                    calc_date in existing_by_date
+                    and int(existing_by_date[calc_date].total_stocks_scanned or 0)
+                    < supported_symbol_count
+                )
+            ]
+        recompute_dates = sorted(set(missing_dates + incomplete_existing_dates + [as_of_date]))
 
-        if len(recompute_dates) == 1 and as_of_date in existing_dates:
+        if (
+            len(recompute_dates) == 1
+            and as_of_date in existing_dates
+            and as_of_date not in incomplete_existing_dates
+        ):
             print(
                 f"[static-breadth] Existing breadth history already covers the last "
                 f"{len(target_dates)} trading days through {as_of_date}.",
@@ -624,6 +647,8 @@ def _ensure_breadth_history(
                 "target_trading_days": len(target_dates),
                 "missing_dates": 0,
                 "recomputed_dates": 0,
+                "validated_existing_dates": len(target_dates),
+                "target_symbols": supported_symbol_count,
             }
 
         print(
@@ -642,6 +667,7 @@ def _ensure_breadth_history(
             trading_dates=recompute_dates,
             cache_only=True,
             exclude_unsupported_price_symbols=True,
+            required_as_of_date=as_of_date,
         )
         error = _static_breadth_backfill_error(stats)
         stats.update(
@@ -652,12 +678,27 @@ def _ensure_breadth_history(
                 "lookback_start_date": start_date.isoformat(),
                 "target_trading_days": len(target_dates),
                 "missing_dates": len(missing_dates),
+                "incomplete_existing_dates": len(incomplete_existing_dates),
                 "recomputed_dates": len(recompute_dates),
             }
         )
         if error:
             stats["error"] = error
         return stats
+
+
+def _static_breadth_supported_symbol_count(db, *, market: str) -> int:
+    symbols = [
+        symbol
+        for symbol, in db.query(StockUniverse.symbol)
+        .filter(
+            StockUniverse.is_active.is_(True),
+            StockUniverse.market == market,
+        )
+        .all()
+    ]
+    supported_symbols, _unsupported_symbols = split_supported_price_symbols(symbols)
+    return len(supported_symbols)
 
 
 def _static_breadth_backfill_error(stats: Mapping[str, Any]) -> str | None:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -30,6 +30,8 @@ from app.services.group_rank_history_backfill_service import (
 )
 from app.services.benchmark_cache_service import BenchmarkFallbackPolicy
 from app.services.benchmark_resolution import BenchmarkResolution
+from app.services.daily_breadth_runner import CACHE_MISS_TOLERANCE_RATIO
+from app.services.market_exposure_service import EXPOSURE_BACKFILL_DAYS
 from app.services.static_daily_price_refresh_service import (
     StaticDailyPriceRefreshService,
     static_daily_price_refresh_batch_size as _static_daily_price_refresh_batch_size,
@@ -577,10 +579,11 @@ def _ensure_breadth_history(
     as_of_date: date,
     market: str = STATIC_DEFAULT_MARKET,
     min_trading_days: int = STATIC_BREADTH_HISTORY_MIN_TRADING_DAYS,
+    lookback_days: int = STATIC_BREADTH_HISTORY_LOOKBACK_DAYS,
 ) -> dict[str, Any]:
     """Backfill recent breadth history so static snapshots include multi-day context."""
     normalized_market = (market or STATIC_DEFAULT_MARKET).upper()
-    start_date = as_of_date - timedelta(days=STATIC_BREADTH_HISTORY_LOOKBACK_DAYS)
+    start_date = as_of_date - timedelta(days=lookback_days)
     desired_dates = _generate_trading_dates(start_date, as_of_date, market=normalized_market)
     target_dates = desired_dates[-min_trading_days:] if min_trading_days > 0 else desired_dates
     if not target_dates:
@@ -639,9 +642,10 @@ def _ensure_breadth_history(
             trading_dates=recompute_dates,
             cache_only=True,
         )
+        error = _static_breadth_backfill_error(stats)
         stats.update(
             {
-                "status": "completed",
+                "status": "errored" if error else "completed",
                 "market": normalized_market,
                 "as_of_date": as_of_date.isoformat(),
                 "lookback_start_date": start_date.isoformat(),
@@ -650,7 +654,49 @@ def _ensure_breadth_history(
                 "recomputed_dates": len(recompute_dates),
             }
         )
+        if error:
+            stats["error"] = error
         return stats
+
+
+def _static_breadth_backfill_error(stats: Mapping[str, Any]) -> str | None:
+    errors = int(stats.get("errors") or 0)
+    if errors > 0:
+        return f"Cache-only breadth backfill has errors (errors={errors})"
+
+    total_dates = int(stats.get("total_dates") or 0)
+    processed = int(stats.get("processed") or 0)
+    if total_dates > 0 and processed == 0:
+        return "Cache-only breadth backfill processed no dates"
+
+    target_symbols = stats.get("target_symbols")
+    if target_symbols is None:
+        return None
+
+    total_symbols = int(target_symbols or 0)
+    if total_symbols == 0:
+        return "Cache-only breadth backfill processed no stocks"
+
+    cache_misses = int(stats.get("cache_miss_stocks") or 0)
+    miss_ratio = cache_misses / total_symbols
+    if miss_ratio > CACHE_MISS_TOLERANCE_RATIO:
+        return (
+            "Cache-only breadth backfill exceeds miss tolerance "
+            f"(cache_misses={cache_misses}, total={total_symbols}, "
+            f"ratio={miss_ratio:.1%}, "
+            f"limit={CACHE_MISS_TOLERANCE_RATIO:.0%})"
+        )
+    return None
+
+
+def _static_breadth_ready_for_exposure(result: Any) -> bool:
+    if not isinstance(result, Mapping):
+        return False
+    if result.get("error"):
+        return False
+    if int(result.get("errors") or 0) > 0:
+        return False
+    return result.get("status") in {"completed", "skipped"}
 
 
 def _run_daily_refresh(
@@ -789,6 +835,8 @@ def _run_daily_refresh(
             breadth_history[selected_market] = _ensure_breadth_history(
                 as_of_date=as_of_by_market[selected_market],
                 market=selected_market,
+                min_trading_days=0,
+                lookback_days=EXPOSURE_BACKFILL_DAYS,
             )
         results["breadth_history"] = breadth_history
 
@@ -805,6 +853,20 @@ def _run_daily_refresh(
                     "market": selected_market,
                     "date": market_as_of.isoformat(),
                 }
+                continue
+            if not _static_breadth_ready_for_exposure(breadth_history.get(selected_market)):
+                market_exposure[selected_market] = {
+                    "status": "skipped",
+                    "reason": "market_breadth_not_ready",
+                    "error": "market_breadth_not_ready",
+                    "market": selected_market,
+                    "date": market_as_of.isoformat(),
+                    "breadth_history": breadth_history.get(selected_market),
+                }
+                warnings.append(
+                    f"Static export market {selected_market} exposure not stored "
+                    f"for {market_as_of.isoformat()}: market_breadth_not_ready."
+                )
                 continue
             try:
                 exposure_result = _compute_static_market_exposure(

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -660,6 +660,13 @@ def _ensure_breadth_history(
 
 
 def _static_breadth_backfill_error(stats: Mapping[str, Any]) -> str | None:
+    calculation_errors = int(stats.get("error_stocks") or 0)
+    if calculation_errors > 0:
+        return (
+            "Cache-only breadth backfill has calculation errors "
+            f"(error_stocks={calculation_errors})"
+        )
+
     errors = int(stats.get("errors") or 0)
     if errors > 0:
         return f"Cache-only breadth backfill has errors (errors={errors})"
@@ -693,6 +700,8 @@ def _static_breadth_ready_for_exposure(result: Any) -> bool:
     if not isinstance(result, Mapping):
         return False
     if result.get("error"):
+        return False
+    if int(result.get("error_stocks") or 0) > 0:
         return False
     if int(result.get("errors") or 0) > 0:
         return False

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -73,6 +73,7 @@ from app.wiring.bootstrap import (
 
 STATIC_BREADTH_HISTORY_MIN_TRADING_DAYS = 20
 STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
+STATIC_BREADTH_RATIO_RECOMPUTE_TRADING_DAYS = 10
 STATIC_BUILD_MODE_PRICE_DELTA = "price_delta"
 STATIC_BUILD_MODE_FULL = "full"
 STATIC_EXPORT_MARKETS = market_registry.supported_market_codes()
@@ -635,7 +636,12 @@ def _ensure_breadth_history(
                     )
                 )
             ]
-        recompute_dates = sorted(set(missing_dates + incomplete_existing_dates + [as_of_date]))
+        repair_dates = sorted(set(missing_dates + incomplete_existing_dates))
+        recompute_dates = _static_breadth_recompute_dates(
+            target_dates=target_dates,
+            repair_dates=repair_dates,
+            as_of_date=as_of_date,
+        )
 
         if (
             len(recompute_dates) == 1
@@ -707,6 +713,31 @@ def _static_breadth_supported_symbol_count(db, *, market: str) -> int:
     ]
     supported_symbols, _unsupported_symbols = split_supported_price_symbols(symbols)
     return len(supported_symbols)
+
+
+def _static_breadth_recompute_dates(
+    *,
+    target_dates: Sequence[date],
+    repair_dates: Sequence[date],
+    as_of_date: date,
+) -> list[date]:
+    recompute_dates = set(repair_dates)
+    index_by_date = {
+        calc_date: index
+        for index, calc_date in enumerate(target_dates)
+    }
+    for repair_date in repair_dates:
+        repair_index = index_by_date.get(repair_date)
+        if repair_index is None:
+            continue
+        affected_end_index = min(
+            len(target_dates),
+            repair_index + STATIC_BREADTH_RATIO_RECOMPUTE_TRADING_DAYS + 1,
+        )
+        recompute_dates.update(target_dates[repair_index:affected_end_index])
+
+    recompute_dates.add(as_of_date)
+    return sorted(recompute_dates)
 
 
 def _static_breadth_minimum_validated_scan_count(

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -575,15 +575,18 @@ def _ensure_group_rank_history(
 def _ensure_breadth_history(
     *,
     as_of_date: date,
+    market: str = STATIC_DEFAULT_MARKET,
     min_trading_days: int = STATIC_BREADTH_HISTORY_MIN_TRADING_DAYS,
 ) -> dict[str, Any]:
     """Backfill recent breadth history so static snapshots include multi-day context."""
+    normalized_market = (market or STATIC_DEFAULT_MARKET).upper()
     start_date = as_of_date - timedelta(days=STATIC_BREADTH_HISTORY_LOOKBACK_DAYS)
-    desired_dates = _generate_trading_dates(start_date, as_of_date)
+    desired_dates = _generate_trading_dates(start_date, as_of_date, market=normalized_market)
     target_dates = desired_dates[-min_trading_days:] if min_trading_days > 0 else desired_dates
     if not target_dates:
         return {
             "status": "skipped",
+            "market": normalized_market,
             "as_of_date": as_of_date.isoformat(),
             "lookback_start_date": start_date.isoformat(),
             "target_trading_days": 0,
@@ -597,7 +600,7 @@ def _ensure_breadth_history(
             .filter(
                 MarketBreadth.date >= target_dates[0],
                 MarketBreadth.date <= as_of_date,
-                MarketBreadth.market == "US",
+                MarketBreadth.market == normalized_market,
             )
             .all()
         }
@@ -612,6 +615,7 @@ def _ensure_breadth_history(
             )
             return {
                 "status": "skipped",
+                "market": normalized_market,
                 "as_of_date": as_of_date.isoformat(),
                 "lookback_start_date": start_date.isoformat(),
                 "target_trading_days": len(target_dates),
@@ -625,7 +629,11 @@ def _ensure_breadth_history(
             f"through {as_of_date}.",
             flush=True,
         )
-        stats = BreadthCalculatorService(db, get_price_cache()).backfill_range(
+        stats = BreadthCalculatorService(
+            db,
+            get_price_cache(),
+            market=normalized_market,
+        ).backfill_range(
             start_date=recompute_dates[0],
             end_date=recompute_dates[-1],
             trading_dates=recompute_dates,
@@ -634,6 +642,7 @@ def _ensure_breadth_history(
         stats.update(
             {
                 "status": "completed",
+                "market": normalized_market,
                 "as_of_date": as_of_date.isoformat(),
                 "lookback_start_date": start_date.isoformat(),
                 "target_trading_days": len(target_dates),
@@ -763,6 +772,25 @@ def _run_daily_refresh(
             is StaticMarketRsArtifactState.NO_CURRENT_ARTIFACT
         }
         warnings.extend(market_rs_no_current_artifact_warnings.values())
+
+        breadth_history: dict[str, Any] = {}
+        for selected_market in selected_markets:
+            if (
+                market_rs_artifact_states[selected_market]
+                is StaticMarketRsArtifactState.NO_CURRENT_ARTIFACT
+            ):
+                breadth_history[selected_market] = {
+                    "status": "skipped",
+                    "reason": "market_rs_not_ready",
+                    "market": selected_market,
+                    "as_of_date": as_of_by_market[selected_market].isoformat(),
+                }
+                continue
+            breadth_history[selected_market] = _ensure_breadth_history(
+                as_of_date=as_of_by_market[selected_market],
+                market=selected_market,
+            )
+        results["breadth_history"] = breadth_history
 
         market_exposure: dict[str, Any] = {}
         for selected_market in selected_markets:

--- a/backend/app/services/breadth_calculator_service.py
+++ b/backend/app/services/breadth_calculator_service.py
@@ -413,9 +413,12 @@ class BreadthCalculatorService:
         }
 
         metrics_by_date: Dict[date, Dict] = {}
+        index_by_date = self._latest_index_by_date(prices_df.index)
         for calc_date in calculation_dates:
-            end_ts = self._timestamp_for_index(calc_date, prices_df.index)
-            latest_idx = prices_df.index.searchsorted(end_ts, side='right') - 1
+            latest_idx = index_by_date.get(calc_date)
+            if latest_idx is None:
+                logger.debug("No exact cached bar for %s", calc_date)
+                continue
             if latest_idx < 69:
                 logger.debug(f"Insufficient cached data through {calc_date}: {latest_idx + 1} days")
                 continue
@@ -428,6 +431,16 @@ class BreadthCalculatorService:
             }
 
         return metrics_by_date
+
+    @staticmethod
+    def _latest_index_by_date(index) -> dict[date, int]:
+        positions: dict[date, int] = {}
+        for position, index_value in enumerate(index):
+            try:
+                positions[pd.Timestamp(index_value).date()] = position
+            except (TypeError, ValueError):
+                continue
+        return positions
 
     @staticmethod
     def _timestamp_for_index(item_date: date, index) -> pd.Timestamp:

--- a/backend/app/services/breadth_calculator_service.py
+++ b/backend/app/services/breadth_calculator_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 
 from ..models.stock_universe import StockUniverse
 from ..models.market_breadth import MarketBreadth
+from ..domain.providers.price_symbol_support import split_supported_price_symbols
 from .breadth_coverage import (
     BreadthCalculationResult,
     BreadthCoverageReport,
@@ -189,6 +190,7 @@ class BreadthCalculatorService:
             DerivedDataExecutionPolicy.provider_allowed()
         ),
         cache_only: bool | None = None,
+        exclude_unsupported_price_symbols: bool = False,
     ) -> Dict:
         """
         Calculate and persist breadth for an entire historical range.
@@ -230,11 +232,27 @@ class BreadthCalculatorService:
             StockUniverse.is_active == True,
             StockUniverse.market == self.market,
         ).all()
+        skipped_unsupported_symbols: list[str] = []
+        if exclude_unsupported_price_symbols:
+            supported_symbols, skipped_unsupported_symbols = split_supported_price_symbols(
+                [stock.symbol for stock in active_stocks]
+            )
+            supported_symbol_set = set(supported_symbols)
+            active_stocks = [
+                stock
+                for stock in active_stocks
+                if stock.symbol in supported_symbol_set
+            ]
         logger.info(
             "Backfilling breadth for %s trading days across %s active stocks",
             len(ordered_dates),
             len(active_stocks),
         )
+        if skipped_unsupported_symbols:
+            logger.info(
+                "Skipping %s unsupported Yahoo price symbols in breadth backfill",
+                len(skipped_unsupported_symbols),
+            )
 
         metrics_by_date = {calc_date: self._empty_metrics() for calc_date in ordered_dates}
         outcomes_by_date = {
@@ -348,6 +366,13 @@ class BreadthCalculatorService:
             'errors': len(error_dates),
             'error_dates': error_dates,
         }
+        if exclude_unsupported_price_symbols:
+            result.update({
+                "skipped_unsupported_symbols": len(skipped_unsupported_symbols),
+                "unsupported_symbols_sample": (
+                    sorted(set(skipped_unsupported_symbols))[:20]
+                ),
+            })
         if policy.cache_only:
             aggregate_outcomes = sum(
                 (

--- a/backend/app/services/breadth_calculator_service.py
+++ b/backend/app/services/breadth_calculator_service.py
@@ -191,6 +191,7 @@ class BreadthCalculatorService:
         ),
         cache_only: bool | None = None,
         exclude_unsupported_price_symbols: bool = False,
+        required_as_of_date: date | None = None,
     ) -> Dict:
         """
         Calculate and persist breadth for an entire historical range.
@@ -275,9 +276,13 @@ class BreadthCalculatorService:
             )
 
             batch_symbols = [stock.symbol for stock in batch]
+            cache_load_kwargs = {}
+            if required_as_of_date is not None:
+                cache_load_kwargs["required_as_of_date"] = required_as_of_date
             price_data_by_symbol, batch_cache_miss_symbols = self._load_price_data_for_batch(
                 batch_symbols=batch_symbols,
                 cache_only=policy.cache_only,
+                **cache_load_kwargs,
             )
             price_coverage.record_batch(
                 batch_symbols,

--- a/backend/app/services/breadth_coverage.py
+++ b/backend/app/services/breadth_coverage.py
@@ -193,6 +193,7 @@ class BreadthCoverageReport:
             "target_symbols": self.candidate_stocks,
             "symbols_with_cached_history": self.symbols_with_cached_history,
             "cache_miss_stocks": self.cache_miss_stocks,
+            "error_stocks": self.error_stocks,
             "cache_miss_symbols_sample": list(self.cache_miss_symbols_sample),
             "cache_coverage_ratio": self.cache_coverage_ratio,
             "insufficient_history_observations": (

--- a/backend/app/services/price_cache_service.py
+++ b/backend/app/services/price_cache_service.py
@@ -247,14 +247,6 @@ class PriceCacheService:
             logger.debug(f"Fresh cache-only MISS for {symbol}")
             return None
 
-        if not self._is_data_fresh(last_date):
-            logger.debug(f"Fresh cache-only STALE for {symbol} (last: {last_date})")
-            return None
-
-        if self._is_intraday_data_stale(symbol):
-            logger.debug(f"Fresh cache-only INTRADAY_STALE for {symbol}")
-            return None
-
         if not self._contains_required_as_of_date(
             cached_data,
             required_as_of_date,
@@ -264,6 +256,14 @@ class PriceCacheService:
                 symbol,
                 required_as_of_date,
             )
+            return None
+
+        if required_as_of_date is None and not self._is_data_fresh(last_date):
+            logger.debug(f"Fresh cache-only STALE for {symbol} (last: {last_date})")
+            return None
+
+        if self._is_intraday_data_stale(symbol):
+            logger.debug(f"Fresh cache-only INTRADAY_STALE for {symbol}")
             return None
 
         logger.debug(f"Fresh cache-only HIT for {symbol} (last: {last_date})")
@@ -310,7 +310,10 @@ class PriceCacheService:
             if (
                 data is not None
                 and not data.empty
-                and self._is_data_fresh(last_date)
+                and (
+                    required_as_of_date is not None
+                    or self._is_data_fresh(last_date)
+                )
                 and not self._is_intraday_data_stale(symbol)
                 and self._contains_required_as_of_date(
                     data,

--- a/backend/tests/unit/test_breadth_calculator_service.py
+++ b/backend/tests/unit/test_breadth_calculator_service.py
@@ -611,6 +611,35 @@ def test_backfill_range_can_exclude_unsupported_yahoo_symbols(monkeypatch):
     assert result["unsupported_symbols_sample"] == ["0335.T"]
 
 
+def test_backfill_range_can_require_target_date_cached_prices(monkeypatch):
+    db = _make_db_session()
+    db.add(StockUniverse(symbol="AAA", is_active=True, status=UNIVERSE_STATUS_ACTIVE))
+    db.commit()
+
+    trading_date = date(2026, 3, 20)
+    service = BreadthCalculatorService(db, MagicMock())
+    load_prices = MagicMock(
+        return_value=({"AAA": _make_price_df(trading_date)}, set())
+    )
+    monkeypatch.setattr(service, "_load_price_data_for_batch", load_prices)
+    monkeypatch.setattr(service, "_store_breadth_records", MagicMock())
+
+    result = service.backfill_range(
+        trading_date,
+        trading_date,
+        trading_dates=[trading_date],
+        policy=_policy("refresh_guarded", trading_date),
+        required_as_of_date=trading_date,
+    )
+
+    assert result["processed"] == 1
+    load_prices.assert_called_once_with(
+        batch_symbols=["AAA"],
+        cache_only=True,
+        required_as_of_date=trading_date,
+    )
+
+
 def test_backfill_range_cache_only_reports_calculation_errors(monkeypatch):
     db = _make_db_session()
     db.add_all([

--- a/backend/tests/unit/test_breadth_calculator_service.py
+++ b/backend/tests/unit/test_breadth_calculator_service.py
@@ -559,11 +559,64 @@ def test_backfill_range_cache_only_reports_gaps_without_provider_fallback():
         "target_symbols": 3,
         "symbols_with_cached_history": 2,
         "cache_miss_stocks": 1,
+        "error_stocks": 0,
         "cache_miss_symbols_sample": ["BBB"],
         "cache_coverage_ratio": pytest.approx(2 / 3),
         "insufficient_history_observations": 1,
     }
     price_cache.get_historical_data.assert_not_called()
+
+
+def test_backfill_range_cache_only_reports_calculation_errors(monkeypatch):
+    db = _make_db_session()
+    db.add_all([
+        StockUniverse(symbol="AAA", is_active=True, status=UNIVERSE_STATUS_ACTIVE),
+        StockUniverse(symbol="BAD", is_active=True, status=UNIVERSE_STATUS_ACTIVE),
+    ])
+    db.commit()
+
+    trading_date = date(2026, 3, 20)
+    aaa_df = _make_price_df(trading_date)
+    bad_df = _make_price_df(trading_date, 200.0)
+    service = BreadthCalculatorService(db, MagicMock())
+    monkeypatch.setattr(
+        service,
+        "_load_price_data_for_batch",
+        MagicMock(return_value=({"AAA": aaa_df, "BAD": bad_df}, set())),
+    )
+
+    def calculate_metrics(prices_df, calculation_dates):
+        if prices_df is bad_df:
+            raise RuntimeError("bad cached prices")
+        return {
+            calculation_dates[0]: {
+                "pct_change_1d": 5.0,
+                "pct_change_21d": 0.0,
+                "pct_change_34d": 0.0,
+                "pct_change_63d": 0.0,
+            }
+        }
+
+    monkeypatch.setattr(
+        service,
+        "_calculate_stock_metrics_by_date_from_prices",
+        calculate_metrics,
+    )
+    monkeypatch.setattr(service, "_store_breadth_records", MagicMock())
+
+    result = service.backfill_range(
+        trading_date,
+        trading_date,
+        trading_dates=[trading_date],
+        policy=_policy("refresh_guarded", trading_date),
+    )
+
+    assert result["processed"] == 1
+    assert result["errors"] == 0
+    assert result["target_symbols"] == 2
+    assert result["cache_miss_stocks"] == 0
+    assert result["error_stocks"] == 1
+    assert result["insufficient_history_observations"] == 0
 
 
 def test_vectorized_stock_metrics_preserve_invalid_close_semantics():
@@ -629,6 +682,7 @@ def test_fill_gaps_propagates_cache_only_to_backfill_range(monkeypatch):
         "target_symbols": 2,
         "symbols_with_cached_history": 1,
         "cache_miss_stocks": 1,
+        "error_stocks": 0,
         "cache_miss_symbols_sample": ["BBB"],
         "cache_coverage_ratio": 0.5,
         "insufficient_history_observations": 0,

--- a/backend/tests/unit/test_breadth_calculator_service.py
+++ b/backend/tests/unit/test_breadth_calculator_service.py
@@ -567,6 +567,50 @@ def test_backfill_range_cache_only_reports_gaps_without_provider_fallback():
     price_cache.get_historical_data.assert_not_called()
 
 
+def test_backfill_range_can_exclude_unsupported_yahoo_symbols(monkeypatch):
+    db = _make_db_session()
+    db.add_all([
+        StockUniverse(
+            symbol="7203.T",
+            market="JP",
+            is_active=True,
+            status=UNIVERSE_STATUS_ACTIVE,
+        ),
+        StockUniverse(
+            symbol="0335.T",
+            market="JP",
+            is_active=True,
+            status=UNIVERSE_STATUS_ACTIVE,
+        ),
+    ])
+    db.commit()
+
+    trading_date = date(2026, 3, 20)
+    supported_df = _make_price_df(trading_date)
+    service = BreadthCalculatorService(db, MagicMock(), market="JP")
+    load_prices = MagicMock(return_value=({"7203.T": supported_df}, set()))
+    monkeypatch.setattr(service, "_load_price_data_for_batch", load_prices)
+    monkeypatch.setattr(service, "_store_breadth_records", MagicMock())
+
+    result = service.backfill_range(
+        trading_date,
+        trading_date,
+        trading_dates=[trading_date],
+        policy=_policy("refresh_guarded", trading_date),
+        exclude_unsupported_price_symbols=True,
+    )
+
+    load_prices.assert_called_once_with(
+        batch_symbols=["7203.T"],
+        cache_only=True,
+    )
+    assert result["processed"] == 1
+    assert result["target_symbols"] == 1
+    assert result["cache_miss_stocks"] == 0
+    assert result["skipped_unsupported_symbols"] == 1
+    assert result["unsupported_symbols_sample"] == ["0335.T"]
+
+
 def test_backfill_range_cache_only_reports_calculation_errors(monkeypatch):
     db = _make_db_session()
     db.add_all([

--- a/backend/tests/unit/test_breadth_calculator_service.py
+++ b/backend/tests/unit/test_breadth_calculator_service.py
@@ -912,6 +912,48 @@ def test_backfill_range_sparse_dates_include_existing_intervening_counts_in_rati
     assert rows[date(2026, 3, 16)].ratio_5day == 2.8
 
 
+def test_backfill_range_requires_exact_bar_for_each_requested_date():
+    db = _make_db_session()
+    db.add_all([
+        StockUniverse(symbol="AAA", is_active=True, status=UNIVERSE_STATUS_ACTIVE),
+        StockUniverse(symbol="GAP", is_active=True, status=UNIVERSE_STATUS_ACTIVE),
+    ])
+    db.commit()
+
+    first_date = date(2026, 3, 12)
+    latest_date = date(2026, 3, 16)
+    aaa_df = _flat_price_df(latest_date)
+    gap_df = _flat_price_df(latest_date)
+    gap_df = gap_df.drop(index=pd.Timestamp(first_date))
+    gap_df.loc[pd.Timestamp(date(2026, 3, 11)), "Close"] = 95.0
+    gap_df.loc[pd.Timestamp(latest_date), "Close"] = 105.0
+
+    price_cache = MagicMock()
+    price_cache.get_many_cached_only_fresh.return_value = {
+        "AAA": aaa_df,
+        "GAP": gap_df,
+    }
+    service = BreadthCalculatorService(db, price_cache)
+
+    result = service.backfill_range(
+        first_date,
+        latest_date,
+        trading_dates=[first_date, latest_date],
+        policy=_policy("refresh_guarded", latest_date),
+    )
+
+    rows = {
+        row.date: row
+        for row in db.query(MarketBreadth)
+        .filter(MarketBreadth.date.in_([first_date, latest_date]))
+        .all()
+    }
+    assert result["processed"] == 2
+    assert result["insufficient_history_observations"] == 1
+    assert rows[first_date].total_stocks_scanned == 1
+    assert rows[latest_date].total_stocks_scanned == 2
+
+
 def test_backfill_range_vectorized_changes_preserve_rounded_thresholds():
     db = _make_db_session()
     symbols = ["UP4", "UP13", "UP25", "UP50"]

--- a/backend/tests/unit/test_breadth_coverage.py
+++ b/backend/tests/unit/test_breadth_coverage.py
@@ -136,6 +136,7 @@ def test_daily_and_backfill_serializers_share_one_report():
         "target_symbols": 2,
         "symbols_with_cached_history": 1,
         "cache_miss_stocks": 1,
+        "error_stocks": 1,
         "cache_miss_symbols_sample": ["BBB"],
         "cache_coverage_ratio": 0.5,
         "insufficient_history_observations": 1,

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -647,3 +647,78 @@ def test_ensure_breadth_history_marks_calculation_errors_not_completed(monkeypat
         "Cache-only breadth backfill has calculation errors "
         "(error_stocks=1)"
     )
+
+
+def test_ensure_breadth_history_marks_undercovered_backfill_rows_not_completed(
+    monkeypatch,
+):
+    as_of_date = date(2026, 7, 31)
+    breadth_rows: list[SimpleNamespace] = []
+
+    class _FakeQuery:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return self.rows
+
+    class _FakeDb(_FakeSession):
+        def query(self, entity, *args):
+            if entity is MarketBreadth:
+                return _FakeQuery(breadth_rows)
+            if entity is StockUniverse.symbol:
+                return _FakeQuery([
+                    (f"AAA{i}",)
+                    for i in range(10)
+                ])
+            return _FakeQuery([])
+
+    class _FakeBreadthCalculator:
+        def __init__(self, db, price_cache, *, market):
+            self.market = market
+
+        def backfill_range(self, **kwargs):
+            breadth_rows.append(
+                SimpleNamespace(
+                    date=as_of_date,
+                    total_stocks_scanned=1,
+                )
+            )
+            return {
+                "total_dates": 1,
+                "processed": 1,
+                "errors": 0,
+                "error_dates": [],
+                "target_symbols": 10,
+                "symbols_with_cached_history": 10,
+                "cache_miss_stocks": 0,
+                "error_stocks": 0,
+                "cache_coverage_ratio": 1.0,
+                "insufficient_history_observations": 9,
+            }
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(export_static_site, "_generate_trading_dates", lambda *args, **kwargs: [as_of_date])
+    monkeypatch.setattr(export_static_site, "get_price_cache", lambda: object())
+    monkeypatch.setattr(
+        export_static_site,
+        "BreadthCalculatorService",
+        _FakeBreadthCalculator,
+    )
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "errored"
+    assert result["undercovered_dates"] == ["2026-07-31"]
+    assert result["minimum_stocks_scanned"] == 9
+    assert result["error"] == (
+        "Cache-only breadth backfill has insufficient usable coverage "
+        "(dates=2026-07-31, minimum_scanned=9)"
+    )

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -215,6 +215,95 @@ def test_static_daily_refresh_skips_exposure_when_breadth_history_errors(monkeyp
     ) in warnings
 
 
+def test_static_daily_refresh_quarantines_breadth_history_exceptions(monkeypatch):
+    monkeypatch.setattr(export_static_site, "STATIC_EXPORT_MARKETS", ("HK",))
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(export_static_site, "disable_serialized_data_fetch_lock", nullcontext)
+    monkeypatch.setattr(export_static_site, "disable_serialized_market_workload", nullcontext)
+    monkeypatch.setattr(export_static_site, "_tracked_ibd_csv_path", lambda: "ibd.csv")
+    monkeypatch.setattr(
+        export_static_site.IBDIndustryService,
+        "load_from_csv",
+        lambda _db, csv_path: 0,
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_resolve_latest_completed_trading_date",
+        lambda market: date(2026, 7, 31),
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date, market: {"status": "completed", "market": market},
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_prepare_static_rs_formula",
+        lambda *, market, as_of_date, formula_version: {
+            "status": "completed",
+            "market": market,
+            "as_of_date": as_of_date.isoformat(),
+            "formula_version": formula_version,
+            "market_rs_run_id": 42,
+        },
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "classify_static_market_rs_artifact_result",
+        lambda *args, **kwargs: StaticMarketRsArtifactState.READY,
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_ensure_breadth_history",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("cache read failed")),
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_compute_static_market_exposure",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("exposure must not compute when breadth raises")
+        ),
+    )
+
+    import app.interfaces.tasks.feature_store_tasks as feature_store_tasks
+
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(
+            run=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("snapshot must not publish after breadth raises")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "_enrich_feature_run_with_ibd_metadata",
+        lambda **kwargs: {"status": "completed"},
+    )
+
+    results, warnings = export_static_site._run_daily_refresh(
+        market="HK",
+        skip_universe_refresh=True,
+        skip_fundamentals_refresh=True,
+        rs_formula_version=BALANCED_RS_FORMULA_VERSION,
+    )
+
+    assert results["breadth_history"]["HK"] == {
+        "status": "errored",
+        "market": "HK",
+        "as_of_date": "2026-07-31",
+        "error": "cache read failed",
+        "exception_type": "RuntimeError",
+    }
+    assert results["market_exposure"]["HK"]["error"] == "market_breadth_not_ready"
+    assert results["feature_snapshots"]["HK"]["reason"] == "market_exposure_not_ready"
+    assert (
+        "Static export market HK breadth history failed for 2026-07-31: "
+        "cache read failed"
+    ) in warnings
+
+
 def test_ensure_breadth_history_marks_backfill_errors_not_completed(monkeypatch):
     as_of_date = date(2026, 7, 31)
     backfill_kwargs: dict[str, object] = {}

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -215,6 +215,7 @@ def test_static_daily_refresh_skips_exposure_when_breadth_history_errors(monkeyp
 
 def test_ensure_breadth_history_marks_backfill_errors_not_completed(monkeypatch):
     as_of_date = date(2026, 7, 31)
+    backfill_kwargs: dict[str, object] = {}
 
     class _FakeQuery:
         def filter(self, *args, **kwargs):
@@ -232,6 +233,7 @@ def test_ensure_breadth_history_marks_backfill_errors_not_completed(monkeypatch)
             self.market = market
 
         def backfill_range(self, **kwargs):
+            backfill_kwargs.update(kwargs)
             return {
                 "total_dates": 1,
                 "processed": 0,
@@ -253,6 +255,7 @@ def test_ensure_breadth_history_marks_backfill_errors_not_completed(monkeypatch)
     assert result["status"] == "errored"
     assert result["errors"] == 1
     assert result["error_dates"] == ["2026-07-31"]
+    assert backfill_kwargs["exclude_unsupported_price_symbols"] is True
 
 
 def test_ensure_breadth_history_marks_calculation_errors_not_completed(monkeypatch):

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 from app.domain.relative_strength import BALANCED_RS_FORMULA_VERSION
 from app.scripts import export_static_site
+from app.services.market_exposure_service import EXPOSURE_BACKFILL_DAYS
 from app.services.static_market_publish_policy import StaticMarketRsArtifactState
 
 
@@ -26,6 +27,7 @@ class _ReadyGroupRankBackfill:
 
 def test_static_daily_refresh_ensures_market_breadth_before_exposure(monkeypatch):
     events: list[tuple[str, str]] = []
+    breadth_call: dict[str, object] = {}
 
     monkeypatch.setattr(export_static_site, "STATIC_EXPORT_MARKETS", ("HK",))
     monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeSession())
@@ -64,7 +66,13 @@ def test_static_daily_refresh_ensures_market_breadth_before_exposure(monkeypatch
         lambda *args, **kwargs: StaticMarketRsArtifactState.READY,
     )
 
-    def ensure_breadth(*, as_of_date, market):
+    def ensure_breadth(*, as_of_date, market, min_trading_days=None, lookback_days=None):
+        breadth_call.update(
+            as_of_date=as_of_date,
+            market=market,
+            min_trading_days=min_trading_days,
+            lookback_days=lookback_days,
+        )
         events.append(("breadth", market))
         return {"status": "completed", "market": market, "as_of_date": as_of_date.isoformat()}
 
@@ -109,3 +117,139 @@ def test_static_daily_refresh_ensures_market_breadth_before_exposure(monkeypatch
     assert warnings == []
     assert results["market_exposure"]["HK"]["status"] == "stored"
     assert events.index(("breadth", "HK")) < events.index(("exposure", "HK"))
+    assert breadth_call == {
+        "as_of_date": date(2026, 7, 31),
+        "market": "HK",
+        "min_trading_days": 0,
+        "lookback_days": EXPOSURE_BACKFILL_DAYS,
+    }
+
+
+def test_static_daily_refresh_skips_exposure_when_breadth_history_errors(monkeypatch):
+    monkeypatch.setattr(export_static_site, "STATIC_EXPORT_MARKETS", ("HK",))
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(export_static_site, "disable_serialized_data_fetch_lock", nullcontext)
+    monkeypatch.setattr(export_static_site, "disable_serialized_market_workload", nullcontext)
+    monkeypatch.setattr(export_static_site, "_tracked_ibd_csv_path", lambda: "ibd.csv")
+    monkeypatch.setattr(
+        export_static_site.IBDIndustryService,
+        "load_from_csv",
+        lambda _db, csv_path: 0,
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_resolve_latest_completed_trading_date",
+        lambda market: date(2026, 7, 31),
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date, market: {"status": "completed", "market": market},
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_prepare_static_rs_formula",
+        lambda *, market, as_of_date, formula_version: {
+            "status": "completed",
+            "market": market,
+            "as_of_date": as_of_date.isoformat(),
+            "formula_version": formula_version,
+            "market_rs_run_id": 42,
+        },
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "classify_static_market_rs_artifact_result",
+        lambda *args, **kwargs: StaticMarketRsArtifactState.READY,
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_ensure_breadth_history",
+        lambda **kwargs: {
+            "status": "errored",
+            "market": kwargs["market"],
+            "as_of_date": kwargs["as_of_date"].isoformat(),
+            "errors": 1,
+            "error_dates": [kwargs["as_of_date"].isoformat()],
+        },
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_compute_static_market_exposure",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("exposure must not compute when breadth is incomplete")
+        ),
+    )
+
+    import app.interfaces.tasks.feature_store_tasks as feature_store_tasks
+
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(
+            run=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("snapshot must not publish after exposure is skipped")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "_enrich_feature_run_with_ibd_metadata",
+        lambda **kwargs: {"status": "completed"},
+    )
+
+    results, warnings = export_static_site._run_daily_refresh(
+        market="HK",
+        skip_universe_refresh=True,
+        skip_fundamentals_refresh=True,
+        rs_formula_version=BALANCED_RS_FORMULA_VERSION,
+    )
+
+    assert results["market_exposure"]["HK"]["error"] == "market_breadth_not_ready"
+    assert results["feature_snapshots"]["HK"]["reason"] == "market_exposure_not_ready"
+    assert (
+        "Static export market HK exposure not stored for 2026-07-31: "
+        "market_breadth_not_ready."
+    ) in warnings
+
+
+def test_ensure_breadth_history_marks_backfill_errors_not_completed(monkeypatch):
+    as_of_date = date(2026, 7, 31)
+
+    class _FakeQuery:
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return []
+
+    class _FakeDb(_FakeSession):
+        def query(self, *args, **kwargs):
+            return _FakeQuery()
+
+    class _FakeBreadthCalculator:
+        def __init__(self, db, price_cache, *, market):
+            self.market = market
+
+        def backfill_range(self, **kwargs):
+            return {
+                "total_dates": 1,
+                "processed": 0,
+                "errors": 1,
+                "error_dates": [as_of_date.isoformat()],
+            }
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(export_static_site, "_generate_trading_dates", lambda *args, **kwargs: [as_of_date])
+    monkeypatch.setattr(export_static_site, "get_price_cache", lambda: object())
+    monkeypatch.setattr(export_static_site, "BreadthCalculatorService", _FakeBreadthCalculator)
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "errored"
+    assert result["errors"] == 1
+    assert result["error_dates"] == ["2026-07-31"]

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -253,3 +253,53 @@ def test_ensure_breadth_history_marks_backfill_errors_not_completed(monkeypatch)
     assert result["status"] == "errored"
     assert result["errors"] == 1
     assert result["error_dates"] == ["2026-07-31"]
+
+
+def test_ensure_breadth_history_marks_calculation_errors_not_completed(monkeypatch):
+    as_of_date = date(2026, 7, 31)
+
+    class _FakeQuery:
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return []
+
+    class _FakeDb(_FakeSession):
+        def query(self, *args, **kwargs):
+            return _FakeQuery()
+
+    class _FakeBreadthCalculator:
+        def __init__(self, db, price_cache, *, market):
+            self.market = market
+
+        def backfill_range(self, **kwargs):
+            return {
+                "total_dates": 1,
+                "processed": 1,
+                "errors": 0,
+                "error_dates": [],
+                "target_symbols": 2,
+                "symbols_with_cached_history": 2,
+                "cache_miss_stocks": 0,
+                "error_stocks": 1,
+                "cache_coverage_ratio": 1.0,
+            }
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(export_static_site, "_generate_trading_dates", lambda *args, **kwargs: [as_of_date])
+    monkeypatch.setattr(export_static_site, "get_price_cache", lambda: object())
+    monkeypatch.setattr(export_static_site, "BreadthCalculatorService", _FakeBreadthCalculator)
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "errored"
+    assert result["error_stocks"] == 1
+    assert result["error"] == (
+        "Cache-only breadth backfill has calculation errors "
+        "(error_stocks=1)"
+    )

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -409,6 +409,91 @@ def test_ensure_breadth_history_recomputes_incomplete_existing_rows(monkeypatch)
     assert backfill_kwargs["trading_dates"] == [as_of_date]
 
 
+def test_ensure_breadth_history_recomputes_ratio_window_after_historical_repair(
+    monkeypatch,
+):
+    target_dates = [
+        date(2026, 7, 16),
+        date(2026, 7, 17),
+        date(2026, 7, 20),
+        date(2026, 7, 21),
+        date(2026, 7, 22),
+        date(2026, 7, 23),
+        date(2026, 7, 24),
+        date(2026, 7, 27),
+        date(2026, 7, 28),
+        date(2026, 7, 29),
+        date(2026, 7, 30),
+        date(2026, 7, 31),
+    ]
+    repair_date = target_dates[1]
+    as_of_date = target_dates[-1]
+    backfill_kwargs: dict[str, object] = {}
+
+    class _FakeQuery:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return self.rows
+
+    class _FakeDb(_FakeSession):
+        def query(self, entity, *args):
+            if entity is MarketBreadth:
+                return _FakeQuery([
+                    SimpleNamespace(date=calc_date, total_stocks_scanned=1)
+                    for calc_date in target_dates
+                    if calc_date != repair_date
+                ])
+            if entity is StockUniverse.symbol:
+                return _FakeQuery([("AAA",)])
+            return _FakeQuery([])
+
+    class _FakeBreadthCalculator:
+        def __init__(self, db, price_cache, *, market):
+            self.market = market
+
+        def backfill_range(self, **kwargs):
+            backfill_kwargs.update(kwargs)
+            return {
+                "total_dates": len(kwargs["trading_dates"]),
+                "processed": len(kwargs["trading_dates"]),
+                "errors": 0,
+                "error_dates": [],
+                "target_symbols": 1,
+                "symbols_with_cached_history": 1,
+                "cache_miss_stocks": 0,
+                "error_stocks": 0,
+                "cache_coverage_ratio": 1.0,
+            }
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(
+        export_static_site,
+        "_generate_trading_dates",
+        lambda *args, **kwargs: target_dates,
+    )
+    monkeypatch.setattr(export_static_site, "get_price_cache", lambda: object())
+    monkeypatch.setattr(
+        export_static_site,
+        "BreadthCalculatorService",
+        _FakeBreadthCalculator,
+    )
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "completed"
+    assert result["recomputed_dates"] == 11
+    assert backfill_kwargs["trading_dates"] == target_dates[1:]
+
+
 def test_ensure_breadth_history_skips_validated_existing_rows(monkeypatch):
     as_of_date = date(2026, 7, 31)
 

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -453,6 +453,67 @@ def test_ensure_breadth_history_skips_validated_existing_rows(monkeypatch):
     assert result["target_symbols"] == 2
 
 
+def test_ensure_breadth_history_skips_existing_rows_with_tolerated_historical_gaps(
+    monkeypatch,
+):
+    previous_date = date(2026, 7, 30)
+    as_of_date = date(2026, 7, 31)
+
+    class _FakeQuery:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return self.rows
+
+    class _FakeDb(_FakeSession):
+        def query(self, entity, *args):
+            if entity is MarketBreadth:
+                return _FakeQuery([
+                    SimpleNamespace(
+                        date=previous_date,
+                        total_stocks_scanned=9,
+                    ),
+                    SimpleNamespace(
+                        date=as_of_date,
+                        total_stocks_scanned=10,
+                    ),
+                ])
+            if entity is StockUniverse.symbol:
+                return _FakeQuery([
+                    (f"AAA{i}",)
+                    for i in range(10)
+                ])
+            return _FakeQuery([])
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(
+        export_static_site,
+        "_generate_trading_dates",
+        lambda *args, **kwargs: [previous_date, as_of_date],
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "BreadthCalculatorService",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("accepted historical coverage should not recompute")
+        ),
+    )
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "skipped"
+    assert result["validated_existing_dates"] == 2
+    assert result["target_symbols"] == 10
+
+
 def test_ensure_breadth_history_marks_calculation_errors_not_completed(monkeypatch):
     as_of_date = date(2026, 7, 31)
 

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -5,6 +5,8 @@ from datetime import date
 from types import SimpleNamespace
 
 from app.domain.relative_strength import BALANCED_RS_FORMULA_VERSION
+from app.models.market_breadth import MarketBreadth
+from app.models.stock_universe import StockUniverse
 from app.scripts import export_static_site
 from app.services.market_exposure_service import EXPOSURE_BACKFILL_DAYS
 from app.services.static_market_publish_policy import StaticMarketRsArtifactState
@@ -256,6 +258,110 @@ def test_ensure_breadth_history_marks_backfill_errors_not_completed(monkeypatch)
     assert result["errors"] == 1
     assert result["error_dates"] == ["2026-07-31"]
     assert backfill_kwargs["exclude_unsupported_price_symbols"] is True
+    assert backfill_kwargs["required_as_of_date"] == as_of_date
+
+
+def test_ensure_breadth_history_recomputes_incomplete_existing_rows(monkeypatch):
+    as_of_date = date(2026, 7, 31)
+    backfill_kwargs: dict[str, object] = {}
+
+    class _FakeQuery:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return self.rows
+
+    class _FakeDb(_FakeSession):
+        def query(self, entity, *args):
+            if entity is MarketBreadth:
+                return _FakeQuery([
+                    SimpleNamespace(date=as_of_date, total_stocks_scanned=1)
+                ])
+            if entity is StockUniverse.symbol:
+                return _FakeQuery([("AAA",), ("BBB",)])
+            return _FakeQuery([])
+
+    class _FakeBreadthCalculator:
+        def __init__(self, db, price_cache, *, market):
+            self.market = market
+
+        def backfill_range(self, **kwargs):
+            backfill_kwargs.update(kwargs)
+            return {
+                "total_dates": 1,
+                "processed": 1,
+                "errors": 0,
+                "error_dates": [],
+                "target_symbols": 2,
+                "symbols_with_cached_history": 2,
+                "cache_miss_stocks": 0,
+                "error_stocks": 0,
+                "cache_coverage_ratio": 1.0,
+            }
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(export_static_site, "_generate_trading_dates", lambda *args, **kwargs: [as_of_date])
+    monkeypatch.setattr(export_static_site, "get_price_cache", lambda: object())
+    monkeypatch.setattr(export_static_site, "BreadthCalculatorService", _FakeBreadthCalculator)
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "completed"
+    assert result["incomplete_existing_dates"] == 1
+    assert result["recomputed_dates"] == 1
+    assert backfill_kwargs["trading_dates"] == [as_of_date]
+
+
+def test_ensure_breadth_history_skips_validated_existing_rows(monkeypatch):
+    as_of_date = date(2026, 7, 31)
+
+    class _FakeQuery:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return self.rows
+
+    class _FakeDb(_FakeSession):
+        def query(self, entity, *args):
+            if entity is MarketBreadth:
+                return _FakeQuery([
+                    SimpleNamespace(date=as_of_date, total_stocks_scanned=2)
+                ])
+            if entity is StockUniverse.symbol:
+                return _FakeQuery([("AAA",), ("BBB",)])
+            return _FakeQuery([])
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(export_static_site, "_generate_trading_dates", lambda *args, **kwargs: [as_of_date])
+    monkeypatch.setattr(
+        export_static_site,
+        "BreadthCalculatorService",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("validated existing breadth should not recompute")
+        ),
+    )
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "skipped"
+    assert result["validated_existing_dates"] == 1
+    assert result["target_symbols"] == 2
 
 
 def test_ensure_breadth_history_marks_calculation_errors_not_completed(monkeypatch):

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from datetime import date
+from types import SimpleNamespace
+
+from app.domain.relative_strength import BALANCED_RS_FORMULA_VERSION
+from app.scripts import export_static_site
+from app.services.static_market_publish_policy import StaticMarketRsArtifactState
+
+
+class _FakeSession:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ReadyGroupRankBackfill:
+    ready_for_enrichment = True
+
+    def as_dict(self) -> dict[str, str]:
+        return {"status": "completed"}
+
+
+def test_static_daily_refresh_ensures_market_breadth_before_exposure(monkeypatch):
+    events: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(export_static_site, "STATIC_EXPORT_MARKETS", ("HK",))
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(export_static_site, "disable_serialized_data_fetch_lock", nullcontext)
+    monkeypatch.setattr(export_static_site, "disable_serialized_market_workload", nullcontext)
+    monkeypatch.setattr(export_static_site, "_tracked_ibd_csv_path", lambda: "ibd.csv")
+    monkeypatch.setattr(
+        export_static_site.IBDIndustryService,
+        "load_from_csv",
+        lambda _db, csv_path: 0,
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_resolve_latest_completed_trading_date",
+        lambda market: date(2026, 7, 31),
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date, market: {"status": "completed", "market": market},
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_prepare_static_rs_formula",
+        lambda *, market, as_of_date, formula_version: {
+            "status": "completed",
+            "market": market,
+            "as_of_date": as_of_date.isoformat(),
+            "formula_version": formula_version,
+            "market_rs_run_id": 42,
+        },
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "classify_static_market_rs_artifact_result",
+        lambda *args, **kwargs: StaticMarketRsArtifactState.READY,
+    )
+
+    def ensure_breadth(*, as_of_date, market):
+        events.append(("breadth", market))
+        return {"status": "completed", "market": market, "as_of_date": as_of_date.isoformat()}
+
+    def compute_exposure(*, as_of_date, market):
+        events.append(("exposure", market))
+        return {"market": market, "date": as_of_date.isoformat(), "status": "stored"}
+
+    monkeypatch.setattr(export_static_site, "_ensure_breadth_history", ensure_breadth)
+    monkeypatch.setattr(export_static_site, "_compute_static_market_exposure", compute_exposure)
+
+    import app.interfaces.tasks.feature_store_tasks as feature_store_tasks
+
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(
+            run=lambda **kwargs: {
+                "status": "published",
+                "run_id": 7,
+                "market": kwargs["market"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "_enrich_feature_run_with_ibd_metadata",
+        lambda **kwargs: {"status": "completed"},
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_ensure_group_rank_history",
+        lambda **kwargs: _ReadyGroupRankBackfill(),
+    )
+
+    results, warnings = export_static_site._run_daily_refresh(
+        market="HK",
+        skip_universe_refresh=True,
+        skip_fundamentals_refresh=True,
+        rs_formula_version=BALANCED_RS_FORMULA_VERSION,
+    )
+
+    assert warnings == []
+    assert results["market_exposure"]["HK"]["status"] == "stored"
+    assert events.index(("breadth", "HK")) < events.index(("exposure", "HK"))

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -83,6 +83,19 @@ def _stub_static_market_exposure(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_static_breadth_history(monkeypatch):
+    monkeypatch.setattr(
+        export_script,
+        "_ensure_breadth_history",
+        lambda *, as_of_date, market: {
+            "status": "completed",
+            "market": market,
+            "as_of_date": as_of_date.isoformat(),
+        },
+    )
+
+
 def test_ensure_group_rank_history_uses_static_bootstrap_coordinator(
     monkeypatch,
 ):

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -88,12 +88,18 @@ def _stub_static_breadth_history(monkeypatch):
     monkeypatch.setattr(
         export_script,
         "_ensure_breadth_history",
-        lambda *, as_of_date, market: {
+        lambda *, as_of_date, market=export_script.STATIC_DEFAULT_MARKET, **_kwargs: {
             "status": "completed",
             "market": market,
             "as_of_date": as_of_date.isoformat(),
         },
     )
+
+
+def test_static_breadth_history_stub_preserves_default_market():
+    result = export_script._ensure_breadth_history(as_of_date=date(2026, 7, 31))
+
+    assert result["market"] == export_script.STATIC_DEFAULT_MARKET
 
 
 def test_ensure_group_rank_history_uses_static_bootstrap_coordinator(

--- a/backend/tests/unit/test_yahoo_batch_ingestion.py
+++ b/backend/tests/unit/test_yahoo_batch_ingestion.py
@@ -1243,6 +1243,30 @@ def test_get_cached_only_fresh_requires_requested_session(monkeypatch):
     ) is frame
 
 
+def test_get_cached_only_fresh_required_session_bypasses_global_freshness(monkeypatch):
+    service = PriceCacheService(
+        redis_client=None,
+        session_factory=lambda: MagicMock(),
+    )
+    frame = _price_df(date(2026, 3, 20), 123.0)
+    monkeypatch.setattr(
+        service,
+        "_get_from_database",
+        lambda symbol, period: (frame, date(2026, 3, 20)),
+    )
+    monkeypatch.setattr(service, "_is_data_fresh", lambda _last: False)
+    monkeypatch.setattr(
+        service,
+        "_is_intraday_data_stale",
+        lambda _symbol: False,
+    )
+
+    assert service.get_cached_only_fresh(
+        "7203.T",
+        required_as_of_date=date(2026, 3, 20),
+    ) is frame
+
+
 def test_get_many_cached_only_fresh_requires_requested_session(monkeypatch):
     service = PriceCacheService(
         redis_client=None,
@@ -1277,6 +1301,37 @@ def test_get_many_cached_only_fresh_requires_requested_session(monkeypatch):
 
     assert result["AAPL"] is complete
     assert result["MSFT"] is None
+
+
+def test_get_many_cached_only_fresh_required_session_bypasses_global_freshness(monkeypatch):
+    service = PriceCacheService(
+        redis_client=None,
+        session_factory=lambda: MagicMock(),
+    )
+    frame = _price_df(date(2026, 3, 20), 123.0)
+    missing_target = _price_df(date(2026, 3, 19), 122.0)
+    monkeypatch.setattr(
+        service,
+        "_get_many_from_database",
+        lambda symbols, period: {
+            "7203.T": (frame, date(2026, 3, 20)),
+            "6758.T": (missing_target, date(2026, 3, 19)),
+        },
+    )
+    monkeypatch.setattr(service, "_is_data_fresh", lambda _last: False)
+    monkeypatch.setattr(
+        service,
+        "_is_intraday_data_stale",
+        lambda _symbol: False,
+    )
+
+    result = service.get_many_cached_only_fresh(
+        ["7203.T", "6758.T"],
+        required_as_of_date=date(2026, 3, 20),
+    )
+
+    assert result["7203.T"] is frame
+    assert result["6758.T"] is None
 
 
 def test_get_many_cached_only_fresh_filters_stale_database_rows(monkeypatch):


### PR DESCRIPTION
## Summary

- Ensure static breadth history is populated before static market exposure is recomputed.
- Make the static breadth-history helper market-aware so exposure reads same-market breadth rows.
- Add regression coverage for breadth-before-exposure ordering and update static export orchestration tests.

## Root Cause

The static refresh flow computed market exposure before ensuring same-date breadth history. In a fresh static export database, exposure could store a score without `net_4pct`, while the later static home payload still showed coherent breadth freshness. That caused the public static app to differ from the local app by exactly the missing breadth penalty.

## Validation

```bash
cd backend && source venv/bin/activate && pytest tests/unit/test_export_static_site_script.py tests/unit/test_export_static_site_refresh.py tests/unit/test_market_exposure_service.py -q
```

Result: `64 passed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily refresh reliability across multiple markets.
  * Breadth history now follows each market’s trading calendar and processes only relevant records.
  * Markets without current relative-strength data are skipped gracefully with clear status reporting.
  * Exposure updates and feature snapshots are skipped when breadth history is unavailable or incomplete.
  * Backfill results now detect processing errors, empty results, excessive cache misses, and symbol-level errors.
  * Unsupported symbols are excluded from historical backfills and reported in results.
  * Refresh status identifies the relevant market for improved visibility.
  * Breadth reports now include the number of symbols with errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->