### PR TITLE
Fix stock-detail watchlist membership state

### DIFF
--- a/backend/app/api/v1/user_watchlists.py
+++ b/backend/app/api/v1/user_watchlists.py
@@ -24,6 +24,7 @@ from ...schemas.user_watchlist import (
     WatchlistCreate, WatchlistUpdate, WatchlistResponse,
     WatchlistItemCreate, WatchlistItemUpdate, WatchlistItemResponse,
     WatchlistDataResponse, WatchlistListResponse,
+    WatchlistMembershipResponse,
     WatchlistStockData, PriceChangeBounds,
     ReorderWatchlistsRequest, ReorderItemsRequest,
     BulkAddItemsRequest,
@@ -74,6 +75,38 @@ async def list_watchlists(db: Session = Depends(get_db)):
         watchlists=[WatchlistResponse.model_validate(w) for w in watchlists],
         total=len(watchlists)
     )
+
+
+@router.get("/memberships", response_model=WatchlistMembershipResponse)
+async def get_watchlist_memberships(
+    symbols: str = Query(..., min_length=1, max_length=2000),
+    db: Session = Depends(get_db),
+):
+    """Return the watchlists containing each requested comma-separated symbol."""
+    normalized_symbols: list[str] = []
+    seen: set[str] = set()
+    for raw_symbol in symbols.split(","):
+        normalized = normalize_symbol(raw_symbol.strip())
+        if normalized is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid symbol format: {raw_symbol.strip()!r}",
+            )
+        if normalized not in seen:
+            seen.add(normalized)
+            normalized_symbols.append(normalized)
+
+    memberships = {symbol: [] for symbol in normalized_symbols}
+    rows = (
+        db.query(WatchlistItem.symbol, WatchlistItem.watchlist_id)
+        .filter(WatchlistItem.symbol.in_(normalized_symbols))
+        .order_by(WatchlistItem.watchlist_id)
+        .all()
+    )
+    for symbol, watchlist_id in rows:
+        memberships[symbol].append(watchlist_id)
+
+    return WatchlistMembershipResponse(memberships=memberships)
 
 
 @router.post("", response_model=WatchlistResponse, include_in_schema=False)

--- a/backend/app/schemas/user_watchlist.py
+++ b/backend/app/schemas/user_watchlist.py
@@ -124,6 +124,11 @@ class WatchlistListResponse(BaseModel):
     total: int
 
 
+class WatchlistMembershipResponse(BaseModel):
+    """Watchlist IDs containing each requested symbol."""
+    memberships: Dict[str, List[int]]
+
+
 # ================= Reorder Schemas =================
 
 class ReorderWatchlistsRequest(BaseModel):

