### PR TITLE
fix: export persisted breadth contributors

### DIFF
--- a/backend/app/services/static_breadth_contributor_exporter.py
+++ b/backend/app/services/static_breadth_contributor_exporter.py
@@ -6,6 +6,7 @@ import json
 import shutil
 import tempfile
 from collections.abc import Callable
+from datetime import date
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -68,7 +69,16 @@ class StaticBreadthContributorExporter:
             for row in history
             if isinstance(row, dict) and row.get("date")
         }
-        index = list_contributor_dates(db, market, limit=20)
+        requested_dates = tuple(
+            date.fromisoformat(calculation_date)
+            for calculation_date in aggregates_by_date
+        )
+        index = list_contributor_dates(
+            db,
+            market,
+            limit=20,
+            dates=requested_dates,
+        )
         dates = tuple(
             calculation_date
             for calculation_date in index.dates

--- a/backend/app/services/static_breadth_section_builder.py
+++ b/backend/app/services/static_breadth_section_builder.py
@@ -165,6 +165,21 @@ class StaticBreadthSectionBuilder:
             ).to_dict()
             payload = dict(snapshot.get("payload", {}))
             if db is not None:
+                benchmark_symbol, benchmark = self._get_market_benchmark_history(
+                    market,
+                    period="1y",
+                )
+                if not benchmark.empty:
+                    benchmark_overlay = self._serialize_history_bars(
+                        benchmark,
+                        period_days=31,
+                        end_date=expected_as_of_date,
+                    )
+                    payload.update(
+                        benchmark_symbol=benchmark_symbol,
+                        benchmark_overlay=benchmark_overlay,
+                        spy_overlay=benchmark_overlay,
+                    )
                 payload = build_persisted_breadth_payload(
                     db=db,
                     market=market,

--- a/backend/app/services/static_breadth_section_builder.py
+++ b/backend/app/services/static_breadth_section_builder.py
@@ -9,6 +9,7 @@ from typing import Any
 import pandas as pd
 from sqlalchemy.orm import Session
 
+from app.models.market_breadth import MarketBreadth
 from app.services.bounded_history_universe import (
     CurrentActiveFallbackUniverseResolver,
 )
@@ -159,7 +160,7 @@ class StaticBreadthSectionBuilder:
             snapshot = self._ui_snapshot_service.publish_breadth_bootstrap(
                 market=market
             ).to_dict()
-            payload = snapshot.get("payload", {})
+            payload = dict(snapshot.get("payload", {}))
             current_date = (payload.get("current") or {}).get("date")
             if current_date != expected_as_of_date.isoformat():
                 raise StaticSiteSectionUnavailableError(
@@ -169,14 +170,56 @@ class StaticBreadthSectionBuilder:
                         f"{expected_as_of_date.isoformat()} (latest snapshot date: {current_date or 'none'})."
                     ),
                 )
