### PR TITLE
Fix Docker market calendar packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,9 @@
 dist
 build
 backend/venv
-backend/data
+backend/data/*
+!backend/data/market_calendars/
+!backend/data/market_calendars/**
 backend/.pytest_cache
 backend/.mypy_cache
 backend/.ruff_cache

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,8 +35,10 @@ RUN groupadd -r -g 1000 stockscanner && \
 ENV HOME=/app/data
 ENV XDG_CACHE_HOME=/app/data/.cache
 ENV PATH=/opt/venv/bin:$PATH
+ENV MARKET_CALENDAR_DATA_ROOT=/opt/stockscanner/market-calendars
 
 COPY --from=builder /opt/venv /opt/venv
+COPY --chown=stockscanner:stockscanner backend/data/market_calendars/ /opt/stockscanner/market-calendars/
 COPY --chown=stockscanner:stockscanner backend/ .
 
 RUN mkdir -p /app/data/.cache && \

--- a/backend/app/services/market_calendar_service.py
+++ b/backend/app/services/market_calendar_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Iterable, Mapping
 from datetime import date, datetime, timedelta
 from importlib import metadata
@@ -10,16 +11,16 @@ from zoneinfo import ZoneInfo
 
 import pandas as pd
 
+from ..domain.markets.calendar_coverage import (
+    AnnualCalendarManifest,
+    CalendarCoverageRegistry,
+    MarketCalendarCoverage,
+)
 from ..domain.markets.calendar_policy import (
     DEFAULT_CALENDAR_SESSION_OVERRIDES,
     REGULAR_MARKET_CLOSE_TIMES,
     CalendarProvider,
     CalendarSessionOverride,
-)
-from ..domain.markets.calendar_coverage import (
-    AnnualCalendarManifest,
-    CalendarCoverageRegistry,
-    MarketCalendarCoverage,
 )
 from ..domain.markets.catalog import (
     MarketCatalog,
@@ -63,7 +64,7 @@ class MarketCalendarService:
             calendar_coverage_registry
             if calendar_coverage_registry is not None
             else CalendarCoverageRegistry.load(
-                self.CALENDAR_DATA_ROOT,
+                self._configured_calendar_data_root(),
                 market_catalog=self._market_catalog,
             )
         )
@@ -89,6 +90,10 @@ class MarketCalendarService:
             tuple[CalendarProvider, str, str],
             MarketCalendarAdapter,
         ] = {}
+
+    def _configured_calendar_data_root(self) -> Path:
+        configured = os.getenv("MARKET_CALENDAR_DATA_ROOT")
+        return Path(configured).expanduser() if configured else self.CALENDAR_DATA_ROOT
 
     def normalize_market(self, market: str | None) -> str:
         try:

--- a/backend/tests/unit/test_market_calendar_service.py
+++ b/backend/tests/unit/test_market_calendar_service.py
@@ -4,15 +4,15 @@ from types import MappingProxyType
 import pandas as pd
 import pytest
 
-from app.domain.markets.calendar_policy import (
-    CalendarProvider,
-    CalendarSessionOverride,
-)
 from app.domain.markets.calendar_coverage import (
     AnnualCalendarManifest,
     CalendarCoverageRegistry,
     CalendarSource,
     MarketCalendarCoverage,
+)
+from app.domain.markets.calendar_policy import (
+    CalendarProvider,
+    CalendarSessionOverride,
 )
 from app.domain.markets.catalog import get_market_catalog
 from app.services import market_calendar_service as calendar_module
@@ -309,6 +309,23 @@ def test_market_calendar_service_supports_mic_specific_fact_lookup():
     )
     assert service.market_timezone("IN", mic="XBOM").key == bombay_facts.timezone
     assert service.default_currency("IN", mic="XBOM") == bombay_facts.default_currency
+
+
+def test_calendar_data_root_env_overrides_default(monkeypatch, tmp_path):
+    repository_calendar_root = MarketCalendarService.CALENDAR_DATA_ROOT
+    monkeypatch.setattr(
+        MarketCalendarService,
+        "CALENDAR_DATA_ROOT",
+        tmp_path / "missing-default",
+    )
+    monkeypatch.setenv(
+        "MARKET_CALENDAR_DATA_ROOT",
+        str(repository_calendar_root),
+    )
+
+    service = MarketCalendarService()
+
+    assert service.is_trading_day("US", date(2026, 1, 2)) is True
 
 
 def test_last_completed_trading_day_before_close_returns_previous_session():


### PR DESCRIPTION
## Summary

- package the checked-in market calendar manifests into the backend image
- store them outside `/app/data` so the Docker bind mount cannot hide them
- allow `MARKET_CALENDAR_DATA_ROOT` to configure the manifest location while preserving the existing local default

## Root cause

The Docker build excluded `backend/data`, and Compose mounts `./data` over `/app/data`. As a result, the backend container could not read `/app/data/market_calendars/index.json` during universe refresh.

## Impact

Fresh Docker deployments can load the verified market calendar data without requiring a host-side calendar copy. Existing non-Docker behavior remains backward compatible.

## Validation

- `56` focused calendar tests passed
- Ruff passed for the changed Python files
- `git diff --check` passed
- backend image built successfully
- container smoke test passed with the production-style `/app/data` bind mount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market calendar data now loads correctly from a configurable location in deployed environments.
  * Added support for packaging required market calendar files in the runtime image.
  * Preserved the default calendar data location when no custom location is configured.

* **Tests**
  * Added coverage confirming that the custom market calendar data location takes precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->