### PR TITLE
Add RS heatmap to group rankings

### DIFF
--- a/frontend/src/features/groups/LiveGroupRankingsTable.jsx
+++ b/frontend/src/features/groups/LiveGroupRankingsTable.jsx
@@ -16,6 +16,7 @@ import {
   derivePctRsAbove80,
   formatGroupRs,
 } from './groupRankingFields';
+import { groupRsCellSx, groupRsTone } from './groupRsVisualEncoding';
 
 const RankChangeCell = ({ value }) => {
   if (value === null || value === undefined) {
@@ -130,19 +131,14 @@ const LiveRankingCell = ({ row, column, showHistoricalRanks }) => {
   }
 
   const value = row[column.field];
+  const isRsRating = column.kind === 'rs';
   return (
     <TableCell
       align={column.align}
+      data-rs-tone={isRsRating ? groupRsTone(value) : undefined}
       sx={{
         fontFamily: 'monospace',
-        ...(column.field === 'avg_rs_rating' && {
-          fontWeight: 600,
-          color: value >= 70
-            ? 'success.main'
-            : value <= 30
-              ? 'error.main'
-              : 'text.primary',
-        }),
+        ...(isRsRating && groupRsCellSx(value)),
       }}
     >
       {formatGroupRs(value)}

--- a/frontend/src/features/groups/groupRankingFields.js
+++ b/frontend/src/features/groups/groupRankingFields.js
@@ -112,13 +112,13 @@ const liveOnlyColumns = Object.freeze([
     field: 'median_rs_rating',
     label: 'Med RS',
     align: 'right',
-    kind: 'rating',
+    kind: 'rs',
   }),
   Object.freeze({
     field: 'weighted_avg_rs_rating',
     label: 'Wtd RS',
     align: 'right',
-    kind: 'rating',
+    kind: 'rs',
   }),
   Object.freeze({
     field: 'rs_std_dev',

--- a/frontend/src/features/groups/groupRsVisualEncoding.js
+++ b/frontend/src/features/groups/groupRsVisualEncoding.js
@@ -2,10 +2,11 @@ import { BREADTH_VISUAL_COLORS } from '../../components/Breadth/breadthVisualEnc
 
 export const groupRsTone = (value) => {
   if (!Number.isFinite(value)) return 'neutral';
-  if (value >= 80) return 'up-strong';
-  if (value >= 70) return 'up-soft';
-  if (value <= 20) return 'down-strong';
-  if (value <= 30) return 'down-soft';
+  const displayedValue = Number(value.toFixed(1));
+  if (displayedValue >= 80) return 'up-strong';
+  if (displayedValue >= 70) return 'up-soft';
+  if (displayedValue <= 20) return 'down-strong';
+  if (displayedValue <= 30) return 'down-soft';
   return 'neutral';
 };
 

--- a/frontend/src/features/groups/groupRsVisualEncoding.js
+++ b/frontend/src/features/groups/groupRsVisualEncoding.js
@@ -1,0 +1,21 @@
+import { BREADTH_VISUAL_COLORS } from '../../components/Breadth/breadthVisualEncoding';
+
+export const groupRsTone = (value) => {
+  if (!Number.isFinite(value)) return 'neutral';
+  if (value >= 80) return 'up-strong';
+  if (value >= 70) return 'up-soft';
+  if (value <= 20) return 'down-strong';
+  if (value <= 30) return 'down-soft';
+  return 'neutral';
+};
+
+export const groupRsCellSx = (value) => {
+  const tone = groupRsTone(value);
+  if (tone === 'neutral') return {};
+
+  return {
+    backgroundColor: BREADTH_VISUAL_COLORS[tone],
+    color: '#fff',
+    fontWeight: 600,
+  };
+};

--- a/frontend/src/features/groups/groupRsVisualEncoding.test.js
+++ b/frontend/src/features/groups/groupRsVisualEncoding.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatGroupRs } from './groupRankingFields';
+import { groupRsTone } from './groupRsVisualEncoding';
+
+describe('groupRsTone', () => {
+  it.each([
+    { value: 79.96, formatted: '80.0', tone: 'up-strong' },
+    { value: 69.96, formatted: '70.0', tone: 'up-soft' },
+    { value: 30.04, formatted: '30.0', tone: 'down-soft' },
+    { value: 20.04, formatted: '20.0', tone: 'down-strong' },
+  ])(
+    'classifies $value from its displayed value $formatted',
+    ({ value, formatted, tone }) => {
+      expect(formatGroupRs(value)).toBe(formatted);
+      expect(groupRsTone(value)).toBe(tone);
+    },
+  );
+});

--- a/frontend/src/pages/GroupRankingsPage.test.jsx
+++ b/frontend/src/pages/GroupRankingsPage.test.jsx
@@ -270,6 +270,64 @@ describe('GroupRankingsPage', () => {
     expect(within(table).getAllByRole('row')[1]).toHaveTextContent('HK Semiconductors');
   });
 
+  it('uses fixed background bands for every live RS rating column', async () => {
+    getCurrentRankings.mockResolvedValue({
+      date: '2026-04-18',
+      total_groups: 2,
+      market_scope: 'HK',
+      rankings: [
+        rankingRowFor('HK'),
+        {
+          ...rankingRowFor('HK'),
+          industry_group: 'HK Retail',
+          rank: 196,
+          avg_rs_rating: 20,
+          avg_rs_rating_1d: 30,
+          avg_rs_rating_1w: 30.1,
+          avg_rs_rating_1m: 69.9,
+          avg_rs_rating_3m: 70,
+          avg_rs_rating_6m: 80,
+          median_rs_rating: 25,
+          weighted_avg_rs_rating: 10,
+          rs_std_dev: 90,
+        },
+      ],
+    });
+
+    renderGroupRankingsPage();
+
+    const table = (await screen.findByRole('columnheader', { name: 'RS' })).closest('table');
+    const rows = within(table).getAllByRole('row');
+    const highCells = within(rows[1]).getAllByRole('cell');
+    const boundaryCells = within(rows[2]).getAllByRole('cell');
+
+    expect(highCells.slice(2, 10).map((cell) => cell.dataset.rsTone)).toEqual([
+      'up-strong',
+      'up-soft',
+      'up-soft',
+      'neutral',
+      'neutral',
+      'up-strong',
+      'up-strong',
+      'up-strong',
+    ]);
+    expect(boundaryCells.slice(2, 10).map((cell) => cell.dataset.rsTone)).toEqual([
+      'down-strong',
+      'down-soft',
+      'neutral',
+      'neutral',
+      'up-soft',
+      'up-strong',
+      'down-soft',
+      'down-strong',
+    ]);
+    expect(highCells[2]).toHaveStyle({ backgroundColor: '#0d7a3e', color: '#fff' });
+    expect(highCells[3]).toHaveStyle({ backgroundColor: '#123d2a', color: '#fff' });
+    expect(boundaryCells[2]).toHaveStyle({ backgroundColor: '#9b1c31', color: '#fff' });
+    expect(boundaryCells[3]).toHaveStyle({ backgroundColor: '#452126', color: '#fff' });
+    expect(boundaryCells[10]).not.toHaveAttribute('data-rs-tone');
+  });
+
   it('sorts live group rankings by top stock', async () => {
     getCurrentRankings.mockResolvedValue({
       date: '2026-04-18',

--- a/frontend/src/static/pages/StaticGroupsPage.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.jsx
@@ -34,6 +34,10 @@ import {
   formatGroupRs,
 } from '../../features/groups/groupRankingFields';
 import { sortGroupRankings } from '../../features/groups/groupRankingSort';
+import {
+  groupRsCellSx,
+  groupRsTone,
+} from '../../features/groups/groupRsVisualEncoding';
 
 function SortableTableCell({ field, label, align = 'left', orderBy, order, onSort }) {
   return (
@@ -65,9 +69,14 @@ function StaticRankingCell({ row, column }) {
   }
 
   if (column.kind === 'rs') {
+    const value = row[column.field];
     return (
-      <TableCell align={align} sx={{ fontFamily: 'monospace' }}>
-        {formatGroupRs(row[column.field])}
+      <TableCell
+        align={align}
+        data-rs-tone={groupRsTone(value)}
+        sx={{ fontFamily: 'monospace', ...groupRsCellSx(value) }}
+      >
+        {formatGroupRs(value)}
       </TableCell>
     );
   }

--- a/frontend/src/static/pages/StaticGroupsPage.test.jsx
+++ b/frontend/src/static/pages/StaticGroupsPage.test.jsx
@@ -152,6 +152,36 @@ describe('StaticGroupsPage', () => {
     expect(within(rows[2]).getAllByRole('cell')[7]).toHaveTextContent('10.0');
   });
 
+  it('uses the same RS background bands in the static rankings table', async () => {
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'US Group Rankings' })).toBeInTheDocument();
+    const table = screen.getByRole('columnheader', { name: 'Avg RS' }).closest('table');
+    const rows = within(table).getAllByRole('row');
+    const leaderCells = within(rows[1]).getAllByRole('cell');
+    const laggardCells = within(rows[2]).getAllByRole('cell');
+
+    expect(leaderCells.slice(2, 8).map((cell) => cell.dataset.rsTone)).toEqual([
+      'up-strong',
+      'up-strong',
+      'up-soft',
+      'neutral',
+      'neutral',
+      'up-strong',
+    ]);
+    expect(laggardCells.slice(2, 8).map((cell) => cell.dataset.rsTone)).toEqual([
+      'down-strong',
+      'down-strong',
+      'neutral',
+      'down-strong',
+      'neutral',
+      'down-strong',
+    ]);
+    expect(leaderCells[2]).toHaveStyle({ backgroundColor: '#0d7a3e', color: '#fff' });
+    expect(leaderCells[4]).toHaveStyle({ backgroundColor: '#123d2a', color: '#fff' });
+    expect(laggardCells[2]).toHaveStyle({ backgroundColor: '#9b1c31', color: '#fff' });
+  });
+
   it('sorts static group rankings by RS columns', async () => {
     renderPage();
 


### PR DESCRIPTION
## Summary

- add a shared fixed-band RS visual encoding that reuses the breadth heatmap palette
- apply background colors to live and static group RS columns, including live median and weighted RS while leaving dispersion unchanged
- classify the same one-decimal RS value displayed in the table so threshold colors remain understandable
- cover threshold boundaries, rounding edges, missing values, and live/static rendering parity

## RS bands

- 80-100: strong green
- 70-79.9: deep green
- 30.1-69.9: neutral
- 20.1-30: muted red
- 0-20: strong red

## Verification

- `npx vitest run --maxWorkers=2 --reporter=dot` (648 tests passed)
- `npm run build`
- `npm run lint` (0 errors; 4 existing warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved relative-strength rating visuals in live and static group rankings.
  * Rating cells now use consistent color bands and text styling to distinguish strong, moderate, neutral, and weak performance.
  * Updated boundary handling so displayed rating values receive accurate, consistent visual treatment across ranking views.

* **Tests**
  * Added coverage confirming rating thresholds, colors, and neutral handling across live and static rankings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->