### PR TITLE
Keep static market exports from falling back stale

### DIFF
--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -313,17 +313,27 @@ jobs:
           PY
           )"
           set +e
+          BUILD_LOG="$(mktemp)"
           python -m app.scripts.build_daily_price_bundle \
             --market "$MARKET" \
             --output-dir /tmp/daily-price \
             --require-complete \
-            --min-symbol-coverage "$MIN_SYMBOL_COVERAGE"
-          status=$?
+            --min-symbol-coverage "$MIN_SYMBOL_COVERAGE" 2>&1 | tee "$BUILD_LOG"
+          build_pipeline_status=("${PIPESTATUS[@]}")
+          status="${build_pipeline_status[0]}"
+          build_log_status="${build_pipeline_status[1]}"
           set -e
+          if [ "$build_log_status" -ne 0 ]; then
+            echo "Failed to persist the daily price bundle build log." >&2
+            exit "$build_log_status"
+          fi
           if [ "$status" -ne 0 ]; then
-            echo "Daily price bundle publication skipped for $MARKET because current-session coverage is below the static publish threshold."
-            echo "price_bundle_ready=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            if grep -q "Daily price bundle coverage .* is below required" "$BUILD_LOG"; then
+              echo "Daily price bundle publication skipped for $MARKET because current-session coverage is below the static publish threshold."
+              echo "price_bundle_ready=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit "$status"
           fi
           echo "price_bundle_ready=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -240,8 +240,14 @@ jobs:
             --market "${{ matrix.market }}" \
             --rs-formula-overrides-json "$RS_FORMULA_OVERRIDES" \
             --rrg-history-dir "$RRG_HISTORY_DIR" 2>&1 | tee "$EXPORT_LOG"
-          status=${PIPESTATUS[0]}
+          pipeline_status=("${PIPESTATUS[@]}")
+          status="${pipeline_status[0]}"
+          log_status="${pipeline_status[1]}"
           set -e
+          if [ "$log_status" -ne 0 ]; then
+            echo "Failed to persist the export log." >&2
+            exit "$log_status"
+          fi
           STATUS_PATH="/tmp/static-data/status/${MARKET_LOWER}/status.json"
           if [ "$status" -eq 78 ]; then
             echo "Market ${{ matrix.market }} is not a trading day; no current static artifact will be uploaded."
@@ -293,15 +299,36 @@ jobs:
           if-no-files-found: ignore
 
       - name: Build daily price bundle
+        id: build-daily-price-bundle
         if: ${{ steps.export-market.outputs.has_price_bundle == 'true' }}
+        env:
+          MARKET: ${{ matrix.market }}
         run: |
           cd backend
+          MIN_SYMBOL_COVERAGE="$(python - <<'PY'
+          import os
+          from app.services.market_rs_inputs import MarketRsInputLoader
+
+          print(MarketRsInputLoader._minimum_current_price_coverage(os.environ["MARKET"]))
+          PY
+          )"
+          set +e
           python -m app.scripts.build_daily_price_bundle \
-            --market "${{ matrix.market }}" \
-            --output-dir /tmp/daily-price
+            --market "$MARKET" \
+            --output-dir /tmp/daily-price \
+            --require-complete \
+            --min-symbol-coverage "$MIN_SYMBOL_COVERAGE"
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "Daily price bundle publication skipped for $MARKET because current-session coverage is below the static publish threshold."
+            echo "price_bundle_ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "price_bundle_ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload daily price assets
-        if: ${{ steps.export-market.outputs.has_price_bundle == 'true' }}
+        if: ${{ steps.export-market.outputs.has_price_bundle == 'true' && steps.build-daily-price-bundle.outputs.price_bundle_ready == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -396,11 +423,13 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           CURRENT_RUN_ID: ${{ github.run_id }}
           BRANCH_NAME: ${{ github.ref_name }}
+          RS_FORMULA_OVERRIDES: ${{ github.event.inputs.rs_formula_overrides || '{}' }}
         run: |
           cd backend
           python -m app.scripts.download_static_market_fallbacks \
             --current-dir /tmp/static-market-artifacts-current \
-            --fallback-dir /tmp/static-market-artifacts-fallback
+            --fallback-dir /tmp/static-market-artifacts-fallback \
+            --fallback-rs-formula-overrides-json "$RS_FORMULA_OVERRIDES"
 
       - name: Validate market artifacts
         env:

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -242,6 +242,7 @@ jobs:
             --rrg-history-dir "$RRG_HISTORY_DIR" 2>&1 | tee "$EXPORT_LOG"
           status=${PIPESTATUS[0]}
           set -e
+          STATUS_PATH="/tmp/static-data/status/${MARKET_LOWER}/status.json"
           if [ "$status" -eq 78 ]; then
             echo "Market ${{ matrix.market }} is not a trading day; no current static artifact will be uploaded."
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
@@ -251,8 +252,9 @@ jobs:
           fi
           if [ "$status" -eq 79 ]; then
             echo "Market ${{ matrix.market }} produced diagnostics but no current market artifact will be uploaded; combine will use fallback artifacts if available."
+            has_price_bundle="$(jq -r '.has_price_bundle // false' "$STATUS_PATH" 2>/dev/null || echo false)"
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
-            echo "has_price_bundle=true" >> "$GITHUB_OUTPUT"
+            echo "has_price_bundle=$has_price_bundle" >> "$GITHUB_OUTPUT"
             echo "rrg_history_publishable=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -244,16 +244,19 @@ jobs:
           if [ "$status" -eq 78 ]; then
             echo "Market ${{ matrix.market }} is not a trading day; no current static artifact will be uploaded."
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
+            echo "has_price_bundle=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$status" -eq 79 ]; then
             echo "Market ${{ matrix.market }} produced diagnostics but no current market artifact will be uploaded; combine will use fallback artifacts if available."
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
+            echo "has_price_bundle=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$status" -ne 0 ]; then
             exit "$status"
           fi
+          echo "has_price_bundle=true" >> "$GITHUB_OUTPUT"
           if [ "$RRG_HISTORY_ENABLED" = "true" ] && [ "$RRG_RESTORE_STATUS" = "failed" ]; then
             echo "Rolling RRG history restore failed for ${{ matrix.market }}; current output will not replace the last good market artifact."
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
@@ -278,7 +281,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Build daily price bundle
-        if: ${{ steps.export-market.outputs.has_artifact == 'true' }}
+        if: ${{ steps.export-market.outputs.has_price_bundle == 'true' }}
         run: |
           cd backend
           python -m app.scripts.build_daily_price_bundle \
@@ -286,7 +289,7 @@ jobs:
             --output-dir /tmp/daily-price
 
       - name: Upload daily price assets
-        if: ${{ steps.export-market.outputs.has_artifact == 'true' }}
+        if: ${{ steps.export-market.outputs.has_price_bundle == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -230,6 +230,7 @@ jobs:
         run: |
           cd backend
           set +e
+          EXPORT_LOG="$(mktemp)"
           python -m app.scripts.export_static_market_artifact \
             --output-dir /tmp/static-data \
             --refresh-daily \
@@ -238,28 +239,37 @@ jobs:
             --skip-fundamentals-refresh \
             --market "${{ matrix.market }}" \
             --rs-formula-overrides-json "$RS_FORMULA_OVERRIDES" \
-            --rrg-history-dir "$RRG_HISTORY_DIR"
-          status=$?
+            --rrg-history-dir "$RRG_HISTORY_DIR" 2>&1 | tee "$EXPORT_LOG"
+          status=${PIPESTATUS[0]}
           set -e
           if [ "$status" -eq 78 ]; then
             echo "Market ${{ matrix.market }} is not a trading day; no current static artifact will be uploaded."
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
             echo "has_price_bundle=false" >> "$GITHUB_OUTPUT"
+            echo "rrg_history_publishable=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$status" -eq 79 ]; then
             echo "Market ${{ matrix.market }} produced diagnostics but no current market artifact will be uploaded; combine will use fallback artifacts if available."
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
             echo "has_price_bundle=true" >> "$GITHUB_OUTPUT"
+            echo "rrg_history_publishable=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$status" -ne 0 ]; then
             exit "$status"
           fi
           echo "has_price_bundle=true" >> "$GITHUB_OUTPUT"
+          if grep -q "using benchmark-backed as-of date" "$EXPORT_LOG"; then
+            echo "Rolling RRG history publication disabled for ${{ matrix.market }} because the market export rewound to an older benchmark-backed date."
+            echo "rrg_history_publishable=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "rrg_history_publishable=true" >> "$GITHUB_OUTPUT"
+          fi
           if [ "$RRG_HISTORY_ENABLED" = "true" ] && [ "$RRG_RESTORE_STATUS" = "failed" ]; then
             echo "Rolling RRG history restore failed for ${{ matrix.market }}; current output will not replace the last good market artifact."
             echo "has_artifact=false" >> "$GITHUB_OUTPUT"