-            return {
+            result = {
                 "schema_version": STATIC_SITE_SCHEMA_VERSION,
                 "generated_at": generated_at,
                 "available": True,
                 "published_at": _coerce_datetime(snapshot.get("published_at")),
                 "source_revision": snapshot.get("source_revision"),
+                "market": market,
                 "payload": payload,
             }
+            if db is None:
+                return result
+
+            metrics_by_date: dict[date, Mapping[str, Any]] = {}
+            for row in payload.get("history_90d") or ():
+                if not isinstance(row, Mapping) or not row.get("date"):
+                    continue
+                calculation_date = date.fromisoformat(str(row["date"]))
+                metrics_by_date[calculation_date] = row
+            ordered_dates = sorted(metrics_by_date)
+            signature_rows = (
+                db.query(
+                    MarketBreadth.date,
+                    MarketBreadth.contributor_calculation_signature,
+                )
+                .filter(
+                    MarketBreadth.market == market.upper(),
+                    MarketBreadth.date.in_(ordered_dates),
+                    MarketBreadth.calculation_revision
+                    == CURRENT_BREADTH_CALCULATION_REVISION,
+                )
+                .all()
+                if ordered_dates
+                else ()
+            )
+            contributor_calculation_signatures = {
+                calculation_date.isoformat(): signature
+                for calculation_date, signature in signature_rows
+                if signature
+            }
+            payload["group_attribution"] = self._build_group_attribution(
+                db=db,
+                market=market.upper(),
+                ordered_dates=ordered_dates,
+                metrics_by_date=metrics_by_date,
+                expected_calculation_signatures=(contributor_calculation_signatures),
+            )
+            result["_contributor_calculation_signatures"] = (
+                contributor_calculation_signatures
+            )
+            return result
 
         scan_symbols = [
             str(row["symbol"]).upper() for row in serialized_rows if row.get("symbol")

--- a/backend/app/services/static_breadth_section_builder.py
+++ b/backend/app/services/static_breadth_section_builder.py
@@ -33,6 +33,9 @@ from app.services.point_in_time_universe_service import (
     hash_point_in_time_universe_symbols,
 )
 from app.services.static_market_artifact_contract import STATIC_SITE_SCHEMA_VERSION
+from app.services.static_persisted_breadth_payload import (
+    build_persisted_breadth_payload,
+)
 from app.services.static_site_errors import StaticSiteSectionUnavailableError
 
 STATIC_BREADTH_HISTORY_LOOKBACK_DAYS = 90
@@ -161,8 +164,15 @@ class StaticBreadthSectionBuilder:
                 market=market
             ).to_dict()
             payload = dict(snapshot.get("payload", {}))
+            if db is not None:
+                payload = build_persisted_breadth_payload(
+                    db=db,
+                    market=market,
+                    expected_as_of_date=expected_as_of_date,
+                    snapshot_payload=payload,
+                )
             current_date = (payload.get("current") or {}).get("date")
-            if current_date != expected_as_of_date.isoformat():
+            if str(current_date) != expected_as_of_date.isoformat():
                 raise StaticSiteSectionUnavailableError(
                     section="breadth",
                     reason=(
@@ -175,7 +185,12 @@ class StaticBreadthSectionBuilder:
                 "generated_at": generated_at,
                 "available": True,
                 "published_at": _coerce_datetime(snapshot.get("published_at")),
-                "source_revision": snapshot.get("source_revision"),
+                "source_revision": (
+                    f"{expected_as_of_date.isoformat()}"
+                    f"|breadth-r{CURRENT_BREADTH_CALCULATION_REVISION}"
+                    if db is not None
+                    else snapshot.get("source_revision")
+                ),
                 "market": market,
                 "payload": payload,
             }

--- a/backend/app/services/static_persisted_breadth_payload.py
+++ b/backend/app/services/static_persisted_breadth_payload.py
@@ -1,0 +1,76 @@
+"""Persisted breadth payloads for static exports pinned to a historical date."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, timedelta
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.market_breadth import MarketBreadth
+from app.services.breadth.query import breadth_query
+from app.services.ui_snapshot_service import market_breadth_to_dict
+
+
+def build_persisted_breadth_payload(
+    *,
+    db: Session,
+    market: str,
+    expected_as_of_date: date,
+    snapshot_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build a canonical breadth payload bounded to the static export date."""
+    canonical = breadth_query(db, market=market).filter(
+        MarketBreadth.date <= expected_as_of_date
+    )
+    current = canonical.filter(
+        MarketBreadth.date == expected_as_of_date
+    ).one_or_none()
+    first_date_row = (
+        canonical.with_entities(MarketBreadth.date)
+        .order_by(MarketBreadth.date.asc())
+        .first()
+    )
+    last_date_row = (
+        canonical.with_entities(MarketBreadth.date)
+        .order_by(MarketBreadth.date.desc())
+        .first()
+    )
+    history_start = expected_as_of_date - timedelta(days=90)
+    chart_start = expected_as_of_date - timedelta(days=31)
+    history = (
+        canonical.filter(MarketBreadth.date >= history_start)
+        .order_by(MarketBreadth.date.desc())
+        .all()
+    )
+    chart = (
+        canonical.filter(MarketBreadth.date >= chart_start)
+        .order_by(MarketBreadth.date.desc())
+        .all()
+    )
+    benchmark_overlay = [
+        dict(row)
+        for row in snapshot_payload.get("benchmark_overlay") or ()
+        if isinstance(row, Mapping)
+        and row.get("date")
+        and chart_start
+        <= date.fromisoformat(str(row["date"]))
+        <= expected_as_of_date
+    ]
+    return {
+        **snapshot_payload,
+        "current": market_breadth_to_dict(current),
+        "summary": {
+            "market": market.upper(),
+            "latest_date": last_date_row[0] if last_date_row else None,
+            "total_records": canonical.count(),
+            "date_range_start": first_date_row[0] if first_date_row else None,
+            "date_range_end": last_date_row[0] if last_date_row else None,
+        },
+        "history_90d": [market_breadth_to_dict(row) for row in history],
+        "chart_data": [market_breadth_to_dict(row) for row in chart],
+        "benchmark_overlay": benchmark_overlay,
+        "spy_overlay": benchmark_overlay,
+        "market": market.upper(),
+    }

--- a/backend/app/services/static_site_export_service.py
+++ b/backend/app/services/static_site_export_service.py
@@ -422,7 +422,6 @@ class StaticSiteExportService:
                 generated_at=generated_at,
                 expected_as_of_date=latest_run.as_of_date,
                 market=market,
-                serialized_rows=serialized_rows,
             ),
         )
         home_payload = self._build_home_payload(

--- a/backend/tests/unit/test_static_breadth_contributor_exporter.py
+++ b/backend/tests/unit/test_static_breadth_contributor_exporter.py
@@ -142,6 +142,25 @@ def test_export_writes_index_and_twenty_date_shards(tmp_path: Path):
     )
 
 