--- a/backend/tests/unit/test_stock_workspace_endpoints.py
+++ b/backend/tests/unit/test_stock_workspace_endpoints.py
@@ -915,3 +915,46 @@ async def test_watchlist_import_endpoint_downgrades_duplicate_insert_race(client
     assert payload["added"] == ["NVDA"]
     assert payload["skipped_existing"] == ["AAPL", "MSFT"]
     assert payload["invalid_symbols"] == []
+
+
+@pytest.mark.asyncio
+async def test_watchlist_memberships_returns_watchlist_ids_by_normalized_symbol(client, session):
+    app.dependency_overrides[get_db] = _override_db(session)
+    leaders = _seed_search_and_import_data(session)
+    portfolio = UserWatchlist(name="Portfolio", position=1)
+    session.add(portfolio)
+    session.commit()
+    session.refresh(portfolio)
+    session.add_all(
+        [
+            WatchlistItem(watchlist_id=leaders.id, symbol="MSFT", position=1),
+            WatchlistItem(watchlist_id=portfolio.id, symbol="MSFT", position=0),
+        ]
+    )
+    session.commit()
+
+    response = await client.get(
+        "/api/v1/user-watchlists/memberships",
+        params={"symbols": "msft,nvda"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "memberships": {
+            "MSFT": [leaders.id, portfolio.id],
+            "NVDA": [],
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_watchlist_memberships_rejects_invalid_symbols(client, session):
+    app.dependency_overrides[get_db] = _override_db(session)
+
+    response = await client.get(
+        "/api/v1/user-watchlists/memberships",
+        params={"symbols": "MSFT,BAD$"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Invalid symbol format: 'BAD$'"

--- a/frontend/src/api/userWatchlists.js
+++ b/frontend/src/api/userWatchlists.js
@@ -18,6 +18,18 @@ export const getWatchlists = async () => {
 };
 
 /**
+ * Get watchlist memberships for one or more symbols.
+ * @param {string[]} symbols - Symbols whose memberships should be returned
+ * @returns {Promise<Object>} Map of normalized symbols to watchlist IDs
+ */
+export const getWatchlistMemberships = async (symbols) => {
+  const response = await apiClient.get(`${BASE_PATH}/memberships`, {
+    params: { symbols: symbols.join(',') },
+  });
+  return response.data;
+};
+
+/**
  * Create a new watchlist.
  * @param {Object} watchlistData - Watchlist data { name, description?, color? }
  * @returns {Promise<Object>} Created watchlist

--- a/frontend/src/components/common/AddToWatchlistMenu.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.jsx
@@ -37,8 +37,21 @@ import {
   bulkAddItems,
 } from '../../api/userWatchlists';
 
+const formatErrorDetail = (detail) => {
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) {
+    return detail.map(formatErrorDetail).filter(Boolean).join('; ');
+  }
+  if (detail && typeof detail === 'object') {
+    return typeof detail.msg === 'string' ? detail.msg : JSON.stringify(detail);
+  }
+  return detail == null ? '' : String(detail);
+};
+
 const getErrorMessage = (error) => (
-  error?.response?.data?.detail || error?.message || 'Unable to update watchlist'
+  formatErrorDetail(error?.response?.data?.detail)
+  || error?.message
+  || 'Unable to update watchlist'
 );
 
 function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
@@ -80,8 +93,8 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
   const watchlists = watchlistsData?.watchlists || [];
   const memberships = membershipData?.memberships || {};
 
-  const recordMembership = (watchlistId, symbolsToRecord = normalizedSymbols) => {
-    queryClient.setQueryData(membershipQueryKey, (current) => {
+  const recordMembership = (watchlistId, querySymbols, symbolsToRecord = querySymbols) => {
+    queryClient.setQueryData(['userWatchlistMemberships', querySymbols], (current) => {
       const nextMemberships = { ...(current?.memberships || {}) };
       symbolsToRecord.forEach((symbol) => {
         nextMemberships[symbol] = [
@@ -109,7 +122,7 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
     mutationFn: ({ watchlistId, data }) => addItem(watchlistId, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['userWatchlistData', variables.watchlistId] });
-      recordMembership(variables.watchlistId);
+      recordMembership(variables.watchlistId, [variables.data.symbol]);
       onSuccess?.();
     },
   });
@@ -121,6 +134,7 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
       queryClient.invalidateQueries({ queryKey: ['userWatchlistData', variables.watchlistId] });
       recordMembership(
         variables.watchlistId,
+        variables.symbols,
         addedItems.map((item) => item.symbol),
       );
       onSuccess?.();

--- a/frontend/src/components/common/AddToWatchlistMenu.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.jsx
@@ -67,7 +67,7 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
 
   const {
     data: membershipData,
-    isLoading: isMembershipLoading,
+    isFetching: isMembershipFetching,
     error: membershipError,
   } = useQuery({
     queryKey: membershipQueryKey,
@@ -158,7 +158,7 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
   };
 
   const isPending = addItemMutation.isPending || bulkAddMutation.isPending || createMutation.isPending;
-  const isLoading = isWatchlistsLoading || isMembershipLoading;
+  const isLoading = isWatchlistsLoading || isMembershipFetching;
   const visibleError = watchlistsError
     || membershipError
     || addItemMutation.error

--- a/frontend/src/components/common/AddToWatchlistMenu.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.jsx
@@ -124,6 +124,10 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
 
   const handleClick = (event) => {
     event.stopPropagation();
+    queryClient.invalidateQueries({
+      queryKey: membershipQueryKey,
+      refetchType: 'none',
+    });
     setAnchorEl(event.currentTarget);
   };
 

--- a/frontend/src/components/common/AddToWatchlistMenu.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.jsx
@@ -51,7 +51,9 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
 
   // Normalize symbols to array
   const symbolList = Array.isArray(symbols) ? symbols : [symbols];
-  const normalizedSymbols = [...new Set(symbolList.map((symbol) => symbol.toUpperCase()))];
+  const normalizedSymbols = [...new Set(symbolList.map(
+    (symbol) => symbol.trim().replace(/^\$+/, '').toUpperCase(),
+  ))];
   const membershipQueryKey = ['userWatchlistMemberships', normalizedSymbols];
 
   // Fetch watchlists
@@ -138,15 +140,15 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
   };
 
   const handleAddToWatchlist = async (watchlistId) => {
-    if (symbolList.length === 1) {
+    if (normalizedSymbols.length === 1) {
       addItemMutation.mutate({
         watchlistId,
-        data: { symbol: symbolList[0].toUpperCase() },
+        data: { symbol: normalizedSymbols[0] },
       });
     } else {
       bulkAddMutation.mutate({
         watchlistId,
-        symbols: symbolList.map((s) => s.toUpperCase()),
+        symbols: normalizedSymbols,
       });
     }
   };

--- a/frontend/src/components/common/AddToWatchlistMenu.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.jsx
@@ -24,37 +24,71 @@ import {
   Typography,
   CircularProgress,
   Tooltip,
+  Alert,
 } from '@mui/material';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import AddIcon from '@mui/icons-material/Add';
 import CheckIcon from '@mui/icons-material/Check';
 import {
   getWatchlists,
+  getWatchlistMemberships,
   createWatchlist,
   addItem,
   bulkAddItems,
 } from '../../api/userWatchlists';
 
+const getErrorMessage = (error) => (
+  error?.response?.data?.detail || error?.message || 'Unable to update watchlist'
+);
+
 function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [newWatchlistName, setNewWatchlistName] = useState('');
   const [showNewInput, setShowNewInput] = useState(false);
-  const [addedToIds, setAddedToIds] = useState(new Set());
   const queryClient = useQueryClient();
 
   const open = Boolean(anchorEl);
 
   // Normalize symbols to array
   const symbolList = Array.isArray(symbols) ? symbols : [symbols];
+  const normalizedSymbols = [...new Set(symbolList.map((symbol) => symbol.toUpperCase()))];
+  const membershipQueryKey = ['userWatchlistMemberships', normalizedSymbols];
 
   // Fetch watchlists
-  const { data: watchlistsData, isLoading } = useQuery({
+  const {
+    data: watchlistsData,
+    isLoading: isWatchlistsLoading,
+    error: watchlistsError,
+  } = useQuery({
     queryKey: ['userWatchlists'],
     queryFn: getWatchlists,
     enabled: open,
   });
 
+  const {
+    data: membershipData,
+    isLoading: isMembershipLoading,
+    error: membershipError,
+  } = useQuery({
+    queryKey: membershipQueryKey,
+    queryFn: () => getWatchlistMemberships(normalizedSymbols),
+    enabled: open && normalizedSymbols.length > 0,
+  });
+
   const watchlists = watchlistsData?.watchlists || [];
+  const memberships = membershipData?.memberships || {};
+
+  const recordMembership = (watchlistId) => {
+    queryClient.setQueryData(membershipQueryKey, (current) => {
+      const nextMemberships = { ...(current?.memberships || {}) };
+      normalizedSymbols.forEach((symbol) => {
+        nextMemberships[symbol] = [
+          ...new Set([...(nextMemberships[symbol] || []), watchlistId]),
+        ];
+      });
+      return { memberships: nextMemberships };
+    });
+  };
 
   // Create watchlist mutation
   const createMutation = useMutation({
@@ -73,7 +107,7 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
     mutationFn: ({ watchlistId, data }) => addItem(watchlistId, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['userWatchlistData', variables.watchlistId] });
-      setAddedToIds((prev) => new Set([...prev, variables.watchlistId]));
+      recordMembership(variables.watchlistId);
       onSuccess?.();
     },
   });
@@ -83,7 +117,7 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
     mutationFn: ({ watchlistId, symbols }) => bulkAddItems(watchlistId, symbols),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['userWatchlistData', variables.watchlistId] });
-      setAddedToIds((prev) => new Set([...prev, variables.watchlistId]));
+      recordMembership(variables.watchlistId);
       onSuccess?.();
     },
   });
@@ -91,7 +125,6 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
   const handleClick = (event) => {
     event.stopPropagation();
     setAnchorEl(event.currentTarget);
-    setAddedToIds(new Set());
   };
 
   const handleClose = () => {
@@ -121,6 +154,12 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
   };
 
   const isPending = addItemMutation.isPending || bulkAddMutation.isPending || createMutation.isPending;
+  const isLoading = isWatchlistsLoading || isMembershipLoading;
+  const visibleError = watchlistsError
+    || membershipError
+    || addItemMutation.error
+    || bulkAddMutation.error
+    || createMutation.error;
 
   return (
     <>
@@ -155,26 +194,42 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
 
         <Divider />
 
+        {visibleError && (
+          <Alert severity="error" sx={{ mx: 1, my: 1 }}>
+            {getErrorMessage(visibleError)}
+          </Alert>
+        )}
+
         {isLoading ? (
           <Box display="flex" justifyContent="center" py={2}>
             <CircularProgress size={24} />
           </Box>
         ) : (
           <>
-            {watchlists.map((watchlist) => (
-              <MenuItem
-                key={watchlist.id}
-                onClick={() => handleAddToWatchlist(watchlist.id)}
-                disabled={isPending}
-              >
-                <ListItemText primary={watchlist.name} />
-                {addedToIds.has(watchlist.id) && (
-                  <ListItemIcon sx={{ minWidth: 'auto', ml: 1 }}>
-                    <CheckIcon fontSize="small" color="success" />
-                  </ListItemIcon>
-                )}
-              </MenuItem>
-            ))}
+            {watchlists.map((watchlist) => {
+              const alreadyAdded = normalizedSymbols.every(
+                (symbol) => memberships[symbol]?.includes(watchlist.id),
+              );
+              return (
+                <MenuItem
+                  key={watchlist.id}
+                  onClick={() => {
+                    if (!alreadyAdded) handleAddToWatchlist(watchlist.id);
+                  }}
+                  disabled={isPending || Boolean(membershipError) || alreadyAdded}
+                >
+                  <ListItemText
+                    primary={watchlist.name}
+                    secondary={alreadyAdded ? 'Already added' : undefined}
+                  />
+                  {alreadyAdded && (
+                    <ListItemIcon sx={{ minWidth: 'auto', ml: 1 }}>
+                      <CheckIcon fontSize="small" color="success" />
+                    </ListItemIcon>
+                  )}
+                </MenuItem>
+              );
+            })}
 
             {watchlists.length === 0 && (
               <Box sx={{ px: 2, py: 1 }}>

--- a/frontend/src/components/common/AddToWatchlistMenu.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.jsx
@@ -80,10 +80,10 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
   const watchlists = watchlistsData?.watchlists || [];
   const memberships = membershipData?.memberships || {};
 
-  const recordMembership = (watchlistId) => {
+  const recordMembership = (watchlistId, symbolsToRecord = normalizedSymbols) => {
     queryClient.setQueryData(membershipQueryKey, (current) => {
       const nextMemberships = { ...(current?.memberships || {}) };
-      normalizedSymbols.forEach((symbol) => {
+      symbolsToRecord.forEach((symbol) => {
         nextMemberships[symbol] = [
           ...new Set([...(nextMemberships[symbol] || []), watchlistId]),
         ];
@@ -117,9 +117,12 @@ function AddToWatchlistMenu({ symbols, trigger, onSuccess, size = 'small' }) {
   // Bulk add mutation
   const bulkAddMutation = useMutation({
     mutationFn: ({ watchlistId, symbols }) => bulkAddItems(watchlistId, symbols),
-    onSuccess: (_, variables) => {
+    onSuccess: (addedItems, variables) => {
       queryClient.invalidateQueries({ queryKey: ['userWatchlistData', variables.watchlistId] });
-      recordMembership(variables.watchlistId);
+      recordMembership(
+        variables.watchlistId,
+        addedItems.map((item) => item.symbol),
+      );
       onSuccess?.();
     },
   });

--- a/frontend/src/components/common/AddToWatchlistMenu.test.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -103,13 +103,20 @@ describe('AddToWatchlistMenu', () => {
 
     fireEvent.click(document.querySelector('.MuiBackdrop-root'));
     await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
-    api.getWatchlistMemberships.mockResolvedValueOnce({
-      memberships: { MSFT: [1] },
+    let resolveRefresh;
+    const refreshPromise = new Promise((resolve) => {
+      resolveRefresh = resolve;
     });
+    api.getWatchlistMemberships.mockImplementationOnce(() => refreshPromise);
 
     fireEvent.click(screen.getByRole('button', { name: 'Add to Watchlist' }));
 
     await waitFor(() => expect(api.getWatchlistMemberships).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Portfolio' })).not.toBeInTheDocument();
+    await act(async () => {
+      resolveRefresh({ memberships: { MSFT: [1] } });
+    });
     expect(await screen.findByRole('menuitem', { name: /Portfolio Already added/i }))
       .toHaveAttribute('aria-disabled', 'true');
   });

--- a/frontend/src/components/common/AddToWatchlistMenu.test.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.test.jsx
@@ -15,14 +15,16 @@ const api = vi.hoisted(() => ({
 
 vi.mock('../../api/userWatchlists', () => api);
 
-const renderMenu = (symbols = 'MSFT') => {
-  renderWithProviders(
+const renderMenu = (symbols = 'MSFT', props = {}) => {
+  const result = renderWithProviders(
     <AddToWatchlistMenu
       symbols={symbols}
       trigger={<button type="button">Add to Watchlist</button>}
+      {...props}
     />,
   );
   fireEvent.click(screen.getByRole('button', { name: 'Add to Watchlist' }));
+  return result;
 };
 
 describe('AddToWatchlistMenu', () => {
@@ -78,6 +80,24 @@ describe('AddToWatchlistMenu', () => {
       expect(api.addItem).toHaveBeenCalledWith(1, { symbol: 'MSFT' });
     });
     expect(api.bulkAddItems).not.toHaveBeenCalled();
+  });
+
+  it('keeps a watchlist selectable when bulk add returns partial success', async () => {
+    const onSuccess = vi.fn();
+    api.getWatchlistMemberships.mockResolvedValueOnce({
+      memberships: { MSFT: [], MISSING: [] },
+    });
+    api.bulkAddItems.mockResolvedValueOnce([
+      { id: 10, watchlist_id: 1, symbol: 'MSFT' },
+    ]);
+    renderMenu(['MSFT', 'MISSING'], { onSuccess });
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Portfolio' }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+    expect(screen.getByRole('menuitem', { name: 'Portfolio' })).toBeEnabled();
+    expect(screen.queryByRole('menuitem', { name: /Portfolio Already added/i }))
+      .not.toBeInTheDocument();
   });
 
   it('shows the backend error when adding fails', async () => {

--- a/frontend/src/components/common/AddToWatchlistMenu.test.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.test.jsx
@@ -1,0 +1,80 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../test/renderWithProviders';
+import AddToWatchlistMenu from './AddToWatchlistMenu';
+
+const api = vi.hoisted(() => ({
+  getWatchlists: vi.fn(),
+  getWatchlistMemberships: vi.fn(),
+  createWatchlist: vi.fn(),
+  addItem: vi.fn(),
+  bulkAddItems: vi.fn(),
+}));
+
+vi.mock('../../api/userWatchlists', () => api);
+
+const renderMenu = () => {
+  renderWithProviders(
+    <AddToWatchlistMenu
+      symbols="MSFT"
+      trigger={<button type="button">Add to Watchlist</button>}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Add to Watchlist' }));
+};
+
+describe('AddToWatchlistMenu', () => {
+  beforeEach(() => {
+    Object.values(api).forEach((mockFn) => mockFn.mockReset());
+    api.getWatchlists.mockResolvedValue({
+      watchlists: [
+        { id: 1, name: 'Portfolio' },
+        { id: 2, name: 'Growth' },
+      ],
+      total: 2,
+    });
+    api.getWatchlistMemberships.mockResolvedValue({
+      memberships: { MSFT: [1] },
+    });
+    api.addItem.mockResolvedValue({ id: 10, watchlist_id: 2, symbol: 'MSFT' });
+  });
+
+  it('marks an existing membership and prevents a duplicate add request', async () => {
+    renderMenu();
+
+    const portfolioItem = await screen.findByRole('menuitem', { name: /Portfolio Already added/i });
+
+    expect(api.getWatchlistMemberships).toHaveBeenCalledWith(['MSFT']);
+    expect(portfolioItem).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(portfolioItem);
+    expect(api.addItem).not.toHaveBeenCalled();
+  });
+
+  it('updates membership immediately after a successful add', async () => {
+    renderMenu();
+
+    const growthItem = await screen.findByRole('menuitem', { name: 'Growth' });
+    fireEvent.click(growthItem);
+
+    await waitFor(() => {
+      expect(api.addItem).toHaveBeenCalledWith(2, { symbol: 'MSFT' });
+      expect(screen.getByRole('menuitem', { name: /Growth Already added/i }))
+        .toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  it('shows the backend error when adding fails', async () => {
+    api.addItem.mockRejectedValueOnce({
+      response: { data: { detail: 'Stock already exists in watchlist' } },
+    });
+    api.getWatchlistMemberships.mockResolvedValueOnce({
+      memberships: { MSFT: [] },
+    });
+    renderMenu();
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Portfolio' }));
+
+    expect(await screen.findByText('Stock already exists in watchlist')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/AddToWatchlistMenu.test.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.test.jsx
@@ -100,6 +100,41 @@ describe('AddToWatchlistMenu', () => {
       .not.toBeInTheDocument();
   });
 
+  it('records a pending single add under the submitted symbol after props change', async () => {
+    const onSuccess = vi.fn();
+    let resolveAdd;
+    api.getWatchlistMemberships
+      .mockResolvedValueOnce({ memberships: { MSFT: [] } })
+      .mockResolvedValueOnce({ memberships: { AAPL: [] } });
+    api.addItem.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveAdd = resolve;
+    }));
+    const { queryClient, rerender } = renderMenu('MSFT', { onSuccess });
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Portfolio' }));
+    await waitFor(() => expect(api.addItem).toHaveBeenCalledWith(1, { symbol: 'MSFT' }));
+
+    rerender(
+      <AddToWatchlistMenu
+        symbols="AAPL"
+        trigger={<button type="button">Add to Watchlist</button>}
+        onSuccess={onSuccess}
+      />,
+    );
+    await waitFor(() => expect(api.getWatchlistMemberships).toHaveBeenCalledWith(['AAPL']));
+
+    await act(async () => {
+      resolveAdd({ id: 10, watchlist_id: 1, symbol: 'MSFT' });
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+    expect(queryClient.getQueryData(['userWatchlistMemberships', ['MSFT']]))
+      .toEqual({ memberships: { MSFT: [1] } });
+    expect(queryClient.getQueryData(['userWatchlistMemberships', ['AAPL']]))
+      .toEqual({ memberships: { AAPL: [] } });
+    expect(screen.getByRole('menuitem', { name: 'Portfolio' })).toBeEnabled();
+  });
+
   it('shows the backend error when adding fails', async () => {
     api.addItem.mockRejectedValueOnce({
       response: { data: { detail: 'Stock already exists in watchlist' } },
@@ -112,6 +147,26 @@ describe('AddToWatchlistMenu', () => {
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Portfolio' }));
 
     expect(await screen.findByText('Stock already exists in watchlist')).toBeInTheDocument();
+  });
+
+  it('renders structured FastAPI validation details as text', async () => {
+    api.getWatchlistMemberships.mockRejectedValueOnce({
+      response: {
+        data: {
+          detail: [
+            {
+              type: 'string_too_long',
+              loc: ['query', 'symbols'],
+              msg: 'String should have at most 2000 characters',
+            },
+          ],
+        },
+      },
+    });
+    renderMenu();
+
+    expect(await screen.findByText('String should have at most 2000 characters'))
+      .toBeInTheDocument();
   });
 
   it('refreshes membership whenever the menu reopens despite the app cache window', async () => {

--- a/frontend/src/components/common/AddToWatchlistMenu.test.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.test.jsx
@@ -1,5 +1,5 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../test/renderWithProviders';
@@ -15,10 +15,10 @@ const api = vi.hoisted(() => ({
 
 vi.mock('../../api/userWatchlists', () => api);
 
-const renderMenu = () => {
+const renderMenu = (symbols = 'MSFT') => {
   renderWithProviders(
     <AddToWatchlistMenu
-      symbols="MSFT"
+      symbols={symbols}
       trigger={<button type="button">Add to Watchlist</button>}
     />,
   );
@@ -65,6 +65,21 @@ describe('AddToWatchlistMenu', () => {
     });
   });
 
+  it('uses canonical deduplicated symbols for membership checks and additions', async () => {
+    api.getWatchlistMemberships.mockResolvedValueOnce({
+      memberships: { MSFT: [] },
+    });
+    renderMenu([' $msft ', 'MSFT']);
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Portfolio' }));
+
+    expect(api.getWatchlistMemberships).toHaveBeenCalledWith(['MSFT']);
+    await waitFor(() => {
+      expect(api.addItem).toHaveBeenCalledWith(1, { symbol: 'MSFT' });
+    });
+    expect(api.bulkAddItems).not.toHaveBeenCalled();
+  });
+
   it('shows the backend error when adding fails', async () => {
     api.addItem.mockRejectedValueOnce({
       response: { data: { detail: 'Stock already exists in watchlist' } },
@@ -88,13 +103,12 @@ describe('AddToWatchlistMenu', () => {
     api.getWatchlistMemberships.mockResolvedValueOnce({
       memberships: { MSFT: [] },
     });
-    render(
-      <QueryClientProvider client={queryClient}>
-        <AddToWatchlistMenu
-          symbols="MSFT"
-          trigger={<button type="button">Add to Watchlist</button>}
-        />
-      </QueryClientProvider>,
+    renderWithProviders(
+      <AddToWatchlistMenu
+        symbols="MSFT"
+        trigger={<button type="button">Add to Watchlist</button>}
+      />,
+      { queryClient },
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Add to Watchlist' }));

--- a/frontend/src/components/common/AddToWatchlistMenu.test.jsx
+++ b/frontend/src/components/common/AddToWatchlistMenu.test.jsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../test/renderWithProviders';
@@ -76,5 +77,40 @@ describe('AddToWatchlistMenu', () => {
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Portfolio' }));
 
     expect(await screen.findByText('Stock already exists in watchlist')).toBeInTheDocument();
+  });
+
+  it('refreshes membership whenever the menu reopens despite the app cache window', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: 300_000 },
+      },
+    });
+    api.getWatchlistMemberships.mockResolvedValueOnce({
+      memberships: { MSFT: [] },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AddToWatchlistMenu
+          symbols="MSFT"
+          trigger={<button type="button">Add to Watchlist</button>}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to Watchlist' }));
+    expect(await screen.findByRole('menuitem', { name: 'Portfolio' })).toBeEnabled();
+    expect(api.getWatchlistMemberships).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(document.querySelector('.MuiBackdrop-root'));
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+    api.getWatchlistMemberships.mockResolvedValueOnce({
+      memberships: { MSFT: [1] },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to Watchlist' }));
+
+    await waitFor(() => expect(api.getWatchlistMemberships).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole('menuitem', { name: /Portfolio Already added/i }))
+      .toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/frontend/src/test/renderWithProviders.jsx
+++ b/frontend/src/test/renderWithProviders.jsx
@@ -34,8 +34,7 @@ function createWrapper(queryClient) {
   };
 }
 
-export function renderWithProviders(ui, options = {}) {
-  const queryClient = createTestQueryClient();
+export function renderWithProviders(ui, { queryClient = createTestQueryClient(), ...options } = {}) {
   const Wrapper = createWrapper(queryClient);
 
   return {


### PR DESCRIPTION
## Summary
- add a lightweight API for resolving symbol membership across user watchlists
- mark existing memberships as already added and prevent duplicate requests
- refresh membership whenever the menu opens and block actions while that refresh is in flight
- surface watchlist API failures in the menu and update membership immediately after successful adds
- add backend and frontend regression coverage

## Testing
- `cd backend && ./venv/bin/pytest tests/unit/test_stock_workspace_endpoints.py -q` (17 passed)
- `cd frontend && npm run test:run` (671 passed)
- `cd frontend && npm run build`
- `cd frontend && npm run lint` (0 errors; 4 existing warnings)

Closes #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added watchlist membership lookup for multiple stock symbols.
  * Watchlist menus identify symbols already added and disable duplicate additions.
  * Membership information refreshes when the menu is reopened.
  * Symbols are normalized and deduplicated for consistent watchlist actions.

* **Bug Fixes**
  * Prevented duplicate watchlist additions.
  * Improved handling of partial bulk additions and invalid symbol formats.
  * Added clear error messages when watchlist actions fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->