### PR TITLE
Fix static breadth contributor input parity

### DIFF
--- a/backend/app/services/static_breadth_section_builder.py
+++ b/backend/app/services/static_breadth_section_builder.py
@@ -183,6 +183,7 @@ class StaticBreadthSectionBuilder:
         ]
         currencies_by_symbol: dict[str, str] = {}
         universes_by_date: dict[date, BreadthUniverseSnapshot] | None = None
+        latest_membership_dates_by_symbol: dict[str, date] | None = None
         symbols = scan_symbols
         if db is not None:
             universe = self._universe_resolver.resolve(
@@ -245,6 +246,14 @@ class StaticBreadthSectionBuilder:
                     for member in universe.members
                 }
             )
+            latest_membership_dates_by_symbol = {}
+            for item_date, universe in universes_by_date.items():
+                for member in universe.members:
+                    previous_date = latest_membership_dates_by_symbol.get(
+                        member.symbol
+                    )
+                    if previous_date is None or item_date > previous_date:
+                        latest_membership_dates_by_symbol[member.symbol] = item_date
             currencies_by_symbol = {
                 member.symbol: member.currency
                 for universe in universes_by_date.values()
@@ -254,6 +263,7 @@ class StaticBreadthSectionBuilder:
             symbols,
             period="2y",
             required_as_of_date=expected_as_of_date,
+            required_as_of_dates_by_symbol=latest_membership_dates_by_symbol,
         )
         engine_inputs = self._engine_input_factory.build(
             market=market,
@@ -469,20 +479,32 @@ class StaticBreadthSectionBuilder:
         *,
         period: str,
         required_as_of_date: date,
+        required_as_of_dates_by_symbol: dict[str, date] | None = None,
     ) -> dict[str, pd.DataFrame | None]:
         results: dict[str, pd.DataFrame | None] = {
             str(symbol).upper(): None for symbol in symbols
         }
+        symbol_dates = {
+            str(symbol).upper(): item_date
+            for symbol, item_date in (required_as_of_dates_by_symbol or {}).items()
+        }
         for start in range(0, len(symbols), STATIC_CHART_LOOKUP_BATCH_SIZE):
             batch = symbols[start : start + STATIC_CHART_LOOKUP_BATCH_SIZE]