+def test_export_queries_contributors_for_pinned_history_dates(tmp_path: Path):
+    db = _db_session()
+    pinned_date = date(2026, 7, 1)
+    _seed(db, "CA", pinned_date)
+    for offset in range(1, 22):
+        _seed(db, "CA", pinned_date + timedelta(days=offset))
+
+    asset = StaticBreadthContributorExporter().export(
+        db,
+        tmp_path,
+        Path("markets/ca"),
+        _breadth_payload("CA", [pinned_date]),
+    )
+
+    assert asset == {"index_path": "markets/ca/breadth/contributors/index.json"}
+    index = json.loads((tmp_path / asset["index_path"]).read_text())
+    assert index["dates"] == [pinned_date.isoformat()]
+
+
 def test_export_is_additive_and_omits_asset_when_no_snapshot(tmp_path: Path):
     db = _db_session()
     payload = _breadth_payload("DE", [date(2026, 8, 28)])

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -327,6 +327,7 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
     """Break caught: recalculating static breadth after feature-price hydration."""
     service, session_factory = service_and_session_factory
     calculation_date = date(2026, 8, 21)
+    latest_calculation_date = date(2026, 8, 24)
     run_id = 130
     _insert_runs(
         session_factory,
@@ -354,6 +355,11 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
         calculation_date=calculation_date,
         contributors=(("AAPL", "Computer Software-Database", 8.0, "up_4pct"),),
     )
+    _insert_breadth_contributors(
+        session_factory,
+        calculation_date=latest_calculation_date,
+        contributors=(("AAPL", "Computer Software-Database", -6.0, "down_4pct"),),
+    )
     with session_factory() as db:
         stored = (
             db.query(MarketBreadth)
@@ -363,10 +369,21 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
             )
             .one()
         )
+        stored_latest = (
+            db.query(MarketBreadth)
+            .filter(
+                MarketBreadth.market == "US",
+                MarketBreadth.date == latest_calculation_date,
+            )
+            .one()
+        )
         stored_row = market_breadth_to_dict(stored)
+        stored_latest_row = market_breadth_to_dict(stored_latest)
         stored_signature = stored.contributor_calculation_signature
     assert stored_row is not None
