### PR TITLE
Use market-calibrated local thresholds for breadth

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -15,7 +15,7 @@ Stock Scanner v1.5.0 delivers a shared revision-2 market-breadth engine, balance
 ### Relative strength and group analytics
 
 - Standardizes balanced market relative strength across live and static workflows and activates it correctly during fresh bootstrap.
-- Hydrates benchmark anchors and RRG history before validation, preventing empty or incomplete first-run relative-strength views.
+- Hydrates benchmark anchors and RRG history before validation, preventing empty or incomplete first-run bootstrap relative-strength views.
 - Repairs static and live group-ranking history, backfill ordering, point-in-time universes, and RRG startup behavior.
 - Adds short-horizon group relative-strength columns and populates live group history and RRG data during bootstrap.
 

--- a/backend/app/domain/bootstrap/plan.py
+++ b/backend/app/domain/bootstrap/plan.py
@@ -91,6 +91,7 @@ def _build_market_plan(
     supports_group_rankings = (
         get_market_catalog().get(market).capabilities.group_rankings
     )
+    supports_breadth = get_market_catalog().get(market).capabilities.breadth
     stages = [
         _stage(
             key="universe",
@@ -182,6 +183,13 @@ def _build_market_plan(
             ),
         ]
     )
+
+    if not supports_breadth:
+        stages = [
+            stage
+            for stage in stages
+            if stage.key not in {"breadth", "exposure"}
+        ]
 
     if supports_group_rankings:
         stages.append(

--- a/backend/app/models/market_breadth.py
+++ b/backend/app/models/market_breadth.py
@@ -43,7 +43,7 @@ class MarketBreadth(Base):
     stocks_up_13pct_34days = Column(Integer, default=0, nullable=False)
     stocks_down_13pct_34days = Column(Integer, default=0, nullable=False)
 
-    # Broad-universe context metrics (revision 2)
+    # Broad-universe context metrics
     advancing_count = Column(Integer, nullable=True)
     declining_count = Column(Integer, nullable=True)
     unchanged_count = Column(Integer, nullable=True)
@@ -53,7 +53,7 @@ class MarketBreadth(Base):
     t2108_pct = Column(Float, nullable=True)
     atr_10x_extension_count = Column(Integer, nullable=True)
 
-    # Explicit metric-family denominators (revision 2)
+    # Explicit metric-family denominators
     broad_universe_count = Column(Integer, nullable=True)
     advance_decline_eligible_count = Column(Integer, nullable=True)
     stockbee_daily_eligible_count = Column(Integer, nullable=True)
@@ -65,7 +65,7 @@ class MarketBreadth(Base):
     atr_extension_eligible_count = Column(Integer, nullable=True)
 
     # Metadata
-    # Deprecated compatibility alias; revision-2 writers set this equal to
+    # Deprecated compatibility alias; current writers set this equal to
     # broad_universe_count.
     total_stocks_scanned = Column(Integer, default=0, nullable=False)
     eligibility_signature = Column(String(64), nullable=True)

--- a/backend/app/schemas/breadth.py
+++ b/backend/app/schemas/breadth.py
@@ -62,7 +62,10 @@ class BreadthResponse(BaseModel):
     )
     eligibility_signature: Optional[str] = Field(None, description="Broad-universe signature")
     stockbee_eligibility_signature: Optional[str] = Field(None, description="StockBee liquidity-universe signature")
-    calculation_revision: Optional[int] = Field(None, description="Internal stale-data guard; current value is 2")
+    calculation_revision: Optional[int] = Field(
+        None,
+        description="Internal stale-data guard; current value is 3",
+    )
     calculation_duration_seconds: Optional[float] = Field(None, description="Time taken to calculate")
 
     class Config:

--- a/backend/app/scripts/export_static_site.py
+++ b/backend/app/scripts/export_static_site.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, Mapping, Sequence
 from app.config import settings
 from app.database import SessionLocal
 from app.domain.markets import market_registry
+from app.domain.markets.catalog import get_market_catalog
 from app.domain.relative_strength import (
     BALANCED_RS_FORMULA_VERSION,
     LEGACY_RS_FORMULA_VERSION,
@@ -774,8 +775,22 @@ def _run_daily_refresh(
         }
         warnings.extend(market_rs_no_current_artifact_warnings.values())
 
+        supports_breadth_by_market = {
+            selected_market: get_market_catalog()
+            .get(selected_market)
+            .capabilities.breadth
+            for selected_market in selected_markets
+        }
         breadth_history: dict[str, Any] = {}
         for selected_market in selected_markets:
+            if not supports_breadth_by_market[selected_market]:
+                breadth_history[selected_market] = {
+                    "status": "skipped",
+                    "reason": "market_breadth_unsupported",
+                    "market": selected_market,
+                    "as_of_date": as_of_by_market[selected_market].isoformat(),
+                }
+                continue
             if (
                 market_rs_artifact_states[selected_market]
                 is StaticMarketRsArtifactState.NO_CURRENT_ARTIFACT
@@ -812,6 +827,14 @@ def _run_daily_refresh(
         market_exposure: dict[str, Any] = {}
         for selected_market in selected_markets:
             market_as_of = as_of_by_market[selected_market]
+            if not supports_breadth_by_market[selected_market]:
+                market_exposure[selected_market] = {
+                    "status": "skipped",
+                    "reason": "market_breadth_unsupported",
+                    "market": selected_market,
+                    "date": market_as_of.isoformat(),
+                }
+                continue
             if (
                 market_rs_artifact_states[selected_market]
                 is StaticMarketRsArtifactState.NO_CURRENT_ARTIFACT

--- a/backend/app/scripts/rebuild_market_breadth.py
+++ b/backend/app/scripts/rebuild_market_breadth.py
@@ -1,4 +1,4 @@
-"""Operator CLI for the revision-2 market breadth shadow rebuild."""
+"""Operator CLI for the current market breadth shadow rebuild."""
 
 from __future__ import annotations
 

--- a/backend/app/services/breadth/__init__.py
+++ b/backend/app/services/breadth/__init__.py
@@ -1,5 +1,6 @@
 """Canonical market-breadth calculation primitives."""
 
+from .market_policy import BREADTH_MARKET_POLICIES, get_breadth_market_policy
 from .types import (
     CURRENT_BREADTH_CALCULATION_REVISION,
     BreadthDailyCount,
@@ -7,6 +8,7 @@ from .types import (
     BreadthEligibilityCounts,
     BreadthFormulaPolicy,
     BreadthIndicatorValues,
+    BreadthMarketPolicy,
     BreadthRatios,
     BreadthUniverseMember,
     BreadthUniverseSnapshot,
@@ -15,15 +17,18 @@ from .types import (
 )
 
 __all__ = [
+    "BREADTH_MARKET_POLICIES",
     "CURRENT_BREADTH_CALCULATION_REVISION",
     "BreadthDailyCount",
     "BreadthDailyResult",
     "BreadthEligibilityCounts",
     "BreadthFormulaPolicy",
     "BreadthIndicatorValues",
+    "BreadthMarketPolicy",
     "BreadthRatios",
     "BreadthUniverseMember",
     "BreadthUniverseSnapshot",
     "SymbolBreadthSignals",
     "SymbolMetricEligibility",
+    "get_breadth_market_policy",
 ]

--- a/backend/app/services/breadth/engine.py
+++ b/backend/app/services/breadth/engine.py
@@ -16,11 +16,13 @@ from app.services.point_in_time_universe_service import (
 from .formulas import prepare_feature_frame, signal_flags_at, validate_price_frame
 from .ratios import calculate_inclusive_ratios
 from .types import (
+    CURRENT_BREADTH_CALCULATION_REVISION,
     BreadthDailyCount,
     BreadthDailyResult,
     BreadthEligibilityCounts,
     BreadthFormulaPolicy,
     BreadthIndicatorValues,
+    BreadthMarketPolicy,
     BreadthUniverseSnapshot,
     SymbolBreadthSignals,
 )
@@ -35,7 +37,7 @@ class BreadthEngineRequest:
     dates: tuple[date, ...]
     universes_by_date: Mapping[date, BreadthUniverseSnapshot]
     prices_by_symbol: Mapping[str, pd.DataFrame]
-    fx_by_currency: Mapping[str, pd.Series]
+    market_policy: BreadthMarketPolicy
     seed_counts: tuple[BreadthDailyCount, ...] = ()
     policy: BreadthFormulaPolicy = field(default_factory=BreadthFormulaPolicy)
 
@@ -44,6 +46,13 @@ class BreadthEngine:
     def calculate(
         self, request: BreadthEngineRequest
     ) -> Mapping[date, BreadthDailyResult]:
+        market = request.market.strip().upper()
+        if request.market_policy.market != market:
+            raise ValueError(
+                f"Breadth policy market {request.market_policy.market} "
+                f"does not match request market {market}"
+            )
+
         dates = tuple(request.dates)
         if dates != tuple(sorted(set(dates))):
             raise ValueError("Breadth calculation dates must be ordered and unique")
@@ -68,7 +77,7 @@ class BreadthEngine:
                     )
 
         features_by_symbol: dict[str, pd.DataFrame] = {}
-        for symbol, currency in currencies_by_symbol.items():
+        for symbol in currencies_by_symbol:
             prices = request.prices_by_symbol.get(symbol)
             if prices is None or prices.empty:
                 continue
@@ -79,35 +88,8 @@ class BreadthEngine:
                     "Skipping malformed breadth prices for %s: %s", symbol, exc
                 )
                 continue
-            fx = request.fx_by_currency.get(currency)
-            if fx is None:
-                if currency == "USD":
-                    fx = pd.Series(1.0, index=prices.index)
-                else:
-                    raise ValueError(f"Missing historical FX series for {currency}")
-            rates_by_date = {
-                pd.Timestamp(value).date(): float(rate)
-                for value, rate in fx.items()
-            }
-            aligned_fx = pd.Series(
-                (
-                    rates_by_date.get(pd.Timestamp(value).date())
-                    for value in prices.index
-                ),
-                index=prices.index,
-                dtype=float,
-            )
-            if aligned_fx.isna().any():
-                missing_date = pd.Timestamp(
-                    aligned_fx[aligned_fx.isna()].index[0]
-                ).date()
-                raise ValueError(
-                    f"Missing historical {currency}->USD FX for "
-                    f"{missing_date.isoformat()}"
-                )
             features_by_symbol[symbol] = prepare_feature_frame(
                 prices,
-                aligned_fx,
                 atr_period=request.policy.atr_period,
             )
 
@@ -124,6 +106,10 @@ class BreadthEngine:
                     features,
                     calculation_date,
                     request.policy,
+                    request.market_policy,
+                    stockbee_currency_matches=(
+                        member.currency.upper() == request.market_policy.currency
+                    ),
                 )
 
             signals = tuple(signals_by_symbol.values())
@@ -188,8 +174,13 @@ class BreadthEngine:
                 raise AssertionError("Advance/decline counts do not reconcile")
             if not 0 <= values.t2108_count <= eligibility.t2108_eligible_count:
                 raise AssertionError("T2108 count exceeds its eligible denominator")
-            if request.policy.calculation_revision != 2:
-                raise AssertionError("Canonical breadth engine must produce revision 2")
+            if (
+                request.policy.calculation_revision
+                != CURRENT_BREADTH_CALCULATION_REVISION
+            ):
+                raise AssertionError(
+                    "Canonical breadth engine must produce the current revision"
+                )
 
             stockbee_symbols = tuple(
                 sorted(
@@ -199,7 +190,7 @@ class BreadthEngine:
                 )
             )
             result = BreadthDailyResult(
-                market=request.market.upper(),
+                market=market,
                 calculation_date=calculation_date,
                 values=values,
                 eligibility=eligibility,
@@ -226,7 +217,7 @@ class BreadthEngine:
         ratios_by_date = calculate_inclusive_ratios(
             daily_counts,
             request.seed_counts,
-            market=request.market.upper(),
+            market=market,
             calculation_revision=request.policy.calculation_revision,
         )
         return {

--- a/backend/app/services/breadth/formulas.py
+++ b/backend/app/services/breadth/formulas.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from .types import (
     BreadthFormulaPolicy,
+    BreadthMarketPolicy,
     SymbolBreadthSignals,
     SymbolMetricEligibility,
 )
@@ -86,11 +87,10 @@ def _wilder_average(values: pd.Series, period: int) -> pd.Series:
 
 def prepare_feature_frame(
     prices: pd.DataFrame,
-    fx_to_usd: pd.Series,
     *,
     atr_period: int = 14,
 ) -> pd.DataFrame:
-    """Prepare adjusted signal inputs while retaining raw USD liquidity inputs."""
+    """Prepare adjusted signals and raw local-market liquidity inputs."""
 
     validate_price_frame(prices)
 
@@ -99,9 +99,6 @@ def prepare_feature_frame(
     frame = frame.sort_index()
     frame = frame.apply(pd.to_numeric, errors="coerce")
 
-    fx = pd.to_numeric(fx_to_usd, errors="coerce").copy()
-    fx.index = _normalized_session_index(fx.index)
-    fx = fx.reindex(frame.index)
     raw_close = frame["Close"].where(frame["Close"] > 0)
     adjusted_close = frame["Adj Close"].where(frame["Adj Close"] > 0)
     adjustment_factor = adjusted_close / raw_close
@@ -116,18 +113,17 @@ def prepare_feature_frame(
     result["adjusted_low"] = frame["Low"] * adjustment_factor
     result["adjusted_close"] = adjusted_close
     result["volume"] = frame["Volume"].where(frame["Volume"] >= 0)
-    result["fx_to_usd"] = fx.where(fx > 0)
-    result["raw_close_usd"] = raw_close * result["fx_to_usd"]
-    result["dollar_volume_usd"] = result["raw_close_usd"] * result["volume"]
-    result["adtv20_usd"] = (
-        result["dollar_volume_usd"].rolling(20, min_periods=20).mean()
+    result["raw_close_local"] = raw_close
+    result["traded_value_local"] = result["raw_close_local"] * result["volume"]
+    result["adtv20_local"] = (
+        result["traded_value_local"].rolling(20, min_periods=20).mean()
     )
 
     result["prior_adjusted_close"] = adjusted_close.shift(1)
     result["prior_volume"] = result["volume"].shift(1)
     result["daily_return"] = adjusted_close / result["prior_adjusted_close"] - 1.0
     result["adjusted_close_20"] = adjusted_close.shift(20)
-    result["raw_close_usd_20"] = result["raw_close_usd"].shift(20)
+    result["raw_close_local_20"] = result["raw_close_local"].shift(20)
     result["month_return"] = adjusted_close / result["adjusted_close_20"] - 1.0
 
     result["low_34"] = adjusted_close.rolling(34, min_periods=34).min()
@@ -190,18 +186,26 @@ def signal_flags_at(
     feature_frame: pd.DataFrame,
     calculation_date: date,
     policy: BreadthFormulaPolicy,
+    market_policy: BreadthMarketPolicy,
+    *,
+    stockbee_currency_matches: bool = True,
 ) -> SymbolBreadthSignals:
     row = _row_at(feature_frame, calculation_date)
     if row is None:
         return SymbolBreadthSignals(eligibility=SymbolMetricEligibility())
 
     advance_decline = _finite(row.adjusted_close, row.prior_adjusted_close)
-    liquid = _finite(row.adtv20_usd) and float(row.adtv20_usd) >= policy.min_adtv_usd
+    liquid = (
+        stockbee_currency_matches
+        and _finite(row.adtv20_local)
+        and float(row.adtv20_local) >= market_policy.min_adtv_local
+    )
     daily = advance_decline and liquid and _finite(row.volume, row.prior_volume)
     month = (
         liquid
-        and _finite(row.adjusted_close, row.adjusted_close_20, row.raw_close_usd_20)
-        and float(row.raw_close_usd_20) >= policy.min_month_reference_price_usd
+        and _finite(row.adjusted_close, row.adjusted_close_20, row.raw_close_local_20)
+        and float(row.raw_close_local_20)
+        >= market_policy.min_month_reference_price_local
     )
     day_34 = liquid and _finite(row.adjusted_close, row.low_34, row.high_34)
     quarter = liquid and _finite(row.adjusted_close, row.low_65, row.high_65)
@@ -230,7 +234,7 @@ def signal_flags_at(
 
     daily_volume_filter = (
         daily
-        and float(row.volume) >= policy.min_daily_volume
+        and float(row.volume) >= market_policy.min_daily_volume
         and float(row.volume) > float(row.prior_volume)
     )
     daily_return = float(row.daily_return) if _finite(row.daily_return) else np.nan

--- a/backend/app/services/breadth/market_policy.py
+++ b/backend/app/services/breadth/market_policy.py
@@ -1,0 +1,31 @@
+"""Fixed local-market eligibility policies for StockBee breadth signals."""
+
+from __future__ import annotations
+
+from .types import BreadthMarketPolicy
+
+
+BREADTH_MARKET_POLICIES: dict[str, BreadthMarketPolicy] = {
+    "US": BreadthMarketPolicy("US", "USD", 250_000, 100_000, 5.00),
+    "CA": BreadthMarketPolicy("CA", "CAD", 5_000, 5_000, 0.30),
+    "DE": BreadthMarketPolicy("DE", "EUR", 5_000, 300, 8.00),
+    "HK": BreadthMarketPolicy("HK", "HKD", 20_000, 150_000, 0.20),
+    "IN": BreadthMarketPolicy("IN", "INR", 100_000, 15_000, 15.00),
+    "JP": BreadthMarketPolicy("JP", "JPY", 8_000_000, 50_000, 500.00),
+    "KR": BreadthMarketPolicy("KR", "KRW", 100_000_000, 50_000, 2_000.00),
+    "TW": BreadthMarketPolicy("TW", "TWD", 3_500_000, 400_000, 20.00),
+    "CN": BreadthMarketPolicy("CN", "CNY", 50_000_000, 10_000_000, 5.00),
+}
+
+
+def get_breadth_market_policy(market: str) -> BreadthMarketPolicy:
+    """Return the canonical breadth policy or fail before calculation starts."""
+
+    market_code = str(market or "").strip().upper()
+    try:
+        return BREADTH_MARKET_POLICIES[market_code]
+    except KeyError as exc:
+        rendered_market = market_code or "<missing>"
+        raise ValueError(
+            f"Breadth is not supported for market {rendered_market}"
+        ) from exc

--- a/backend/app/services/breadth/ratios.py
+++ b/backend/app/services/breadth/ratios.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from datetime import date
 
-from .types import BreadthDailyCount, BreadthRatios
+from .types import (
+    CURRENT_BREADTH_CALCULATION_REVISION,
+    BreadthDailyCount,
+    BreadthRatios,
+)
 
 
 class IncompatibleBreadthSeedError(ValueError):
@@ -46,7 +50,7 @@ def calculate_inclusive_ratios(
     seed_counts: Iterable[BreadthDailyCount] = (),
     *,
     market: str | None = None,
-    calculation_revision: int = 2,
+    calculation_revision: int = CURRENT_BREADTH_CALCULATION_REVISION,
 ) -> dict[date, BreadthRatios]:
     current = tuple(sorted(counts, key=lambda item: item.date))
     seeds = tuple(sorted(seed_counts, key=lambda item: item.date))

--- a/backend/app/services/breadth/rebuild.py
+++ b/backend/app/services/breadth/rebuild.py
@@ -1,4 +1,4 @@
-"""Shadow rebuild, validation, and atomic cutover for breadth revision 2."""
+"""Shadow rebuild, validation, and atomic cutover for the current breadth revision."""
 
 from __future__ import annotations
 
@@ -170,7 +170,10 @@ class BreadthRebuildService:
         inserted = 0
         for result in results:
             if result.calculation_revision != CURRENT_BREADTH_CALCULATION_REVISION:
-                raise ValueError("Staging accepts only canonical revision-2 results")
+                raise ValueError(
+                    "Staging accepts only results from the current canonical "
+                    f"breadth revision ({CURRENT_BREADTH_CALCULATION_REVISION})"
+                )
             values = result.to_record_mapping()
             values["calculation_duration_seconds"] = (
                 duration_seconds_by_date.get(result.calculation_date)

--- a/backend/app/services/breadth/rebuild.py
+++ b/backend/app/services/breadth/rebuild.py
@@ -462,8 +462,9 @@ class BreadthRebuildService:
             "calculation_revision": CURRENT_BREADTH_CALCULATION_REVISION,
             "formula_contract": {
                 "signals": "adjusted_ohlc",
-                "liquidity": "raw_close_usd_x_volume_adtv20",
-                "fx": "exact_or_prior_7_calendar_days_never_future",
+                "liquidity": "raw_close_local_x_volume_adtv20",
+                "market_policy": "fixed_market_calibrated_thresholds",
+                "currency_mismatch": "stockbee_ineligible_context_preserved",
                 "ratios": "today_inclusive",
             },
         }
@@ -512,7 +513,10 @@ class BreadthRebuildService:
             )
             if inserted != report["row_count"] or wrong_revision:
                 raise RuntimeError("Breadth activation verification failed")
-        return {"activated": inserted, "calculation_revision": 2}
+        return {
+            "activated": inserted,
+            "calculation_revision": CURRENT_BREADTH_CALCULATION_REVISION,
+        }
 
     def cleanup(self) -> None:
         self.db.execute(text(f"DROP TABLE IF EXISTS {STAGING_TABLE}"))

--- a/backend/app/services/breadth/types.py
+++ b/backend/app/services/breadth/types.py
@@ -6,18 +6,23 @@ from dataclasses import asdict, dataclass
 from datetime import date
 from typing import Any
 
-CURRENT_BREADTH_CALCULATION_REVISION = 2
+CURRENT_BREADTH_CALCULATION_REVISION = 3
+
+
+@dataclass(frozen=True, slots=True)
+class BreadthMarketPolicy:
+    market: str
+    currency: str
+    min_adtv_local: float
+    min_daily_volume: int
+    min_month_reference_price_local: float
 
 
 @dataclass(frozen=True, slots=True)
 class BreadthFormulaPolicy:
     calculation_revision: int = CURRENT_BREADTH_CALCULATION_REVISION
-    min_adtv_usd: float = 250_000.0
-    min_daily_volume: int = 100_000
-    min_month_reference_price_usd: float = 5.0
     atr_period: int = 14
     atr_extension_threshold: float = 10.0
-    fx_max_age_days: int = 7
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/app/services/breadth/universe.py
+++ b/backend/app/services/breadth/universe.py
@@ -1,4 +1,4 @@
-"""Point-in-time universe and historical-FX adapters for breadth calculations."""
+"""Point-in-time universe adapters for breadth calculations."""
 
 from __future__ import annotations
 
@@ -6,7 +6,6 @@ import hashlib
 from collections.abc import Collection, Iterable, Mapping
 from datetime import date
 
-import numpy as np
 import pandas as pd
 
 from app.models.stock_universe import StockUniverse
@@ -34,51 +33,6 @@ def breadth_eligibility_signature(symbols: Iterable[str]) -> str:
         )
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
-
-
-class MissingHistoricalFXError(RuntimeError):
-    def __init__(self, currency: str, calculation_date: date) -> None:
-        self.currency = currency
-        self.calculation_date = calculation_date
-        super().__init__(
-            f"Missing historical {currency}->USD FX rate for "
-            f"{calculation_date.isoformat()}"
-        )
-
-
-def resolve_historical_fx_series(
-    currency: str,
-    calculation_dates: Collection[date],
-    observations: Mapping[date, float],
-    *,
-    max_age_days: int,
-) -> pd.Series:
-    normalized_currency = currency.strip().upper()
-    requested = tuple(calculation_dates)
-    index = pd.DatetimeIndex(requested)
-    if normalized_currency == "USD":
-        return pd.Series(1.0, index=index, dtype=float)
-
-    valid_observations = sorted(
-        (
-            observation_date,
-            float(rate),
-        )
-        for observation_date, rate in observations.items()
-        if rate is not None and np.isfinite(float(rate)) and float(rate) > 0
-    )
-
-    resolved: list[float] = []
-    for requested_date in requested:
-        prior = [item for item in valid_observations if item[0] <= requested_date]
-        if not prior:
-            raise MissingHistoricalFXError(normalized_currency, requested_date)
-        observation_date, rate = prior[-1]
-        if (requested_date - observation_date).days > max_age_days:
-            raise MissingHistoricalFXError(normalized_currency, requested_date)
-        resolved.append(rate)
-
-    return pd.Series(resolved, index=index, dtype=float)
 
 
 def _snapshot_members(db, point_in_time) -> tuple[BreadthUniverseMember, ...]:

--- a/backend/app/services/breadth/universe.py
+++ b/backend/app/services/breadth/universe.py
@@ -15,6 +15,7 @@ from app.services.point_in_time_universe_service import PointInTimeUniverseServi
 from .formulas import signal_flags_at
 from .types import (
     BreadthFormulaPolicy,
+    BreadthMarketPolicy,
     BreadthUniverseMember,
     BreadthUniverseSnapshot,
     SymbolMetricEligibility,
@@ -147,19 +148,29 @@ def classify_metric_eligibility(
     member: BreadthUniverseMember,
     features: pd.DataFrame,
     policy: BreadthFormulaPolicy,
+    market_policy: BreadthMarketPolicy,
     *,
     calculation_date: date | None = None,
 ) -> SymbolMetricEligibility:
     if not member.is_common_stock or features.empty:
         return SymbolMetricEligibility()
     target_date = calculation_date or pd.Timestamp(features.index[-1]).date()
-    return signal_flags_at(features, target_date, policy).eligibility
+    return signal_flags_at(
+        features,
+        target_date,
+        policy,
+        market_policy,
+        stockbee_currency_matches=(
+            member.currency.upper() == market_policy.currency
+        ),
+    ).eligibility
 
 
 def stockbee_eligible_symbols(
     snapshot: BreadthUniverseSnapshot,
     features_by_symbol: Mapping[str, pd.DataFrame],
     policy: BreadthFormulaPolicy,
+    market_policy: BreadthMarketPolicy,
 ) -> tuple[str, ...]:
     eligible: list[str] = []
     for member in snapshot.members:
@@ -170,6 +181,7 @@ def stockbee_eligible_symbols(
             member,
             features,
             policy,
+            market_policy,
             calculation_date=snapshot.calculation_date,
         )
         if metric_eligibility.stockbee_daily:
@@ -181,11 +193,17 @@ def stockbee_eligibility_signature(
     snapshot: BreadthUniverseSnapshot,
     features_by_symbol: Mapping[str, pd.DataFrame],
     policy: BreadthFormulaPolicy,
+    market_policy: BreadthMarketPolicy,
 ) -> str:
     from app.services.point_in_time_universe_service import (
         hash_point_in_time_universe_symbols,
     )
 
     return hash_point_in_time_universe_symbols(
-        stockbee_eligible_symbols(snapshot, features_by_symbol, policy)
+        stockbee_eligible_symbols(
+            snapshot,
+            features_by_symbol,
+            policy,
+            market_policy,
+        )
     )

--- a/backend/app/services/breadth_attribution_service.py
+++ b/backend/app/services/breadth_attribution_service.py
@@ -99,9 +99,8 @@ class BreadthAttributionService:
             history = price_data.get(symbol)
             if history is None or getattr(history, "empty", True):
                 continue
-            currency = str(
-                (currencies_by_symbol or {}).get(symbol) or market_policy.currency
-            ).upper()
+            raw_currency = (currencies_by_symbol or {}).get(symbol)
+            currency = str(raw_currency).upper() if raw_currency else None
             try:
                 features = prepare_feature_frame(
                     history,
@@ -129,7 +128,9 @@ class BreadthAttributionService:
                     d,
                     formula_policy,
                     market_policy,
-                    stockbee_currency_matches=(currency == market_policy.currency),
+                    stockbee_currency_matches=(
+                        currency is not None and currency == market_policy.currency
+                    ),
                 )
                 direction = (
                     "up"

--- a/backend/app/services/breadth_attribution_service.py
+++ b/backend/app/services/breadth_attribution_service.py
@@ -16,6 +16,7 @@ from typing import Any
 import pandas as pd
 
 from app.services.breadth.formulas import prepare_feature_frame, signal_flags_at
+from app.services.breadth.market_policy import get_breadth_market_policy
 from app.services.breadth.types import BreadthFormulaPolicy
 
 logger = logging.getLogger(__name__)
@@ -33,8 +34,8 @@ class BreadthAttributionService:
         symbols_meta: Iterable[Mapping[str, Any]],
         price_data: Mapping[str, pd.DataFrame | None],
         target_dates: Iterable[date],
+        market: str = "US",
         currencies_by_symbol: Mapping[str, str] | None = None,
-        fx_by_currency: Mapping[str, pd.Series] | None = None,
         symbols_by_date: Mapping[date, Iterable[str]] | None = None,
         policy: BreadthFormulaPolicy | None = None,
     ) -> list[dict[str, Any]]:
@@ -67,6 +68,7 @@ class BreadthAttributionService:
                 ],
             }
         """
+        market_policy = get_breadth_market_policy(market)
         meta_by_symbol: dict[str, Mapping[str, Any]] = {}
         for entry in symbols_meta:
             if not entry:
@@ -97,36 +99,12 @@ class BreadthAttributionService:
             history = price_data.get(symbol)
             if history is None or getattr(history, "empty", True):
                 continue
-            currency = str((currencies_by_symbol or {}).get(symbol) or "USD").upper()
-            fx = (fx_by_currency or {}).get(currency)
-            if fx is None:
-                if currency != "USD":
-                    raise ValueError(f"Missing historical FX series for {currency}")
-                fx = pd.Series(1.0, index=history.index)
-            rates_by_date = {
-                pd.Timestamp(value).date(): float(rate)
-                for value, rate in fx.items()
-            }
-            aligned_fx = pd.Series(
-                (
-                    rates_by_date.get(pd.Timestamp(value).date())
-                    for value in history.index
-                ),
-                index=history.index,
-                dtype=float,
-            )
-            if aligned_fx.isna().any():
-                missing_date = pd.Timestamp(
-                    aligned_fx[aligned_fx.isna()].index[0]
-                ).date()
-                raise ValueError(
-                    f"Missing historical {currency}->USD FX for "
-                    f"{missing_date.isoformat()}"
-                )
+            currency = str(
+                (currencies_by_symbol or {}).get(symbol) or market_policy.currency
+            ).upper()
             try:
                 features = prepare_feature_frame(
                     history,
-                    aligned_fx,
                     atr_period=formula_policy.atr_period,
                 )
             except ValueError as exc:
@@ -146,7 +124,13 @@ class BreadthAttributionService:
                     and symbol not in normalized_symbols_by_date.get(d, frozenset())
                 ):
                     continue
-                flags = signal_flags_at(features, d, formula_policy)
+                flags = signal_flags_at(
+                    features,
+                    d,
+                    formula_policy,
+                    market_policy,
+                    stockbee_currency_matches=(currency == market_policy.currency),
+                )
                 direction = (
                     "up"
                     if flags.up_4pct

--- a/backend/app/services/breadth_backfill.py
+++ b/backend/app/services/breadth_backfill.py
@@ -22,7 +22,6 @@ from .breadth_coverage import (
     BreadthPriceCoverageAccumulator,
 )
 from .derived_data_execution_policy import DerivedDataExecutionPolicy
-from .fx_service import default_currency_for_market
 from .static_breadth_eligibility import static_breadth_eligibility_signature
 
 if TYPE_CHECKING:
@@ -208,7 +207,7 @@ class BreadthBackfillExecutor:
             currency_by_symbol = {
                 symbol: (
                     getattr(rows_by_symbol.get(symbol), "currency", None)
-                    or default_currency_for_market(calculator.market)
+                    or calculator.market_policy.currency
                 )
                 for symbol in target_symbols
             }
@@ -345,21 +344,13 @@ class BreadthBackfillExecutor:
             prices_by_symbol,
             tuple(processed_dates),
         )
-        all_members = tuple(
-            BreadthUniverseMember(symbol, currency_by_symbol[symbol])
-            for symbol in target_symbols
-        )
-        fx_by_currency = calculator._load_fx_for_prices(
-            all_members,
-            prices_by_symbol,
-        )
         canonical_by_date = calculator.engine.calculate(
             BreadthEngineRequest(
                 market=calculator.market,
                 dates=tuple(processed_dates),
                 universes_by_date=universes_by_date,
                 prices_by_symbol=prices_by_symbol,
-                fx_by_currency=fx_by_currency,
+                market_policy=calculator.market_policy,
                 seed_counts=calculator._load_ratio_context_counts(processed_dates),
             )
         )

--- a/backend/app/services/breadth_calculator_service.py
+++ b/backend/app/services/breadth_calculator_service.py
@@ -20,6 +20,7 @@ from .breadth.formulas import (
     prices_for_feature_window,
     validate_price_frame,
 )
+from .breadth.market_policy import get_breadth_market_policy
 from .breadth.persistence import BreadthPersistence
 from .breadth.types import (
     CURRENT_BREADTH_CALCULATION_REVISION,
@@ -27,7 +28,6 @@ from .breadth.types import (
     BreadthDailyResult,
     BreadthEligibilityCounts,
     BreadthIndicatorValues,
-    BreadthUniverseMember,
 )
 from .breadth.universe import build_breadth_universe_snapshots
 from .breadth_backfill import BreadthBackfillExecutor, BreadthBackfillPlan
@@ -42,7 +42,6 @@ from .derived_data_execution_policy import (
     DerivedDataExecutionPolicy,
     DerivedDataTargetKind,
 )
-from .fx_service import get_fx_service
 from .price_cache_service import PriceCacheService
 
 logger = logging.getLogger(__name__)
@@ -72,7 +71,6 @@ class BreadthCalculatorService:
         market: str | None = None,
         *,
         engine: BreadthEngine | None = None,
-        fx_service=None,
     ):
         """
         Initialize breadth calculator service.
@@ -83,8 +81,8 @@ class BreadthCalculatorService:
         self.db = db
         self.price_cache = price_cache
         self.market = (market or "US").upper()
+        self.market_policy = get_breadth_market_policy(self.market)
         self.engine = engine or BreadthEngine()
-        self.fx_service = fx_service or get_fx_service()
         self.persistence = BreadthPersistence(db)
 
     def calculate_daily_breadth(
@@ -158,7 +156,6 @@ class BreadthCalculatorService:
             prices_by_symbol,
             (calculation_date,),
         )
-        fx_by_currency = self._load_fx_for_prices(members, prices_by_symbol)
         seeds = self._load_ratio_seed_counts(calculation_date, limit=9)
         canonical = self.engine.calculate(
             BreadthEngineRequest(
@@ -166,7 +163,7 @@ class BreadthCalculatorService:
                 dates=(calculation_date,),
                 universes_by_date={calculation_date: snapshot},
                 prices_by_symbol=prices_by_symbol,
-                fx_by_currency=fx_by_currency,
+                market_policy=self.market_policy,
                 seed_counts=seeds,
             )
         )[calculation_date]
@@ -200,34 +197,6 @@ class BreadthCalculatorService:
         except (TypeError, ValueError):
             return False
         return math.isfinite(value) and value > 0
-
-    def _load_fx_for_prices(
-        self,
-        members: tuple[BreadthUniverseMember, ...],
-        prices_by_symbol: Mapping[str, pd.DataFrame],
-    ) -> Mapping[str, pd.Series]:
-        currency_by_symbol = {member.symbol: member.currency.upper() for member in members}
-        dates_by_currency: dict[str, set[date]] = {}
-        for symbol, history in prices_by_symbol.items():
-            currency = currency_by_symbol[symbol]
-            dates_by_currency.setdefault(currency, set()).update(
-                pd.Timestamp(value).date() for value in history.index
-            )
-        result: dict[str, pd.Series] = {}
-        for currency, required_dates in dates_by_currency.items():
-            if currency == "USD":
-                result[currency] = pd.Series(
-                    1.0,
-                    index=pd.DatetimeIndex(sorted(required_dates)),
-                )
-                continue
-            result.update(
-                self.fx_service.get_historical_usd_rates(
-                    (currency,),
-                    required_dates,
-                )
-            )
-        return result
 
     def _history_period_for_dates(
         self,

--- a/backend/app/services/fx_service.py
+++ b/backend/app/services/fx_service.py
@@ -384,7 +384,7 @@ class FXService:
         max_age_days: int = 7,
     ) -> Mapping[str, pd.Series]:
         """Resolve reproducible backward-only FX rates without live fallbacks."""
-        from .breadth.universe import resolve_historical_fx_series
+        from .historical_fx import resolve_historical_fx_series
 
         requested = tuple(sorted(set(dates)))
         normalized_currencies = tuple(

--- a/backend/app/services/historical_fx.py
+++ b/backend/app/services/historical_fx.py
@@ -1,0 +1,51 @@
+"""Pure historical-FX resolution shared by non-breadth currency consumers."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from datetime import date
+
+import numpy as np
+import pandas as pd
+
+
+class MissingHistoricalFXError(RuntimeError):
+    def __init__(self, currency: str, calculation_date: date) -> None:
+        self.currency = currency
+        self.calculation_date = calculation_date
+        super().__init__(
+            f"Missing historical {currency}->USD FX rate for "
+            f"{calculation_date.isoformat()}"
+        )
+
+
+def resolve_historical_fx_series(
+    currency: str,
+    calculation_dates: Collection[date],
+    observations: Mapping[date, float],
+    *,
+    max_age_days: int,
+) -> pd.Series:
+    normalized_currency = currency.strip().upper()
+    requested = tuple(calculation_dates)
+    index = pd.DatetimeIndex(requested)
+    if normalized_currency == "USD":
+        return pd.Series(1.0, index=index, dtype=float)
+
+    valid_observations = sorted(
+        (observation_date, float(rate))
+        for observation_date, rate in observations.items()
+        if rate is not None and np.isfinite(float(rate)) and float(rate) > 0
+    )
+
+    resolved: list[float] = []
+    for requested_date in requested:
+        prior = [item for item in valid_observations if item[0] <= requested_date]
+        if not prior:
+            raise MissingHistoricalFXError(normalized_currency, requested_date)
+        observation_date, rate = prior[-1]
+        if (requested_date - observation_date).days > max_age_days:
+            raise MissingHistoricalFXError(normalized_currency, requested_date)
+        resolved.append(rate)
+
+    return pd.Series(resolved, index=index, dtype=float)

--- a/backend/app/services/static_artifact_combiner.py
+++ b/backend/app/services/static_artifact_combiner.py
@@ -15,6 +15,7 @@ from app.services.static_market_artifact_contract import (
     read_static_market_manifest,
 )
 from app.services.static_site_errors import NoPublishedStaticMarketArtifact
+from app.services.breadth.types import CURRENT_BREADTH_CALCULATION_REVISION
 
 
 @dataclass(frozen=True)
@@ -175,6 +176,11 @@ class StaticArtifactCombiner:
         selected = dict(current)
         fallback_reasons: dict[str, str] = {}
         for market, fallback_artifact in fallback.items():
+            if not cls._artifact_matches_breadth_revision(
+                market=market,
+                artifact=fallback_artifact,
+            ):
+                continue
             expected_fallback_formula = fallback_required.get(market)
             if (
                 expected_fallback_formula is not None
@@ -246,6 +252,24 @@ class StaticArtifactCombiner:
         return True
 
     @classmethod
+    def _artifact_matches_breadth_revision(
+        cls,
+        *,
+        market: str,
+        artifact: dict[str, Any],
+    ) -> bool:
+        try:
+            cls._validate_breadth_revision(
+                market=market,
+                source_label=artifact["source_label"],
+                metadata=artifact["metadata"],
+                market_dir=artifact["market_dir"],
+            )
+        except StaticArtifactFormulaError:
+            return False
+        return True
+
+    @classmethod
     def _validate_selected_formulas(
         cls,
         *,
@@ -260,14 +284,19 @@ class StaticArtifactCombiner:
                 else required
             )
             expected = required_formulas.get(market)
-            if expected is None:
-                continue
-            artifact["entry"] = cls._validate_formula(
+            if expected is not None:
+                artifact["entry"] = cls._validate_formula(
+                    market=market,
+                    source_label=artifact["source_label"],
+                    metadata=artifact["metadata"],
+                    market_dir=artifact["market_dir"],
+                    expected_formula=expected,
+                )
+            artifact["entry"] = cls._validate_breadth_revision(
                 market=market,
                 source_label=artifact["source_label"],
                 metadata=artifact["metadata"],
                 market_dir=artifact["market_dir"],
-                expected_formula=expected,
             )
 
     def _discover(
@@ -418,6 +447,47 @@ class StaticArtifactCombiner:
             raise StaticArtifactFormulaError(
                 f"{market} {source_label} artifact uses incompatible RS formula: "
                 f"{rendered}; expected {expected_formula!r}"
+            )
+        return entry
+
+    @staticmethod
+    def _validate_breadth_revision(
+        *,
+        market: str,
+        source_label: str,
+        metadata: dict,
+        market_dir: Path,
+    ) -> dict:
+        entry = metadata.get("entry")
+        if not isinstance(entry, dict):
+            raise RuntimeError(f"{market} {source_label} metadata has no Market entry")
+        features = entry.get("features") if isinstance(entry.get("features"), dict) else {}
+        if not features.get("breadth"):
+            return entry
+
+        breadth_path = market_dir / "breadth.json"
+        if not breadth_path.is_file():
+            raise StaticArtifactFormulaError(
+                f"{market} {source_label} artifact advertises breadth but "
+                "breadth.json is absent"
+            )
+        breadth = json.loads(breadth_path.read_text(encoding="utf-8"))
+        payload = breadth.get("payload")
+        current = payload.get("current") if isinstance(payload, dict) else None
+        observed_revision = (
+            current.get("calculation_revision") if isinstance(current, dict) else None
+        )
+        source_revision = str(breadth.get("source_revision") or "")
+        expected_marker = f"|breadth-r{CURRENT_BREADTH_CALCULATION_REVISION}"
+        if (
+            observed_revision != CURRENT_BREADTH_CALCULATION_REVISION
+            or not source_revision.endswith(expected_marker)
+        ):
+            raise StaticArtifactFormulaError(
+                f"{market} {source_label} artifact uses incompatible breadth revision: "
+                f"revision={observed_revision!r}, source_revision={source_revision!r}; "
+                f"expected {CURRENT_BREADTH_CALCULATION_REVISION} and marker "
+                f"{expected_marker!r}"
             )
         return entry
 

--- a/backend/app/services/static_breadth_section_builder.py
+++ b/backend/app/services/static_breadth_section_builder.py
@@ -14,6 +14,7 @@ from app.services.bounded_history_universe import (
 )
 from app.services.breadth.engine import BreadthEngine, BreadthEngineRequest
 from app.services.breadth.formulas import prices_for_feature_window
+from app.services.breadth.market_policy import get_breadth_market_policy
 from app.services.breadth.types import (
     CURRENT_BREADTH_CALCULATION_REVISION,
     BreadthUniverseMember,
@@ -21,7 +22,6 @@ from app.services.breadth.types import (
 )
 from app.services.breadth.universe import build_breadth_universe_snapshots
 from app.services.breadth_attribution_service import BreadthAttributionService
-from app.services.fx_service import default_currency_for_market, get_fx_service
 from app.services.point_in_time_universe_service import (
     hash_point_in_time_universe_symbols,
 )
@@ -44,9 +44,6 @@ class StaticBreadthEngineInputs:
 class StaticBreadthEngineInputFactory:
     """Build cache-only canonical inputs for static breadth generation."""
 
-    def __init__(self, *, fx_service=None) -> None:
-        self._fx_service = fx_service
-
     def build(
         self,
         *,
@@ -57,11 +54,11 @@ class StaticBreadthEngineInputFactory:
         universes_by_date: Mapping[date, BreadthUniverseSnapshot] | None = None,
     ) -> StaticBreadthEngineInputs:
         normalized_market = market.upper()
-        default_currency = default_currency_for_market(normalized_market)
+        market_policy = get_breadth_market_policy(normalized_market)
         symbols = tuple(sorted(str(symbol).upper() for symbol in price_data))
         currency_map = {
             symbol: str(
-                (currencies_by_symbol or {}).get(symbol) or default_currency
+                (currencies_by_symbol or {}).get(symbol) or market_policy.currency
             ).upper()
             for symbol in symbols
         }
@@ -98,34 +95,13 @@ class StaticBreadthEngineInputFactory:
             },
             tuple(canonical_dates),
         )
-        dates_by_currency: dict[str, set[date]] = {}
-        for symbol, history in usable_prices.items():
-            currency = currency_map[str(symbol).upper()]
-            dates_by_currency.setdefault(currency, set()).update(
-                pd.Timestamp(value).date() for value in history.index
-            )
-        fx_by_currency: dict[str, pd.Series] = {}
-        for currency, required_dates in dates_by_currency.items():
-            if currency == "USD":
-                fx_by_currency[currency] = pd.Series(
-                    1.0,
-                    index=pd.DatetimeIndex(sorted(required_dates)),
-                )
-                continue
-            fx_service = self._fx_service or get_fx_service()
-            fx_by_currency.update(
-                fx_service.get_historical_usd_rates(
-                    (currency,),
-                    required_dates,
-                )
-            )
         return StaticBreadthEngineInputs(
             request=BreadthEngineRequest(
                 market=normalized_market,
                 dates=tuple(canonical_dates),
                 universes_by_date=universes,
                 prices_by_symbol=usable_prices,
-                fx_by_currency=fx_by_currency,
+                market_policy=market_policy,
             ),
             currencies_by_symbol=currency_map,
         )
@@ -379,8 +355,8 @@ class StaticBreadthSectionBuilder:
             symbols_meta=symbols_meta,
             price_data=price_data,
             target_dates=attribution_dates,
+            market=market,
             currencies_by_symbol=engine_inputs.currencies_by_symbol,
-            fx_by_currency=engine_inputs.request.fx_by_currency,
             symbols_by_date={
                 calculation_date: frozenset(
                     member.symbol

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -518,6 +518,14 @@ class StaticSiteExportService:
         return self._chart_exporter.export(**kwargs)
 
     def _build_breadth_payload(self, **kwargs) -> dict[str, Any]:
+        market = str(kwargs.get("market") or STATIC_DEFAULT_MARKET).upper()
+        market_profile = _MARKET_CATALOG.get(market)
+        if not market_profile.capabilities.breadth:
+            raise StaticSiteSectionUnavailableError(
+                section="breadth",
+                reason=f"Market {market} does not support breadth.",
+            )
+        kwargs["market"] = market
         if kwargs.get("serialized_rows") is not None and kwargs.get("db") is None:
             with self._session_factory() as db:
                 return self._breadth_builder.build(db=db, **kwargs)

--- a/backend/app/tasks/daily_market_pipeline_tasks.py
+++ b/backend/app/tasks/daily_market_pipeline_tasks.py
@@ -10,6 +10,7 @@ from celery import chain
 
 from app.celery_app import celery_app
 from app.database import SessionLocal
+from app.domain.markets.catalog import get_market_catalog
 from app.domain.relative_strength import (
     BALANCED_RS_FORMULA_VERSION,
     LEGACY_RS_FORMULA_VERSION,
@@ -238,7 +239,7 @@ def _build_daily_market_pipeline_signatures(market: str, trading_date: date) -> 
 
     market_code = _normalize_pipeline_market(market)
     as_of_date = trading_date.isoformat()
-    return [
+    signatures = [
         smart_refresh_cache.si(mode="delta", market=market_code).set(
             queue=data_fetch_queue_for_market(market_code)
         ),
@@ -254,24 +255,27 @@ def _build_daily_market_pipeline_signatures(market: str, trading_date: date) -> 
             market=market_code,
             calculation_date=as_of_date,
         ).set(queue=market_jobs_queue_for_market(market_code)),
-        calculate_daily_breadth_with_gapfill.si(
+    ]
+    if get_market_catalog().get(market_code).capabilities.breadth:
+        signatures.extend([
+            calculate_daily_breadth_with_gapfill.si(
             market=market_code,
             calculation_date=as_of_date,
             execution_policy="refresh_guarded",
-        ).set(
-            queue=market_jobs_queue_for_market(market_code)
-        ),
-        guard_breadth_result.s(market=market_code).set(
-            queue=market_jobs_queue_for_market(market_code)
-        ),
-        # Exposure blends breadth + index OHLCV; runs after the breadth guard.
-        # .si() — it re-reads breadth from the DB, ignoring the guard's result.
-        calculate_market_exposure.si(market=market_code, calculation_date=as_of_date).set(
-            queue=market_jobs_queue_for_market(market_code)
-        ),
-        guard_exposure_result.s(market=market_code).set(
-            queue=market_jobs_queue_for_market(market_code)
-        ),
+            ).set(queue=market_jobs_queue_for_market(market_code)),
+            guard_breadth_result.s(market=market_code).set(
+                queue=market_jobs_queue_for_market(market_code)
+            ),
+            # Exposure blends breadth + index OHLCV and runs after its guard.
+            calculate_market_exposure.si(
+                market=market_code,
+                calculation_date=as_of_date,
+            ).set(queue=market_jobs_queue_for_market(market_code)),
+            guard_exposure_result.s(market=market_code).set(
+                queue=market_jobs_queue_for_market(market_code)
+            ),
+        ])
+    signatures.extend([
         calculate_daily_group_rankings_with_gapfill.si(
             market=market_code,
             calculation_date=as_of_date,
@@ -292,7 +296,8 @@ def _build_daily_market_pipeline_signatures(market: str, trading_date: date) -> 
         guard_snapshot_result.s(market=market_code).set(
             queue=market_jobs_queue_for_market(market_code)
         ),
-    ]
+    ])
+    return signatures
 
 
 def _market_pipeline_active(market: str) -> dict | None:

--- a/backend/tests/helpers/mcp_fixture.py
+++ b/backend/tests/helpers/mcp_fixture.py
@@ -242,7 +242,7 @@ def seed_market_copilot_data(session_factory: sessionmaker) -> None:
                     ratio_5day=1.82,
                     ratio_10day=1.54,
                     total_stocks_scanned=4081,
-                    calculation_revision=2,
+                    calculation_revision=3,
                 ),
                 MarketBreadth(
                     date=date(2026, 3, 28),
@@ -251,7 +251,7 @@ def seed_market_copilot_data(session_factory: sessionmaker) -> None:
                     ratio_5day=1.70,
                     ratio_10day=1.48,
                     total_stocks_scanned=4075,
-                    calculation_revision=2,
+                    calculation_revision=3,
                 ),
                 MarketBreadth(
                     date=date(2026, 3, 27),
@@ -260,7 +260,7 @@ def seed_market_copilot_data(session_factory: sessionmaker) -> None:
                     ratio_5day=1.55,
                     ratio_10day=1.42,
                     total_stocks_scanned=4070,
-                    calculation_revision=2,
+                    calculation_revision=3,
                 ),
             ]
         )

--- a/backend/tests/integration/test_breadth_revision_cutover.py
+++ b/backend/tests/integration/test_breadth_revision_cutover.py
@@ -107,6 +107,7 @@ def test_revision_cutover_replaces_legacy_rows_and_preserves_unrelated_tables(tm
                     stocks_up_13pct_34days=0,
                     stocks_down_13pct_34days=0,
                     total_stocks_scanned=100,
+                    calculation_revision=2,
                 )
             )
             db.commit()
@@ -120,11 +121,20 @@ def test_revision_cutover_replaces_legacy_rows_and_preserves_unrelated_tables(tm
 
             report = service.validate()
             assert report["valid"] is True
-            service.activate()
+            assert report["calculation_revision"] == 3
+            assert report["formula_contract"] == {
+                "signals": "adjusted_ohlc",
+                "liquidity": "raw_close_local_x_volume_adtv20",
+                "market_policy": "fixed_market_calibrated_thresholds",
+                "currency_mismatch": "stockbee_ineligible_context_preserved",
+                "ratios": "today_inclusive",
+            }
+            activation = service.activate()
+            assert activation == {"activated": 1, "calculation_revision": 3}
 
             rows = db.query(MarketBreadth).all()
             assert [(row.date, row.calculation_revision) for row in rows] == [
-                (date(2026, 8, 21), 2)
+                (date(2026, 8, 21), 3)
             ]
             unrelated = db.execute(
                 text("SELECT value FROM unrelated WHERE id = 1")

--- a/backend/tests/unit/domain/test_bootstrap_plan.py
+++ b/backend/tests/unit/domain/test_bootstrap_plan.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.domain.bootstrap.plan import (
     BootstrapOperation,
     BootstrapQueueKind,
@@ -82,6 +84,18 @@ def test_au_bootstrap_plan_refreshes_universe_before_prices_and_fundamentals() -
         == BootstrapOperation.REFRESH_OFFICIAL_MARKET_UNIVERSE
     )
     assert au_plan.stages[0].kwargs["market"] == "AU"
+
+
+@pytest.mark.parametrize("market", ("AU", "SG", "MY"))
+def test_breadth_disabled_bootstrap_omits_breadth_and_exposure(
+    market: str,
+) -> None:
+    plan = build_bootstrap_plan(primary_market=market, enabled_markets=(market,))
+    stage_keys = [stage.key for stage in plan.market_plans[0].stages]
+
+    assert "breadth" not in stage_keys
+    assert "exposure" not in stage_keys
+    assert "snapshot" in stage_keys
 
 
 def test_bootstrap_plan_deduplicates_primary_and_enabled_markets_in_order() -> None:

--- a/backend/tests/unit/services/test_static_artifact_combiner.py
+++ b/backend/tests/unit/services/test_static_artifact_combiner.py
@@ -27,6 +27,8 @@ def write_market_artifact(
     formula: str,
     scan_formula: str | None = None,
     chunk_formula: str | None = None,
+    breadth_revision: int | None = None,
+    breadth_source_revision: str | None = None,
 ) -> Path:
     # actions/upload-artifact uploads the contents of the selected market
     # directory, so download-artifact restores manifest.market.json directly
@@ -62,7 +64,7 @@ def write_market_artifact(
         "rs_formula_version": formula,
         "features": {
             "scan": True,
-            "breadth": False,
+            "breadth": breadth_revision is not None,
             "groups": False,
             "charts": False,
         },
@@ -83,6 +85,28 @@ def write_market_artifact(
         ),
         encoding="utf-8",
     )
+    if breadth_revision is not None:
+        (market_dir / "breadth.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": STATIC_SITE_SCHEMA_VERSION,
+                    "available": True,
+                    "source_revision": (
+                        breadth_source_revision
+                        or f"2026-04-10|breadth-r{breadth_revision}"
+                    ),
+                    "payload": {
+                        "current": {
+                            "market": market,
+                            "date": "2026-04-10",
+                            "calculation_revision": breadth_revision,
+                        }
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
     return root
 
 
@@ -367,3 +391,78 @@ def test_combiner_requires_every_market_named_by_formula_map(tmp_path):
             clean=True,
         )
     assert exc_info.value.markets == ("HK",)
+
+
+def test_combiner_accepts_current_breadth_revision_three(tmp_path):
+    current = write_market_artifact(
+        tmp_path / "current",
+        market="US",
+        formula=BALANCED_RS_FORMULA_VERSION,
+        breadth_revision=3,
+    )
+
+    result = combiner().combine(
+        artifacts_dir=current,
+        fallback_artifacts_dir=None,
+        output_dir=tmp_path / "out",
+        required_formula_by_market={"US": BALANCED_RS_FORMULA_VERSION},
+        clean=True,
+    )
+
+    assert result.manifest["markets"]["US"]["features"]["breadth"] is True
+
+
+def test_combiner_rejects_current_breadth_revision_two(tmp_path):
+    current = write_market_artifact(
+        tmp_path / "current",
+        market="US",
+        formula=BALANCED_RS_FORMULA_VERSION,
+        breadth_revision=2,
+    )
+
+    with pytest.raises(StaticArtifactFormulaError, match="breadth revision"):
+        combiner().combine(
+            artifacts_dir=current,
+            fallback_artifacts_dir=None,
+            output_dir=tmp_path / "out",
+            required_formula_by_market={"US": BALANCED_RS_FORMULA_VERSION},
+            clean=True,
+        )
+
+
+def test_combiner_filters_revision_two_breadth_fallback_without_rs_policy(tmp_path):
+    fallback = write_market_artifact(
+        tmp_path / "fallback",
+        market="HK",
+        formula=LEGACY_RS_FORMULA_VERSION,
+        breadth_revision=2,
+    )
+
+    with pytest.raises(NoPublishedStaticMarketArtifact, match="HK"):
+        combiner().combine(
+            artifacts_dir=tmp_path / "empty-current",
+            fallback_artifacts_dir=fallback,
+            output_dir=tmp_path / "out",
+            required_formula_by_market={"HK": BALANCED_RS_FORMULA_VERSION},
+            fallback_required_formula_by_market={},
+            clean=True,
+        )
+
+
+def test_combiner_rejects_revision_three_with_revision_two_source_marker(tmp_path):
+    current = write_market_artifact(
+        tmp_path / "current",
+        market="US",
+        formula=BALANCED_RS_FORMULA_VERSION,
+        breadth_revision=3,
+        breadth_source_revision="2026-04-10|breadth-r2",
+    )
+
+    with pytest.raises(StaticArtifactFormulaError, match="breadth revision"):
+        combiner().combine(
+            artifacts_dir=current,
+            fallback_artifacts_dir=None,
+            output_dir=tmp_path / "out",
+            required_formula_by_market={"US": BALANCED_RS_FORMULA_VERSION},
+            clean=True,
+        )

--- a/backend/tests/unit/test_breadth_attribution_service.py
+++ b/backend/tests/unit/test_breadth_attribution_service.py
@@ -283,3 +283,20 @@ def test_compute_uses_adjusted_return_and_stockbee_volume_filters():
     assert result[0]["stocks_up_4pct"] == 1
     assert result[0]["groups"][0]["up_stocks"][0]["symbol"] == "ELIGIBLE"
     assert result[0]["groups"][0]["up_stocks"][0]["pct_change"] == pytest.approx(5.0)
+
+
+def test_compute_currency_mismatch_is_stockbee_ineligible_without_fx() -> None:
+    history = _frame([100.0, 105.0])
+    target = _last_date(history)
+
+    result = BreadthAttributionService().compute(
+        symbols_meta=[{"symbol": "CROSS", "ibd_industry_group": "Software"}],
+        price_data={"CROSS": history},
+        target_dates=[target],
+        market="CA",
+        currencies_by_symbol={"CROSS": "USD"},
+    )
+
+    assert result[0]["stocks_up_4pct"] == 0
+    assert result[0]["stocks_down_4pct"] == 0
+    assert result[0]["groups"] == []

--- a/backend/tests/unit/test_breadth_attribution_service.py
+++ b/backend/tests/unit/test_breadth_attribution_service.py
@@ -49,6 +49,10 @@ def _last_date(frame: pd.DataFrame) -> date:
     return pd.Timestamp(frame.index[-1]).date()
 
 
+def _usd_currencies(price_data: dict[str, pd.DataFrame | None]) -> dict[str, str]:
+    return {symbol: "USD" for symbol in price_data}
+
+
 def test_compute_returns_empty_when_no_symbols():
     service = BreadthAttributionService()
     result = service.compute(
@@ -75,6 +79,7 @@ def test_compute_attributes_up_mover_to_ibd_group():
         symbols_meta=symbols_meta,
         price_data=price_data,
         target_dates=[_last_date(price_data["PLTR"])],
+        currencies_by_symbol=_usd_currencies(price_data),
     )
 
     assert len(result) == 1
@@ -102,6 +107,7 @@ def test_compute_attributes_down_mover():
         symbols_meta=[{"symbol": "XYZ", "ibd_industry_group": "Banks-Money Center"}],
         price_data=price_data,
         target_dates=[_last_date(price_data["XYZ"])],
+        currencies_by_symbol=_usd_currencies(price_data),
     )
 
     day = result[0]
@@ -128,6 +134,7 @@ def test_compute_buckets_missing_group_into_no_group():
         symbols_meta=symbols_meta,
         price_data=price_data,
         target_dates=[_last_date(price_data["AAA"])],
+        currencies_by_symbol=_usd_currencies(price_data),
     )
 
     day = result[0]
@@ -147,6 +154,7 @@ def test_compute_skips_movers_below_threshold():
         symbols_meta=[{"symbol": "FLAT", "ibd_industry_group": "Retail"}],
         price_data=price_data,
         target_dates=[_last_date(price_data["FLAT"])],
+        currencies_by_symbol=_usd_currencies(price_data),
     )
     assert result[0]["groups"] == []
     assert result[0]["stocks_up_4pct"] == 0
@@ -177,6 +185,7 @@ def test_compute_sorts_groups_by_total_activity_then_net():
         symbols_meta=meta,
         price_data=price_data,
         target_dates=[_last_date(price_data["A1"])],
+        currencies_by_symbol=_usd_currencies(price_data),
     )
     groups = [g["group"] for g in result[0]["groups"]]
     # Bravo first (highest activity=3), then Charlie (activity=2), then Alpha.
@@ -194,6 +203,7 @@ def test_compute_returns_history_oldest_to_newest():
         symbols_meta=[{"symbol": "X", "ibd_industry_group": "G"}],
         price_data=price_data,
         target_dates=dates,
+        currencies_by_symbol=_usd_currencies(price_data),
     )
     assert [day["date"] for day in result] == [value.isoformat() for value in dates]
     assert result[0]["stocks_up_4pct"] == 1
@@ -208,6 +218,7 @@ def test_compute_filters_movers_by_each_dates_universe():
         symbols_meta=[{"symbol": "NEW", "ibd_industry_group": "Software"}],
         price_data={"NEW": history},
         target_dates=dates,
+        currencies_by_symbol={"NEW": "USD"},
         symbols_by_date={
             dates[0]: frozenset(),
             dates[1]: frozenset({"NEW"}),
@@ -226,6 +237,7 @@ def test_compute_skips_dates_with_missing_price_data():
         symbols_meta=[{"symbol": "X", "ibd_industry_group": "G"}],
         price_data=price_data,
         target_dates=[present, date(2026, 5, 10)],
+        currencies_by_symbol=_usd_currencies(price_data),
     )
     # 2026-05-10 has no price → no group entry for that day.
     by_date = {row["date"]: row for row in result}
@@ -256,6 +268,7 @@ def test_compute_isolates_malformed_symbol_history():
         ],
         price_data={"VALID": valid, "BAD": malformed},
         target_dates=[target],
+        currencies_by_symbol={"VALID": "USD", "BAD": "USD"},
     )
 
     assert result[0]["stocks_up_4pct"] == 1
@@ -278,6 +291,7 @@ def test_compute_uses_adjusted_return_and_stockbee_volume_filters():
         ],
         price_data={"ELIGIBLE": eligible, "FLATVOL": flat_volume},
         target_dates=[target],
+        currencies_by_symbol={"ELIGIBLE": "USD", "FLATVOL": "USD"},
     )
 
     assert result[0]["stocks_up_4pct"] == 1
@@ -295,6 +309,24 @@ def test_compute_currency_mismatch_is_stockbee_ineligible_without_fx() -> None:
         target_dates=[target],
         market="CA",
         currencies_by_symbol={"CROSS": "USD"},
+    )
+
+    assert result[0]["stocks_up_4pct"] == 0
+    assert result[0]["stocks_down_4pct"] == 0
+    assert result[0]["groups"] == []
+
+
+def test_compute_unknown_currency_is_stockbee_ineligible() -> None:
+    """Break caught: inferring a market-currency match from missing metadata."""
+    history = _frame([100.0, 105.0])
+    target = _last_date(history)
+
+    result = BreadthAttributionService().compute(
+        symbols_meta=[{"symbol": "UNKNOWN", "ibd_industry_group": "Software"}],
+        price_data={"UNKNOWN": history},
+        target_dates=[target],
+        market="US",
+        currencies_by_symbol={},
     )
 
     assert result[0]["stocks_up_4pct"] == 0

--- a/backend/tests/unit/test_breadth_backfill.py
+++ b/backend/tests/unit/test_breadth_backfill.py
@@ -324,7 +324,7 @@ def test_backfill_range_reuses_loaded_histories_and_computes_chronological_ratio
             stocks_down_13pct_34days=0,
             total_stocks_scanned=2,
             broad_universe_count=2,
-            calculation_revision=2,
+            calculation_revision=3,
         ))
     db.commit()
 
@@ -577,7 +577,7 @@ def test_backfill_range_preserves_existing_failed_date_in_ratio_context():
                 stocks_down_4pct=1,
                 total_stocks_scanned=1,
                 broad_universe_count=1,
-                calculation_revision=2,
+                calculation_revision=3,
             )
         )
     db.add(
@@ -588,7 +588,7 @@ def test_backfill_range_preserves_existing_failed_date_in_ratio_context():
             stocks_down_4pct=10,
             total_stocks_scanned=10,
             broad_universe_count=10,
-            calculation_revision=2,
+            calculation_revision=3,
         )
     )
     db.commit()

--- a/backend/tests/unit/test_breadth_calculator_service.py
+++ b/backend/tests/unit/test_breadth_calculator_service.py
@@ -143,7 +143,7 @@ def _add_breadth_row(
         stocks_down_13pct_34days=0,
         total_stocks_scanned=total,
         broad_universe_count=total,
-        calculation_revision=2,
+        calculation_revision=3,
     ))
 
 
@@ -897,7 +897,7 @@ def test_backfill_range_requests_history_for_old_narrow_interval(monkeypatch):
     )
 
 
-def test_daily_breadth_ignores_fx_dates_before_the_feature_window():
+def test_daily_breadth_does_not_load_historical_fx(monkeypatch):
     db = _make_db_session()
     calculation_date = date(2026, 8, 25)
     db.add(
@@ -925,24 +925,16 @@ def test_daily_breadth_ignores_fx_dates_before_the_feature_window():
     )
     price_cache = MagicMock()
     price_cache.get_many_cached_only_fresh.return_value = {"0700.HK": prices}
-    fx_service = MagicMock()
-
-    def historical_rates(currencies, required_dates):
-        assert currencies == ("HKD",)
-        assert date(2020, 1, 2) not in required_dates
-        return {
-            "HKD": pd.Series(
-                0.13,
-                index=pd.DatetimeIndex(sorted(required_dates)),
-            )
-        }
-
-    fx_service.get_historical_usd_rates.side_effect = historical_rates
+    monkeypatch.setattr(
+        breadth_calculator_module,
+        "get_fx_service",
+        MagicMock(side_effect=AssertionError("breadth must not request FX")),
+        raising=False,
+    )
     service = BreadthCalculatorService(
         db,
         price_cache,
         market="HK",
-        fx_service=fx_service,
     )
 
     result = service.calculate_daily_breadth(calculation_date)
@@ -1359,4 +1351,4 @@ def test_live_and_backfill_use_identical_canonical_counts():
     ).one()
     for field in BreadthIndicatorValues.__dataclass_fields__:
         assert getattr(stored, field) == live.indicators[field]
-    assert stored.calculation_revision == live.indicators["calculation_revision"] == 2
+    assert stored.calculation_revision == live.indicators["calculation_revision"] == 3

--- a/backend/tests/unit/test_breadth_endpoints.py
+++ b/backend/tests/unit/test_breadth_endpoints.py
@@ -71,11 +71,11 @@ def _breadth_row(market: str, day: date, *, up: int, down: int) -> MarketBreadth
         stocks_down_13pct_34days=down + 3,
         total_stocks_scanned=up + down,
         calculation_duration_seconds=1.25,
-        calculation_revision=2,
+        calculation_revision=3,
     )
 
 
-def _revision_2_values() -> dict:
+def _revision_3_values() -> dict:
     return {
         "advancing_count": 120,
         "declining_count": 80,
@@ -96,7 +96,7 @@ def _revision_2_values() -> dict:
         "atr_extension_eligible_count": 195,
         "eligibility_signature": "a" * 64,
         "stockbee_eligibility_signature": "b" * 64,
-        "calculation_revision": 2,
+        "calculation_revision": 3,
     }
 
 
@@ -126,7 +126,7 @@ async def test_current_breadth_filters_by_market(client, session):
     assert payload["stocks_up_4pct"] == 22
     assert payload["stocks_down_4pct"] == 8
     assert payload["broad_universe_count"] is None
-    assert payload["calculation_revision"] == 2
+    assert payload["calculation_revision"] == 3
 
 
 @pytest.mark.asyncio
@@ -134,7 +134,7 @@ async def test_current_breadth_ignores_newer_legacy_row(client, session):
     app.dependency_overrides[get_db] = _override_db(session)
     corrected = _breadth_row("US", date(2026, 8, 20), up=12, down=3)
     stale = _breadth_row("US", date(2026, 8, 21), up=99, down=1)
-    stale.calculation_revision = None
+    stale.calculation_revision = 2
     session.add_all([corrected, stale])
     session.commit()
 
@@ -151,7 +151,7 @@ async def test_current_breadth_returns_not_found_when_only_legacy_rows_exist(
 ):
     app.dependency_overrides[get_db] = _override_db(session)
     stale = _breadth_row("US", date(2026, 8, 21), up=99, down=1)
-    stale.calculation_revision = None
+    stale.calculation_revision = 2
     session.add(stale)
     session.commit()
 
@@ -161,10 +161,10 @@ async def test_current_breadth_returns_not_found_when_only_legacy_rows_exist(
 
 
 @pytest.mark.asyncio
-async def test_revision_2_fields_are_flat_and_legacy_fields_are_unchanged(client, session):
+async def test_revision_3_fields_are_flat_and_legacy_fields_are_unchanged(client, session):
     app.dependency_overrides[get_db] = _override_db(session)
     row = _breadth_row("US", date(2026, 8, 21), up=10, down=4)
-    for name, value in _revision_2_values().items():
+    for name, value in _revision_3_values().items():
         setattr(row, name, value)
     session.add(row)
     session.commit()
@@ -178,16 +178,16 @@ async def test_revision_2_fields_are_flat_and_legacy_fields_are_unchanged(client
     assert payload["t2108_pct"] == pytest.approx(75.0)
     assert payload["stockbee_daily_eligible_count"] == 190
     assert payload["stockbee_eligibility_signature"] == "b" * 64
-    assert payload["calculation_revision"] == 2
+    assert payload["calculation_revision"] == 3
     assert "stockbee" not in payload
     assert "context" not in payload
 
 
 @pytest.mark.asyncio
-async def test_trend_accepts_revision_2_indicators_and_denominators(client, session):
+async def test_trend_accepts_revision_3_indicators_and_denominators(client, session):
     app.dependency_overrides[get_db] = _override_db(session)
     row = _breadth_row("US", date.today(), up=10, down=4)
-    for name, value in _revision_2_values().items():
+    for name, value in _revision_3_values().items():
         setattr(row, name, value)
     session.add(row)
     session.commit()

--- a/backend/tests/unit/test_breadth_engine.py
+++ b/backend/tests/unit/test_breadth_engine.py
@@ -3,6 +3,7 @@ from datetime import date
 import pandas as pd
 import pytest
 from app.services.breadth.engine import BreadthEngine, BreadthEngineRequest
+from app.services.breadth.market_policy import get_breadth_market_policy
 from app.services.breadth.types import (
     BreadthUniverseMember,
     BreadthUniverseSnapshot,
@@ -55,9 +56,7 @@ def test_engine_tracks_metric_specific_eligibility_for_mixed_history():
                 "VETERAN": _prices(veteran_index, [100.0] * 251 + [104.0]),
                 "IPO": _prices(ipo_index, [10.0, 11.0]),
             },
-            fx_by_currency={
-                "USD": pd.Series(1.0, index=veteran_index),
-            },
+            market_policy=get_breadth_market_policy("US"),
         )
     )[calculation_date]
 
@@ -77,7 +76,7 @@ def test_engine_tracks_metric_specific_eligibility_for_mixed_history():
     assert result.stockbee_eligibility_signature == (
         hash_point_in_time_universe_symbols(("VETERAN",))
     )
-    assert result.calculation_revision == 2
+    assert result.calculation_revision == 3
 
     record = result.to_record_mapping()
     assert record["total_stocks_scanned"] == record["broad_universe_count"] == 2
@@ -98,7 +97,7 @@ def test_engine_persists_the_canonical_broad_eligibility_signature():
             dates=(calculation_date,),
             universes_by_date={calculation_date: snapshot},
             prices_by_symbol={"AAA": _prices(index, [100.0, 101.0])},
-            fx_by_currency={"USD": pd.Series(1.0, index=index)},
+            market_policy=get_breadth_market_policy("US"),
         )
     )[calculation_date]
 
@@ -124,7 +123,7 @@ def test_stockbee_signature_tracks_liquidity_when_daily_history_is_ineligible():
             dates=(calculation_date,),
             universes_by_date={calculation_date: snapshot},
             prices_by_symbol={"LIQUID": prices},
-            fx_by_currency={"USD": pd.Series(1.0, index=index)},
+            market_policy=get_breadth_market_policy("US"),
         )
     )[calculation_date]
 
@@ -159,10 +158,54 @@ def test_engine_isolates_a_malformed_symbol_frame():
                 "BAD": _prices(malformed_index, [100.0] * len(malformed_index)),
                 "GOOD": _prices(index, [100.0] * 251 + [104.0]),
             },
-            fx_by_currency={"USD": pd.Series(1.0, index=malformed_index)},
+            market_policy=get_breadth_market_policy("US"),
         )
     )[calculation_date]
 
     assert result.broad_universe_count == 2
     assert result.eligibility.advance_decline_eligible_count == 1
     assert result.values.advancing_count == 1
+
+
+def test_engine_currency_mismatch_preserves_context_eligibility() -> None:
+    index = pd.bdate_range(end="2026-08-21", periods=252)
+    calculation_date = date(2026, 8, 21)
+    snapshot = BreadthUniverseSnapshot(
+        calculation_date=calculation_date,
+        members=(BreadthUniverseMember("CROSS", "USD"),),
+        broad_signature=hash_point_in_time_universe_symbols(("CROSS",)),
+    )
+
+    result = BreadthEngine().calculate(
+        BreadthEngineRequest(
+            market="CA",
+            dates=(calculation_date,),
+            universes_by_date={calculation_date: snapshot},
+            prices_by_symbol={
+                "CROSS": _prices(index, [100.0] * 251 + [104.0]),
+            },
+            market_policy=get_breadth_market_policy("CA"),
+        )
+    )[calculation_date]
+
+    assert result.eligibility.stockbee_daily_eligible_count == 0
+    assert result.eligibility.stockbee_month_eligible_count == 0
+    assert result.eligibility.stockbee_34day_eligible_count == 0
+    assert result.eligibility.stockbee_quarter_eligible_count == 0
+    assert result.eligibility.advance_decline_eligible_count == 1
+    assert result.eligibility.t2108_eligible_count == 1
+    assert result.eligibility.high_low_52week_eligible_count == 1
+    assert result.eligibility.atr_extension_eligible_count == 1
+
+
+def test_engine_rejects_a_policy_for_another_market() -> None:
+    with pytest.raises(ValueError, match="policy market CA does not match request market US"):
+        BreadthEngine().calculate(
+            BreadthEngineRequest(
+                market="US",
+                dates=(),
+                universes_by_date={},
+                prices_by_symbol={},
+                market_policy=get_breadth_market_policy("CA"),
+            )
+        )

--- a/backend/tests/unit/test_breadth_formulas.py
+++ b/backend/tests/unit/test_breadth_formulas.py
@@ -1,10 +1,32 @@
 import pandas as pd
 import pytest
 
-from app.services.breadth.formulas import prepare_feature_frame, signal_flags_at
+from app.services.breadth.formulas import (
+    prepare_feature_frame,
+    signal_flags_at as calculate_signal_flags,
+)
+from app.services.breadth.market_policy import get_breadth_market_policy
 from app.services.breadth.types import BreadthFormulaPolicy
 
 CALCULATION_DATE = pd.Timestamp("2026-08-21")
+US_POLICY = get_breadth_market_policy("US")
+
+
+def signal_flags_at(
+    feature_frame,
+    calculation_date,
+    formula_policy,
+    market_policy=US_POLICY,
+    *,
+    stockbee_currency_matches=True,
+):
+    return calculate_signal_flags(
+        feature_frame,
+        calculation_date,
+        formula_policy,
+        market_policy,
+        stockbee_currency_matches=stockbee_currency_matches,
+    )
 
 
 def _feature_row(**overrides):
@@ -14,9 +36,9 @@ def _feature_row(**overrides):
         "daily_return": 0.04,
         "volume": 100_000.0,
         "prior_volume": 99_999.0,
-        "adtv20_usd": 250_000.0,
+        "adtv20_local": 250_000.0,
         "adjusted_close_20": 100.0,
-        "raw_close_usd_20": 5.0,
+        "raw_close_local_20": 5.0,
         "month_return": 0.04,
         "low_34": 92.0,
         "high_34": 104.0,
@@ -47,13 +69,13 @@ def test_prepare_feature_frame_separates_adjusted_signals_from_raw_liquidity():
         },
         index=index,
     )
-    fx = pd.Series([0.8, 0.8], index=prices.index)
-
-    result = prepare_feature_frame(prices, fx)
+    result = prepare_feature_frame(prices)
 
     assert result.iloc[0].adjusted_high == pytest.approx(51.0)
-    assert result.iloc[0].raw_close_usd == pytest.approx(80.0)
-    assert result.iloc[0].dollar_volume_usd == pytest.approx(16_000_000.0)
+    assert result.iloc[0].raw_close_local == pytest.approx(100.0)
+    assert result.iloc[0].traded_value_local == pytest.approx(20_000_000.0)
+    assert "fx_to_usd" not in result
+    assert "adtv20_usd" not in result
 
 
 def test_prepare_feature_frame_normalizes_timezone_aware_daily_sessions():
@@ -69,9 +91,7 @@ def test_prepare_feature_frame_normalizes_timezone_aware_daily_sessions():
         },
         index=index,
     )
-    fx = pd.Series(1.0, index=index.tz_localize(None))
-
-    features = prepare_feature_frame(prices, fx)
+    features = prepare_feature_frame(prices)
     signals = signal_flags_at(
         features,
         index[-1].date(),
@@ -97,7 +117,7 @@ def test_prepare_feature_frame_rejects_a_missing_session():
     )
 
     with pytest.raises(ValueError, match="valid sessions"):
-        prepare_feature_frame(prices, pd.Series(1.0, index=index))
+        prepare_feature_frame(prices)
 
 
 def test_prepare_feature_frame_initializes_and_smooths_wilder_atr():
@@ -114,7 +134,7 @@ def test_prepare_feature_frame_initializes_and_smooths_wilder_atr():
         index=index,
     )
 
-    result = prepare_feature_frame(prices, pd.Series(1.0, index=index))
+    result = prepare_feature_frame(prices)
 
     assert result.atr14.iloc[:13].isna().all()
     assert result.atr14.iloc[13] == pytest.approx(2.0)
@@ -138,7 +158,6 @@ def test_prepare_feature_frame_restarts_wilder_atr_after_initial_gap():
 
     result = prepare_feature_frame(
         prices,
-        pd.Series(1.0, index=index),
         atr_period=14,
     )
 
@@ -160,7 +179,7 @@ def test_prepare_feature_frame_restarts_wilder_atr_after_initial_gap():
             False,
             False,
         ),
-        ({"daily_return": 0.04, "adtv20_usd": 249_999.99}, False, False),
+        ({"daily_return": 0.04, "adtv20_local": 249_999.99}, False, False),
     ],
 )
 def test_daily_stockbee_boundaries(overrides, expected_up, expected_down):
@@ -195,22 +214,80 @@ def test_month_stockbee_boundaries(month_return, up_25, down_25, up_50, down_50)
     assert signals.down_50pct_month is down_50
 
 
-def test_month_reference_price_is_usd_five_inclusive():
+def test_month_reference_price_uses_market_local_threshold_inclusively():
+    ca_policy = get_breadth_market_policy("CA")
     eligible = signal_flags_at(
-        _feature_row(raw_close_usd_20=5.0, month_return=0.25),
+        _feature_row(
+            adtv20_local=5_000.0,
+            raw_close_local_20=0.30,
+            month_return=0.25,
+        ),
         CALCULATION_DATE.date(),
         BreadthFormulaPolicy(),
+        ca_policy,
     )
     ineligible = signal_flags_at(
-        _feature_row(raw_close_usd_20=4.999, month_return=0.25),
+        _feature_row(
+            adtv20_local=5_000.0,
+            raw_close_local_20=0.299,
+            month_return=0.25,
+        ),
         CALCULATION_DATE.date(),
         BreadthFormulaPolicy(),
+        ca_policy,
     )
 
     assert eligible.eligibility.stockbee_month is True
     assert eligible.up_25pct_month is True
     assert ineligible.eligibility.stockbee_month is False
     assert ineligible.up_25pct_month is False
+
+
+def test_daily_volume_uses_market_local_share_threshold():
+    de_policy = get_breadth_market_policy("DE")
+    eligible = signal_flags_at(
+        _feature_row(
+            adtv20_local=5_000.0,
+            volume=300.0,
+            prior_volume=299.0,
+        ),
+        CALCULATION_DATE.date(),
+        BreadthFormulaPolicy(),
+        de_policy,
+    )
+    ineligible = signal_flags_at(
+        _feature_row(
+            adtv20_local=5_000.0,
+            volume=299.0,
+            prior_volume=298.0,
+        ),
+        CALCULATION_DATE.date(),
+        BreadthFormulaPolicy(),
+        de_policy,
+    )
+
+    assert eligible.up_4pct is True
+    assert ineligible.up_4pct is False
+
+
+def test_currency_mismatch_disables_only_stockbee_eligibility():
+    signals = signal_flags_at(
+        _feature_row(),
+        CALCULATION_DATE.date(),
+        BreadthFormulaPolicy(),
+        US_POLICY,
+        stockbee_currency_matches=False,
+    )
+
+    assert signals.eligibility.stockbee_liquidity is False
+    assert signals.eligibility.stockbee_daily is False
+    assert signals.eligibility.stockbee_month is False
+    assert signals.eligibility.stockbee_34day is False
+    assert signals.eligibility.stockbee_quarter is False
+    assert signals.eligibility.advance_decline is True
+    assert signals.eligibility.t2108 is True
+    assert signals.eligibility.high_low_52week is True
+    assert signals.eligibility.atr_extension is True
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_breadth_market_policy.py
+++ b/backend/tests/unit/test_breadth_market_policy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from app.domain.markets.catalog import get_market_catalog
+from app.services.breadth.market_policy import (
+    BREADTH_MARKET_POLICIES,
+    get_breadth_market_policy,
+)
+from app.services.breadth.types import (
+    CURRENT_BREADTH_CALCULATION_REVISION,
+    BreadthFormulaPolicy,
+    BreadthMarketPolicy,
+)
+
+
+def test_breadth_market_policy_keys_match_catalog_capability() -> None:
+    expected = set(get_market_catalog().market_codes_with_capability("breadth"))
+
+    assert set(BREADTH_MARKET_POLICIES) == expected
+
+
+@pytest.mark.parametrize(
+    ("market", "expected"),
+    (
+        ("US", BreadthMarketPolicy("US", "USD", 250_000, 100_000, 5.00)),
+        ("CA", BreadthMarketPolicy("CA", "CAD", 5_000, 5_000, 0.30)),
+        ("DE", BreadthMarketPolicy("DE", "EUR", 5_000, 300, 8.00)),
+        ("HK", BreadthMarketPolicy("HK", "HKD", 20_000, 150_000, 0.20)),
+        ("IN", BreadthMarketPolicy("IN", "INR", 100_000, 15_000, 15.00)),
+        ("JP", BreadthMarketPolicy("JP", "JPY", 8_000_000, 50_000, 500.00)),
+        ("KR", BreadthMarketPolicy("KR", "KRW", 100_000_000, 50_000, 2_000.00)),
+        ("TW", BreadthMarketPolicy("TW", "TWD", 3_500_000, 400_000, 20.00)),
+        ("CN", BreadthMarketPolicy("CN", "CNY", 50_000_000, 10_000_000, 5.00)),
+    ),
+)
+def test_breadth_market_policies_store_selected_local_thresholds(
+    market: str,
+    expected: BreadthMarketPolicy,
+) -> None:
+    assert get_breadth_market_policy(market.lower()) == expected
+
+
+@pytest.mark.parametrize("market", ("AU", "SG", "MY", "", "XX"))
+def test_unsupported_market_policy_lookup_fails_closed(market: str) -> None:
+    rendered = market or "<missing>"
+
+    with pytest.raises(
+        ValueError,
+        match=f"Breadth is not supported for market {rendered}",
+    ):
+        get_breadth_market_policy(market)
+
+
+def test_formula_policy_contains_only_formula_wide_settings() -> None:
+    policy = BreadthFormulaPolicy()
+
+    assert policy.calculation_revision == 3
+    assert policy.atr_period == 14
+    assert policy.atr_extension_threshold == 10.0
+    assert not hasattr(policy, "min_adtv_usd")
+    assert not hasattr(policy, "min_daily_volume")
+    assert not hasattr(policy, "min_month_reference_price_usd")
+    assert not hasattr(policy, "fx_max_age_days")
+
+
+def test_current_breadth_revision_is_three() -> None:
+    assert CURRENT_BREADTH_CALCULATION_REVISION == 3

--- a/backend/tests/unit/test_breadth_persistence.py
+++ b/backend/tests/unit/test_breadth_persistence.py
@@ -36,7 +36,7 @@ def _result(*, advancing: int = 8) -> BreadthDailyResult:
     )
 
 
-def test_persistence_upserts_every_revision_2_field_in_one_market_partition():
+def test_persistence_upserts_every_current_field_in_one_market_partition():
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine, tables=[MarketBreadth.__table__])
     db = sessionmaker(bind=engine)()
@@ -53,5 +53,5 @@ def test_persistence_upserts_every_revision_2_field_in_one_market_partition():
     assert row.broad_universe_count == 12
     assert row.total_stocks_scanned == 12
     assert row.stockbee_eligibility_signature == "b" * 64
-    assert row.calculation_revision == 2
+    assert row.calculation_revision == 3
     assert row.calculation_duration_seconds == 0.75

--- a/backend/tests/unit/test_breadth_universe.py
+++ b/backend/tests/unit/test_breadth_universe.py
@@ -1,14 +1,11 @@
 from datetime import date
 
 import pandas as pd
-import pytest
 from app.services.breadth.market_policy import get_breadth_market_policy
 from app.services.breadth.types import BreadthFormulaPolicy, BreadthUniverseMember
 from app.services.breadth.universe import (
-    MissingHistoricalFXError,
     build_breadth_universe_snapshots,
     classify_metric_eligibility,
-    resolve_historical_fx_series,
     stockbee_eligibility_signature,
 )
 from app.services.point_in_time_universe_service import (
@@ -16,56 +13,6 @@ from app.services.point_in_time_universe_service import (
     PointInTimeUniverseMember,
     hash_point_in_time_universe_symbols,
 )
-
-
-def test_historical_fx_prefers_exact_date_then_prior_within_seven_days():
-    requested = (date(2026, 8, 20), date(2026, 8, 21))
-    result = resolve_historical_fx_series(
-        "HKD",
-        requested,
-        {
-            date(2026, 8, 14): 0.127,
-            date(2026, 8, 21): 0.128,
-        },
-        max_age_days=7,
-    )
-
-    assert result.loc[pd.Timestamp("2026-08-20")] == pytest.approx(0.127)
-    assert result.loc[pd.Timestamp("2026-08-21")] == pytest.approx(0.128)
-
-
-def test_historical_fx_rejects_quote_older_than_seven_calendar_days():
-    with pytest.raises(MissingHistoricalFXError) as exc_info:
-        resolve_historical_fx_series(
-            "HKD",
-            (date(2026, 8, 22),),
-            {date(2026, 8, 14): 0.127},
-            max_age_days=7,
-        )
-
-    assert exc_info.value.currency == "HKD"
-    assert exc_info.value.calculation_date == date(2026, 8, 22)
-
-
-def test_historical_fx_never_uses_future_quote():
-    with pytest.raises(MissingHistoricalFXError):
-        resolve_historical_fx_series(
-            "HKD",
-            (date(2026, 8, 21),),
-            {date(2026, 8, 22): 0.128},
-            max_age_days=7,
-        )
-
-
-def test_historical_fx_usd_is_identity_without_observations():
-    result = resolve_historical_fx_series(
-        "usd",
-        (date(2026, 8, 20), date(2026, 8, 21)),
-        {},
-        max_age_days=7,
-    )
-
-    assert result.tolist() == [1.0, 1.0]
 
 
 class _UniverseResolver:

--- a/backend/tests/unit/test_breadth_universe.py
+++ b/backend/tests/unit/test_breadth_universe.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pandas as pd
 import pytest
+from app.services.breadth.market_policy import get_breadth_market_policy
 from app.services.breadth.types import BreadthFormulaPolicy, BreadthUniverseMember
 from app.services.breadth.universe import (
     MissingHistoricalFXError,
@@ -112,9 +113,9 @@ def test_metric_eligibility_is_independent_and_stockbee_requires_common_stock():
                 "daily_return": 0.01,
                 "volume": 100_000.0,
                 "prior_volume": 90_000.0,
-                "adtv20_usd": 250_000.0,
+                "adtv20_local": 250_000.0,
                 "adjusted_close_20": float("nan"),
-                "raw_close_usd_20": float("nan"),
+                "raw_close_local_20": float("nan"),
                 "month_return": float("nan"),
                 "low_34": float("nan"),
                 "high_34": float("nan"),
@@ -136,12 +137,14 @@ def test_metric_eligibility_is_independent_and_stockbee_requires_common_stock():
         BreadthUniverseMember("IPO", "USD", True),
         features,
         BreadthFormulaPolicy(),
+        get_breadth_market_policy("US"),
         calculation_date=calculation_date.date(),
     )
     excluded = classify_metric_eligibility(
         BreadthUniverseMember("ETF", "USD", False),
         features,
         BreadthFormulaPolicy(),
+        get_breadth_market_policy("US"),
         calculation_date=calculation_date.date(),
     )
 
@@ -181,9 +184,9 @@ def test_stockbee_signature_contains_only_liquid_broad_members():
                 "daily_return": 0.01,
                 "volume": 100_000.0,
                 "prior_volume": 90_000.0,
-                "adtv20_usd": 250_000.0,
+                "adtv20_local": 250_000.0,
                 "adjusted_close_20": float("nan"),
-                "raw_close_usd_20": float("nan"),
+                "raw_close_local_20": float("nan"),
                 "month_return": float("nan"),
                 "low_34": float("nan"),
                 "high_34": float("nan"),
@@ -201,7 +204,7 @@ def test_stockbee_signature_contains_only_liquid_broad_members():
         index=[pd.Timestamp(calculation_date)],
     )
     illiquid_features = liquid_features.copy()
-    illiquid_features.loc[:, "adtv20_usd"] = 249_999.0
+    illiquid_features.loc[:, "adtv20_local"] = 249_999.0
 
     signature = stockbee_eligibility_signature(
         snapshot,
@@ -210,6 +213,7 @@ def test_stockbee_signature_contains_only_liquid_broad_members():
             illiquid.symbol: illiquid_features,
         },
         BreadthFormulaPolicy(),
+        get_breadth_market_policy("US"),
     )
 
     assert signature == hash_point_in_time_universe_symbols(("COMMON",))

--- a/backend/tests/unit/test_breadth_workflow_parity.py
+++ b/backend/tests/unit/test_breadth_workflow_parity.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pandas as pd
 
 from app.services.breadth.engine import BreadthEngine, BreadthEngineRequest
+from app.services.breadth.market_policy import get_breadth_market_policy
 from app.services.breadth.types import BreadthUniverseMember, BreadthUniverseSnapshot
 from app.services.breadth_attribution_service import BreadthAttributionService
 from app.services.point_in_time_universe_service import (
@@ -47,7 +48,7 @@ def test_static_and_attribution_daily_counts_match_canonical_engine():
             dates=(calculation_date,),
             universes_by_date={calculation_date: snapshot},
             prices_by_symbol=prices,
-            fx_by_currency={"USD": pd.Series(1.0, index=prices["UP"].index)},
+            market_policy=get_breadth_market_policy("US"),
         )
     )[calculation_date]
 
@@ -68,6 +69,8 @@ def test_static_and_attribution_daily_counts_match_canonical_engine():
         ],
         price_data=prices,
         target_dates=[calculation_date],
+        market="US",
+        currencies_by_symbol={"UP": "USD", "DOWN": "USD"},
     )[0]
 
     expected = (

--- a/backend/tests/unit/test_daily_breadth_runner.py
+++ b/backend/tests/unit/test_daily_breadth_runner.py
@@ -65,7 +65,7 @@ def _calculation(
             "stocks_down_13pct_34days": 2,
             "total_stocks_scanned": candidates,
             "broad_universe_count": candidates,
-            "calculation_revision": 2,
+            "calculation_revision": 3,
         }
     daily_result = BreadthDailyResult(
         market="US",

--- a/backend/tests/unit/test_daily_market_pipeline_tasks.py
+++ b/backend/tests/unit/test_daily_market_pipeline_tasks.py
@@ -98,6 +98,53 @@ def test_daily_market_pipeline_orders_refresh_compute_and_scan(monkeypatch):
     }
 
 
+@pytest.mark.parametrize("market", ("AU", "SG", "MY"))
+def test_daily_pipeline_omits_breadth_tasks_and_guards_for_disabled_market(
+    monkeypatch,
+    market,
+):
+    from app.tasks import daily_market_pipeline_tasks as module
+
+    monkeypatch.setattr(
+        "app.tasks.cache_tasks.smart_refresh_cache",
+        _FakeTask("app.tasks.cache_tasks.smart_refresh_cache"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.market_rs_tasks.calculate_market_rs_snapshot",
+        _FakeTask("app.tasks.market_rs_tasks.calculate_market_rs_snapshot"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill",
+        _FakeTask("app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.breadth_tasks.calculate_market_exposure",
+        _FakeTask("app.tasks.breadth_tasks.calculate_market_exposure"),
+    )
+    monkeypatch.setattr(
+        "app.tasks.group_rank_tasks.calculate_daily_group_rankings_with_gapfill",
+        _FakeTask("app.tasks.group_rank_tasks.calculate_daily_group_rankings_with_gapfill"),
+    )
+    monkeypatch.setattr(
+        "app.interfaces.tasks.feature_store_tasks.build_daily_snapshot",
+        _FakeTask("app.interfaces.tasks.feature_store_tasks.build_daily_snapshot"),
+    )
+
+    tasks = [
+        signature.task
+        for signature in module._build_daily_market_pipeline_signatures(
+            market,
+            date(2026, 3, 16),
+        )
+    ]
+
+    assert "app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill" not in tasks
+    assert "app.tasks.daily_market_pipeline_tasks.guard_breadth_result" not in tasks
+    assert "app.tasks.breadth_tasks.calculate_market_exposure" not in tasks
+    assert "app.tasks.daily_market_pipeline_tasks.guard_exposure_result" not in tasks
+    assert "app.interfaces.tasks.feature_store_tasks.build_daily_snapshot" in tasks
+
+
 def test_queue_daily_market_pipeline_skips_disabled_market(monkeypatch):
     from app.tasks import daily_market_pipeline_tasks as module
 

--- a/backend/tests/unit/test_digest_service.py
+++ b/backend/tests/unit/test_digest_service.py
@@ -160,7 +160,7 @@ def _seed_digest_data(session):
             stocks_up_13pct_34days=0,
             stocks_down_13pct_34days=0,
             total_stocks_scanned=4200,
-            calculation_revision=2,
+            calculation_revision=3,
         )
     )
     session.add_all(

--- a/backend/tests/unit/test_export_static_site_script.py
+++ b/backend/tests/unit/test_export_static_site_script.py
@@ -1651,6 +1651,87 @@ def test_run_daily_refresh_computes_market_exposure_before_snapshot(monkeypatch)
     }
 
 
+def test_run_daily_refresh_skips_unsupported_breadth_and_builds_snapshot(
+    monkeypatch,
+):
+    calls: list[str] = []
+
+    @contextmanager
+    def fake_session():
+        yield object()
+
+    monkeypatch.setattr(export_script, "SessionLocal", fake_session)
+    monkeypatch.setattr(
+        export_script,
+        "_resolve_latest_completed_trading_date",
+        lambda _market: date(2026, 6, 25),
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_refresh_static_daily_prices",
+        lambda *, as_of_date, market=None: calls.append(
+            f"price:{market}:{as_of_date.isoformat()}"
+        )
+        or {"task": "price_refresh"},
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_ensure_breadth_history",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unsupported market must not calculate breadth")
+        ),
+    )
+    monkeypatch.setattr(
+        export_script,
+        "_compute_static_market_exposure",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unsupported market must not calculate exposure")
+        ),
+    )
+    monkeypatch.setattr(
+        feature_store_tasks,
+        "build_daily_snapshot",
+        SimpleNamespace(
+            run=lambda **kwargs: calls.append(
+                f"snapshot:{kwargs['market']}:{kwargs['as_of_date_str']}"
+            )
+            or {"status": "published", "run_id": 77}
+        ),
+    )
+    monkeypatch.setattr(
+        export_script.IBDIndustryService,
+        "load_from_csv",
+        lambda db, csv_path=None: 10105,
+    )
+    _stub_ready_group_rank_history(monkeypatch)
+    monkeypatch.setattr(export_script, "_upsert_feature_run_pointer", lambda **_kwargs: None)
+
+    results, warnings = export_script._run_daily_refresh(
+        market="SG",
+        skip_universe_refresh=True,
+        skip_fundamentals_refresh=True,
+    )
+
+    assert warnings == []
+    assert calls == ["price:SG:2026-06-25", "snapshot:SG:2026-06-25"]
+    assert results["breadth_history"]["SG"] == {
+        "status": "skipped",
+        "reason": "market_breadth_unsupported",
+        "market": "SG",
+        "as_of_date": "2026-06-25",
+    }
+    assert results["market_exposure"]["SG"] == {
+        "status": "skipped",
+        "reason": "market_breadth_unsupported",
+        "market": "SG",
+        "date": "2026-06-25",
+    }
+    assert results["feature_snapshots"]["SG"] == {
+        "status": "published",
+        "run_id": 77,
+    }
+
+
 def test_run_daily_refresh_skips_snapshot_when_market_exposure_errors(monkeypatch):
     calls: list[str] = []
 

--- a/backend/tests/unit/test_historical_fx.py
+++ b/backend/tests/unit/test_historical_fx.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from app.services.historical_fx import (
+    MissingHistoricalFXError,
+    resolve_historical_fx_series,
+)
+
+
+def test_historical_fx_prefers_exact_date_then_prior_within_seven_days() -> None:
+    requested = (date(2026, 8, 20), date(2026, 8, 21))
+
+    result = resolve_historical_fx_series(
+        "HKD",
+        requested,
+        {
+            date(2026, 8, 14): 0.127,
+            date(2026, 8, 21): 0.128,
+        },
+        max_age_days=7,
+    )
+
+    assert result.loc[pd.Timestamp("2026-08-20")] == pytest.approx(0.127)
+    assert result.loc[pd.Timestamp("2026-08-21")] == pytest.approx(0.128)
+
+
+def test_historical_fx_rejects_quote_older_than_seven_calendar_days() -> None:
+    with pytest.raises(MissingHistoricalFXError) as exc_info:
+        resolve_historical_fx_series(
+            "HKD",
+            (date(2026, 8, 22),),
+            {date(2026, 8, 14): 0.127},
+            max_age_days=7,
+        )
+
+    assert exc_info.value.currency == "HKD"
+    assert exc_info.value.calculation_date == date(2026, 8, 22)
+
+
+def test_historical_fx_never_uses_future_quote() -> None:
+    with pytest.raises(MissingHistoricalFXError):
+        resolve_historical_fx_series(
+            "HKD",
+            (date(2026, 8, 21),),
+            {date(2026, 8, 22): 0.128},
+            max_age_days=7,
+        )
+
+
+def test_historical_fx_usd_is_identity_without_observations() -> None:
+    result = resolve_historical_fx_series(
+        "usd",
+        (date(2026, 8, 20), date(2026, 8, 21)),
+        {},
+        max_age_days=7,
+    )
+
+    assert result.tolist() == [1.0, 1.0]

--- a/backend/tests/unit/test_static_breadth_section_builder.py
+++ b/backend/tests/unit/test_static_breadth_section_builder.py
@@ -29,25 +29,12 @@ def _price_frame(index: pd.DatetimeIndex) -> pd.DataFrame:
     )
 
 
-class _HistoricalFx:
-    def get_historical_usd_rates(self, currencies, required_dates):
-        return {
-            currency: pd.Series(
-                0.13,
-                index=pd.DatetimeIndex(sorted(required_dates)),
-            )
-            for currency in currencies
-        }
-
-
-def test_static_inputs_retain_only_the_feature_window_for_prices_and_fx():
+def test_static_inputs_retain_only_the_local_price_feature_window():
     recent_index = pd.bdate_range(end="2026-08-21", periods=400)
     full_index = pd.DatetimeIndex([pd.Timestamp("2020-01-02"), *recent_index])
     canonical_dates = list(recent_index[-120:].date)
 
-    inputs = StaticBreadthEngineInputFactory(
-        fx_service=_HistoricalFx()
-    ).build(
+    inputs = StaticBreadthEngineInputFactory().build(
         market="HK",
         canonical_dates=canonical_dates,
         price_data={"0700.HK": _price_frame(full_index)},
@@ -58,7 +45,9 @@ def test_static_inputs_retain_only_the_feature_window_for_prices_and_fx():
     assert len(retained_index) == 371
     assert retained_index[0] == recent_index[29]
     assert pd.Timestamp("2020-01-02") not in retained_index
-    assert pd.Timestamp("2020-01-02") not in inputs.request.fx_by_currency["HKD"].index
+    assert inputs.request.market_policy.market == "HK"
+    assert inputs.request.market_policy.currency == "HKD"
+    assert not hasattr(inputs.request, "fx_by_currency")
 
 
 def test_static_inputs_keep_each_dates_point_in_time_universe():

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1969,6 +1969,25 @@ def test_export_marks_optional_sections_unavailable_without_aborting(
     assert home["top_groups"] == []
 
 
+def test_build_breadth_payload_rejects_market_without_breadth_capability(
+    service_and_session_factory,
+):
+    """Break caught: unsupported markets reaching the breadth policy factory."""
+    service, session_factory = service_and_session_factory
+
+    with session_factory() as db, pytest.raises(
+        StaticSiteSectionUnavailableError,
+        match="Market AU does not support breadth",
+    ):
+        service._build_breadth_payload(  # noqa: SLF001 - regression coverage
+            db=db,
+            generated_at="2026-08-21T22:00:00Z",
+            expected_as_of_date=date(2026, 8, 21),
+            market="AU",
+            serialized_rows=[{"symbol": "BHP.AX"}],
+        )
+
+
 def test_build_breadth_payload_requires_target_date(service_and_session_factory, monkeypatch):
     service, _session_factory = service_and_session_factory
 

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -1379,7 +1379,7 @@ def test_combine_market_artifacts_builds_manifest_from_subset(tmp_path):
         "market": "US",
         "display_name": "United States",
         "as_of_date": "2026-04-04",
-        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": True},
         "pages": {"home": {"path": "markets/us/home.json"}, "scan": {"path": "markets/us/scan/manifest.json"}},
         "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
         "freshness": {"scan_run_id": 11},
@@ -1454,7 +1454,7 @@ def test_combine_market_artifacts_uses_fallback_only_for_missing_markets(tmp_pat
         "market": "US",
         "display_name": "United States",
         "as_of_date": "2026-04-05",
-        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": True},
         "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
         "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
     }
@@ -1462,7 +1462,7 @@ def test_combine_market_artifacts_uses_fallback_only_for_missing_markets(tmp_pat
         "market": "US",
         "display_name": "United States",
         "as_of_date": "2026-04-04",
-        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": True},
         "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
         "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
     }
@@ -1531,7 +1531,7 @@ def test_combine_market_artifacts_uses_newer_fallback_for_rewound_current_market
         "market": "US",
         "display_name": "United States",
         "as_of_date": "2026-07-31",
-        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": True},
         "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
         "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
     }
@@ -1539,7 +1539,7 @@ def test_combine_market_artifacts_uses_newer_fallback_for_rewound_current_market
         "market": "US",
         "display_name": "United States",
         "as_of_date": "2026-08-03",
-        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": True},
         "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
         "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
     }
@@ -1600,7 +1600,7 @@ def test_combine_market_artifacts_keeps_current_override_when_newer_fallback_use
         "display_name": "United States",
         "as_of_date": "2026-08-03",
         "rs_formula_version": LEGACY_RS_FORMULA_VERSION,
-        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": True},
         "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
         "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
     }
@@ -1609,7 +1609,7 @@ def test_combine_market_artifacts_keeps_current_override_when_newer_fallback_use
         "display_name": "United States",
         "as_of_date": "2026-08-04",
         "rs_formula_version": BALANCED_RS_FORMULA_VERSION,
-        "features": {"scan": True, "breadth": True, "groups": False, "charts": True},
+        "features": {"scan": True, "breadth": False, "groups": False, "charts": True},
         "pages": {"scan": {"path": "markets/us/scan/manifest.json"}},
         "assets": {"charts": {"path": "markets/us/charts/index.json", "limit": 200, "symbols_total": 1}},
     }

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -132,13 +132,6 @@ class _FakeBenchmarkCache:
         return self._symbol
 
 
-class _FakeHistoricalFx:
-    def get_historical_usd_rates(self, currencies, dates, *, max_age_days=7):
-        del max_age_days
-        index = pd.DatetimeIndex(sorted(dates))
-        return {currency: pd.Series(0.13, index=index) for currency in currencies}
-
-
 def _service_with_static_caches(
     session_factory,
     *,
@@ -2036,9 +2029,7 @@ def test_build_breadth_payload_serialized_rows_emit_market_benchmark_overlay(
         ),
         fundamentals_cache=object(),
         benchmark_cache=_FakeBenchmarkCache("^HSI"),
-        breadth_engine_input_factory=StaticBreadthEngineInputFactory(
-            fx_service=_FakeHistoricalFx()
-        ),
+        breadth_engine_input_factory=StaticBreadthEngineInputFactory(),
     )
 
     payload = service._build_breadth_payload(  # noqa: SLF001 - intentional unit coverage
@@ -2158,9 +2149,7 @@ def test_build_breadth_payload_uses_builder_cache_dependencies_without_rebinding
             get_benchmark_candidates=lambda market: ("^HSI",),
             get_benchmark_symbol=lambda market: "^HSI",
         ),
-        engine_input_factory=StaticBreadthEngineInputFactory(
-            fx_service=_FakeHistoricalFx()
-        ),
+        engine_input_factory=StaticBreadthEngineInputFactory(),
     )
 
     payload = service._build_breadth_payload(  # noqa: SLF001 - regression coverage

--- a/backend/tests/unit/test_stock_workspace_endpoints.py
+++ b/backend/tests/unit/test_stock_workspace_endpoints.py
@@ -197,7 +197,7 @@ def _seed_dashboard_data(session):
             ratio_5day=1.6,
             ratio_10day=1.3,
             total_stocks_scanned=4800,
-            calculation_revision=2,
+            calculation_revision=3,
         )
     )
     theme = ThemeCluster(
@@ -769,7 +769,7 @@ async def test_decision_dashboard_uses_market_specific_latest_run_pointer_for_no
             ratio_5day=1.6,
             ratio_10day=1.3,
             total_stocks_scanned=4800,
-            calculation_revision=2,
+            calculation_revision=3,
         )
     )
     session.commit()

--- a/backend/tests/unit/test_ui_snapshot_service.py
+++ b/backend/tests/unit/test_ui_snapshot_service.py
@@ -505,7 +505,7 @@ def test_market_breadth_snapshot_serializes_revision_2_context_and_denominators(
         atr_extension_eligible_count=92,
         eligibility_signature="broad",
         stockbee_eligibility_signature="stockbee",
-        calculation_revision=2,
+        calculation_revision=3,
     )
 
     payload = market_breadth_to_dict(row)
@@ -514,7 +514,7 @@ def test_market_breadth_snapshot_serializes_revision_2_context_and_denominators(
     assert payload["broad_universe_count"] == 110
     assert payload["stockbee_daily_eligible_count"] == 95
     assert payload["stockbee_eligibility_signature"] == "stockbee"
-    assert payload["calculation_revision"] == 2
+    assert payload["calculation_revision"] == 3
 
 
 def test_breadth_source_revision_includes_calculation_revision():
@@ -538,13 +538,13 @@ def test_breadth_source_revision_includes_calculation_revision():
                 stocks_up_13pct_34days=0,
                 stocks_down_13pct_34days=0,
                 total_stocks_scanned=1,
-                calculation_revision=2,
+                calculation_revision=3,
             )
         )
         db.commit()
         revision = service._resolve_breadth_source_revision(db, "US")  # noqa: SLF001
 
-    assert revision == "2026-08-21|breadth-r2"
+    assert revision == "2026-08-21|breadth-r3"
 
 
 def test_publish_groups_bootstrap_serializes_rankings_when_available():

--- a/backend/tests/unit/test_watchlist_stewardship_service.py
+++ b/backend/tests/unit/test_watchlist_stewardship_service.py
@@ -167,7 +167,7 @@ def _seed_watchlist_stewardship_data(session):
             ratio_5day=0.8,
             ratio_10day=0.7,
             total_stocks_scanned=4200,
-            calculation_revision=2,
+            calculation_revision=3,
         )
     )
     session.add_all([

--- a/docs/LIVE_APP_GUIDE.md
+++ b/docs/LIVE_APP_GUIDE.md
@@ -343,6 +343,24 @@ Directional cells use a dark neutral background for ordinary readings, lighter g
 
 Formula tooltips identify the source, required history, liquidity rule, and eligible denominator. The **Stockbee MM** tab on the Daily page surfaces the same daily counts in a market-monitor grid. The chart time-range selector covers 1M, 3M, 6M, and 1Y windows.
 
+### StockBee market thresholds
+
+StockBee eligibility uses fixed thresholds in each market's primary trading currency. These are rounded initial settings from a one-time cross-market calibration; they are maintained manually in the shared server-side policy and are not recalculated from daily FX or changing percentiles.
+
+| Market | Currency | Minimum ADTV20 (local) | Minimum daily shares | Minimum raw reference price (local) |
+|--------|----------|-----------------------:|---------------------:|------------------------------------:|
+| US | USD | 250,000 | 100,000 | 5.00 |
+| CA | CAD | 5,000 | 5,000 | 0.30 |
+| DE | EUR | 5,000 | 300 | 8.00 |
+| HK | HKD | 20,000 | 150,000 | 0.20 |
+| IN | INR | 100,000 | 15,000 | 15.00 |
+| JP | JPY | 8,000,000 | 50,000 | 500 |
+| KR | KRW | 100,000,000 | 50,000 | 2,000 |
+| TW | TWD | 3,500,000 | 400,000 | 20.00 |
+| CN | CNY | 50,000,000 | 10,000,000 | 5.00 |
+
+`ADTV20` is the 20-session mean of raw local close × shares traded. Monthly StockBee signals also require the raw close exactly 20 sessions earlier to meet the local reference-price floor. A listing whose currency differs from its market's policy currency is excluded from StockBee metrics, but it can still contribute to advance/decline, T2108, 52-week high/low, and ATR context indicators.
+
 ---
 
 ## Groups & Relative Rotation Graph

--- a/docs/STATIC_SITE.md
+++ b/docs/STATIC_SITE.md
@@ -52,6 +52,12 @@ Balanced activation validates every declared Scan chunk and requires exact formu
 
 RRG rolling-history assets use `static-rrg-history-v4` and identify their RS formula version. The weekly RS-Ratio/RS-Momentum transformation is unchanged, but history from different formulas is never merged. A fallback market artifact or RRG-history bundle is rejected when its schema or formula does not match the requested export, so the site cannot silently combine legacy and balanced rankings. Until enough balanced history exists, RRG can correctly report insufficient history rather than falling back to legacy coordinates.
 
+## Breadth Data Contract
+
+Breadth-capable static market artifacts must contain a revision-3 `breadth.json` payload and a `breadth-r3` source marker. The combiner rejects revision-1 or revision-2 breadth artifacts even when their Market RS formula is otherwise compatible. If no current revision-3 artifact exists, that market's breadth is unavailable; the publisher does not silently reuse an older breadth formula.
+
+Revision 3 uses the same fixed local-market StockBee thresholds as the live app and has no historical-FX input. Markets whose catalog capability disables breadth (currently AU, SG, and MY) publish their other supported static sections without requiring breadth or breadth-derived exposure.
+
 ## Maintaining Static Assets
 
 - Keep the static page tour GIF aligned with the exported static routes.

--- a/docs/release-notes/market-calibrated-breadth-r3.md
+++ b/docs/release-notes/market-calibrated-breadth-r3.md
@@ -1,0 +1,7 @@
+# Market-calibrated breadth revision 3
+
+Market breadth now uses fixed, rounded StockBee eligibility thresholds expressed in each supported market's primary trading currency. The shared live, backfill, attribution, and static calculation layer no longer depends on historical FX; broad context indicators remain available when a listing's currency differs from the market policy, while only its StockBee eligibility is excluded.
+
+Existing installations must run the revision-3 shadow rebuild and atomic activation for all breadth-enabled markets. Revision-2 rows and static fallbacks are intentionally not served after the new code is deployed, so breadth can be temporarily unavailable until activation and dependent exposure/snapshot/static rebuilds finish. No database schema migration is required.
+
+AU, SG, and MY remain breadth-disabled. Their bootstrap, daily, snapshot, and static workflows now skip breadth and breadth-derived exposure instead of treating those absent sections as failures.

--- a/docs/runbooks/market-breadth-revision-3-cutover.md
+++ b/docs/runbooks/market-breadth-revision-3-cutover.md
@@ -7,7 +7,13 @@ This runbook replaces all revision-2 breadth history with the revision-3 dataset
 - Deploy code that sets `CURRENT_BREADTH_CALCULATION_REVISION = 3`.
 - Confirm local OHLCV caches and point-in-time common-stock universe history cover the rebuild period plus 252 trading sessions of warm-up.
 - Confirm the policy registry covers US, CA, DE, HK, IN, JP, KR, TW, and CN.
-- Choose the first date that should remain publicly available after cutover.
+- Choose the inclusive calendar bounds that should remain publicly available after cutover and export them for the commands below:
+
+  ```bash
+  export FIRST_DATE=YYYY-MM-DD
+  export END_DATE=YYYY-MM-DD
+  ```
+
 - Run commands from `backend` with the production virtual environment active.
 
 Revision-aware API reads hide revision-2 rows as soon as revision-3 code is deployed. Breadth may therefore be temporarily unavailable until activation completes; this is intentional and safer than serving mixed methodologies.
@@ -23,17 +29,42 @@ pg_dump --format=custom --table=market_breadth "$BREADTH_DATABASE_URL" \
 
 Retain a copy of the current static market artifacts and the database dump through the monitoring and rollback windows.
 
-## 2. Build and validate the complete shadow dataset
+## 2. Pause breadth-dependent writers
+
+Stop Celery beat and prevent these tasks or workflows from starting. Wait for active instances to finish:
+
+- daily breadth calculation and gap fill;
+- breadth backfill and revision rebuild;
+- market exposure calculation/backfill;
+- daily market pipelines and runtime bootstrap;
+- static breadth/export publication.
+
+Keep these writers paused until activation and all dependent rebuilds are complete. This prevents a concurrent live or staging write from invalidating the dataset after validation.
+
+## 3. Build and validate the complete shadow dataset
 
 Omit `--market` so the build stages every breadth-enabled market. A selective build is diagnostic only and cannot activate the full-table replacement.
 
 ```bash
 python -m app.scripts.rebuild_market_breadth build \
-  --start-date 2024-01-01 \
-  --end-date 2026-08-28
+  --start-date "$FIRST_DATE" \
+  --end-date "$END_DATE"
 
 python -m app.scripts.rebuild_market_breadth validate \
   > breadth-revision-3-validation.json
+
+jq -e --arg first "$FIRST_DATE" --arg end "$END_DATE" '
+  .valid == true
+  and .errors == []
+  and .calculation_revision == 3
+  and ([.markets[] |
+    .row_count > 0
+    and .start_date >= $first
+    and .end_date <= $end
+  ] | all)
+' breadth-revision-3-validation.json
+
+jq '.markets' breadth-revision-3-validation.json
 ```
 
 Validation must exit zero and report:
@@ -45,19 +76,9 @@ Validation must exit zero and report:
 - exact market/date manifest coverage;
 - reconciled denominators, ratios, and eligibility signatures.
 
-Re-running `build` recreates only the staging dataset and manifest. It does not modify `market_breadth`.
+Before activation, inspect the printed per-market coverage. Each `start_date` must be the first canonical trading session on or after `FIRST_DATE`, each `end_date` must be the last canonical trading session on or before `END_DATE`, and every `row_count` must be nonzero. Market holidays mean these dates do not necessarily equal the raw calendar bounds. The valid report's exact manifest check confirms there are no missing or unexpected sessions between those endpoints.
 
-## 3. Pause breadth-dependent writers
-
-Stop Celery beat and prevent these tasks or workflows from starting. Wait for active instances to finish:
-
-- daily breadth calculation and gap fill;
-- breadth backfill and revision rebuild;
-- market exposure calculation/backfill;
-- daily market pipelines and runtime bootstrap;
-- static breadth/export publication.
-
-Do not activate while any process can write breadth or its dependent outputs.
+Re-running `build` recreates only the staging dataset and manifest. It does not modify `market_breadth`; keep writers paused while rebuilding and revalidating.
 
 ## 4. Activate atomically
 

--- a/docs/runbooks/market-breadth-revision-3-cutover.md
+++ b/docs/runbooks/market-breadth-revision-3-cutover.md
@@ -1,0 +1,110 @@
+# Market breadth revision 3 cutover
+
+This runbook replaces all revision-2 breadth history with the revision-3 dataset built from fixed local-market StockBee thresholds. There is no schema or Alembic migration: the existing `calculation_revision` column is the stale-data guard, and the existing shadow rebuild tables provide the atomic data migration.
+
+## Preconditions
+
+- Deploy code that sets `CURRENT_BREADTH_CALCULATION_REVISION = 3`.
+- Confirm local OHLCV caches and point-in-time common-stock universe history cover the rebuild period plus 252 trading sessions of warm-up.
+- Confirm the policy registry covers US, CA, DE, HK, IN, JP, KR, TW, and CN.
+- Choose the first date that should remain publicly available after cutover.
+- Run commands from `backend` with the production virtual environment active.
+
+Revision-aware API reads hide revision-2 rows as soon as revision-3 code is deployed. Breadth may therefore be temporarily unavailable until activation completes; this is intentional and safer than serving mixed methodologies.
+
+## 1. Back up the live data and published artifacts
+
+No `alembic upgrade` is required for this cutover.
+
+```bash
+pg_dump --format=custom --table=market_breadth "$BREADTH_DATABASE_URL" \
+  --file=market_breadth_before_revision_3.dump
+```
+
+Retain a copy of the current static market artifacts and the database dump through the monitoring and rollback windows.
+
+## 2. Build and validate the complete shadow dataset
+
+Omit `--market` so the build stages every breadth-enabled market. A selective build is diagnostic only and cannot activate the full-table replacement.
+
+```bash
+python -m app.scripts.rebuild_market_breadth build \
+  --start-date 2024-01-01 \
+  --end-date 2026-08-28
+
+python -m app.scripts.rebuild_market_breadth validate \
+  > breadth-revision-3-validation.json
+```
+
+Validation must exit zero and report:
+
+- `"valid": true`;
+- `"calculation_revision": 3`;
+- local traded-value liquidity in the formula contract;
+- the fixed market-policy contract;
+- exact market/date manifest coverage;
+- reconciled denominators, ratios, and eligibility signatures.
+
+Re-running `build` recreates only the staging dataset and manifest. It does not modify `market_breadth`.
+
+## 3. Pause breadth-dependent writers
+
+Stop Celery beat and prevent these tasks or workflows from starting. Wait for active instances to finish:
+
+- daily breadth calculation and gap fill;
+- breadth backfill and revision rebuild;
+- market exposure calculation/backfill;
+- daily market pipelines and runtime bootstrap;
+- static breadth/export publication.
+
+Do not activate while any process can write breadth or its dependent outputs.
+
+## 4. Activate atomically
+
+```bash
+python -m app.scripts.rebuild_market_breadth validate
+python -m app.scripts.rebuild_market_breadth activate --confirm-replace
+```
+
+Activation locks and revalidates the live, staging, and manifest tables; deletes every existing `market_breadth` row, including US revision-2 rows; inserts only validated revision-3 rows; and verifies the revision and row count before committing one transaction.
+
+## 5. Rebuild dependent outputs
+
+Keep writers paused while completing these steps:
+
+1. Rebuild market exposure for the same date range.
+2. Rebuild StockBee group attribution where enabled.
+3. Republish breadth UI snapshots for every breadth-enabled market.
+4. Regenerate static market artifacts and combine only `breadth-r3` outputs.
+5. Clear breadth and exposure response/snapshot caches.
+6. Restart API, workers, and frontend on revision-3 code.
+7. Resume workers and Celery beat.
+
+AU, SG, and MY do not require breadth or exposure rebuilds; their snapshots and static sections continue independently.
+
+## 6. Verify and monitor
+
+For every breadth-enabled market, verify:
+
+- `/api/v1/breadth/current` returns `calculation_revision: 3`;
+- UI snapshot and static source markers end with `breadth-r3`;
+- live and static latest dates match;
+- advancing + declining + unchanged equals its eligible denominator;
+- T2108 stays between 0% and 100%;
+- StockBee counts do not exceed their metric-specific denominators;
+- new daily writers continue producing revision-3 rows;
+- exposure and other breadth-dependent views have been regenerated.
+
+Monitor at least two normal market closes before deleting the staging data or backup.
+
+## Rollback
+
+Pause the same writers. Restore the backup into a separate inspection table, validate it, then replace `market_breadth` in one transaction while rolling the application back to revision-2-compatible code. Rebuild exposure, UI snapshots, and static artifacts from the restored dataset before resuming writers. Never restore directly over a live table without inspecting the backup first.
+
+## Delayed cleanup
+
+```bash
+python -m app.scripts.rebuild_market_breadth cleanup
+```
+
+Cleanup drops only the shadow table and build manifest. After cleanup, staged data is recoverable only by running the rebuild again.

--- a/docs/superpowers/plans/2026-08-28-market-calibrated-breadth-thresholds.md
+++ b/docs/superpowers/plans/2026-08-28-market-calibrated-breadth-thresholds.md
@@ -1,0 +1,669 @@
+# Market-Calibrated Breadth Thresholds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace breadth's historical-FX dependency with one revision-3 shared calculation layer using fixed, documented local-market StockBee thresholds.
+
+**Architecture:** A new immutable market-policy registry supplies local ADTV, daily-volume, and reference-price thresholds to the existing pure breadth engine. Live, backfill, attribution, and static adapters resolve that same policy and pass raw local OHLCV without FX; catalog capability gates keep breadth-disabled markets out of breadth and exposure workflows. Existing API field names remain stable while revision-aware reads, rebuild activation, and static artifact validation enforce an atomic revision-3 cutover.
+
+**Tech Stack:** Python 3, FastAPI, pandas, SQLAlchemy, Celery, pytest, React, Vitest, Docker/static JSON artifacts
+
+**Spec:** `docs/superpowers/specs/2026-08-27-market-calibrated-breadth-thresholds-design.md`
+
+## Global Constraints
+
+- Use one shared calculation layer for live, backfill, attribution, and static breadth; no adapter-specific formulas or thresholds.
+- Set `CURRENT_BREADTH_CALCULATION_REVISION = 3`; revision 2 is not a selectable methodology and must not be served after cutover.
+- Do not add a schema migration, runtime calibration service, scheduled calibration task, committed calibration CLI, or daily FX dependency.
+- Leave `FXService` and stored FX data intact for fundamentals, valuation, scanning, and other non-breadth consumers.
+- A currency mismatch disables only StockBee eligibility; broad context indicators still calculate from adjusted local prices.
+- AU, SG, and MY remain breadth-disabled and must skip breadth and breadth-derived exposure without blocking snapshots or static publication.
+- Preserve existing breadth API field names and types.
+- Preserve all unrelated user-owned working-tree files.
+
+---
+
+### Task 1: Add the canonical market-policy registry and revision-3 contract
+
+**Files:**
+- Create: `backend/app/services/breadth/market_policy.py`
+- Modify: `backend/app/services/breadth/types.py`
+- Modify: `backend/app/services/breadth/__init__.py`
+- Test: `backend/tests/unit/test_breadth_market_policy.py`
+- Test: `backend/tests/unit/domain/test_market_catalog.py`
+
+**Interfaces:**
+- Consumes: `get_market_catalog().market_codes_with_capability("breadth")` from `app.domain.markets.catalog`.
+- Produces: `BreadthMarketPolicy`, `BREADTH_MARKET_POLICIES`, and `get_breadth_market_policy(market: str) -> BreadthMarketPolicy`.
+- Produces: `BreadthFormulaPolicy(calculation_revision=3, atr_period=14, atr_extension_threshold=10.0)` with no liquidity or FX fields.
+
+- [ ] **Step 1: Write the failing registry and parity tests**
+
+```python
+from app.domain.markets.catalog import get_market_catalog
+from app.services.breadth.market_policy import (
+    BREADTH_MARKET_POLICIES,
+    get_breadth_market_policy,
+)
+from app.services.breadth.types import (
+    CURRENT_BREADTH_CALCULATION_REVISION,
+    BreadthMarketPolicy,
+)
+
+
+def test_breadth_market_policy_keys_match_catalog_capability():
+    expected = set(get_market_catalog().market_codes_with_capability("breadth"))
+    assert set(BREADTH_MARKET_POLICIES) == expected
+
+
+def test_breadth_market_policies_store_selected_local_thresholds():
+    assert get_breadth_market_policy("us") == BreadthMarketPolicy(
+        market="US", currency="USD", min_adtv_local=250_000,
+        min_daily_volume=100_000, min_month_reference_price_local=5.0,
+    )
+    assert get_breadth_market_policy("CA").min_adtv_local == 5_000
+    assert get_breadth_market_policy("DE").min_daily_volume == 300
+    assert get_breadth_market_policy("HK").min_month_reference_price_local == 0.20
+    assert get_breadth_market_policy("IN").min_daily_volume == 15_000
+    assert get_breadth_market_policy("JP").min_adtv_local == 8_000_000
+    assert get_breadth_market_policy("KR").min_month_reference_price_local == 2_000
+    assert get_breadth_market_policy("TW").min_daily_volume == 400_000
+    assert get_breadth_market_policy("CN").min_adtv_local == 50_000_000
+
+
+def test_unsupported_market_policy_lookup_fails_closed():
+    with pytest.raises(ValueError, match="Breadth is not supported for market AU"):
+        get_breadth_market_policy("au")
+
+
+def test_current_breadth_revision_is_three():
+    assert CURRENT_BREADTH_CALCULATION_REVISION == 3
+```
+
+- [ ] **Step 2: Run the focused tests and confirm RED**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_market_policy.py tests/unit/domain/test_market_catalog.py -q`
+
+Expected: FAIL because `market_policy.py` and revision 3 do not exist.
+
+- [ ] **Step 3: Add the immutable policy and exact nine-market registry**
+
+```python
+# backend/app/services/breadth/types.py
+CURRENT_BREADTH_CALCULATION_REVISION = 3
+
+
+@dataclass(frozen=True, slots=True)
+class BreadthMarketPolicy:
+    market: str
+    currency: str
+    min_adtv_local: float
+    min_daily_volume: int
+    min_month_reference_price_local: float
+
+
+@dataclass(frozen=True, slots=True)
+class BreadthFormulaPolicy:
+    calculation_revision: int = CURRENT_BREADTH_CALCULATION_REVISION
+    atr_period: int = 14
+    atr_extension_threshold: float = 10.0
+```
+
+```python
+# backend/app/services/breadth/market_policy.py
+BREADTH_MARKET_POLICIES = {
+    "US": BreadthMarketPolicy("US", "USD", 250_000, 100_000, 5.00),
+    "CA": BreadthMarketPolicy("CA", "CAD", 5_000, 5_000, 0.30),
+    "DE": BreadthMarketPolicy("DE", "EUR", 5_000, 300, 8.00),
+    "HK": BreadthMarketPolicy("HK", "HKD", 20_000, 150_000, 0.20),
+    "IN": BreadthMarketPolicy("IN", "INR", 100_000, 15_000, 15.00),
+    "JP": BreadthMarketPolicy("JP", "JPY", 8_000_000, 50_000, 500.00),
+    "KR": BreadthMarketPolicy("KR", "KRW", 100_000_000, 50_000, 2_000.00),
+    "TW": BreadthMarketPolicy("TW", "TWD", 3_500_000, 400_000, 20.00),
+    "CN": BreadthMarketPolicy("CN", "CNY", 50_000_000, 10_000_000, 5.00),
+}
+
+
+def get_breadth_market_policy(market: str) -> BreadthMarketPolicy:
+    market_code = str(market or "").strip().upper()
+    try:
+        return BREADTH_MARKET_POLICIES[market_code]
+    except KeyError as exc:
+        raise ValueError(f"Breadth is not supported for market {market_code or '<missing>'}") from exc
+```
+
+Export the new type and lookup from `breadth/__init__.py`. Keep registry parity as a test rather than an import-time catalog dependency, so the domain value module remains lightweight.
+
+- [ ] **Step 4: Run the focused tests and confirm GREEN**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_market_policy.py tests/unit/domain/test_market_catalog.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the policy contract**
+
+```bash
+git add backend/app/services/breadth/types.py backend/app/services/breadth/market_policy.py backend/app/services/breadth/__init__.py backend/tests/unit/test_breadth_market_policy.py backend/tests/unit/domain/test_market_catalog.py
+git commit -m "feat: add market-calibrated breadth policies"
+```
+
+### Task 2: Convert the shared formulas and engine from USD to local inputs
+
+**Files:**
+- Modify: `backend/app/services/breadth/formulas.py`
+- Modify: `backend/app/services/breadth/engine.py`
+- Test: `backend/tests/unit/test_breadth_formulas.py`
+- Test: `backend/tests/unit/test_breadth_engine.py`
+
+**Interfaces:**
+- Consumes: `BreadthMarketPolicy` and `BreadthFormulaPolicy` from Task 1.
+- Produces: `prepare_feature_frame(prices: pd.DataFrame, *, atr_period: int = 14) -> pd.DataFrame`.
+- Produces: `signal_flags_at(feature_frame, calculation_date, formula_policy, market_policy, *, stockbee_currency_matches=True)`.
+- Produces: `BreadthEngineRequest(..., market_policy: BreadthMarketPolicy, policy: BreadthFormulaPolicy = ...)` without `fx_by_currency`.
+
+- [ ] **Step 1: Rewrite formula and engine tests for local values and currency mismatch**
+
+```python
+def test_prepare_feature_frame_uses_raw_local_traded_value():
+    result = prepare_feature_frame(_prices(close=80.0, volume=200_000))
+    assert result.iloc[-1].raw_close_local == pytest.approx(80.0)
+    assert result.iloc[-1].traded_value_local == pytest.approx(16_000_000.0)
+    assert "fx_to_usd" not in result
+    assert "adtv20_usd" not in result
+
+
+@pytest.mark.parametrize(
+    ("market_policy", "adtv", "volume", "reference_price", "eligible"),
+    [
+        (BreadthMarketPolicy("CA", "CAD", 5_000, 5_000, 0.30), 5_000, 5_000, 0.30, True),
+        (BreadthMarketPolicy("CA", "CAD", 5_000, 5_000, 0.30), 4_999.99, 5_000, 0.30, False),
+        (BreadthMarketPolicy("DE", "EUR", 5_000, 300, 8.00), 5_000, 299, 8.00, False),
+        (BreadthMarketPolicy("HK", "HKD", 20_000, 150_000, 0.20), 20_000, 150_000, 0.199, False),
+    ],
+)
+def test_stockbee_local_threshold_boundaries(market_policy, adtv, volume, reference_price, eligible):
+    row = _feature_row(
+        adtv20_local=adtv,
+        volume=volume,
+        prior_volume=volume - 1,
+        raw_close_local_20=reference_price,
+    )
+    signals = signal_flags_at(_frame(row), TARGET_DATE, BreadthFormulaPolicy(), market_policy)
+    assert signals.eligibility.stockbee_month is eligible
+
+
+def test_currency_mismatch_disables_only_stockbee_signals():
+    result = BreadthEngine().calculate(BreadthEngineRequest(
+        market="CA",
+        dates=(TARGET_DATE,),
+        universes_by_date={TARGET_DATE: _universe("USD")},
+        prices_by_symbol={"CROSS": _long_prices()},
+        market_policy=get_breadth_market_policy("CA"),
+    ))[TARGET_DATE]
+    assert result.eligibility.stockbee_daily_eligible_count == 0
+    assert result.eligibility.advance_decline_eligible_count == 1
+    assert result.eligibility.t2108_eligible_count == 1
+    assert result.eligibility.high_low_52week_eligible_count == 1
+    assert result.eligibility.atr_extension_eligible_count == 1
+```
+
+- [ ] **Step 2: Run formula and engine tests and confirm RED**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_formulas.py tests/unit/test_breadth_engine.py -q`
+
+Expected: FAIL on the removed FX argument, missing local columns, and missing market policy.
+
+- [ ] **Step 3: Implement local feature names and market-aware signal eligibility**
+
+```python
+# formulas.py
+result["raw_close_local"] = raw_close
+result["traded_value_local"] = result["raw_close_local"] * result["volume"]
+result["adtv20_local"] = result["traded_value_local"].rolling(20, min_periods=20).mean()
+result["raw_close_local_20"] = result["raw_close_local"].shift(20)
+
+liquid = (
+    stockbee_currency_matches
+    and _finite(row.adtv20_local)
+    and float(row.adtv20_local) >= market_policy.min_adtv_local
+)
+month = (
+    liquid
+    and _finite(row.adjusted_close, row.adjusted_close_20, row.raw_close_local_20)
+    and float(row.raw_close_local_20) >= market_policy.min_month_reference_price_local
+)
+daily_volume_filter = (
+    daily
+    and float(row.volume) >= market_policy.min_daily_volume
+    and float(row.volume) > float(row.prior_volume)
+)
+```
+
+In `BreadthEngine.calculate`, validate `request.market_policy.market == request.market.upper()`, build every feature frame directly with `prepare_feature_frame(prices, atr_period=request.policy.atr_period)`, and pass `member.currency.upper() == request.market_policy.currency` into `signal_flags_at`. Replace the hard-coded revision-2 assertion with `CURRENT_BREADTH_CALCULATION_REVISION`.
+
+- [ ] **Step 4: Run formula, engine, ratios, and universe tests and confirm GREEN**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_formulas.py tests/unit/test_breadth_engine.py tests/unit/test_breadth_ratios.py tests/unit/test_breadth_universe.py -q`
+
+Expected: PASS, with exact-boundary behavior preserved.
+
+- [ ] **Step 5: Commit the shared calculation change**
+
+```bash
+git add backend/app/services/breadth/formulas.py backend/app/services/breadth/engine.py backend/tests/unit/test_breadth_formulas.py backend/tests/unit/test_breadth_engine.py
+git commit -m "refactor: calculate breadth in market-local units"
+```
+
+### Task 3: Remove breadth FX loading from live, backfill, attribution, and static adapters
+
+**Files:**
+- Modify: `backend/app/services/breadth_calculator_service.py`
+- Modify: `backend/app/services/breadth_backfill.py`
+- Modify: `backend/app/services/breadth_attribution_service.py`
+- Modify: `backend/app/services/static_breadth_section_builder.py`
+- Modify: `backend/tests/unit/test_breadth_calculator_service.py`
+- Modify: `backend/tests/unit/test_breadth_backfill.py`
+- Modify: `backend/tests/unit/test_breadth_attribution_service.py`
+- Modify: `backend/tests/unit/test_static_breadth_section_builder.py`
+- Modify: `backend/tests/unit/test_breadth_workflow_parity.py`
+
+**Interfaces:**
+- Consumes: `get_breadth_market_policy(market)` and the FX-free `BreadthEngineRequest` from Tasks 1-2.
+- Produces: all four adapters passing the same `BreadthMarketPolicy`; none import, inject, load, or pass historical FX for breadth.
+- Produces: attribution entry point accepting `market: str` and `currencies_by_symbol`, resolving the canonical policy internally.
+
+- [ ] **Step 1: Add adapter regression tests proving FX is not touched and workflows agree**
+
+```python
+class ExplodingFXService:
+    def get_historical_usd_rates(self, *args, **kwargs):
+        raise AssertionError("breadth must not request FX")
+
+
+def test_calculator_does_not_request_fx(db_session, price_provider):
+    calculator = BreadthCalculatorService(db_session, price_provider=price_provider)
+    calculator.calculate_daily_breadth(calculation_date=TARGET_DATE, market="CA")
+
+
+def test_live_backfill_attribution_and_static_use_same_ca_policy(shared_inputs):
+    expected = _calculate_with_engine(shared_inputs, market="CA")
+    assert _calculate_live(shared_inputs, market="CA") == expected
+    assert _calculate_backfill(shared_inputs, market="CA") == expected
+    assert _calculate_attribution(shared_inputs, market="CA") == expected
+    assert _calculate_static(shared_inputs, market="CA") == expected
+```
+
+Update existing constructors and fixtures so passing `fx_service=` is a test failure rather than a supported compatibility path. Update currency-mismatch attribution coverage to assert StockBee counts are zero while context counts remain populated.
+
+- [ ] **Step 2: Run adapter tests and confirm RED**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_calculator_service.py tests/unit/test_breadth_backfill.py tests/unit/test_breadth_attribution_service.py tests/unit/test_static_breadth_section_builder.py tests/unit/test_breadth_workflow_parity.py -q`
+
+Expected: FAIL because adapters still construct FX maps and the engine request no longer accepts them.
+
+- [ ] **Step 3: Resolve the canonical policy once per adapter and delete breadth FX plumbing**
+
+```python
+market_policy = get_breadth_market_policy(market)
+request = BreadthEngineRequest(
+    market=market_policy.market,
+    dates=calculation_dates,
+    universes_by_date=universes_by_date,
+    prices_by_symbol=prices_by_symbol,
+    seed_counts=seed_counts,
+    market_policy=market_policy,
+    policy=formula_policy,
+)
+```
+
+Delete `fx_service` constructor state, `_load_fx_for_prices`, `default_currency_for_market` fallback logic used only for breadth conversion, all `fx_by_currency` arguments, and all calls to historical FX loading in the calculator, backfill coordinator, attribution service, and static breadth input factory. Keep each universe member's actual currency so the engine can apply mismatch behavior.
+
+- [ ] **Step 4: Run adapter and parity tests and confirm GREEN**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_calculator_service.py tests/unit/test_breadth_backfill.py tests/unit/test_breadth_attribution_service.py tests/unit/test_static_breadth_section_builder.py tests/unit/test_breadth_workflow_parity.py -q`
+
+Expected: PASS, and `rg -n "fx_by_currency|_load_fx_for_prices|get_historical_usd_rates" backend/app/services/breadth* backend/app/services/static_breadth_section_builder.py` returns no breadth call sites.
+
+- [ ] **Step 5: Commit the adapter cutover**
+
+```bash
+git add backend/app/services/breadth_calculator_service.py backend/app/services/breadth_backfill.py backend/app/services/breadth_attribution_service.py backend/app/services/static_breadth_section_builder.py backend/tests/unit/test_breadth_calculator_service.py backend/tests/unit/test_breadth_backfill.py backend/tests/unit/test_breadth_attribution_service.py backend/tests/unit/test_static_breadth_section_builder.py backend/tests/unit/test_breadth_workflow_parity.py
+git commit -m "refactor: remove FX from breadth workflows"
+```
+
+### Task 4: Gate breadth and exposure by the market catalog
+
+**Files:**
+- Modify: `backend/app/domain/bootstrap/plan.py`
+- Modify: `backend/app/tasks/daily_market_pipeline_tasks.py`
+- Modify: `backend/app/scripts/export_static_site.py`
+- Modify: `backend/tests/unit/domain/test_bootstrap_plan.py`
+- Modify: `backend/tests/unit/test_daily_market_pipeline_tasks.py`
+- Modify: `backend/tests/unit/test_export_static_site_script.py`
+
+**Interfaces:**
+- Consumes: `get_market_catalog().get(market).capabilities.breadth`.
+- Produces: breadth and exposure stages only for breadth-capable markets; static skip payloads use `status="skipped"` and `reason="market_breadth_unsupported"`.
+- Produces: snapshots and static market artifacts for unsupported markets without breadth or exposure.
+
+- [ ] **Step 1: Add capability-gating tests for supported and unsupported markets**
+
+```python
+@pytest.mark.parametrize("market", ["AU", "SG", "MY"])
+def test_bootstrap_omits_breadth_and_exposure_for_unsupported_markets(market):
+    stage_keys = [stage.key for stage in _build_market_plan(market).stages]
+    assert "breadth" not in stage_keys
+    assert "exposure" not in stage_keys
+    assert "snapshot" in stage_keys
+
+
+@pytest.mark.parametrize("market", ["US", "CA", "DE", "HK", "IN", "JP", "KR", "TW", "CN"])
+def test_daily_pipeline_keeps_breadth_and_exposure_for_supported_markets(market):
+    names = [signature.task for signature in _build_daily_market_pipeline_signatures(market, TARGET_DATE)]
+    assert "app.tasks.breadth_tasks.calculate_daily_breadth_with_gapfill" in names
+    assert "app.tasks.breadth_tasks.calculate_market_exposure" in names
+
+
+def test_static_refresh_skips_unsupported_breadth_but_builds_snapshot(monkeypatch):
+    results = run_daily_refresh(markets=("SG",), as_of_date=TARGET_DATE)
+    assert results["breadth_history"]["SG"] == {
+        "status": "skipped", "reason": "market_breadth_unsupported"
+    }
+    assert results["market_exposure"]["SG"] == {
+        "status": "skipped", "reason": "market_breadth_unsupported"
+    }
+    assert results["feature_snapshot"]["SG"]["status"] != "skipped"
+```
+
+- [ ] **Step 2: Run orchestration tests and confirm RED**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/domain/test_bootstrap_plan.py tests/unit/test_daily_market_pipeline_tasks.py tests/unit/test_export_static_site_script.py -q`
+
+Expected: FAIL because current orchestration schedules or requires breadth for every enabled market.
+
+- [ ] **Step 3: Build breadth/exposure stage slices only when capability is enabled**
+
+```python
+supports_breadth = get_market_catalog().get(market).capabilities.breadth
+if supports_breadth:
+    stages.extend((breadth_stage, exposure_stage))
+```
+
+Apply the same condition when assembling Celery signatures: omit the breadth task, breadth guard, exposure task, and exposure guard together. In static refresh, precompute `supports_breadth_by_market`; for false entries store the two explicit skip payloads, do not call `_ensure_breadth_history` or `_compute_static_market_exposure`, and allow feature snapshot generation to continue because the skip payload contains no `error`.
+
+- [ ] **Step 4: Run orchestration tests and confirm GREEN**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/domain/test_bootstrap_plan.py tests/unit/test_daily_market_pipeline_tasks.py tests/unit/test_export_static_site_script.py -q`
+
+Expected: PASS for both supported and unsupported market matrices.
+
+- [ ] **Step 5: Commit capability-aware orchestration**
+
+```bash
+git add backend/app/domain/bootstrap/plan.py backend/app/tasks/daily_market_pipeline_tasks.py backend/app/scripts/export_static_site.py backend/tests/unit/domain/test_bootstrap_plan.py backend/tests/unit/test_daily_market_pipeline_tasks.py backend/tests/unit/test_export_static_site_script.py
+git commit -m "fix: gate breadth workflows by market capability"
+```
+
+### Task 5: Enforce revision 3 in database rebuilds, reads, and static fallback selection
+
+**Files:**
+- Modify: `backend/app/services/breadth/rebuild.py`
+- Modify: `backend/app/services/static_artifact_combiner.py`
+- Modify: `backend/app/schemas/breadth.py`
+- Modify: `backend/tests/unit/test_breadth_rebuild.py`
+- Modify: `backend/tests/integration/test_breadth_revision_cutover.py`
+- Modify: `backend/tests/unit/services/test_static_artifact_combiner.py`
+- Modify: `backend/tests/unit/test_breadth_endpoints.py`
+- Modify: `backend/tests/unit/test_ui_snapshot_service.py`
+
+**Interfaces:**
+- Consumes: `CURRENT_BREADTH_CALCULATION_REVISION == 3`.
+- Produces: rebuild manifests with `liquidity="raw_close_local_x_volume_adtv20"`, fixed market-policy metadata, and no FX contract.
+- Produces: static fallback compatibility requiring `breadth.json.payload.current.calculation_revision == 3` and `source_revision` ending in `|breadth-r3` whenever `entry.features.breadth` is true.
+
+- [ ] **Step 1: Add cutover and fallback rejection tests**
+
+```python
+def test_activation_replaces_revision_two_rows_with_revision_three_rows(db_session, staged_rebuild):
+    staged_rebuild.activate()
+    revisions = {row.calculation_revision for row in db_session.query(MarketBreadth).all()}
+    assert revisions == {3}
+
+
+def test_fallback_breadth_revision_two_is_not_selected(tmp_path):
+    _write_market_artifact(tmp_path / "fallback", market="CA", breadth_revision=2)
+    with pytest.raises(NoPublishedStaticMarketArtifact):
+        _combine(current=None, fallback=tmp_path / "fallback", required=("CA",))
+
+
+def test_current_breadth_revision_three_and_marker_are_required(tmp_path):
+    artifact = _write_market_artifact(tmp_path / "current", market="CA", breadth_revision=3)
+    payload = json.loads((artifact / "breadth.json").read_text())
+    payload["source_revision"] = "2026-08-27|breadth-r2"
+    (artifact / "breadth.json").write_text(json.dumps(payload))
+    with pytest.raises(StaticArtifactFormulaError, match="breadth revision"):
+        _combine(current=tmp_path / "current", fallback=None, required=("CA",))
+```
+
+Also update endpoint and UI snapshot fixtures so revision-2 rows are absent/unavailable and revision-3 rows produce `breadth-r3`.
+
+- [ ] **Step 2: Run migration and static validation tests and confirm RED**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_rebuild.py tests/integration/test_breadth_revision_cutover.py tests/unit/services/test_static_artifact_combiner.py tests/unit/test_breadth_endpoints.py tests/unit/test_ui_snapshot_service.py -q`
+
+Expected: FAIL on stale hard-coded revision 2, old formula-contract text, and fallback selection accepting old breadth artifacts.
+
+- [ ] **Step 3: Make the rebuild contract and static validator revision-aware**
+
+```python
+# rebuild.py manifest fragment
+"calculation_revision": CURRENT_BREADTH_CALCULATION_REVISION,
+"formula_contract": {
+    "liquidity": "raw_close_local_x_volume_adtv20",
+    "market_policy": "fixed_market_calibrated_thresholds",
+    "currency_mismatch": "stockbee_ineligible_context_preserved",
+},
+```
+
+Add a combiner helper that reads `breadth.json` only when the market entry advertises breadth, then validates both fields:
+
+```python
+current = payload.get("payload", {}).get("current")
+observed_revision = current.get("calculation_revision") if isinstance(current, dict) else None
+source_revision = str(payload.get("source_revision") or "")
+if observed_revision != CURRENT_BREADTH_CALCULATION_REVISION or not source_revision.endswith(
+    f"|breadth-r{CURRENT_BREADTH_CALCULATION_REVISION}"
+):
+    raise StaticArtifactFormulaError(
+        f"{market} {source_label} artifact uses incompatible breadth revision: "
+        f"revision={observed_revision!r}, source_revision={source_revision!r}; "
+        f"expected {CURRENT_BREADTH_CALCULATION_REVISION}"
+    )
+```
+
+Use this validator both when filtering fallback candidates and when validating selected current artifacts. Change the schema description to `current value is 3`; replace hard-coded activation return values with the shared constant.
+
+- [ ] **Step 4: Run migration and static validation tests and confirm GREEN**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_rebuild.py tests/integration/test_breadth_revision_cutover.py tests/unit/services/test_static_artifact_combiner.py tests/unit/test_breadth_endpoints.py tests/unit/test_ui_snapshot_service.py -q`
+
+Expected: PASS; revision-2 fallback fixtures are filtered before publication and current incompatible artifacts fail explicitly.
+
+- [ ] **Step 5: Commit the revision-3 safeguards**
+
+```bash
+git add backend/app/services/breadth/rebuild.py backend/app/services/static_artifact_combiner.py backend/app/schemas/breadth.py backend/tests/unit/test_breadth_rebuild.py backend/tests/integration/test_breadth_revision_cutover.py backend/tests/unit/services/test_static_artifact_combiner.py backend/tests/unit/test_breadth_endpoints.py backend/tests/unit/test_ui_snapshot_service.py
+git commit -m "feat: enforce breadth revision three cutover"
+```
+
+### Task 6: Update user-facing formula copy and operational documentation
+
+**Files:**
+- Modify: `frontend/src/components/Breadth/breadthMetricDefinitions.js`
+- Modify: `frontend/src/components/Breadth/BreadthMetricTooltip.jsx`
+- Modify: `frontend/src/components/Breadth/BreadthHistoryTable.test.jsx`
+- Modify: `frontend/src/pages/BreadthPage.test.jsx`
+- Modify: `docs/LIVE_APP_GUIDE.md`
+- Modify: `docs/STATIC_SITE.md`
+- Create: `docs/runbooks/market-breadth-revision-3-cutover.md`
+- Create: `docs/release-notes/market-calibrated-breadth-r3.md`
+
+**Interfaces:**
+- Consumes: the fixed policy table and migration behavior from the approved spec.
+- Produces: UI copy that says “selected market's local threshold” without embedding US values for every market.
+- Produces: an operator runbook that rebuilds all nine markets, validates revision 3, activates atomically, rebuilds dependents, and clears caches.
+
+- [ ] **Step 1: Add frontend copy tests that reject universal USD wording**
+
+```javascript
+it('describes StockBee eligibility in selected-market local units', () => {
+  render(<BreadthMetricTooltip metric="stocks_up_4pct" />);
+  expect(screen.getByText(/local-currency traded value/i)).toBeInTheDocument();
+  expect(screen.getByText(/market-specific daily share threshold/i)).toBeInTheDocument();
+  expect(screen.queryByText(/US\$250,000/i)).not.toBeInTheDocument();
+});
+
+it('describes the monthly reference price as market-specific', () => {
+  render(<BreadthMetricTooltip metric="stocks_up_25pct_month" />);
+  expect(screen.getByText(/market-specific local reference-price threshold/i)).toBeInTheDocument();
+  expect(screen.queryByText(/US\$5/i)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the frontend test and confirm RED**
+
+Run: `cd frontend && npm run test:run -- src/components/Breadth/BreadthHistoryTable.test.jsx src/pages/BreadthPage.test.jsx`
+
+Expected: FAIL because the definitions still advertise US$250,000, 100,000 shares, and US$5 globally.
+
+- [ ] **Step 3: Replace universal USD copy and write the revision-3 runbook**
+
+```javascript
+const STOCKBEE_LIQUIDITY =
+  "20-session average raw traded value must meet the selected market's fixed local-currency threshold.";
+
+const STOCKBEE_DAILY_VOLUME =
+  "Target-session volume must meet the selected market's fixed daily share threshold and exceed the prior session.";
+
+const STOCKBEE_MONTH_REFERENCE =
+  "The raw close exactly 20 sessions earlier must meet the selected market's fixed local reference-price threshold.";
+```
+
+Use these phrases in the relevant metric descriptions and required-history text. In `LIVE_APP_GUIDE.md`, add the exact nine-row policy table and explain that the values are rounded initial settings maintained in code. In `STATIC_SITE.md`, state that breadth-capable artifacts require revision 3 and old fallbacks are unavailable rather than silently reused. Add a reusable release-note fragment stating that breadth now uses fixed local-market thresholds, upgrades require a revision-3 rebuild, and breadth can be temporarily unavailable until activation completes. In the new runbook, record this exact sequence:
+
+1. Deploy revision-3 code with breadth-dependent writers paused.
+2. Back up PostgreSQL and current static artifacts.
+3. Rebuild US, CA, DE, HK, IN, JP, KR, TW, and CN into the existing shadow tables.
+4. Validate revision, counts, denominators, ratios, signatures, and manifest policy contract.
+5. Atomically activate the shadow dataset, replacing every revision-2 `market_breadth` row.
+6. Rebuild exposure, attribution, UI snapshots, and static market artifacts.
+7. Clear breadth/exposure caches, resume writers, and verify API/static `breadth-r3` markers.
+
+- [ ] **Step 4: Run frontend tests, lint touched code, and inspect documentation terms**
+
+Run: `cd frontend && npm run test:run -- src/components/Breadth/BreadthHistoryTable.test.jsx src/pages/BreadthPage.test.jsx && npm run lint`
+
+Run: `rg -n "US\$250,000|US\$5|USD-normalized|historical FX" frontend/src/components/Breadth docs/LIVE_APP_GUIDE.md docs/STATIC_SITE.md docs/runbooks/market-breadth-revision-3-cutover.md`
+
+Expected: tests and lint PASS; search returns only explicitly historical/migration explanations, not current-formula copy.
+
+- [ ] **Step 5: Commit UI copy and operational docs**
+
+```bash
+git add frontend/src/components/Breadth/breadthMetricDefinitions.js frontend/src/components/Breadth/BreadthMetricTooltip.jsx frontend/src/components/Breadth/BreadthHistoryTable.test.jsx frontend/src/pages/BreadthPage.test.jsx docs/LIVE_APP_GUIDE.md docs/STATIC_SITE.md docs/runbooks/market-breadth-revision-3-cutover.md docs/release-notes/market-calibrated-breadth-r3.md
+git commit -m "docs: explain local breadth thresholds and cutover"
+```
+
+### Task 7: Update remaining revision fixtures and run focused architecture checks
+
+**Files:**
+- Modify: `backend/tests/helpers/mcp_fixture.py`
+- Modify: `backend/tests/unit/test_daily_breadth_runner.py`
+- Modify: `backend/tests/unit/test_stock_workspace_endpoints.py`
+- Modify: `backend/tests/unit/test_digest_service.py`
+- Modify: `backend/tests/unit/test_watchlist_stewardship_service.py`
+- Modify: `backend/tests/unit/test_breadth_persistence.py`
+
+**Interfaces:**
+- Consumes: revision 3 as the only current breadth contract.
+- Produces: no test fixture representing current breadth as revision 2; deliberate stale-row tests retain revision 2 with names explaining rejection.
+
+- [ ] **Step 1: Run a targeted stale-revision inventory and classify each hit**
+
+Run: `rg -n "calculation_revision\s*[=:]\s*2|breadth-r2" backend/tests frontend/src --glob '*test*' --glob '*fixture*'`
+
+Expected: current-data fixtures and deliberate stale-data tests are listed separately during editing; only deliberate stale-data tests remain revision 2 at the end.
+
+- [ ] **Step 2: Update current-data fixtures to revision 3**
+
+```python
+current_breadth = MarketBreadth(
+    market="US",
+    date=date(2026, 8, 27),
+    calculation_revision=3,
+)
+```
+
+Keep revision 2 only in tests named like `test_revision_two_rows_are_not_served` or `test_revision_two_static_fallback_is_rejected`.
+
+- [ ] **Step 3: Run the complete breadth-focused backend suite**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_breadth_*.py tests/unit/test_daily_breadth_runner.py tests/unit/test_stock_workspace_endpoints.py tests/unit/test_digest_service.py tests/unit/services/test_static_artifact_combiner.py tests/integration/test_breadth_revision_cutover.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run static workflow and architecture searches**
+
+Run: `cd backend && ./venv/bin/pytest tests/unit/test_static_site_workflow.py tests/unit/test_export_static_site_no_current_artifacts.py -q`
+
+Run: `rg -n "fx_by_currency|min_adtv_usd|min_month_reference_price_usd|raw_close_usd_20|adtv20_usd|fx_max_age_days" backend/app/services/breadth backend/app/services/breadth_calculator_service.py backend/app/services/breadth_backfill.py backend/app/services/breadth_attribution_service.py backend/app/services/static_breadth_section_builder.py`
+
+Expected: tests PASS and architecture search returns no hits.
+
+- [ ] **Step 5: Commit fixture and regression cleanup**
+
+```bash
+git add backend/tests/helpers/mcp_fixture.py backend/tests/unit/test_daily_breadth_runner.py backend/tests/unit/test_stock_workspace_endpoints.py backend/tests/unit/test_digest_service.py backend/tests/unit/test_watchlist_stewardship_service.py backend/tests/unit/test_breadth_persistence.py
+git commit -m "test: align breadth fixtures with revision three"
+```
+
+### Task 8: Perform end-to-end verification and prepare branch handoff
+
+**Files:**
+- Verify only; modify files only when a failing check exposes an in-scope defect.
+
+**Interfaces:**
+- Consumes: all earlier task outputs.
+- Produces: a clean, reviewable branch with evidence that backend, frontend, static, and migration behavior meet the spec.
+
+- [ ] **Step 1: Run the complete backend test suite**
+
+Run: `cd backend && ./venv/bin/pytest -q`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend tests, lint, and production build**
+
+Run: `cd frontend && npm run test:run && npm run lint && npm run build`
+
+Expected: all commands PASS and Vite produces the production bundle.
+
+- [ ] **Step 3: Run repository-wide revision and FX ownership checks**
+
+Run: `rg -n "calculation_revision\s*[=:]\s*2|breadth-r2" backend/app frontend/src`
+
+Expected: no current application contract uses revision 2.
+
+Run: `rg -n "fx_by_currency|min_adtv_usd|min_month_reference_price_usd|raw_close_usd_20|adtv20_usd|fx_max_age_days" backend/app/services/breadth*`
+
+Expected: no breadth runtime code depends on FX or USD thresholds.
+
+- [ ] **Step 4: Review the final diff and working tree**
+
+Run: `git diff --check && git status --short --branch && git log --oneline origin/main..HEAD`
+
+Expected: no whitespace errors; only intended tracked changes and the user's pre-existing untracked files remain; commits are scoped by task.
+
+- [ ] **Step 5: Record the deployment handoff**
+
+Report the exact test results, the nine market policies, revision-3 rebuild requirement, temporary-unavailability behavior before activation, and the fact that AU/SG/MY now skip breadth/exposure while continuing snapshot/static publication. Do not activate a production rebuild or publish static artifacts without a separate deployment request.

--- a/docs/superpowers/specs/2026-08-27-market-calibrated-breadth-thresholds-design.md
+++ b/docs/superpowers/specs/2026-08-27-market-calibrated-breadth-thresholds-design.md
@@ -1,0 +1,310 @@
+# Market-Calibrated Breadth Thresholds Design
+
+**Date:** 2026-08-27
+
+## Objective
+
+Replace the revision-2 StockBee USD-liquidity policy with fixed,
+market-calibrated thresholds expressed in each market's primary trading
+currency. Remove historical FX from breadth calculation, preserve one shared
+calculation engine for live, backfill, attribution, and static workflows, and
+cut all breadth-enabled markets over to calculation revision 3.
+
+This design supersedes the USD-normalized liquidity, historical-FX, and
+revision-2 cutover decisions in
+`docs/superpowers/specs/2026-08-25-shared-market-breadth-design.md`. All other
+formula, universe, UI, and API decisions in that document remain in force.
+
+## Product Decisions
+
+- StockBee eligibility is market-relative rather than normalized to one USD
+  liquidity threshold.
+- Every breadth-enabled market uses one fixed, documented policy containing:
+  primary currency, minimum 20-session average traded value, minimum daily
+  share volume, and minimum raw reference price 20 sessions ago.
+- The policy values are initial settings. They are deliberately rounded and
+  loosely calibrated; runtime calculations do not optimize or recalculate them.
+- The existing US settings remain numerically unchanged, but US moves to
+  calculation revision 3 with every other breadth-enabled market.
+- Historical and current FX are not inputs to any breadth formula.
+- FX services and stored FX data remain available to fundamentals, valuation,
+  and other non-breadth consumers.
+- A listing whose currency differs from its market policy currency is excluded
+  from StockBee eligibility only. It can still contribute to advancing,
+  declining, T2108, 52-week high/low, and ATR context indicators.
+- AU, SG, and MY remain breadth-disabled. Runtime bootstrap, daily pipelines,
+  and static export must not calculate or require breadth or breadth-derived
+  exposure for them.
+- Revision 2 is not retained as a selectable methodology. Revision guards hide
+  old rows, and atomic rebuild activation replaces them with revision-3 rows.
+
+## Analysis-Only Calibration
+
+The calibration was a one-time analysis performed on 2026-08-27. It is not an
+application service, scheduled task, command, or committed calibration tool.
+Only the selected policy and this evidence are permanent.
+
+### Inputs
+
+The analysis used the latest market-specific assets from the GitHub releases:
+
+- `daily-price-data`: two-year raw OHLCV bundles;
+- `weekly-reference-data`: active market universe and primary currency.
+
+The following daily-price assets were used:
+
+| Market | Currency | Daily-price asset | As-of date | Complete recent features |
+|---|---|---|---:|---:|
+| US | USD | `daily-price-us-20260826.json.gz` | 2026-08-26 | 9,995 |
+| CA | CAD | `daily-price-ca-20260826.json.gz` | 2026-08-26 | 3,656 |
+| DE | EUR | `daily-price-de-20260825.json.gz` | 2026-08-25 | 1,415 |
+| HK | HKD | `daily-price-hk-20260826.json.gz` | 2026-08-26 | 2,762 |
+| IN | INR | `daily-price-in-20260826.json.gz` | 2026-08-26 | 4,688 |
+| JP | JPY | `daily-price-jp-20260826.json.gz` | 2026-08-26 | 3,708 |
+| KR | KRW | `daily-price-kr-20260826.json.gz` | 2026-08-26 | 2,683 |
+| TW | TWD | `daily-price-tw-20260826.json.gz` | 2026-08-26 | 1,085 |
+| CN | CNY | `daily-price-cn-20260805.json.gz` | 2026-08-05 | 5,197 |
+
+The corresponding `weekly-reference-*-20260822-*.json.gz` assets supplied the
+active universe and currency. Those artifacts predate explicit common-stock
+classification in their serialized rows. The analysis therefore followed the
+current importer default: active non-manual rows not explicitly marked false
+were treated as common stocks. This is acceptable for initial calibration but
+is recorded as a limitation. Runtime revision-3 calculation continues to use
+the authoritative point-in-time `is_common_stock` classification.
+
+### Method
+
+For each symbol with at least 21 price sessions and a latest bar no more than
+seven calendar days behind the bundle as-of date, the analysis calculated:
+
+```text
+adtv20_local = mean(raw_close * volume over the latest 20 sessions)
+typical_volume = median(volume over the latest 20 sessions)
+reference_price_local = raw close exactly 20 sessions earlier
+```
+
+The existing US policy produced these reference pass rates:
+
+- ADTV eligibility: 7,693 / 9,995 = 76.97%;
+- typical volume at least 100,000 among liquid stocks: 66.62%;
+- reference price at least USD 5 among liquid stocks: 85.92%.
+
+Each non-US raw threshold was selected at the corresponding market quantile,
+then rounded to a simple local value. The target was directional, not an
+acceptance gate. No threshold is recalculated at runtime, and no test asserts
+that future market coverage must remain near these percentages.
+
+### Selected Initial Policies
+
+| Market | Currency | Min ADTV20 local | Min daily shares | Min reference price local | ADTV pass | Typical-volume pass among liquid | Reference-price pass among liquid |
+|---|---|---:|---:|---:|---:|---:|---:|
+| US | USD | 250,000 | 100,000 | 5.00 | 77.0% | 66.6% | 85.9% |
+| CA | CAD | 5,000 | 5,000 | 0.30 | 75.7% | 67.6% | 86.5% |
+| DE | EUR | 5,000 | 300 | 8.00 | 74.8% | 68.4% | 85.8% |
+| HK | HKD | 20,000 | 150,000 | 0.20 | 77.4% | 68.2% | 86.4% |
+| IN | INR | 100,000 | 15,000 | 15.00 | 76.5% | 66.2% | 86.1% |
+| JP | JPY | 8,000,000 | 50,000 | 500 | 77.0% | 64.0% | 86.6% |
+| KR | KRW | 100,000,000 | 50,000 | 2,000 | 74.7% | 66.1% | 82.3% |
+| TW | TWD | 3,500,000 | 400,000 | 20.00 | 76.6% | 66.5% | 84.5% |
+| CN | CNY | 50,000,000 | 10,000,000 | 5.00 | 80.0% | 60.2% | 86.4% |
+
+The calibration's median-volume measurement stabilizes the one-time suggestion.
+The production StockBee daily predicate remains unchanged in shape: it compares
+the target session's actual volume to the fixed policy threshold and requires
+target-session volume to exceed prior-session volume.
+
+## Permanent Architecture
+
+### Market policy
+
+Add one immutable `BreadthMarketPolicy` value with this contract:
+
+```python
+@dataclass(frozen=True, slots=True)
+class BreadthMarketPolicy:
+    market: str
+    currency: str
+    min_adtv_local: float
+    min_daily_volume: int
+    min_month_reference_price_local: float
+```
+
+A single registry owns the nine policies in the selected table. Lookup accepts
+a normalized breadth-enabled market code and fails for unsupported or missing
+entries. Tests enforce exact key parity with the market catalog's `breadth`
+capability.
+
+`BreadthFormulaPolicy` retains formula-wide settings such as ATR period and
+extension threshold. It no longer owns USD liquidity, USD reference-price, or
+FX-age settings.
+
+### Local-currency features
+
+`prepare_feature_frame` no longer accepts an FX series. It prepares:
+
+```text
+raw_close_local = raw close
+traded_value_local = raw_close_local * volume
+adtv20_local = rolling 20-session mean of traded_value_local
+raw_close_local_20 = raw close shifted by 20 sessions
+```
+
+Adjusted OHLC continues to drive returns, rolling extrema, moving averages,
+ATR, T2108, and high/low signals exactly as in revision 2.
+
+For a symbol whose currency matches the market policy:
+
+```text
+stockbee_liquidity_eligible = adtv20_local >= min_adtv_local
+stockbee_month_eligible =
+    stockbee_liquidity_eligible
+    and raw_close_local_20 >= min_month_reference_price_local
+```
+
+The daily +4%/-4% predicates require target-session volume greater than or
+equal to `min_daily_volume` and greater than prior-session volume.
+
+For a symbol whose currency does not match the policy currency, every StockBee
+eligibility flag is false. Broad context eligibility is evaluated normally.
+The symbol is not silently converted or compared against the wrong currency.
+
+### Shared engine and adapters
+
+`BreadthEngineRequest` carries a `BreadthMarketPolicy` instead of
+`fx_by_currency`. The pure engine remains provider-free and database-free.
+
+`BreadthCalculatorService` stops loading historical FX and delegates with the
+policy resolved for its market. Live calculation, gap fill, historical rebuild,
+group attribution, and static section building continue to use the same engine
+and policy registry. No adapter may define its own thresholds.
+
+The general `FXService`, `fx_rates` table, and fundamentals currency conversion
+remain unchanged because they serve non-breadth domains.
+
+### Capability gating
+
+The market catalog remains authoritative. Bootstrap plans, daily market
+pipelines, and static export include breadth and breadth-derived exposure only
+when `capabilities.breadth` is true. For breadth-disabled markets, snapshot and
+static publication must not fail merely because breadth or exposure is absent.
+
+This gating change does not enable new breadth markets. It corrects orchestration
+to match the existing catalog and frontend behavior.
+
+## Revision 3 and Existing Databases
+
+Set `CURRENT_BREADTH_CALCULATION_REVISION = 3`. Revision is a stale-data guard,
+not a user-selectable formula version.
+
+There is no new database column and no Alembic schema change. Existing rows are
+handled by the existing shadow rebuild workflow:
+
+1. Revision-3 code causes revision-aware reads to ignore revision-2 rows.
+2. Rebuild every breadth-enabled market/date into the staging tables using the
+   fixed market policies.
+3. Validate manifests, denominators, ratios, signatures, and revision 3.
+4. Pause breadth-dependent writers and take the operational backup.
+5. Atomically activate the staging dataset; activation deletes all existing
+   `market_breadth` rows and inserts only validated revision-3 rows.
+6. Rebuild `market_exposure`, group attribution, UI snapshots, and static
+   artifacts from revision-3 breadth.
+7. Clear breadth/exposure snapshot caches and resume writers.
+
+US participates in the same purge and rebuild even though its numerical
+thresholds are unchanged. A deployment with no completed revision-3 rebuild
+returns unavailable breadth rather than serving revision-2 data.
+
+Static artifact validation requires revision 3 and a `breadth-r3` source marker.
+Revision-1 or revision-2 fallbacks must not be published as current data. The
+deployment may retain diagnostics, but an affected market is reported
+unavailable until a current revision-3 artifact exists.
+
+## API and UI Contract
+
+All existing breadth field names and types remain unchanged. Update the
+`calculation_revision` description and fixtures from 2 to 3.
+
+Tooltips and documentation replace USD language with the selected market's
+local thresholds. The breadth response remains flat; the permanent threshold
+registry is server-side policy and does not require a new public API field.
+
+The UI continues to display broad context indicators even when a
+currency-mismatched listing is ineligible for StockBee metrics. Denominators
+make the difference explicit.
+
+## Error Handling
+
+- Missing or invalid raw local prices exclude the symbol only from affected
+  StockBee metrics.
+- Missing or invalid adjusted history follows existing metric-specific
+  eligibility rules.
+- A currency mismatch excludes StockBee eligibility but never fails the entire
+  market/date calculation.
+- A breadth-enabled market with no registered policy fails before calculation.
+- A breadth-disabled market skips breadth-dependent workflow stages.
+- Static publication never substitutes an older calculation revision.
+- A market/date result still commits atomically or not at all.
+
+## Testing
+
+### Policy tests
+
+- Registry keys exactly equal catalog breadth-enabled market codes.
+- Every policy has the expected market, currency, and selected threshold values.
+- Unsupported-market lookup fails clearly.
+- US retains 250,000 ADTV, 100,000 shares, and USD 5.
+
+### Formula and engine tests
+
+- ADTV uses raw local close times volume with no FX input.
+- Every local threshold passes at equality and fails immediately below it.
+- The daily volume predicate uses the market-specific threshold.
+- Monthly reference-price eligibility uses the market-specific local threshold.
+- Currency mismatch disables only StockBee eligibility.
+- Advancing/declining, T2108, 52-week high/low, and ATR remain available for a
+  currency-mismatched symbol.
+- The engine and calculator do not call `FXService` for breadth.
+- All canonical results carry calculation revision 3.
+
+### Workflow and migration tests
+
+- Live, backfill, attribution, and static fixtures produce identical results
+  from the same market policy.
+- Bootstrap, daily pipeline, and static export omit breadth-dependent stages for
+  AU, SG, and MY.
+- Revision-aware reads reject revision 2.
+- Shadow rebuild validation and activation require revision 3.
+- Static validation rejects revision-1/revision-2 fallback artifacts.
+- Existing additive API fields remain backward compatible.
+
+## Documentation
+
+- This design is the authoritative calibration record.
+- User-facing breadth documentation lists each fixed market policy and explains
+  that thresholds are local, initial, and manually maintained.
+- Formula tooltips identify local ADTV, local reference price, and local daily
+  volume without referring to FX.
+- Release notes explain the revision-3 rebuild and temporary unavailability
+  behavior for installations upgrading an existing database.
+
+## Completion Criteria
+
+- Breadth has no runtime or static dependency on historical FX.
+- One registry owns fixed policies for every breadth-enabled market.
+- All live, backfill, attribution, and static calculations use the same policy.
+- Every served breadth row and current static artifact is revision 3.
+- Revision-2 data is atomically replaced, not exposed as a parallel formula.
+- Breadth-disabled markets are not blocked by missing breadth or exposure.
+- Thresholds and calibration evidence are documented.
+- Relevant backend, migration/rebuild, static export, and frontend tests pass.
+
+## Non-Goals
+
+- Runtime percentile calibration or automatic threshold adjustment.
+- A committed calibration CLI or scheduled calibration job.
+- Cross-market conversion of breadth liquidity into USD.
+- Removing FX from fundamentals, valuation, or other non-breadth domains.
+- Enabling breadth for AU, SG, or MY.
+- Redesigning StockBee signal percentages, ratios, T2108, high/low, or ATR
+  formulas.

--- a/frontend/src/components/Breadth/BreadthHistoryTable.test.jsx
+++ b/frontend/src/components/Breadth/BreadthHistoryTable.test.jsx
@@ -1,8 +1,10 @@
 import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../test/renderWithProviders';
 import BreadthHistoryTable from './BreadthHistoryTable';
+import { breadthMetricDefinitions } from './breadthMetricDefinitions';
 
 
 const row = {
@@ -88,6 +90,26 @@ describe('BreadthHistoryTable', () => {
     expect(screen.getByTestId('breadth-history-scroll')).toHaveStyle({
       overflowX: 'auto',
     });
+  });
+
+  it('describes StockBee thresholds in selected-market local units', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<BreadthHistoryTable rows={[row]} />);
+
+    await user.hover(
+      screen.getByRole('button', { name: /stocks up 4%\+ formula details/i }),
+    );
+
+    expect(await screen.findByText(
+      /local-currency traded value must meet the selected market's fixed threshold/i,
+    )).toBeInTheDocument();
+    expect(breadthMetricDefinitions.stocks_up_4pct.description).toMatch(
+      /market-specific daily share threshold/i,
+    );
+    expect(breadthMetricDefinitions.stocks_up_25pct_month.requiredHistory).toMatch(
+      /market-specific local reference-price threshold/i,
+    );
+    expect(JSON.stringify(breadthMetricDefinitions)).not.toMatch(/US\$250,000|US\$5/);
   });
 
   it('renders metric values as unavailable when their eligible denominator is zero', () => {

--- a/frontend/src/components/Breadth/breadthMetricDefinitions.js
+++ b/frontend/src/components/Breadth/breadthMetricDefinitions.js
@@ -1,5 +1,11 @@
 const STOCKBEE_LIQUIDITY =
-  '20-session average raw dollar volume must be at least US$250,000.';
+  "20-session average raw local-currency traded value must meet the selected market's fixed threshold.";
+
+const STOCKBEE_DAILY_VOLUME =
+  'Volume must meet the market-specific daily share threshold and exceed the prior session.';
+
+const STOCKBEE_MONTH_REFERENCE =
+  '21 sessions; raw close 20 sessions earlier must meet the market-specific local reference-price threshold';
 
 const stockBee = (definition) => ({
   formulaOrigin: 'StockBee',
@@ -12,14 +18,14 @@ export const breadthMetricDefinitions = {
   stocks_up_4pct: stockBee({
     label: 'Stocks Up 4%+',
     description:
-      'Adjusted close rises at least 4% today, volume is at least 100,000 shares and exceeds the prior session.',
+      `Adjusted close rises at least 4% today. ${STOCKBEE_DAILY_VOLUME}`,
     requiredHistory: '20 sessions for liquidity plus the prior session',
     eligibleField: 'stockbee_daily_eligible_count',
   }),
   stocks_down_4pct: stockBee({
     label: 'Stocks Down 4%+',
     description:
-      'Adjusted close falls at least 4% today, volume is at least 100,000 shares and exceeds the prior session.',
+      `Adjusted close falls at least 4% today. ${STOCKBEE_DAILY_VOLUME}`,
     requiredHistory: '20 sessions for liquidity plus the prior session',
     eligibleField: 'stockbee_daily_eligible_count',
   }),
@@ -50,25 +56,25 @@ export const breadthMetricDefinitions = {
   stocks_up_25pct_month: stockBee({
     label: 'Up 25%+ Month',
     description: 'Adjusted close is at least 25% above the adjusted close exactly 20 sessions ago.',
-    requiredHistory: '21 sessions; raw reference close must be at least US$5',
+    requiredHistory: STOCKBEE_MONTH_REFERENCE,
     eligibleField: 'stockbee_month_eligible_count',
   }),
   stocks_down_25pct_month: stockBee({
     label: 'Down 25%+ Month',
     description: 'Adjusted close is at least 25% below the adjusted close exactly 20 sessions ago.',
-    requiredHistory: '21 sessions; raw reference close must be at least US$5',
+    requiredHistory: STOCKBEE_MONTH_REFERENCE,
     eligibleField: 'stockbee_month_eligible_count',
   }),
   stocks_up_50pct_month: stockBee({
     label: 'Up 50%+ Month',
     description: 'Adjusted close is at least 50% above the adjusted close exactly 20 sessions ago.',
-    requiredHistory: '21 sessions; raw reference close must be at least US$5',
+    requiredHistory: STOCKBEE_MONTH_REFERENCE,
     eligibleField: 'stockbee_month_eligible_count',
   }),
   stocks_down_50pct_month: stockBee({
     label: 'Down 50%+ Month',
     description: 'Adjusted close is at least 50% below the adjusted close exactly 20 sessions ago.',
-    requiredHistory: '21 sessions; raw reference close must be at least US$5',
+    requiredHistory: STOCKBEE_MONTH_REFERENCE,
     eligibleField: 'stockbee_month_eligible_count',
   }),
   stocks_up_13pct_34days: stockBee({

--- a/frontend/src/pages/BreadthPage.test.jsx
+++ b/frontend/src/pages/BreadthPage.test.jsx
@@ -104,7 +104,7 @@ function breadthRow(market = 'HK') {
     atr_10x_extension_count: 3,
     atr_extension_eligible_count: 28,
     broad_universe_count: 32,
-    calculation_revision: 2,
+    calculation_revision: 3,
     calculation_duration_seconds: 1.25,
   };
 }


### PR DESCRIPTION
## Summary

- replace historical-FX-normalized StockBee eligibility with fixed, rounded thresholds in each market's primary trading currency
- use one revision-3 calculation layer across live, backfill, attribution, rebuild, and static workflows
- preserve advance/decline, T2108, 52-week high/low, and ATR context when a listing currency mismatches the market policy, while excluding that listing from StockBee metrics
- skip breadth and breadth-derived exposure for AU, SG, and MY without blocking their other snapshot/static outputs
- reject revision-1/revision-2 static breadth fallbacks and document the atomic revision-3 cutover
- update UI formula descriptions to explain market-local thresholds

## Market policies

Thresholds are ADTV20 / daily shares / raw 20-session reference price:

- US: USD 250,000 / 100,000 / 5
- CA: CAD 5,000 / 5,000 / 0.30
- DE: EUR 5,000 / 300 / 8
- HK: HKD 20,000 / 150,000 / 0.20
- IN: INR 100,000 / 15,000 / 15
- JP: JPY 8,000,000 / 50,000 / 500
- KR: KRW 100,000,000 / 50,000 / 2,000
- TW: TWD 3,500,000 / 400,000 / 20
- CN: CNY 50,000,000 / 10,000,000 / 5

## Migration

No Alembic/schema migration is required. Existing installations must run the documented revision-3 shadow rebuild and atomic activation. Revision-2 rows are intentionally hidden after deploying revision-3 code, so breadth can be temporarily unavailable until activation and dependent exposure/snapshot/static rebuilds complete.

Runbook: `docs/runbooks/market-breadth-revision-3-cutover.md`

## Verification

- 338 breadth/static/migration backend tests passed
- 642 frontend tests passed
- frontend production build passed
- frontend lint: 0 errors (4 existing warnings)
- repository searches confirm no revision-2 application contract or breadth FX/USD threshold dependency remains

A repository-wide backend run reached 6,344 passes. Four branch-related legacy static fixtures found by that run were corrected and now pass. Eight remaining failures are outside this PR's changed areas:

- 3 theme-pipeline integration tests return 503
- 4 load tests require missing simulator profiles for AU/CA/CN/DE/IN/KR/MY/SG
- 1 existing v1.5.0 release-note assertion expects the phrase `first-run bootstrap`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Market-specific breadth thresholds now use local currencies across supported markets without historical FX conversion.
  - Currency-mismatched listings remain eligible for broader indicators but are excluded from StockBee eligibility.
  - Breadth and exposure processing is skipped for unsupported markets while other market data continues.
  - Static artifacts now validate breadth calculation compatibility.

- **Bug Fixes**
  - Updated breadth calculations and displayed results to revision 3.
  - Prevented outdated breadth data from being served.

- **Documentation**
  - Added guidance on market thresholds, static breadth compatibility, and the revision 3 rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->