-            results.update(
-                self._price_cache.get_many_cached_only_fresh(
-                    batch,
-                    period=period,
-                    required_as_of_date=required_as_of_date,
-                    minimum_rows=1,
+            grouped_symbols: dict[date, list[str]] = {}
+            for symbol in batch:
+                symbol_date = symbol_dates.get(
+                    str(symbol).upper(), required_as_of_date
                 )
-            )
+                grouped_symbols.setdefault(symbol_date, []).append(symbol)
+            for symbol_date, date_symbols in grouped_symbols.items():
+                results.update(
+                    self._price_cache.get_many_cached_only_fresh(
+                        date_symbols,
+                        period=period,
+                        required_as_of_date=symbol_date,
+                        minimum_rows=1,
+                    )
+                )
         return results
 
     def _get_market_benchmark_history(

--- a/backend/app/services/static_breadth_section_builder.py
+++ b/backend/app/services/static_breadth_section_builder.py
@@ -250,7 +250,11 @@ class StaticBreadthSectionBuilder:
                 for universe in universes_by_date.values()
                 for member in universe.members
             }
-        price_data = self._get_cached_price_histories(symbols, period="2y")
+        price_data = self._get_cached_price_histories(
+            symbols,
+            period="2y",
+            required_as_of_date=expected_as_of_date,
+        )
         engine_inputs = self._engine_input_factory.build(
             market=market,
             canonical_dates=canonical_dates,
@@ -464,13 +468,21 @@ class StaticBreadthSectionBuilder:
         symbols: list[str],
         *,
         period: str,
+        required_as_of_date: date,
     ) -> dict[str, pd.DataFrame | None]:
         results: dict[str, pd.DataFrame | None] = {
             str(symbol).upper(): None for symbol in symbols
         }
         for start in range(0, len(symbols), STATIC_CHART_LOOKUP_BATCH_SIZE):
             batch = symbols[start : start + STATIC_CHART_LOOKUP_BATCH_SIZE]
-            results.update(self._price_cache.get_many_cached_only(batch, period=period))
+            results.update(
+                self._price_cache.get_many_cached_only_fresh(
+                    batch,
+                    period=period,
+                    required_as_of_date=required_as_of_date,
+                    minimum_rows=1,
+                )
+            )
         return results
 
     def _get_market_benchmark_history(

--- a/backend/tests/unit/test_static_breadth_section_builder.py
+++ b/backend/tests/unit/test_static_breadth_section_builder.py
@@ -120,8 +120,17 @@ def test_static_builder_resolves_and_passes_a_universe_for_each_history_date():
             assert (symbol, period) == ("SPY", "1y")
             return price_frame
 
-        def get_many_cached_only(self, symbols, *, period):
+        def get_many_cached_only_fresh(
+            self,
+            symbols,
+            *,
+            period,
+            required_as_of_date,
+            minimum_rows,
+        ):
             assert period == "2y"
+            assert required_as_of_date == second_date
+            assert minimum_rows == 1
             return {symbol: price_frame for symbol in symbols}
 
     class _BenchmarkCache:
@@ -164,6 +173,82 @@ def test_static_builder_resolves_and_passes_a_universe_for_each_history_date():
         "NEW",
         "OLD",
     )
+
+
+def test_static_builder_keeps_short_history_when_a_formula_can_use_it():
+    calculation_date = date(2026, 8, 28)
+    index = pd.bdate_range(end=calculation_date, periods=34)
+    stock_prices = _price_frame(index)
+    stock_prices.loc[index[-1], ["Open", "High", "Close", "Adj Close"]] = (
+        105.0,
+        106.0,
+        105.0,
+        105.0,
+    )
+    stock_prices.loc[index[-1], "Volume"] = 2_000_000
+    benchmark_prices = _price_frame(index)
+
+    class _Resolver:
+        def resolve(self, _db, *, market, as_of_date):
+            return PointInTimeUniverse(
+                market=market,
+                as_of_date=as_of_date,
+                symbols=("NEW.TO",),
+                universe_hash=hash_point_in_time_universe_symbols(("NEW.TO",)),
+                members=(
+                    PointInTimeUniverseMember(symbol="NEW.TO", currency="CAD"),
+                ),
+            )
+
+    class _PriceCache:
+        def get_cached_only(self, symbol, *, period):
+            assert period == "1y"
+            return benchmark_prices
+
+        def get_many_cached_only(self, symbols, *, period):
+            assert period == "2y"
+            return {symbol: None for symbol in symbols}
+
+        def get_many_cached_only_fresh(
+            self,
+            symbols,
+            *,
+            period,
+            required_as_of_date,
+            minimum_rows,
+        ):
+            assert period == "2y"
+            assert required_as_of_date == calculation_date
+            return {
+                symbol: stock_prices if minimum_rows <= len(stock_prices) else None
+                for symbol in symbols
+            }
+
+    class _BenchmarkCache:
+        def get_benchmark_candidates(self, market):
+            assert market == "CA"
+            return ("^GSPTSE",)
+
+        def get_benchmark_symbol(self, market):
+            return "^GSPTSE"
+
+    payload = StaticBreadthSectionBuilder(
+        ui_snapshot_service=object(),
+        price_cache=_PriceCache(),
+        benchmark_cache=_BenchmarkCache(),
+        universe_resolver=_Resolver(),
+    ).build(
+        generated_at="2026-08-29T22:00:00Z",
+        expected_as_of_date=calculation_date,
+        market="CA",
+        serialized_rows=[{"symbol": "NEW.TO"}],
+        db=object(),
+    )
+
+    assert payload["payload"]["current"]["stocks_up_4pct"] == 1
+    assert calculation_date.isoformat() in payload[
+        "_contributor_calculation_signatures"
+    ]
 
 
 class _EmptyUniverseResolver:

--- a/backend/tests/unit/test_static_breadth_section_builder.py
+++ b/backend/tests/unit/test_static_breadth_section_builder.py
@@ -251,6 +251,92 @@ def test_static_builder_keeps_short_history_when_a_formula_can_use_it():
     ]
 
 