+    assert stored_latest_row is not None
     stored_row["date"] = calculation_date.isoformat()
+    stored_latest_row["date"] = latest_calculation_date.isoformat()
 
     monkeypatch.setattr(
         service._ui_snapshot_service,
@@ -376,17 +393,17 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
                 "published_at": "2026-08-21T22:00:00Z",
                 "source_revision": "2026-08-21|breadth-r3",
                 "payload": {
-                    "current": stored_row,
+                    "current": stored_latest_row,
                     "summary": {
                         "market": "US",
-                        "latest_date": calculation_date.isoformat(),
-                        "total_records": 1,
+                        "latest_date": latest_calculation_date.isoformat(),
+                        "total_records": 2,
                         "date_range_start": calculation_date.isoformat(),
-                        "date_range_end": calculation_date.isoformat(),
+                        "date_range_end": latest_calculation_date.isoformat(),
                     },
-                    "history_90d": [stored_row],
+                    "history_90d": [stored_latest_row, stored_row],
                     "chart_range": "1M",
-                    "chart_data": [stored_row],
+                    "chart_data": [stored_latest_row, stored_row],
                     "benchmark_symbol": "SPY",
                     "benchmark_overlay": [],
                     "spy_overlay": [],
@@ -478,6 +495,10 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
             encoding="utf-8"
         )
     )
+    assert breadth["payload"]["current"]["date"] == calculation_date.isoformat()
+    assert [row["date"] for row in breadth["payload"]["history_90d"]] == [
+        calculation_date.isoformat()
+    ]
     assert breadth["payload"]["group_attribution"]["available"] is True
     assert (
         breadth["payload"]["group_attribution"]["history"][0]["groups"][0]["group"]

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -327,7 +327,7 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
     """Break caught: recalculating static breadth after feature-price hydration."""
     service, session_factory = service_and_session_factory
     calculation_date = date(2026, 8, 21)
-    latest_calculation_date = date(2026, 8, 24)
+    latest_calculation_date = date(2026, 10, 1)
     run_id = 130
     _insert_runs(
         session_factory,
@@ -391,7 +391,7 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
         lambda market="US": SimpleNamespace(
             to_dict=lambda: {
                 "published_at": "2026-08-21T22:00:00Z",
-                "source_revision": "2026-08-21|breadth-r3",
+                "source_revision": "2026-10-01|breadth-r3",
                 "payload": {
                     "current": stored_latest_row,
                     "summary": {
@@ -405,14 +405,36 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
                     "chart_range": "1M",
                     "chart_data": [stored_latest_row, stored_row],
                     "benchmark_symbol": "SPY",
-                    "benchmark_overlay": [],
+                    "benchmark_overlay": [
+                        {
+                            "date": latest_calculation_date.isoformat(),
+                            "open": 200.0,
+                            "high": 201.0,
+                            "low": 199.0,
+                            "close": 200.0,
+                            "volume": 1_000_000,
+                        }
+                    ],
                     "spy_overlay": [],
                 },
             }
         ),
     )
 
-    def changed_cache(*_args, **_kwargs):
+    benchmark_prices = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0, 200.0],
+            "High": [101.0, 102.0, 201.0],
+            "Low": [99.0, 100.0, 199.0],
+            "Close": [100.0, 101.0, 200.0],
+            "Volume": [1_000_000, 1_100_000, 1_200_000],
+        },
+        index=pd.to_datetime(["2026-08-20", "2026-08-21", "2026-10-01"]),
+    )
+
+    def changed_cache(symbols, *, period):
+        if symbols == ["SPY"] and period == "1y":
+            return {"SPY": benchmark_prices}
         raise AssertionError(
             "static breadth must not recalculate from the post-hydration price cache"
         )