+            echo "rrg_history_publishable=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "has_artifact=true" >> "$GITHUB_OUTPUT"
@@ -314,7 +324,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish rolling RRG history
-        if: ${{ steps.export-market.outputs.has_artifact == 'true' && steps.rrg-history.outputs.enabled == 'true' && steps.restore-rrg-history.outputs.safe_to_publish == 'true' }}
+        if: ${{ steps.export-market.outputs.has_artifact == 'true' && steps.export-market.outputs.rrg_history_publishable == 'true' && steps.rrg-history.outputs.enabled == 'true' && steps.restore-rrg-history.outputs.safe_to_publish == 'true' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/backend/app/scripts/download_static_market_fallbacks.py
+++ b/backend/app/scripts/download_static_market_fallbacks.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import argparse
-from datetime import date, datetime
 import json
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import tempfile
-from typing import Any, Sequence
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
 from urllib.parse import urlencode
 
+from app.services.static_artifact_combiner import (
+    StaticArtifactCombiner,
+    StaticArtifactFormulaError,
+)
 from app.services.static_market_artifact_contract import (
     STATIC_MARKET_METADATA_FILENAME,
     StaticMarketArtifactContractError,
@@ -175,6 +180,50 @@ def downloaded_market_is_compatible(
     return True
 
 
+def downloaded_market_matches_required_formula(
+    target_dir: Path,
+    *,
+    market: str,
+    artifact_name: str,
+    run_id: int,
+    required_formula_by_market: Mapping[str, str],
+) -> bool:
+    expected_formula = required_formula_by_market.get(market)
+    if expected_formula is None:
+        return True
+    metadata_paths = sorted(target_dir.rglob(STATIC_MARKET_METADATA_FILENAME))
+    if len(metadata_paths) != 1:
+        warn(
+            f"{artifact_name} from run {run_id} has no unique "
+            f"{STATIC_MARKET_METADATA_FILENAME} for formula validation."
+        )
+        return False
+    metadata_path = metadata_paths[0]
+    try:
+        metadata = read_static_market_manifest(metadata_path, expected_market=market)
+        StaticArtifactCombiner._validate_formula(
+            market=market,
+            source_label="fallback",
+            metadata=metadata,
+            market_dir=metadata_path.parent,
+            expected_formula=expected_formula,
+        )
+    except (
+        OSError,
+        json.JSONDecodeError,
+        TypeError,
+        RuntimeError,
+        StaticMarketArtifactContractError,
+        StaticArtifactFormulaError,
+    ) as exc:
+        warn(
+            f"{artifact_name} from run {run_id} does not match the requested "
+            f"RS formula {expected_formula!r} for {market} ({exc})."
+        )
+        return False
+    return True
+
+
 def _coerce_manifest_date(value: object) -> date | None:
     if isinstance(value, datetime):
         return value.date()
@@ -234,7 +283,7 @@ def _run_cannot_beat_incumbent(
     return (
         run_upper_bound is not None
         and incumbent_date is not None
-        and run_upper_bound <= incumbent_date
+        and run_upper_bound + timedelta(days=1) <= incumbent_date
     )
 
 
@@ -270,8 +319,14 @@ def download_fallback_artifacts(
     branch_name: str,
     current_dir: Path,
     fallback_dir: Path,
+    required_formula_by_market: Mapping[str, str] | None = None,
 ) -> set[str]:
     fallback_dir.mkdir(parents=True, exist_ok=True)
+    formula_requirements = {
+        str(market).strip().upper(): str(formula).strip()
+        for market, formula in (required_formula_by_market or {}).items()
+        if str(market).strip() and str(formula).strip()
+    }
     query = urlencode(
         {
             "branch": branch_name,
@@ -401,6 +456,16 @@ def download_fallback_artifacts(
                 shutil.rmtree(candidate_dir, ignore_errors=True)
                 continue
 
+            if not downloaded_market_matches_required_formula(
+                candidate_dir,
+                market=market,
+                artifact_name=artifact_name,
+                run_id=int(run_id),
+                required_formula_by_market=formula_requirements,
+            ):
+                shutil.rmtree(candidate_dir, ignore_errors=True)
+                continue
+
             candidate_date = downloaded_market_as_of_date(candidate_dir)
             if market in fallback_markets and not _candidate_is_newer(
                 candidate_date,
@@ -439,6 +504,20 @@ def download_fallback_artifacts(
     return fallback_markets
 
 
+def parse_formula_requirements(raw: str) -> dict[str, str]:
+    try:
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(f"invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise argparse.ArgumentTypeError("expected a JSON object keyed by market")
+    return {
+        str(market).strip().upper(): str(formula).strip()
+        for market, formula in payload.items()
+        if str(market).strip() and str(formula).strip()
+    }
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--current-dir", type=Path, required=True)
@@ -446,6 +525,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--repo", default=os.environ.get("REPOSITORY", ""))
     parser.add_argument("--current-run-id", default=os.environ.get("CURRENT_RUN_ID", "0"))
     parser.add_argument("--branch", default=os.environ.get("BRANCH_NAME", "main"))
+    parser.add_argument(
+        "--fallback-rs-formula-overrides-json",
+        type=parse_formula_requirements,
+        default={},
+    )
     args = parser.parse_args(argv)
 
     if not args.repo:
@@ -457,6 +541,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         branch_name=args.branch,
         current_dir=args.current_dir,
         fallback_dir=args.fallback_dir,
+        required_formula_by_market=args.fallback_rs_formula_overrides_json,
     )
     return 0
 

--- a/backend/app/scripts/download_static_market_fallbacks.py
+++ b/backend/app/scripts/download_static_market_fallbacks.py
@@ -180,6 +180,45 @@ def downloaded_market_is_compatible(
     return True
 
 
+def downloaded_market_has_advertised_assets(
+    target_dir: Path,
+    *,
+    market: str,
+    artifact_name: str,
+    run_id: int,
+) -> bool:
+    metadata_paths = sorted(target_dir.rglob(STATIC_MARKET_METADATA_FILENAME))
+    if len(metadata_paths) != 1:
+        warn(
+            f"{artifact_name} from run {run_id} has no unique "
+            f"{STATIC_MARKET_METADATA_FILENAME} for asset validation."
+        )
+        return False
+
+    metadata_path = metadata_paths[0]
+    try:
+        metadata = read_static_market_manifest(metadata_path, expected_market=market)
+        entry = metadata.get("entry")
+        if not isinstance(entry, dict):
+            return True
+        StaticArtifactCombiner._validate_advertised_assets(
+            market=market,
+            source_label="fallback",
+            entry=entry,
+            market_dir=metadata_path.parent,
+        )
+    except (
+        OSError,
+        json.JSONDecodeError,
+        TypeError,
+        StaticMarketArtifactContractError,
+        StaticArtifactFormulaError,
+    ) as exc:
+        warn(f"{artifact_name} from run {run_id} has invalid advertised assets ({exc}).")
+        return False
+    return True
+
+
 def downloaded_market_matches_required_formula(
     target_dir: Path,
     *,
@@ -448,6 +487,15 @@ def download_fallback_artifacts(
                 continue
 
             if not downloaded_market_is_compatible(
+                candidate_dir,
+                market=market,
+                artifact_name=artifact_name,
+                run_id=int(run_id),
+            ):
+                shutil.rmtree(candidate_dir, ignore_errors=True)
+                continue
+
+            if not downloaded_market_has_advertised_assets(
                 candidate_dir,
                 market=market,
                 artifact_name=artifact_name,

--- a/backend/app/scripts/download_static_market_fallbacks.py
+++ b/backend/app/scripts/download_static_market_fallbacks.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import argparse
+from datetime import date, datetime
 import json
 import os
+from pathlib import Path
 import shutil
 import subprocess
-from pathlib import Path
+import tempfile
 from typing import Any, Sequence
 from urllib.parse import urlencode
 
@@ -173,6 +175,49 @@ def downloaded_market_is_compatible(
     return True
 
 
+def _coerce_manifest_date(value: object) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text.split("T", 1)[0])
+    except ValueError:
+        return None
+
+
+def downloaded_market_as_of_date(target_dir: Path) -> date | None:
+    metadata_paths = sorted(target_dir.rglob(STATIC_MARKET_METADATA_FILENAME))
+    if len(metadata_paths) != 1:
+        return None
+    try:
+        metadata = read_static_market_manifest(metadata_paths[0])
+    except (
+        OSError,
+        json.JSONDecodeError,
+        TypeError,
+        StaticMarketArtifactContractError,
+    ):
+        return None
+    entry = metadata.get("entry")
+    value = entry.get("as_of_date") if isinstance(entry, dict) else None
+    return _coerce_manifest_date(value)
+
+
+def _candidate_is_newer(
+    candidate_date: date | None,
+    incumbent_date: date | None,
+) -> bool:
+    return candidate_date is not None and (
+        incumbent_date is None or candidate_date > incumbent_date
+    )
+
+
 def download_fallback_artifacts(
     *,
     repo: str,
@@ -215,6 +260,7 @@ def download_fallback_artifacts(
 
     current_markets = collect_current_markets(current_dir)
     fallback_markets: set[str] = set()
+    fallback_dates_by_market: dict[str, date | None] = {}
     if current_markets:
         print(
             f"Current run already has market artifacts: {', '.join(sorted(current_markets))}.",
@@ -261,11 +307,13 @@ def download_fallback_artifacts(
             # Download fallback artifacts for current markets too; the combiner
             # compares dates and keeps a newer last-known-good artifact when a
             # cache-only current run had to rewind.
-            if market in fallback_markets:
-                continue
-
             target_dir = fallback_dir / artifact_name
-            shutil.rmtree(target_dir, ignore_errors=True)
+            candidate_dir = Path(
+                tempfile.mkdtemp(
+                    prefix=f".{artifact_name}.candidate-{run_id}-",
+                    dir=fallback_dir,
+                )
+            )
 
             try:
                 subprocess.run(
@@ -279,7 +327,7 @@ def download_fallback_artifacts(
                         "--name",
                         artifact_name,
                         "--dir",
-                        str(target_dir),
+                        str(candidate_dir),
                     ],
                     check=True,
                     capture_output=True,
@@ -290,19 +338,30 @@ def download_fallback_artifacts(
                     f"{artifact_name} from run {run_id} failed to download "
                     f"with exit {exc.returncode}.{command_error_detail(exc)}"
                 )
-                shutil.rmtree(target_dir, ignore_errors=True)
+                shutil.rmtree(candidate_dir, ignore_errors=True)
                 continue
 
             if not downloaded_market_is_compatible(
-                target_dir,
+                candidate_dir,
                 market=market,
                 artifact_name=artifact_name,
                 run_id=int(run_id),
             ):
-                shutil.rmtree(target_dir, ignore_errors=True)
+                shutil.rmtree(candidate_dir, ignore_errors=True)
                 continue
 
+            candidate_date = downloaded_market_as_of_date(candidate_dir)
+            if market in fallback_markets and not _candidate_is_newer(
+                candidate_date,
+                fallback_dates_by_market.get(market),
+            ):
+                shutil.rmtree(candidate_dir, ignore_errors=True)
+                continue
+
+            shutil.rmtree(target_dir, ignore_errors=True)
+            candidate_dir.rename(target_dir)
             fallback_markets.add(market)
+            fallback_dates_by_market[market] = candidate_date
             print(
                 f"Using fallback artifact {artifact_name} from Static Site run {run_id} "
                 f"on {branch_name}.",

--- a/backend/app/scripts/download_static_market_fallbacks.py
+++ b/backend/app/scripts/download_static_market_fallbacks.py
@@ -218,6 +218,51 @@ def _candidate_is_newer(
     )
 
 
+def _workflow_run_upper_bound_date(run: dict[str, Any]) -> date | None:
+    for key in ("run_started_at", "created_at", "updated_at"):
+        run_date = _coerce_manifest_date(run.get(key))
+        if run_date is not None:
+            return run_date
+    return None
+
+
+def _run_cannot_beat_incumbent(
+    *,
+    run_upper_bound: date | None,
+    incumbent_date: date | None,
+) -> bool:
+    return (
+        run_upper_bound is not None
+        and incumbent_date is not None
+        and run_upper_bound <= incumbent_date
+    )
+
+
+def _install_market_candidate(
+    *,
+    target_dir: Path,
+    candidate_dir: Path,
+) -> None:
+    backup_dir: Path | None = None
+    if target_dir.exists() or target_dir.is_symlink():
+        backup_dir = Path(
+            tempfile.mkdtemp(
+                prefix=f".{target_dir.name}.previous-",
+                dir=target_dir.parent,
+            )
+        )
+        shutil.rmtree(backup_dir)
+        target_dir.rename(backup_dir)
+    try:
+        candidate_dir.rename(target_dir)
+    except Exception:
+        if backup_dir is not None and backup_dir.exists() and not target_dir.exists():
+            backup_dir.rename(target_dir)
+        raise
+    if backup_dir is not None and backup_dir.exists():
+        shutil.rmtree(backup_dir)
+
+
 def download_fallback_artifacts(
     *,
     repo: str,
@@ -271,6 +316,7 @@ def download_fallback_artifacts(
         run_id = run.get("id")
         if run_id == current_run_id:
             continue
+        run_upper_bound = _workflow_run_upper_bound_date(run)
         try:
             artifact_pages = gh_json(
                 [
@@ -307,6 +353,11 @@ def download_fallback_artifacts(
             # Download fallback artifacts for current markets too; the combiner
             # compares dates and keeps a newer last-known-good artifact when a
             # cache-only current run had to rewind.
+            if market in fallback_markets and _run_cannot_beat_incumbent(
+                run_upper_bound=run_upper_bound,
+                incumbent_date=fallback_dates_by_market.get(market),
+            ):
+                continue
             target_dir = fallback_dir / artifact_name
             candidate_dir = Path(
                 tempfile.mkdtemp(
@@ -358,8 +409,18 @@ def download_fallback_artifacts(
                 shutil.rmtree(candidate_dir, ignore_errors=True)
                 continue
 
-            shutil.rmtree(target_dir, ignore_errors=True)
-            candidate_dir.rename(target_dir)
+            try:
+                _install_market_candidate(
+                    target_dir=target_dir,
+                    candidate_dir=candidate_dir,
+                )
+            except OSError as exc:
+                warn(
+                    f"{artifact_name} from run {run_id} could not replace "
+                    f"the incumbent fallback artifact ({exc})."
+                )
+                shutil.rmtree(candidate_dir, ignore_errors=True)
+                continue
             fallback_markets.add(market)
             fallback_dates_by_market[market] = candidate_date
             print(

--- a/backend/app/scripts/download_static_market_fallbacks.py
+++ b/backend/app/scripts/download_static_market_fallbacks.py
@@ -258,7 +258,10 @@ def download_fallback_artifacts(
             market = market_from_static_market_artifact_name(artifact_name)
             if not market:
                 continue
-            if market in current_markets or market in fallback_markets:
+            # Download fallback artifacts for current markets too; the combiner
+            # compares dates and keeps a newer last-known-good artifact when a
+            # cache-only current run had to rewind.
+            if market in fallback_markets:
                 continue
 
             target_dir = fallback_dir / artifact_name

--- a/backend/app/scripts/export_static_market_artifact.py
+++ b/backend/app/scripts/export_static_market_artifact.py
@@ -58,8 +58,11 @@ def _has_price_bundle(*, output_dir: Path, market: str, exit_code: int) -> bool:
     payload = _failure_diagnostic_payload(output_dir=output_dir, market=market)
     if payload is None:
         return False
-    if payload.get("reason") != "market_rs_not_ready":
+    reason = payload.get("reason")
+    if reason == "market_exposure_not_ready":
         return True
+    if reason != "market_rs_not_ready":
+        return False
     reason_code = _failure_diagnostic_reason_code(payload)
     return reason_code is not None and (
         reason_code != MARKET_RS_REASON_CURRENT_ADJUSTED_PRICE_COVERAGE_BELOW_THRESHOLD

--- a/backend/app/scripts/export_static_market_artifact.py
+++ b/backend/app/scripts/export_static_market_artifact.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 from app.scripts import export_static_site
+from app.services.market_rs_result_contract import (
+    MARKET_RS_REASON_CURRENT_ADJUSTED_PRICE_COVERAGE_BELOW_THRESHOLD,
+)
 
 
 def _status_for_exit_code(exit_code: int) -> tuple[bool, str, str | None]:
@@ -25,6 +28,44 @@ def _system_exit_code(exc: SystemExit) -> int:
     return 1
 
 
+def _failure_diagnostic_payload(*, output_dir: Path, market: str) -> dict | None:
+    diagnostics_path = output_dir / "diagnostics" / market.lower() / "snapshot-failure.json"
+    try:
+        payload = json.loads(diagnostics_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _failure_diagnostic_reason_code(payload: dict) -> str | None:
+    failure_diagnostics = payload.get("failure_diagnostics")
+    if not isinstance(failure_diagnostics, dict):
+        return None
+    reason_code = failure_diagnostics.get("reason_code")
+    if not isinstance(reason_code, str):
+        return None
+    normalized_reason_code = reason_code.strip()
+    return normalized_reason_code or None
+
+
+def _has_price_bundle(*, output_dir: Path, market: str, exit_code: int) -> bool:
+    if exit_code == 0:
+        return True
+    if exit_code != export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE:
+        return False
+    payload = _failure_diagnostic_payload(output_dir=output_dir, market=market)
+    if payload is None:
+        return False
+    if payload.get("reason") != "market_rs_not_ready":
+        return True
+    reason_code = _failure_diagnostic_reason_code(payload)
+    return reason_code is not None and (
+        reason_code != MARKET_RS_REASON_CURRENT_ADJUSTED_PRICE_COVERAGE_BELOW_THRESHOLD
+    )
+
+
 def write_market_status(
     *,
     output_dir: Path,
@@ -41,6 +82,11 @@ def write_market_status(
             {
                 "market": normalized_market,
                 "has_current_artifact": has_current_artifact,
+                "has_price_bundle": _has_price_bundle(
+                    output_dir=output_dir,
+                    market=normalized_market,
+                    exit_code=exit_code,
+                ),
                 "status": status,
                 "reason": reason,
             },

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, Mapping, Sequence
 
@@ -402,6 +402,8 @@ def _benchmark_resolution_candidates(resolution: Any) -> tuple[str, ...]:
 
 
 def _date_from_iso(value: object) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
     if isinstance(value, date):
         return value
     if not isinstance(value, str):
@@ -732,7 +734,7 @@ def _ensure_breadth_history(
         undercovered_dates = _static_breadth_undercovered_backfill_dates(
             db,
             market=normalized_market,
-            dates=recompute_dates,
+            dates=target_dates,
             as_of_date=as_of_date,
             minimum_validated_stocks=minimum_validated_stocks,
             stats=stats,
@@ -799,18 +801,23 @@ def _static_breadth_undercovered_backfill_dates(
         .all()
     )
     rows_by_date = {row.date: row for row in rows}
-    return [
-        calc_date
-        for calc_date in dates
-        if calc_date == as_of_date
-        and (
-            calc_date not in rows_by_date
-            or not _static_breadth_row_has_accepted_coverage(
-                rows_by_date[calc_date],
+    undercovered_dates: list[date] = []
+    has_seen_valid_history = False
+    for calc_date in sorted(set(dates)):
+        row = rows_by_date.get(calc_date)
+        has_accepted_coverage = (
+            row is not None
+            and _static_breadth_row_has_accepted_coverage(
+                row,
                 minimum_validated_stocks=minimum_validated_stocks,
             )
         )
-    ]
+        if has_accepted_coverage:
+            has_seen_valid_history = True
+            continue
+        if calc_date == as_of_date or has_seen_valid_history:
+            undercovered_dates.append(calc_date)
+    return undercovered_dates
 
 
 def _static_breadth_recompute_dates(

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -401,6 +401,51 @@ def _benchmark_resolution_candidates(resolution: Any) -> tuple[str, ...]:
     return ()
 
 
+def _date_from_iso(value: object) -> date | None:
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _latest_static_rs_benchmark_backed_as_of_date(
+    result: Mapping[str, Any],
+    *,
+    requested_as_of_date: date,
+) -> date | None:
+    if (
+        result.get("reason_code")
+        != MARKET_RS_REASON_BENCHMARK_ADJUSTED_ANCHOR_MISSING
+    ):
+        return None
+    diagnostics = result.get("diagnostics")
+    if not isinstance(diagnostics, Mapping):
+        return None
+    if _date_from_iso(diagnostics.get("date")) != requested_as_of_date:
+        return None
+    candidates = diagnostics.get("benchmark_candidates")
+    if not isinstance(candidates, Sequence) or isinstance(candidates, (str, bytes)):
+        return None
+
+    latest_dates = [
+        latest_date
+        for candidate in candidates
+        if isinstance(candidate, Mapping)
+        for latest_date in (_date_from_iso(candidate.get("latest_date")),)
+        if latest_date is not None and latest_date <= requested_as_of_date
+    ]
+    if not latest_dates:
+        return None
+    latest_backed_date = max(latest_dates)
+    if latest_backed_date >= requested_as_of_date:
+        return None
+    return latest_backed_date
+
+
 def _hydrate_remaining_static_rs_benchmarks(
     *,
     market: str,
@@ -688,6 +733,7 @@ def _ensure_breadth_history(
             db,
             market=normalized_market,
             dates=recompute_dates,
+            as_of_date=as_of_date,
             minimum_validated_stocks=minimum_validated_stocks,
             stats=stats,
         )
@@ -734,6 +780,7 @@ def _static_breadth_undercovered_backfill_dates(
     *,
     market: str,
     dates: Sequence[date],
+    as_of_date: date,
     minimum_validated_stocks: int,
     stats: Mapping[str, Any],
 ) -> list[date]:
@@ -755,7 +802,8 @@ def _static_breadth_undercovered_backfill_dates(
     return [
         calc_date
         for calc_date in dates
-        if (
+        if calc_date == as_of_date
+        and (
             calc_date not in rows_by_date
             or not _static_breadth_row_has_accepted_coverage(
                 rows_by_date[calc_date],
@@ -947,11 +995,29 @@ def _run_daily_refresh(
         # and select balanced RS before any Feature, Group, or RRG consumer runs.
         market_rs_results: dict[str, Any] = {}
         for selected_market in selected_markets:
-            market_rs_results[selected_market] = _prepare_static_rs_formula(
+            market_as_of = as_of_by_market[selected_market]
+            market_rs_result = _prepare_static_rs_formula(
                 market=selected_market,
-                as_of_date=as_of_by_market[selected_market],
+                as_of_date=market_as_of,
                 formula_version=formula_by_market[selected_market],
             )
+            benchmark_backed_as_of = _latest_static_rs_benchmark_backed_as_of_date(
+                market_rs_result,
+                requested_as_of_date=market_as_of,
+            )
+            if benchmark_backed_as_of is not None:
+                warnings.append(
+                    f"Static export market {selected_market} using benchmark-backed "
+                    f"as-of date {benchmark_backed_as_of.isoformat()} because "
+                    f"benchmarks were unavailable for {market_as_of.isoformat()}."
+                )
+                as_of_by_market[selected_market] = benchmark_backed_as_of
+                market_rs_result = _prepare_static_rs_formula(
+                    market=selected_market,
+                    as_of_date=benchmark_backed_as_of,
+                    formula_version=formula_by_market[selected_market],
+                )
+            market_rs_results[selected_market] = market_rs_result
         results["market_rs"] = market_rs_results
         market_rs_artifact_states = {
             selected_market: classify_static_market_rs_artifact_result(

--- a/backend/app/services/static_artifact_combiner.py
+++ b/backend/app/services/static_artifact_combiner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 import json
 from pathlib import Path
 import shutil
@@ -85,9 +85,10 @@ class StaticArtifactCombiner:
             if fallback_artifacts_dir is not None
             else {}
         )
-        selected = dict(current)
-        for market, artifact in fallback.items():
-            selected.setdefault(market, artifact)
+        selected, fallback_reasons = self._select_artifacts(
+            current=current,
+            fallback=fallback,
+        )
 
         if required:
             missing = sorted(
@@ -113,10 +114,16 @@ class StaticArtifactCombiner:
             entries[market] = artifact["entry"]
             warnings.extend(str(item) for item in artifact["metadata"].get("warnings", []))
             if artifact["source_label"] == "fallback":
-                warnings.append(
-                    f"{market} reused from a previous static-site market artifact "
-                    "because the current run produced no artifact."
-                )
+                if fallback_reasons.get(market) == "newer":
+                    warnings.append(
+                        f"{market} reused from a previous static-site market artifact "
+                        "because it is newer than the current artifact."
+                    )
+                else:
+                    warnings.append(
+                        f"{market} reused from a previous static-site market artifact "
+                        "because the current run produced no artifact."
+                    )
         optional_missing = sorted(market for market in optional if market not in entries)
         warnings.extend(
             f"Static export market {market} was omitted from the combined bundle "
@@ -149,6 +156,56 @@ class StaticArtifactCombiner:
             warnings=tuple(warnings),
             manifest=manifest,
         )
+
+    @classmethod
+    def _select_artifacts(
+        cls,
+        *,
+        current: dict[str, dict[str, Any]],
+        fallback: dict[str, dict[str, Any]],
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+        selected = dict(current)
+        fallback_reasons: dict[str, str] = {}
+        for market, fallback_artifact in fallback.items():
+            current_artifact = selected.get(market)
+            if current_artifact is None:
+                selected[market] = fallback_artifact
+                fallback_reasons[market] = "missing"
+                continue
+            if cls._artifact_is_newer(fallback_artifact, current_artifact):
+                selected[market] = fallback_artifact
+                fallback_reasons[market] = "newer"
+        return selected, fallback_reasons
+
+    @classmethod
+    def _artifact_is_newer(
+        cls,
+        candidate: dict[str, Any],
+        incumbent: dict[str, Any],
+    ) -> bool:
+        candidate_date = cls._artifact_as_of_date(candidate)
+        incumbent_date = cls._artifact_as_of_date(incumbent)
+        return candidate_date is not None and (
+            incumbent_date is None or candidate_date > incumbent_date
+        )
+
+    @staticmethod
+    def _artifact_as_of_date(artifact: dict[str, Any]) -> date | None:
+        entry = artifact.get("entry")
+        value = entry.get("as_of_date") if isinstance(entry, dict) else None
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        if not isinstance(value, str):
+            return None
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return date.fromisoformat(text.split("T", 1)[0])
+        except ValueError:
+            return None
 
     def _discover(
         self,

--- a/backend/app/services/static_artifact_combiner.py
+++ b/backend/app/services/static_artifact_combiner.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import date, datetime
 import json
-from pathlib import Path
 import shutil
 import tempfile
-from typing import Any, Iterable, Mapping
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
 
 from app.services.static_market_artifact_contract import (
     STATIC_MARKET_METADATA_FILENAME,
@@ -174,11 +175,6 @@ class StaticArtifactCombiner:
         selected = dict(current)
         fallback_reasons: dict[str, str] = {}
         for market, fallback_artifact in fallback.items():
-            current_artifact = selected.get(market)
-            if current_artifact is None:
-                selected[market] = fallback_artifact
-                fallback_reasons[market] = "missing"
-                continue
             expected_fallback_formula = fallback_required.get(market)
             if (
                 expected_fallback_formula is not None
@@ -188,6 +184,11 @@ class StaticArtifactCombiner:
                     expected_formula=expected_fallback_formula,
                 )
             ):
+                continue
+            current_artifact = selected.get(market)
+            if current_artifact is None:
+                selected[market] = fallback_artifact
+                fallback_reasons[market] = "missing"
                 continue
             if cls._artifact_is_newer(fallback_artifact, current_artifact):
                 selected[market] = fallback_artifact

--- a/backend/app/services/static_artifact_combiner.py
+++ b/backend/app/services/static_artifact_combiner.py
@@ -74,13 +74,13 @@ class StaticArtifactCombiner:
         current = self._discover(
             Path(artifacts_dir),
             source_label="current",
-            required=required,
+            required={},
         )
         fallback = (
             self._discover(
                 Path(fallback_artifacts_dir),
                 source_label="fallback",
-                required=fallback_required,
+                required={},
             )
             if fallback_artifacts_dir is not None
             else {}
@@ -106,6 +106,11 @@ class StaticArtifactCombiner:
             raise RuntimeError(
                 "No market artifacts are available to combine into a static-site bundle"
             )
+        self._validate_selected_formulas(
+            selected=selected,
+            required=required,
+            fallback_required=fallback_required,
+        )
 
         generated_at = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
         warnings: list[str] = []
@@ -206,6 +211,31 @@ class StaticArtifactCombiner:
             return date.fromisoformat(text.split("T", 1)[0])
         except ValueError:
             return None
+
+    @classmethod
+    def _validate_selected_formulas(
+        cls,
+        *,
+        selected: dict[str, dict[str, Any]],
+        required: Mapping[str, str],
+        fallback_required: Mapping[str, str],
+    ) -> None:
+        for market, artifact in selected.items():
+            required_formulas = (
+                fallback_required
+                if artifact["source_label"] == "fallback"
+                else required
+            )
+            expected = required_formulas.get(market)
+            if expected is None:
+                continue
+            artifact["entry"] = cls._validate_formula(
+                market=market,
+                source_label=artifact["source_label"],
+                metadata=artifact["metadata"],
+                market_dir=artifact["market_dir"],
+                expected_formula=expected,
+            )
 
     def _discover(
         self,

--- a/backend/app/services/static_artifact_combiner.py
+++ b/backend/app/services/static_artifact_combiner.py
@@ -88,6 +88,7 @@ class StaticArtifactCombiner:
         selected, fallback_reasons = self._select_artifacts(
             current=current,
             fallback=fallback,
+            fallback_required=fallback_required,
         )
 
         if required:
@@ -168,6 +169,7 @@ class StaticArtifactCombiner:
         *,
         current: dict[str, dict[str, Any]],
         fallback: dict[str, dict[str, Any]],
+        fallback_required: Mapping[str, str],
     ) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
         selected = dict(current)
         fallback_reasons: dict[str, str] = {}
@@ -176,6 +178,16 @@ class StaticArtifactCombiner:
             if current_artifact is None:
                 selected[market] = fallback_artifact
                 fallback_reasons[market] = "missing"
+                continue
+            expected_fallback_formula = fallback_required.get(market)
+            if (
+                expected_fallback_formula is not None
+                and not cls._artifact_matches_formula(
+                    market=market,
+                    artifact=fallback_artifact,
+                    expected_formula=expected_fallback_formula,
+                )
+            ):
                 continue
             if cls._artifact_is_newer(fallback_artifact, current_artifact):
                 selected[market] = fallback_artifact
@@ -211,6 +223,26 @@ class StaticArtifactCombiner:
             return date.fromisoformat(text.split("T", 1)[0])
         except ValueError:
             return None
+
+    @classmethod
+    def _artifact_matches_formula(
+        cls,
+        *,
+        market: str,
+        artifact: dict[str, Any],
+        expected_formula: str,
+    ) -> bool:
+        try:
+            cls._validate_formula(
+                market=market,
+                source_label=artifact["source_label"],
+                metadata=artifact["metadata"],
+                market_dir=artifact["market_dir"],
+                expected_formula=expected_formula,
+            )
+        except StaticArtifactFormulaError:
+            return False
+        return True
 
     @classmethod
     def _validate_selected_formulas(

--- a/backend/tests/unit/services/test_static_artifact_combiner.py
+++ b/backend/tests/unit/services/test_static_artifact_combiner.py
@@ -143,7 +143,7 @@ def test_combiner_rejects_wrong_formula_fallback(tmp_path):
     fallback = write_market_artifact(
         tmp_path / "fallback", market="HK", formula=LEGACY_RS_FORMULA_VERSION
     )
-    with pytest.raises(StaticArtifactFormulaError, match="HK fallback"):
+    with pytest.raises(NoPublishedStaticMarketArtifact, match="HK"):
         combiner().combine(
             artifacts_dir=tmp_path / "empty-current",
             fallback_artifacts_dir=fallback,

--- a/backend/tests/unit/test_export_static_market_artifact_script.py
+++ b/backend/tests/unit/test_export_static_market_artifact_script.py
@@ -133,6 +133,53 @@ def test_export_static_market_artifact_allows_price_bundle_for_exposure_soft_ski
     ] is True
 
 
+@pytest.mark.parametrize("payload", [
+    {
+        "market": "DE",
+        "status": "skipped",
+        "failure_diagnostics": {"error": "missing reason"},
+    },
+    {
+        "market": "DE",
+        "status": "skipped",
+        "reason": "new_unclassified_soft_skip",
+        "failure_diagnostics": {"error": "unknown"},
+    },
+])
+def test_export_static_market_artifact_blocks_price_bundle_for_unknown_soft_skip(
+    monkeypatch,
+    tmp_path: Path,
+    payload: dict,
+) -> None:
+    from app.scripts import export_static_market_artifact
+
+    def fake_export_main(_argv):
+        diagnostics_dir = tmp_path / "diagnostics" / "de"
+        diagnostics_dir.mkdir(parents=True)
+        (diagnostics_dir / "snapshot-failure.json").write_text(
+            json.dumps(payload),
+            encoding="utf-8",
+        )
+        return export_static_market_artifact.export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+
+    monkeypatch.setattr(export_static_market_artifact.export_static_site, "main", fake_export_main)
+
+    result = export_static_market_artifact.main(
+        [
+            "--output-dir",
+            str(tmp_path),
+            "--refresh-daily",
+            "--market",
+            "DE",
+        ]
+    )
+
+    assert result == export_static_market_artifact.export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+    assert json.loads((tmp_path / "status" / "de" / "status.json").read_text())[
+        "has_price_bundle"
+    ] is False
+
+
 def test_export_static_market_artifact_allows_price_bundle_for_benchmark_gap(
     monkeypatch,
     tmp_path: Path,

--- a/backend/tests/unit/test_export_static_market_artifact_script.py
+++ b/backend/tests/unit/test_export_static_market_artifact_script.py
@@ -41,9 +41,139 @@ def test_export_static_market_artifact_writes_status_and_preserves_exit_code(
     assert json.loads((tmp_path / "status" / "cn" / "status.json").read_text()) == {
         "market": "CN",
         "has_current_artifact": False,
+        "has_price_bundle": False,
         "status": "failed",
         "reason": "no_current_artifact",
     }
+
+
+def test_export_static_market_artifact_blocks_price_bundle_for_price_coverage_gap(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from app.scripts import export_static_market_artifact
+
+    def fake_export_main(_argv):
+        diagnostics_dir = tmp_path / "diagnostics" / "de"
+        diagnostics_dir.mkdir(parents=True)
+        (diagnostics_dir / "snapshot-failure.json").write_text(
+            json.dumps(
+                {
+                    "market": "DE",
+                    "status": "skipped",
+                    "reason": "market_rs_not_ready",
+                    "failure_diagnostics": {
+                        "reason_code": "current_adjusted_price_coverage_below_threshold",
+                        "diagnostics": {
+                            "current_price_coverage": 0.84,
+                            "minimum_current_price_coverage": 0.88,
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return export_static_market_artifact.export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+
+    monkeypatch.setattr(export_static_market_artifact.export_static_site, "main", fake_export_main)
+
+    result = export_static_market_artifact.main(
+        [
+            "--output-dir",
+            str(tmp_path),
+            "--refresh-daily",
+            "--market",
+            "DE",
+        ]
+    )
+
+    assert result == export_static_market_artifact.export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+    assert json.loads((tmp_path / "status" / "de" / "status.json").read_text())[
+        "has_price_bundle"
+    ] is False
+
+
+def test_export_static_market_artifact_allows_price_bundle_for_exposure_soft_skip(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from app.scripts import export_static_market_artifact
+
+    def fake_export_main(_argv):
+        diagnostics_dir = tmp_path / "diagnostics" / "de"
+        diagnostics_dir.mkdir(parents=True)
+        (diagnostics_dir / "snapshot-failure.json").write_text(
+            json.dumps(
+                {
+                    "market": "DE",
+                    "status": "skipped",
+                    "reason": "market_exposure_not_ready",
+                    "failure_diagnostics": {"error": "market_breadth_not_ready"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return export_static_market_artifact.export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+
+    monkeypatch.setattr(export_static_market_artifact.export_static_site, "main", fake_export_main)
+
+    result = export_static_market_artifact.main(
+        [
+            "--output-dir",
+            str(tmp_path),
+            "--refresh-daily",
+            "--market",
+            "DE",
+        ]
+    )
+
+    assert result == export_static_market_artifact.export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+    assert json.loads((tmp_path / "status" / "de" / "status.json").read_text())[
+        "has_price_bundle"
+    ] is True
+
+
+def test_export_static_market_artifact_allows_price_bundle_for_benchmark_gap(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from app.scripts import export_static_market_artifact
+
+    def fake_export_main(_argv):
+        diagnostics_dir = tmp_path / "diagnostics" / "de"
+        diagnostics_dir.mkdir(parents=True)
+        (diagnostics_dir / "snapshot-failure.json").write_text(
+            json.dumps(
+                {
+                    "market": "DE",
+                    "status": "skipped",
+                    "reason": "market_rs_not_ready",
+                    "failure_diagnostics": {
+                        "reason_code": "benchmark_adjusted_anchor_missing",
+                        "diagnostics": {"date": "2026-08-03"},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return export_static_market_artifact.export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+
+    monkeypatch.setattr(export_static_market_artifact.export_static_site, "main", fake_export_main)
+
+    result = export_static_market_artifact.main(
+        [
+            "--output-dir",
+            str(tmp_path),
+            "--refresh-daily",
+            "--market",
+            "DE",
+        ]
+    )
+
+    assert result == export_static_market_artifact.export_static_site.STATIC_EXPORT_NO_CURRENT_ARTIFACT_EXIT_CODE
+    assert json.loads((tmp_path / "status" / "de" / "status.json").read_text())[
+        "has_price_bundle"
+    ] is True
 
 
 def test_export_static_market_artifact_writes_success_status(monkeypatch, tmp_path: Path) -> None:
@@ -64,6 +194,7 @@ def test_export_static_market_artifact_writes_success_status(monkeypatch, tmp_pa
     assert json.loads((tmp_path / "status" / "cn" / "status.json").read_text()) == {
         "market": "CN",
         "has_current_artifact": True,
+        "has_price_bundle": True,
         "status": "published",
         "reason": None,
     }
@@ -94,6 +225,7 @@ def test_export_static_market_artifact_writes_skipped_status_for_not_trading_day
     assert json.loads((tmp_path / "status" / "cn" / "status.json").read_text()) == {
         "market": "CN",
         "has_current_artifact": False,
+        "has_price_bundle": False,
         "status": "skipped",
         "reason": "not_trading_day",
     }
@@ -123,6 +255,7 @@ def test_export_static_market_artifact_writes_failed_status_when_export_raises(
     assert json.loads((tmp_path / "status" / "cn" / "status.json").read_text()) == {
         "market": "CN",
         "has_current_artifact": False,
+        "has_price_bundle": False,
         "status": "failed",
         "reason": "export_failed",
     }
@@ -152,6 +285,7 @@ def test_export_static_market_artifact_writes_failed_status_when_export_exits(
     assert json.loads((tmp_path / "status" / "cn" / "status.json").read_text()) == {
         "market": "CN",
         "has_current_artifact": False,
+        "has_price_bundle": False,
         "status": "failed",
         "reason": "export_failed",
     }

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -167,6 +167,130 @@ def test_static_daily_refresh_ensures_market_breadth_before_exposure(monkeypatch
     }
 
 
+def test_static_daily_refresh_rewinds_to_latest_benchmark_backed_session(
+    monkeypatch,
+):
+    prepare_calls: list[date] = []
+    snapshot_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(export_static_site, "STATIC_EXPORT_MARKETS", ("DE",))
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(export_static_site, "disable_serialized_data_fetch_lock", nullcontext)
+    monkeypatch.setattr(export_static_site, "disable_serialized_market_workload", nullcontext)
+    monkeypatch.setattr(export_static_site, "_tracked_ibd_csv_path", lambda: "ibd.csv")
+    monkeypatch.setattr(
+        export_static_site.IBDIndustryService,
+        "load_from_csv",
+        lambda _db, csv_path: 0,
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_resolve_latest_completed_trading_date",
+        lambda market: date(2026, 8, 3),
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date, market: {"status": "completed", "market": market},
+    )
+
+    def prepare_static_rs(*, market, as_of_date, formula_version):
+        prepare_calls.append(as_of_date)
+        if as_of_date == date(2026, 8, 3):
+            return {
+                "status": "failed",
+                "market": market,
+                "as_of_date": "2026-08-03",
+                "formula_version": formula_version,
+                "reason_code": "benchmark_adjusted_anchor_missing",
+                "diagnostics": {
+                    "error": "benchmark_not_current",
+                    "market": market,
+                    "date": "2026-08-03",
+                    "benchmark_candidates": [
+                        {
+                            "symbol": "^GDAXI",
+                            "role": "primary",
+                            "source": "fetch",
+                            "status": "stale_required_date",
+                            "latest_date": "2026-07-31",
+                        },
+                    ],
+                },
+                "market_rs_run_id": None,
+            }
+        return {
+            "status": "completed",
+            "market": market,
+            "as_of_date": as_of_date.isoformat(),
+            "formula_version": formula_version,
+            "market_rs_run_id": 42,
+        }
+
+    monkeypatch.setattr(export_static_site, "_prepare_static_rs_formula", prepare_static_rs)
+    monkeypatch.setattr(
+        export_static_site,
+        "_ensure_breadth_history",
+        lambda **kwargs: {
+            "status": "completed",
+            "market": kwargs["market"],
+            "as_of_date": kwargs["as_of_date"].isoformat(),
+        },
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_compute_static_market_exposure",
+        lambda **kwargs: {
+            "market": kwargs["market"],
+            "date": kwargs["as_of_date"].isoformat(),
+            "status": "stored",
+        },
+    )
+
+    import app.interfaces.tasks.feature_store_tasks as feature_store_tasks
+
+    def build_snapshot(**kwargs):
+        snapshot_calls.append(kwargs)
+        return {
+            "status": "published",
+            "run_id": 7,
+            "market": kwargs["market"],
+            "as_of_date": kwargs["as_of_date_str"],
+        }
+
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(run=build_snapshot),
+    )
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "_enrich_feature_run_with_ibd_metadata",
+        lambda **kwargs: {"status": "completed"},
+    )
+    monkeypatch.setattr(
+        export_static_site,
+        "_ensure_group_rank_history",
+        lambda **kwargs: _ReadyGroupRankBackfill(),
+    )
+
+    results, warnings = export_static_site._run_daily_refresh(
+        market="DE",
+        skip_universe_refresh=True,
+        skip_fundamentals_refresh=True,
+        rs_formula_version=BALANCED_RS_FORMULA_VERSION,
+    )
+
+    assert prepare_calls == [date(2026, 8, 3), date(2026, 7, 31)]
+    assert results["market_rs"]["DE"]["status"] == "completed"
+    assert results["market_rs"]["DE"]["as_of_date"] == "2026-07-31"
+    assert snapshot_calls[0]["as_of_date_str"] == "2026-07-31"
+    assert (
+        "Static export market DE using benchmark-backed as-of date 2026-07-31 "
+        "because benchmarks were unavailable for 2026-08-03."
+    ) in warnings
+
+
 def test_static_daily_refresh_skips_exposure_when_breadth_history_errors(monkeypatch):
     monkeypatch.setattr(export_static_site, "STATIC_EXPORT_MARKETS", ("HK",))
     monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeSession())
@@ -762,3 +886,85 @@ def test_ensure_breadth_history_marks_undercovered_backfill_rows_not_completed(
         "Cache-only breadth backfill has insufficient usable coverage "
         "(dates=2026-07-31, minimum_scanned=9)"
     )
+
+
+def test_ensure_breadth_history_accepts_historical_warmup_undercoverage(
+    monkeypatch,
+):
+    older_date = date(2026, 7, 30)
+    as_of_date = date(2026, 7, 31)
+    breadth_rows: list[SimpleNamespace] = []
+
+    class _FakeQuery:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return self.rows
+
+    class _FakeDb(_FakeSession):
+        def query(self, entity, *args):
+            if entity is MarketBreadth:
+                return _FakeQuery(breadth_rows)
+            if entity is StockUniverse.symbol:
+                return _FakeQuery([
+                    (f"AAA{i}",)
+                    for i in range(10)
+                ])
+            return _FakeQuery([])
+
+    class _FakeBreadthCalculator:
+        def __init__(self, db, price_cache, *, market):
+            self.market = market
+
+        def backfill_range(self, **kwargs):
+            breadth_rows.extend(
+                [
+                    SimpleNamespace(
+                        date=older_date,
+                        total_stocks_scanned=1,
+                    ),
+                    SimpleNamespace(
+                        date=as_of_date,
+                        total_stocks_scanned=10,
+                    ),
+                ]
+            )
+            return {
+                "total_dates": 2,
+                "processed": 2,
+                "errors": 0,
+                "error_dates": [],
+                "target_symbols": 10,
+                "symbols_with_cached_history": 10,
+                "cache_miss_stocks": 0,
+                "error_stocks": 0,
+                "cache_coverage_ratio": 1.0,
+                "insufficient_history_observations": 9,
+            }
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(
+        export_static_site,
+        "_generate_trading_dates",
+        lambda *args, **kwargs: [older_date, as_of_date],
+    )
+    monkeypatch.setattr(export_static_site, "get_price_cache", lambda: object())
+    monkeypatch.setattr(
+        export_static_site,
+        "BreadthCalculatorService",
+        _FakeBreadthCalculator,
+    )
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "completed"
+    assert "undercovered_dates" not in result
+    assert "error" not in result

--- a/backend/tests/unit/test_export_static_site_refresh.py
+++ b/backend/tests/unit/test_export_static_site_refresh.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
-from datetime import date
+from datetime import date, datetime
 from types import SimpleNamespace
 
 from app.domain.relative_strength import BALANCED_RS_FORMULA_VERSION
@@ -213,7 +213,7 @@ def test_static_daily_refresh_rewinds_to_latest_benchmark_backed_session(
                             "role": "primary",
                             "source": "fetch",
                             "status": "stale_required_date",
-                            "latest_date": "2026-07-31",
+                            "latest_date": datetime(2026, 7, 31, 15, 30),
                         },
                     ],
                 },
@@ -968,3 +968,104 @@ def test_ensure_breadth_history_accepts_historical_warmup_undercoverage(
     assert result["status"] == "completed"
     assert "undercovered_dates" not in result
     assert "error" not in result
+
+
+def test_ensure_breadth_history_rejects_undercoverage_after_warmup(
+    monkeypatch,
+):
+    warmup_date = date(2026, 7, 27)
+    covered_date = date(2026, 7, 28)
+    recent_gap_date = date(2026, 7, 30)
+    as_of_date = date(2026, 7, 31)
+    breadth_rows: list[SimpleNamespace] = []
+
+    class _FakeQuery:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return self.rows
+
+    class _FakeDb(_FakeSession):
+        def query(self, entity, *args):
+            if entity is MarketBreadth:
+                return _FakeQuery(breadth_rows)
+            if entity is StockUniverse.symbol:
+                return _FakeQuery([
+                    (f"AAA{i}",)
+                    for i in range(10)
+                ])
+            return _FakeQuery([])
+
+    class _FakeBreadthCalculator:
+        def __init__(self, db, price_cache, *, market):
+            self.market = market
+
+        def backfill_range(self, **kwargs):
+            breadth_rows.extend(
+                [
+                    SimpleNamespace(
+                        date=warmup_date,
+                        total_stocks_scanned=1,
+                    ),
+                    SimpleNamespace(
+                        date=covered_date,
+                        total_stocks_scanned=10,
+                    ),
+                    SimpleNamespace(
+                        date=recent_gap_date,
+                        total_stocks_scanned=1,
+                    ),
+                    SimpleNamespace(
+                        date=as_of_date,
+                        total_stocks_scanned=10,
+                    ),
+                ]
+            )
+            return {
+                "total_dates": 4,
+                "processed": 4,
+                "errors": 0,
+                "error_dates": [],
+                "target_symbols": 10,
+                "symbols_with_cached_history": 10,
+                "cache_miss_stocks": 0,
+                "error_stocks": 0,
+                "cache_coverage_ratio": 1.0,
+                "insufficient_history_observations": 10,
+            }
+
+    monkeypatch.setattr(export_static_site, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(
+        export_static_site,
+        "_generate_trading_dates",
+        lambda *args, **kwargs: [
+            warmup_date,
+            covered_date,
+            recent_gap_date,
+            as_of_date,
+        ],
+    )
+    monkeypatch.setattr(export_static_site, "get_price_cache", lambda: object())
+    monkeypatch.setattr(
+        export_static_site,
+        "BreadthCalculatorService",
+        _FakeBreadthCalculator,
+    )
+
+    result = export_static_site._ensure_breadth_history(
+        as_of_date=as_of_date,
+        market="HK",
+        min_trading_days=0,
+    )
+
+    assert result["status"] == "errored"
+    assert result["undercovered_dates"] == ["2026-07-30"]
+    assert result["minimum_stocks_scanned"] == 9
+    assert result["error"] == (
+        "Cache-only breadth backfill has insufficient usable coverage "
+        "(dates=2026-07-30, minimum_scanned=9)"
+    )

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1298,6 +1298,71 @@ def test_combine_market_artifacts_uses_fallback_only_for_missing_markets(tmp_pat
     assert not any(warning.startswith("US reused from previous") for warning in manifest["warnings"])
 
 
+def test_combine_market_artifacts_uses_newer_fallback_for_rewound_current_market(tmp_path):
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    output_dir = tmp_path / "combined"
+
+    current_us_dir = current_dir / "static-market-US" / "markets" / "us"
+    fallback_us_dir = fallback_dir / "static-market-US" / "markets" / "us"
+    for market_dir in (current_us_dir, fallback_us_dir):
+        (market_dir / "scan").mkdir(parents=True)
+        (market_dir / "scan" / "manifest.json").write_text(
+            json.dumps({"source": str(market_dir)}),
+            encoding="utf-8",
+        )
+
+    current_us_entry = {
+        "market": "US",
+        "display_name": "United States",
+        "as_of_date": "2026-07-31",
+        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
+    }
+    fallback_us_entry = {
+        "market": "US",
+        "display_name": "United States",
+        "as_of_date": "2026-08-03",
+        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
+    }
+
+    for market_dir, entry in (
+        (current_us_dir, current_us_entry),
+        (fallback_us_dir, fallback_us_entry),
+    ):
+        (market_dir / STATIC_MARKET_METADATA_FILENAME).write_text(
+            json.dumps(
+                {
+                    "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                    "generated_at": "2026-08-03T22:00:00Z",
+                    "market": "US",
+                    "entry": entry,
+                    "warnings": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    result = StaticSiteExportService.combine_market_artifacts(
+        current_dir,
+        output_dir,
+        fallback_artifacts_dir=fallback_dir,
+    )
+
+    manifest = result.manifest
+    assert manifest["markets"]["US"]["as_of_date"] == "2026-08-03"
+    assert json.loads((output_dir / "markets" / "us" / "scan" / "manifest.json").read_text(encoding="utf-8")) == {
+        "source": str(fallback_us_dir)
+    }
+    assert (
+        "US reused from a previous static-site market artifact because it is newer "
+        "than the current artifact."
+    ) in manifest["warnings"]
+
+
 def test_combine_market_artifacts_accepts_fallback_when_current_is_empty(tmp_path):
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1363,7 +1363,7 @@ def test_combine_market_artifacts_uses_newer_fallback_for_rewound_current_market
     ) in manifest["warnings"]
 
 
-def test_combine_market_artifacts_ignores_incompatible_fallback_when_current_override_selected(tmp_path):
+def test_combine_market_artifacts_keeps_current_override_when_newer_fallback_uses_other_formula(tmp_path):
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"
     output_dir = tmp_path / "combined"
@@ -1392,7 +1392,7 @@ def test_combine_market_artifacts_ignores_incompatible_fallback_when_current_ove
     fallback_us_entry = {
         "market": "US",
         "display_name": "United States",
-        "as_of_date": "2026-07-31",
+        "as_of_date": "2026-08-04",
         "rs_formula_version": BALANCED_RS_FORMULA_VERSION,
         "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
         "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1435,6 +1435,50 @@ def test_combine_market_artifacts_keeps_current_override_when_newer_fallback_use
     )
 
 
+def test_combine_market_artifacts_rejects_incompatible_fallback_when_current_missing(tmp_path):
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    output_dir = tmp_path / "combined"
+
+    fallback_us_dir = fallback_dir / "static-market-US" / "markets" / "us"
+    (fallback_us_dir / "scan").mkdir(parents=True)
+    (fallback_us_dir / "scan" / "manifest.json").write_text(
+        json.dumps({"rs_formula_version": BALANCED_RS_FORMULA_VERSION}),
+        encoding="utf-8",
+    )
+    fallback_us_entry = {
+        "market": "US",
+        "display_name": "United States",
+        "as_of_date": "2026-08-04",
+        "rs_formula_version": BALANCED_RS_FORMULA_VERSION,
+        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
+    }
+    (fallback_us_dir / STATIC_MARKET_METADATA_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                "generated_at": "2026-08-04T22:00:00Z",
+                "market": "US",
+                "entry": fallback_us_entry,
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(NoPublishedStaticMarketArtifact, match="US"):
+        StaticSiteExportService.combine_market_artifacts(
+            current_dir,
+            output_dir,
+            fallback_artifacts_dir=fallback_dir,
+            rs_formula_version_overrides={"US": LEGACY_RS_FORMULA_VERSION},
+        )
+
+    assert not output_dir.exists()
+
+
 def test_combine_market_artifacts_accepts_fallback_when_current_is_empty(tmp_path):
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1363,6 +1363,78 @@ def test_combine_market_artifacts_uses_newer_fallback_for_rewound_current_market
     ) in manifest["warnings"]
 
 
+def test_combine_market_artifacts_ignores_incompatible_fallback_when_current_override_selected(tmp_path):
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    output_dir = tmp_path / "combined"
+
+    current_us_dir = current_dir / "static-market-US" / "markets" / "us"
+    fallback_us_dir = fallback_dir / "static-market-US" / "markets" / "us"
+    for market_dir, formula_version in (
+        (current_us_dir, LEGACY_RS_FORMULA_VERSION),
+        (fallback_us_dir, BALANCED_RS_FORMULA_VERSION),
+    ):
+        (market_dir / "scan").mkdir(parents=True)
+        (market_dir / "scan" / "manifest.json").write_text(
+            json.dumps({"rs_formula_version": formula_version}),
+            encoding="utf-8",
+        )
+
+    current_us_entry = {
+        "market": "US",
+        "display_name": "United States",
+        "as_of_date": "2026-08-03",
+        "rs_formula_version": LEGACY_RS_FORMULA_VERSION,
+        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
+    }
+    fallback_us_entry = {
+        "market": "US",
+        "display_name": "United States",
+        "as_of_date": "2026-07-31",
+        "rs_formula_version": BALANCED_RS_FORMULA_VERSION,
+        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
+        "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
+    }
+
+    for market_dir, entry in (
+        (current_us_dir, current_us_entry),
+        (fallback_us_dir, fallback_us_entry),
+    ):
+        (market_dir / STATIC_MARKET_METADATA_FILENAME).write_text(
+            json.dumps(
+                {
+                    "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                    "generated_at": "2026-08-03T22:00:00Z",
+                    "market": "US",
+                    "entry": entry,
+                    "warnings": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    result = StaticSiteExportService.combine_market_artifacts(
+        current_dir,
+        output_dir,
+        fallback_artifacts_dir=fallback_dir,
+        rs_formula_version_overrides={"US": LEGACY_RS_FORMULA_VERSION},
+    )
+
+    manifest = result.manifest
+    assert manifest["markets"]["US"]["rs_formula_version"] == LEGACY_RS_FORMULA_VERSION
+    assert manifest["markets"]["US"]["as_of_date"] == "2026-08-03"
+    assert json.loads((output_dir / "markets" / "us" / "scan" / "manifest.json").read_text(encoding="utf-8")) == {
+        "rs_formula_version": LEGACY_RS_FORMULA_VERSION
+    }
+    assert not any(
+        "US reused from a previous static-site market artifact" in warning
+        for warning in manifest["warnings"]
+    )
+
+
 def test_combine_market_artifacts_accepts_fallback_when_current_is_empty(tmp_path):
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -162,6 +162,23 @@ def test_static_site_market_export_soft_skips_no_current_artifact_exit_code() ->
     assert "no current market artifact will be uploaded" in export_step
 
 
+def test_static_site_market_export_uses_status_price_bundle_signal_for_soft_skip() -> None:
+    build_market_job = _build_market_job()
+    export_step = build_market_job.split("      - name: Export market static data bundle\n", 1)[1].split(
+        "\n      - name: Upload market status",
+        1,
+    )[0]
+    soft_skip_branch = export_step.split('if [ "$status" -eq 79 ]; then', 1)[1].split(
+        "exit 0",
+        1,
+    )[0]
+
+    assert 'STATUS_PATH="/tmp/static-data/status/${MARKET_LOWER}/status.json"' in export_step
+    assert ".has_price_bundle // false" in soft_skip_branch
+    assert 'echo "has_price_bundle=$has_price_bundle" >> "$GITHUB_OUTPUT"' in soft_skip_branch
+    assert 'echo "has_price_bundle=true" >> "$GITHUB_OUTPUT"' not in soft_skip_branch
+
+
 def test_static_site_uploads_canonical_market_status_after_export() -> None:
     build_market_job = _build_market_job()
     export_step = build_market_job.split("      - name: Export market static data bundle\n", 1)[1].split(

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -230,7 +230,7 @@ def test_static_site_validation_uses_python_module_not_inline_control_plane() ->
     assert "snapshot-failure.json" not in validation_step
 
 
-def test_static_site_fallback_downloader_only_fetches_missing_current_markets(tmp_path) -> None:
+def test_static_site_fallback_downloader_fetches_current_markets_for_date_comparison(tmp_path) -> None:
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"
     current_us_dir = current_dir / "static-market-US" / "markets" / "us"
@@ -307,12 +307,15 @@ def test_static_site_fallback_downloader_only_fetches_missing_current_markets(tm
         json.loads(line)
         for line in downloads_log.read_text(encoding="utf-8").splitlines()
     ]
-    assert downloads == [{"artifact": "static-market-TW"}]
+    assert downloads == [
+        {"artifact": "static-market-TW"},
+        {"artifact": "static-market-US"},
+    ]
     assert not (fallback_dir / "static-market-diagnostics-CN").exists()
     assert not (fallback_dir / "static-market-status-CN").exists()
-    assert not (fallback_dir / "static-market-US").exists()
     assert not (fallback_dir / "static-market-HK").exists()
     assert (fallback_dir / "static-market-TW" / "manifest.market.json").exists()
+    assert (fallback_dir / "static-market-US" / "manifest.market.json").exists()
     assert "exit 7. Details: stderr: download denied for HK" in result.stdout
 
 

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -253,10 +253,16 @@ def test_static_site_daily_price_build_requires_current_session_coverage() -> No
 
     assert "id: build-daily-price-bundle" in build_price_step
     assert "MarketRsInputLoader._minimum_current_price_coverage" in build_price_step
+    assert 'BUILD_LOG="$(mktemp)"' in build_price_step
+    assert '| tee "$BUILD_LOG"' in build_price_step
+    assert 'build_pipeline_status=("${PIPESTATUS[@]}")' in build_price_step
+    assert 'build_log_status="${build_pipeline_status[1]}"' in build_price_step
     assert "--require-complete" in build_price_step
     assert '--min-symbol-coverage "$MIN_SYMBOL_COVERAGE"' in build_price_step
+    assert "Daily price bundle coverage .* is below required" in build_price_step
     assert "price_bundle_ready=false" in build_price_step
     assert "price_bundle_ready=true" in build_price_step
+    assert 'exit "$status"' in build_price_step
     assert "steps.build-daily-price-bundle.outputs.price_bundle_ready == 'true'" in upload_price_step
 
 

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -8,6 +8,9 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
+from app.scripts import download_static_market_fallbacks as fallback_script
 from app.scripts.download_static_market_fallbacks import (
     collect_current_markets,
     downloaded_market_is_compatible,
@@ -230,6 +233,55 @@ def test_static_site_validation_uses_python_module_not_inline_control_plane() ->
     assert "snapshot-failure.json" not in validation_step
 
 
+def test_static_site_fallback_candidate_install_restores_incumbent_on_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    target_dir = tmp_path / "static-market-US"
+    candidate_dir = tmp_path / ".static-market-US.candidate-222"
+    target_dir.mkdir()
+    candidate_dir.mkdir()
+    (target_dir / "manifest.market.json").write_text(
+        json.dumps(
+            {
+                "market": "US",
+                "schema_version": "static-site-v3",
+                "entry": {"as_of_date": "2026-07-31"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (candidate_dir / "manifest.market.json").write_text(
+        json.dumps(
+            {
+                "market": "US",
+                "schema_version": "static-site-v3",
+                "entry": {"as_of_date": "2026-08-03"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    original_rename = Path.rename
+
+    def flaky_rename(self, target):
+        if self == candidate_dir and Path(target) == target_dir:
+            raise OSError("install failed")
+        return original_rename(self, target)
+
+    monkeypatch.setattr(Path, "rename", flaky_rename)
+
+    with pytest.raises(OSError, match="install failed"):
+        fallback_script._install_market_candidate(
+            target_dir=target_dir,
+            candidate_dir=candidate_dir,
+        )
+
+    manifest = json.loads(
+        (target_dir / "manifest.market.json").read_text(encoding="utf-8")
+    )
+    assert manifest["entry"]["as_of_date"] == "2026-07-31"
+
+
 def test_static_site_fallback_downloader_keeps_newest_candidate_for_current_market(tmp_path) -> None:
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"
@@ -261,10 +313,10 @@ def test_static_site_fallback_downloader_keeps_newest_candidate_for_current_mark
         args = sys.argv[1:]
         if args[:3] == ["api", "--paginate", "--slurp"] and "actions/workflows/static-site.yml/runs" in args[3]:
             print(json.dumps([{{"workflow_runs": [
-                {{"id": 999, "conclusion": "failure"}},
-                {{"id": 333, "conclusion": "success"}},
-                {{"id": 222, "conclusion": "success"}},
-                {{"id": 111, "conclusion": "success"}}
+                {{"id": 999, "conclusion": "failure", "created_at": "2026-08-05T00:00:00Z"}},
+                {{"id": 333, "conclusion": "success", "created_at": "2026-08-05T00:00:00Z"}},
+                {{"id": 222, "conclusion": "success", "created_at": "2026-08-04T00:00:00Z"}},
+                {{"id": 111, "conclusion": "success", "created_at": "2026-08-03T00:00:00Z"}}
             ]}}]))
         elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/333/artifacts" in args[3]:
             print(json.dumps([{{"artifacts": [
@@ -337,7 +389,6 @@ def test_static_site_fallback_downloader_keeps_newest_candidate_for_current_mark
         {"run": "333", "artifact": "static-market-TW"},
         {"run": "333", "artifact": "static-market-US"},
         {"run": "222", "artifact": "static-market-US"},
-        {"run": "111", "artifact": "static-market-US"},
     ]
     us_manifest = json.loads(
         (fallback_dir / "static-market-US" / "manifest.market.json").read_text(

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -587,6 +587,82 @@ def test_static_site_fallback_downloader_keeps_formula_compatible_candidate(tmp_
     assert manifest["entry"]["rs_formula_version"] == "legacy-linear-v1"
 
 
+def test_static_site_fallback_downloader_skips_damaged_advertised_assets(tmp_path) -> None:
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+    current_us_dir = current_dir / "static-market-US" / "markets" / "us"
+    current_us_dir.mkdir(parents=True)
+    (current_us_dir / "manifest.market.json").write_text(
+        json.dumps(
+            {
+                "market": "US",
+                "schema_version": "static-site-v3",
+                "entry": {"as_of_date": "2026-08-04"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    _write_fake_gh(
+        fake_gh,
+        """\
+        import json
+        import pathlib
+        import sys
+
+        args = sys.argv[1:]
+        if args[:3] == ["api", "--paginate", "--slurp"] and "actions/workflows/static-site.yml/runs" in args[3]:
+            print(json.dumps([{"workflow_runs": [
+                {"id": 999, "created_at": "2026-08-05T00:00:00Z"},
+                {"id": 333, "created_at": "2026-08-04T00:00:00Z"}
+            ]}]))
+        elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/333/artifacts" in args[3]:
+            print(json.dumps([{"artifacts": [
+                {"name": "static-market-US", "expired": False}
+            ]}]))
+        elif args[:2] == ["run", "download"]:
+            target_dir = pathlib.Path(args[args.index("--dir") + 1])
+            market_dir = target_dir / "markets" / "us"
+            market_dir.mkdir(parents=True, exist_ok=True)
+            (market_dir / "manifest.market.json").write_text(json.dumps({
+                "market": "US",
+                "schema_version": "static-site-v3",
+                "entry": {
+                    "market": "US",
+                    "as_of_date": "2026-08-04",
+                    "features": {"groups": True},
+                },
+            }))
+        else:
+            print(f"unexpected gh args: {args}", file=sys.stderr)
+            sys.exit(2)
+        """,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "app.scripts.download_static_market_fallbacks",
+            "--current-dir",
+            str(current_dir),
+            "--fallback-dir",
+            str(fallback_dir),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_fallback_downloader_env(fake_bin),
+        cwd=ROOT / "backend",
+    )
+
+    assert not (fallback_dir / "static-market-US").exists()
+    assert "advertises GROUPS but groups.json is absent" in result.stdout
+
+
 def test_static_site_fallback_downloader_skips_incompatible_schema_and_keeps_searching(tmp_path) -> None:
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -230,13 +230,19 @@ def test_static_site_validation_uses_python_module_not_inline_control_plane() ->
     assert "snapshot-failure.json" not in validation_step
 
 
-def test_static_site_fallback_downloader_fetches_current_markets_for_date_comparison(tmp_path) -> None:
+def test_static_site_fallback_downloader_keeps_newest_candidate_for_current_market(tmp_path) -> None:
     current_dir = tmp_path / "current"
     fallback_dir = tmp_path / "fallback"
     current_us_dir = current_dir / "static-market-US" / "markets" / "us"
     current_us_dir.mkdir(parents=True)
     (current_us_dir / "manifest.market.json").write_text(
-        json.dumps({"market": "US", "schema_version": "static-site-v3"}),
+        json.dumps(
+            {
+                "market": "US",
+                "schema_version": "static-site-v3",
+                "entry": {"as_of_date": "2026-07-31"},
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -256,9 +262,11 @@ def test_static_site_fallback_downloader_fetches_current_markets_for_date_compar
         if args[:3] == ["api", "--paginate", "--slurp"] and "actions/workflows/static-site.yml/runs" in args[3]:
             print(json.dumps([{{"workflow_runs": [
                 {{"id": 999, "conclusion": "failure"}},
-                {{"id": 222, "conclusion": "failure"}}
+                {{"id": 333, "conclusion": "success"}},
+                {{"id": 222, "conclusion": "success"}},
+                {{"id": 111, "conclusion": "success"}}
             ]}}]))
-        elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/222/artifacts" in args[3]:
+        elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/333/artifacts" in args[3]:
             print(json.dumps([{{"artifacts": [
                 {{"name": "static-market-diagnostics-CN", "expired": False}},
                 {{"name": "static-market-HK", "expired": False}},
@@ -266,7 +274,16 @@ def test_static_site_fallback_downloader_fetches_current_markets_for_date_compar
                 {{"name": "static-market-US", "expired": False}},
                 {{"name": "static-market-TW", "expired": False}}
             ]}}]))
+        elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/222/artifacts" in args[3]:
+            print(json.dumps([{{"artifacts": [
+                {{"name": "static-market-US", "expired": False}}
+            ]}}]))
+        elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/111/artifacts" in args[3]:
+            print(json.dumps([{{"artifacts": [
+                {{"name": "static-market-US", "expired": False}}
+            ]}}]))
         elif args[:2] == ["run", "download"]:
+            run_id = args[2]
             artifact_name = args[args.index("--name") + 1]
             if artifact_name == "static-market-HK":
                 target_dir = pathlib.Path(args[args.index("--dir") + 1])
@@ -276,9 +293,18 @@ def test_static_site_fallback_downloader_fetches_current_markets_for_date_compar
                 sys.exit(7)
             target_dir = pathlib.Path(args[args.index("--dir") + 1])
             target_dir.mkdir(parents=True, exist_ok=True)
-            (target_dir / "manifest.market.json").write_text(json.dumps({{"market": artifact_name.rsplit("-", 1)[1], "schema_version": "static-site-v3"}}))
+            as_of_date_by_run = {{
+                "333": "2026-07-31",
+                "222": "2026-08-03",
+                "111": "2026-07-30",
+            }}
+            (target_dir / "manifest.market.json").write_text(json.dumps({{
+                "market": artifact_name.rsplit("-", 1)[1],
+                "schema_version": "static-site-v3",
+                "entry": {{"as_of_date": as_of_date_by_run.get(run_id, "2026-08-02")}},
+            }}))
             with downloads_log.open("a", encoding="utf-8") as handle:
-                handle.write(json.dumps({{"artifact": artifact_name}}) + "\\n")
+                handle.write(json.dumps({{"run": run_id, "artifact": artifact_name}}) + "\\n")
         else:
             print(f"unexpected gh args: {{args}}", file=sys.stderr)
             sys.exit(2)
@@ -308,14 +334,21 @@ def test_static_site_fallback_downloader_fetches_current_markets_for_date_compar
         for line in downloads_log.read_text(encoding="utf-8").splitlines()
     ]
     assert downloads == [
-        {"artifact": "static-market-TW"},
-        {"artifact": "static-market-US"},
+        {"run": "333", "artifact": "static-market-TW"},
+        {"run": "333", "artifact": "static-market-US"},
+        {"run": "222", "artifact": "static-market-US"},
+        {"run": "111", "artifact": "static-market-US"},
     ]
+    us_manifest = json.loads(
+        (fallback_dir / "static-market-US" / "manifest.market.json").read_text(
+            encoding="utf-8"
+        )
+    )
     assert not (fallback_dir / "static-market-diagnostics-CN").exists()
     assert not (fallback_dir / "static-market-status-CN").exists()
     assert not (fallback_dir / "static-market-HK").exists()
     assert (fallback_dir / "static-market-TW" / "manifest.market.json").exists()
-    assert (fallback_dir / "static-market-US" / "manifest.market.json").exists()
+    assert us_manifest["entry"]["as_of_date"] == "2026-08-03"
     assert "exit 7. Details: stderr: download denied for HK" in result.stdout
 
 

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -138,7 +138,7 @@ def test_static_site_market_export_preserves_price_bundle_after_soft_skip() -> N
     )[0]
 
     assert "id: export-market" in export_step
-    assert "status=$?" in export_step
+    assert "status=${PIPESTATUS[0]}" in export_step
     assert 'if [ "$status" -eq 78 ]; then' in export_step
     assert "has_artifact=false" in export_step
     assert "has_artifact=true" in export_step
@@ -196,6 +196,26 @@ def test_static_site_uploads_market_diagnostics_after_export() -> None:
     assert "name: static-market-diagnostics-${{ matrix.market }}" in diagnostics_step
     assert "path: /tmp/static-data/diagnostics/${{ env.MARKET_LOWER }}" in diagnostics_step
     assert "if-no-files-found: ignore" in diagnostics_step
+
+
+def test_static_site_rrg_history_publish_skips_rewound_market_exports() -> None:
+    build_market_job = _build_market_job()
+    export_step = build_market_job.split("      - name: Export market static data bundle\n", 1)[1].split(
+        "\n      - name: Upload market status",
+        1,
+    )[0]
+    publish_rrg_step = build_market_job.split("      - name: Publish rolling RRG history\n", 1)[1].split(
+        "\n\n  combine-and-build:",
+        1,
+    )[0]
+
+    assert 'EXPORT_LOG="$(mktemp)"' in export_step
+    assert '| tee "$EXPORT_LOG"' in export_step
+    assert "status=${PIPESTATUS[0]}" in export_step
+    assert "using benchmark-backed as-of date" in export_step
+    assert "rrg_history_publishable=false" in export_step
+    assert "rrg_history_publishable=true" in export_step
+    assert "steps.export-market.outputs.rrg_history_publishable == 'true'" in publish_rrg_step
 
 
 def test_static_site_combine_downloads_current_and_per_market_fallback_artifacts() -> None:

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -6,6 +6,7 @@ import shlex
 import subprocess
 import sys
 import textwrap
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -138,7 +139,7 @@ def test_static_site_market_export_preserves_price_bundle_after_soft_skip() -> N
     )[0]
 
     assert "id: export-market" in export_step
-    assert "status=${PIPESTATUS[0]}" in export_step
+    assert 'status="${pipeline_status[0]}"' in export_step
     assert 'if [ "$status" -eq 78 ]; then' in export_step
     assert "has_artifact=false" in export_step
     assert "has_artifact=true" in export_step
@@ -228,11 +229,35 @@ def test_static_site_rrg_history_publish_skips_rewound_market_exports() -> None:
 
     assert 'EXPORT_LOG="$(mktemp)"' in export_step
     assert '| tee "$EXPORT_LOG"' in export_step
-    assert "status=${PIPESTATUS[0]}" in export_step
+    assert 'pipeline_status=("${PIPESTATUS[@]}")' in export_step
+    assert 'status="${pipeline_status[0]}"' in export_step
+    assert 'log_status="${pipeline_status[1]}"' in export_step
+    assert 'if [ "$log_status" -ne 0 ]; then' in export_step
+    assert 'exit "$log_status"' in export_step
     assert "using benchmark-backed as-of date" in export_step
     assert "rrg_history_publishable=false" in export_step
     assert "rrg_history_publishable=true" in export_step
     assert "steps.export-market.outputs.rrg_history_publishable == 'true'" in publish_rrg_step
+
+
+def test_static_site_daily_price_build_requires_current_session_coverage() -> None:
+    build_market_job = _build_market_job()
+    build_price_step = build_market_job.split("      - name: Build daily price bundle\n", 1)[1].split(
+        "\n      - name: Upload daily price assets",
+        1,
+    )[0]
+    upload_price_step = build_market_job.split("      - name: Upload daily price assets\n", 1)[1].split(
+        "\n      - name: Upload market artifact",
+        1,
+    )[0]
+
+    assert "id: build-daily-price-bundle" in build_price_step
+    assert "MarketRsInputLoader._minimum_current_price_coverage" in build_price_step
+    assert "--require-complete" in build_price_step
+    assert '--min-symbol-coverage "$MIN_SYMBOL_COVERAGE"' in build_price_step
+    assert "price_bundle_ready=false" in build_price_step
+    assert "price_bundle_ready=true" in build_price_step
+    assert "steps.build-daily-price-bundle.outputs.price_bundle_ready == 'true'" in upload_price_step
 
 
 def test_static_site_combine_downloads_current_and_per_market_fallback_artifacts() -> None:
@@ -317,6 +342,17 @@ def test_static_site_fallback_candidate_install_restores_incumbent_on_failure(
         (target_dir / "manifest.market.json").read_text(encoding="utf-8")
     )
     assert manifest["entry"]["as_of_date"] == "2026-07-31"
+
+
+def test_static_site_fallback_run_bound_allows_next_day_session_dates() -> None:
+    assert not fallback_script._run_cannot_beat_incumbent(
+        run_upper_bound=date(2026, 8, 4),
+        incumbent_date=date(2026, 8, 4),
+    )
+    assert fallback_script._run_cannot_beat_incumbent(
+        run_upper_bound=date(2026, 8, 4),
+        incumbent_date=date(2026, 8, 5),
+    )
 
 
 def test_static_site_fallback_downloader_keeps_newest_candidate_for_current_market(tmp_path) -> None:
@@ -426,6 +462,7 @@ def test_static_site_fallback_downloader_keeps_newest_candidate_for_current_mark
         {"run": "333", "artifact": "static-market-TW"},
         {"run": "333", "artifact": "static-market-US"},
         {"run": "222", "artifact": "static-market-US"},
+        {"run": "111", "artifact": "static-market-US"},
     ]
     us_manifest = json.loads(
         (fallback_dir / "static-market-US" / "manifest.market.json").read_text(
@@ -438,6 +475,110 @@ def test_static_site_fallback_downloader_keeps_newest_candidate_for_current_mark
     assert (fallback_dir / "static-market-TW" / "manifest.market.json").exists()
     assert us_manifest["entry"]["as_of_date"] == "2026-08-03"
     assert "exit 7. Details: stderr: download denied for HK" in result.stdout
+
+
+def test_static_site_fallback_downloader_keeps_formula_compatible_candidate(tmp_path) -> None:
+    current_dir = tmp_path / "current"
+    fallback_dir = tmp_path / "fallback"
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    downloads_log = tmp_path / "downloads.jsonl"
+    _write_fake_gh(
+        fake_gh,
+        f"""\
+        import json
+        import pathlib
+        import sys
+
+        downloads_log = pathlib.Path({str(downloads_log)!r})
+        args = sys.argv[1:]
+        if args[:3] == ["api", "--paginate", "--slurp"] and "actions/workflows/static-site.yml/runs" in args[3]:
+            print(json.dumps([{{"workflow_runs": [
+                {{"id": 999, "created_at": "2026-08-05T00:00:00Z"}},
+                {{"id": 333, "created_at": "2026-08-04T00:00:00Z"}},
+                {{"id": 222, "created_at": "2026-08-03T00:00:00Z"}}
+            ]}}]))
+        elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/333/artifacts" in args[3]:
+            print(json.dumps([{{"artifacts": [
+                {{"name": "static-market-US", "expired": False}}
+            ]}}]))
+        elif args[:3] == ["api", "--paginate", "--slurp"] and "actions/runs/222/artifacts" in args[3]:
+            print(json.dumps([{{"artifacts": [
+                {{"name": "static-market-US", "expired": False}}
+            ]}}]))
+        elif args[:2] == ["run", "download"]:
+            run_id = args[2]
+            artifact_name = args[args.index("--name") + 1]
+            target_dir = pathlib.Path(args[args.index("--dir") + 1])
+            market_dir = target_dir / "markets" / "us"
+            (market_dir / "scan").mkdir(parents=True, exist_ok=True)
+            formula_by_run = {{
+                "333": "balanced-horizon-percentile-v2",
+                "222": "legacy-linear-v1",
+            }}
+            date_by_run = {{
+                "333": "2026-08-04",
+                "222": "2026-08-03",
+            }}
+            formula = formula_by_run[run_id]
+            (market_dir / "scan" / "manifest.json").write_text(
+                json.dumps({{"rs_formula_version": formula}})
+            )
+            (market_dir / "manifest.market.json").write_text(json.dumps({{
+                "market": "US",
+                "schema_version": "static-site-v3",
+                "entry": {{
+                    "market": "US",
+                    "as_of_date": date_by_run[run_id],
+                    "rs_formula_version": formula,
+                    "features": {{"scan": True}},
+                    "pages": {{"scan": {{"path": "markets/us/scan/manifest.json"}}}},
+                }},
+            }}))
+            with downloads_log.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps({{"run": run_id, "artifact": artifact_name}}) + "\\n")
+        else:
+            print(f"unexpected gh args: {{args}}", file=sys.stderr)
+            sys.exit(2)
+        """,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "app.scripts.download_static_market_fallbacks",
+            "--current-dir",
+            str(current_dir),
+            "--fallback-dir",
+            str(fallback_dir),
+            "--fallback-rs-formula-overrides-json",
+            '{"US":"legacy-linear-v1"}',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_fallback_downloader_env(fake_bin),
+        cwd=ROOT / "backend",
+    )
+
+    assert downloads_log.exists(), f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    downloads = [
+        json.loads(line)
+        for line in downloads_log.read_text(encoding="utf-8").splitlines()
+    ]
+    assert downloads == [
+        {"run": "333", "artifact": "static-market-US"},
+        {"run": "222", "artifact": "static-market-US"},
+    ]
+    manifest = json.loads(
+        (fallback_dir / "static-market-US" / "markets" / "us" / "manifest.market.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert manifest["entry"]["rs_formula_version"] == "legacy-linear-v1"
 
 
 def test_static_site_fallback_downloader_skips_incompatible_schema_and_keeps_searching(tmp_path) -> None:

--- a/backend/tests/unit/test_static_site_workflow.py
+++ b/backend/tests/unit/test_static_site_workflow.py
@@ -115,7 +115,7 @@ def test_static_site_daily_price_seed_allows_stale_bootstrap() -> None:
     assert "--allow-stale" in seed_step
 
 
-def test_static_site_market_export_skips_artifact_steps_for_closed_market() -> None:
+def test_static_site_market_export_preserves_price_bundle_after_soft_skip() -> None:
     build_market_job = _build_market_job()
     export_step = build_market_job.split("      - name: Export market static data bundle\n", 1)[1].split(
         "\n      - name: Build daily price bundle",
@@ -139,8 +139,10 @@ def test_static_site_market_export_skips_artifact_steps_for_closed_market() -> N
     assert 'if [ "$status" -eq 78 ]; then' in export_step
     assert "has_artifact=false" in export_step
     assert "has_artifact=true" in export_step
-    assert "steps.export-market.outputs.has_artifact == 'true'" in build_price_step
-    assert "steps.export-market.outputs.has_artifact == 'true'" in upload_price_step
+    assert "has_price_bundle=false" in export_step
+    assert "has_price_bundle=true" in export_step
+    assert "steps.export-market.outputs.has_price_bundle == 'true'" in build_price_step
+    assert "steps.export-market.outputs.has_price_bundle == 'true'" in upload_price_step
     assert "steps.export-market.outputs.has_artifact == 'true'" in upload_market_step
 
 


### PR DESCRIPTION
## Summary
- Retry static Market RS at the latest benchmark-backed session when the requested completed session is missing from benchmark data, instead of immediately suppressing the market artifact.
- Allow historical breadth warmup undercoverage when the current breadth row is covered, so exposure can publish with the available static price history.
- Upload daily price bundles after export exit 79 so successful OHLCV refreshes are not discarded when the market artifact is withheld.

## Root Cause
The latest static-site run succeeded overall, but US/CA/DE did not upload current `static-market-*` artifacts. The combine job then published last-known-good fallbacks, leaving `/groups` at `2026-07-31`. US/DE were blocked by `benchmark_adjusted_anchor_missing` for `2026-08-03` while benchmark candidates only reported `2026-07-31`; CA was blocked by cache-only breadth history undercoverage on old warmup dates even though current-session coverage was usable. Because the workflow skipped daily price bundle upload when artifacts were withheld, the successful price refreshes from failed market exports were also thrown away.

## Validation
- `./venv/bin/pytest tests/unit/test_export_static_site_refresh.py tests/unit/test_export_static_site_script.py tests/unit/test_export_static_site_no_current_artifacts.py tests/unit/test_static_market_publish_policy.py tests/unit/test_static_site_workflow.py`
- `./venv/bin/python -m compileall app/scripts/export_static_site.py app/scripts/export_static_market_artifact.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Daily price bundles are generated and uploaded when current-session coverage is sufficient, even during eligible soft skips.
  - Price data remains available during diagnostic-only refreshes and eligible soft skips.
  - Static-site refreshes fall back to the latest session with valid benchmark data when needed.
  - Historical breadth coverage is evaluated more accurately.
  - Newer valid fallback market artifacts replace outdated data when appropriate.
  - Rolling RRG history is published only when its data is reliable.
  - Fallback downloads preserve the newest compatible market data and recover safely from failed updates.
  - Formula compatibility is validated when selecting current and fallback artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->