+def test_static_builder_keeps_departed_member_through_last_membership_date():
+    benchmark_index = pd.bdate_range(end="2026-08-28", periods=35)
+    departure_date = benchmark_index[-2].date()
+    calculation_date = benchmark_index[-1].date()
+    departed_prices = _price_frame(benchmark_index[:-1])
+    departed_prices.loc[
+        benchmark_index[-2], ["Open", "High", "Close", "Adj Close"]
+    ] = (105.0, 106.0, 105.0, 105.0)
+    departed_prices.loc[benchmark_index[-2], "Volume"] = 2_000_000
+    current_prices = _price_frame(benchmark_index)
+    benchmark_prices = _price_frame(benchmark_index)
+
+    class _Resolver:
+        def resolve(self, _db, *, market, as_of_date):
+            symbols = (
+                ("CURRENT.TO", "DEPARTED.TO")
+                if as_of_date <= departure_date
+                else ("CURRENT.TO",)
+            )
+            return PointInTimeUniverse(
+                market=market,
+                as_of_date=as_of_date,
+                symbols=symbols,
+                universe_hash=hash_point_in_time_universe_symbols(symbols),
+                members=tuple(
+                    PointInTimeUniverseMember(symbol=symbol, currency="CAD")
+                    for symbol in symbols
+                ),
+            )
+
+    class _PriceCache:
+        def get_cached_only(self, symbol, *, period):
+            assert period == "1y"
+            return benchmark_prices
+
+        def get_many_cached_only_fresh(
+            self,
+            symbols,
+            *,
+            period,
+            required_as_of_date,
+            minimum_rows,
+        ):
+            assert period == "2y"
+            assert minimum_rows == 1
+            return {
+                symbol: (
+                    departed_prices
+                    if symbol == "DEPARTED.TO"
+                    and required_as_of_date <= departure_date
+                    else current_prices
+                    if symbol == "CURRENT.TO"
+                    else None
+                )
+                for symbol in symbols
+            }
+
+    class _BenchmarkCache:
+        def get_benchmark_candidates(self, market):
+            assert market == "CA"
+            return ("^GSPTSE",)
+
+        def get_benchmark_symbol(self, market):
+            return "^GSPTSE"
+
+    payload = StaticBreadthSectionBuilder(
+        ui_snapshot_service=object(),
+        price_cache=_PriceCache(),
+        benchmark_cache=_BenchmarkCache(),
+        universe_resolver=_Resolver(),
+    ).build(
+        generated_at="2026-08-29T22:00:00Z",
+        expected_as_of_date=calculation_date,
+        market="CA",
+        serialized_rows=[{"symbol": "CURRENT.TO"}],
+        db=object(),
+    )
+
+    departure_row = next(
+        row
+        for row in payload["payload"]["history_90d"]
+        if row["date"] == departure_date.isoformat()
+    )
+    assert departure_row["stocks_up_4pct"] == 1
+
+
 class _EmptyUniverseResolver:
     def resolve(self, _db, *, market, as_of_date):
         return PointInTimeUniverse(

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -192,6 +192,16 @@ class _FakePriceCache:
     def get_many_cached_only(self, symbols, period="2y"):
         return self._get_many_cached_only(symbols, period=period)
 
+    def get_many_cached_only_fresh(
+        self,
+        symbols,
+        period="2y",
+        *,
+        required_as_of_date=None,
+        minimum_rows=50,
+    ):
+        return self._get_many_cached_only(symbols, period=period)
+
     def get_cached_only(self, symbol, period="2y"):
         return self.get_many_cached_only([symbol], period=period).get(symbol.upper())
 


### PR DESCRIPTION
## Summary
- load static breadth price histories with the same freshness and as-of-date contract as canonical breadth calculations
- validate historical symbols through their latest point-in-time universe membership date
- allow each breadth formula to decide whether available history is sufficient instead of imposing a global 50-row cutoff
- add regression coverage for both a short-history CA stock and a departed member that remains eligible for earlier sessions

## Root cause
The static builder used a cache helper with a default 50-row minimum, while the canonical/live calculation path used a one-row minimum and applied formula-specific eligibility later. The first parity fix then anchored the union of historical members to the latest export date, which incorrectly rejected members that had valid data only through an earlier final membership date.

## Verification
- 6,185 backend unit tests passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Static breadth reports now use price histories current through each symbol’s required as-of date.
  * Symbols without sufficient cached data are excluded more reliably.
  * Short but valid price histories are retained when supported by the calculation.
  * Historical results continue to include symbols through their final universe-membership date.
  * Improved consistency in breadth results and calculation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->