@@ -498,6 +520,10 @@ def test_static_export_uses_persisted_breadth_after_price_cache_changes(
     assert breadth["payload"]["current"]["date"] == calculation_date.isoformat()
     assert [row["date"] for row in breadth["payload"]["history_90d"]] == [
         calculation_date.isoformat()
+    ]
+    assert [row["date"] for row in breadth["payload"]["benchmark_overlay"]] == [
+        "2026-08-20",
+        calculation_date.isoformat(),
     ]
     assert breadth["payload"]["group_attribution"]["available"] is True
     assert (

--- a/backend/tests/unit/test_static_site_export_service.py
+++ b/backend/tests/unit/test_static_site_export_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from inspect import Parameter, getsource, signature
 from pathlib import Path
 from types import MappingProxyType, SimpleNamespace
@@ -72,6 +72,7 @@ from app.services.static_site_export_service import (
     StaticSiteExportService,
     StaticSiteSectionUnavailableError,
 )
+from app.services.ui_snapshot_service import market_breadth_to_dict
 
 
 @pytest.fixture
@@ -316,6 +317,177 @@ def _static_rrg_payload(market: str, as_of_date: str) -> dict:
             },
         },
     }
+
+
+def test_static_export_uses_persisted_breadth_after_price_cache_changes(
+    service_and_session_factory,
+    monkeypatch,
+    tmp_path,
+):
+    """Break caught: recalculating static breadth after feature-price hydration."""
+    service, session_factory = service_and_session_factory
+    calculation_date = date(2026, 8, 21)
+    run_id = 130
+    _insert_runs(
+        session_factory,
+        FeatureRun(
+            id=run_id,
+            as_of_date=calculation_date,
+            run_type="daily_snapshot",
+            status="published",
+            published_at=datetime(2026, 8, 21, 21, 30, 0, tzinfo=UTC),
+            config_json={
+                "universe": {"market": "US"},
+                "rs_formula_version": LEGACY_RS_FORMULA_VERSION,
+            },
+        ),
+        pointer_run_id=run_id,
+        pointer_key="latest_published_market:US",
+    )
+    _insert_common_stock_universe(
+        session_factory,
+        market="US",
+        symbols=("AAPL",),
+    )
+    _insert_breadth_contributors(
+        session_factory,
+        calculation_date=calculation_date,
+        contributors=(("AAPL", "Computer Software-Database", 8.0, "up_4pct"),),
+    )
+    with session_factory() as db:
+        stored = (
+            db.query(MarketBreadth)
+            .filter(
+                MarketBreadth.market == "US",
+                MarketBreadth.date == calculation_date,
+            )
+            .one()
+        )
+        stored_row = market_breadth_to_dict(stored)
+        stored_signature = stored.contributor_calculation_signature
+    assert stored_row is not None
+    stored_row["date"] = calculation_date.isoformat()
+
+    monkeypatch.setattr(
+        service._ui_snapshot_service,
+        "publish_breadth_bootstrap",
+        lambda market="US": SimpleNamespace(
+            to_dict=lambda: {
+                "published_at": "2026-08-21T22:00:00Z",
+                "source_revision": "2026-08-21|breadth-r3",
+                "payload": {
+                    "current": stored_row,
+                    "summary": {
+                        "market": "US",
+                        "latest_date": calculation_date.isoformat(),
+                        "total_records": 1,
+                        "date_range_start": calculation_date.isoformat(),
+                        "date_range_end": calculation_date.isoformat(),
+                    },
+                    "history_90d": [stored_row],
+                    "chart_range": "1M",
+                    "chart_data": [stored_row],
+                    "benchmark_symbol": "SPY",
+                    "benchmark_overlay": [],
+                    "spy_overlay": [],
+                },
+            }
+        ),
+    )
+
+    def changed_cache(*_args, **_kwargs):
+        raise AssertionError(
+            "static breadth must not recalculate from the post-hydration price cache"
+        )
+
+    service._breadth_builder = StaticBreadthSectionBuilder(
+        ui_snapshot_service=service._ui_snapshot_service,
+        price_cache=_FakePriceCache(changed_cache),
+        benchmark_cache=_FakeBenchmarkCache(),
+    )
+    scan_manifest = {
+        "schema_version": "static-scan-v1",
+        "generated_at": "2026-08-21T22:00:00Z",
+        "as_of_date": calculation_date.isoformat(),
+        "run_id": run_id,
+        "rs_formula_version": LEGACY_RS_FORMULA_VERSION,
+        "market_rs_run_id": None,
+        "rs_as_of_date": calculation_date.isoformat(),
+        "rs_universe_size": 1,
+        "rows_total": 1,
+        "default_filtered_rows_total": 1,
+        "chunks": [],
+        "preview_rows": [{"symbol": "AAPL"}],
+        "preset_screens": [],
+    }
+    monkeypatch.setattr(
+        service,
+        "_load_scan_export_source",
+        lambda *_args, **_kwargs: ([], SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        service,
+        "_export_scan_bundle",
+        lambda **_kwargs: (scan_manifest, [{"symbol": "AAPL"}]),
+    )
+    monkeypatch.setattr(
+        service,
+        "_export_chart_bundle",
+        lambda **_kwargs: {
+            "path": "markets/us/charts/index.json",
+            "limit": 200,
+            "symbols_total": 0,
+            "available": False,
+            "skipped_symbols": [],
+        },
+    )
+    unavailable = {
+        "schema_version": STATIC_SITE_SCHEMA_VERSION,
+        "available": False,
+        "payload": {},
+    }
+    monkeypatch.setattr(service, "_build_groups_payload", lambda **_kwargs: unavailable)
+    monkeypatch.setattr(
+        service, "_build_groups_rrg_payload", lambda **_kwargs: unavailable
+    )
+    monkeypatch.setattr(
+        service,
+        "_build_home_payload",
+        lambda **_kwargs: {
+            "schema_version": STATIC_SITE_SCHEMA_VERSION,
+            "as_of_date": calculation_date.isoformat(),
+            "freshness": {"scan_run_id": run_id},
+        },
+    )
+
+    result = service.export(
+        tmp_path / "static-data",
+        markets=("US",),
+        rs_formula_version_overrides={"US": LEGACY_RS_FORMULA_VERSION},
+        feature_run_ids_by_market={"US": run_id},
+    )
+
+    contributor_root = (
+        tmp_path / "static-data" / "markets" / "us" / "breadth" / "contributors"
+    )
+    assert json.loads((contributor_root / "index.json").read_text(encoding="utf-8"))[
+        "dates"
+    ] == [calculation_date.isoformat()]
+    breadth = json.loads(
+        (tmp_path / "static-data" / "markets" / "us" / "breadth.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert breadth["payload"]["group_attribution"]["available"] is True
+    assert (
+        breadth["payload"]["group_attribution"]["history"][0]["groups"][0]["group"]
+        == "Computer Software-Database"
+    )
+    assert not any(
+        "breadth contributor data unavailable" in item.lower()
+        for item in result.warnings
+    )
+    assert stored_signature is not None
 
 
 def _export_zero_row_feature_run(


### PR DESCRIPTION
## Summary

- export static breadth from the canonical persisted breadth snapshot instead of recalculating after feature-price hydration
- load persisted contributor calculation signatures for exact provenance validation
- rebuild static group attribution from the frozen contributor snapshots
- add an export-level regression test for the post-hydration cache mismatch

## Root cause

The static exporter independently recalculated breadth after the daily snapshot workflow had hydrated broader price histories. Those mutated inputs produced signatures that no longer matched the already-persisted contributor snapshots, so contributor drill-down assets were excluded even though the canonical breadth run was valid.

## Testing

- Full backend unit suite: 6,186 passed
- Ruff on the modified production files: passed
- Git patch integrity check: passed
- Independent code review: ready to merge, no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Static site exports now use persisted market breadth data for the selected feature-run date, preventing results from changing after later price-cache updates.
  * Historical breadth exports now include accurate current values, summaries, 90-day history, 31-day chart data, and filtered benchmark comparisons.
  * Breadth snapshots retain market details, group attribution, contributor signatures, and related metadata when available.
  * Contributor history exports now include only dates represented in the breadth history, improving consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->